### PR TITLE
Add Slack image upload support with procedural image generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,8 @@ version = "0.1.0"
 dependencies = [
  "acteon-core",
  "acteon-provider",
+ "base64",
+ "image",
  "reqwest",
  "serde",
  "serde_json",
@@ -223,6 +225,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +249,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -330,12 +356,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arc-swap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -385,6 +443,49 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c8fbc0f831f4519fe8b810b6a7a91410ec83031b8233f730a0480029f6a23f"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "axum"
@@ -545,6 +646,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +667,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitstream-io"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+dependencies = [
+ "core2",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,16 +685,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -605,6 +739,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -706,6 +842,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +909,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +940,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "criterion"
@@ -1013,6 +1173,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,10 +1231,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "filetime"
@@ -1072,6 +1296,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -1260,6 +1494,16 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -1648,6 +1892,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core 0.5.1",
+ "zune-jpeg 0.5.12",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1968,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1738,10 +2033,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1805,6 +2119,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "lettre"
 version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +2157,16 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libm"
@@ -1893,6 +2223,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,6 +2251,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
 
 [[package]]
 name = "md-5"
@@ -1952,6 +2301,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +2320,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1981,6 +2350,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,6 +2373,12 @@ checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notify"
@@ -2057,7 +2438,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -2067,6 +2448,17 @@ name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "num-integer"
@@ -2084,6 +2476,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -2209,6 +2612,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,6 +2706,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2334,6 +2762,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,6 +2789,30 @@ dependencies = [
  "ar_archive_writer",
  "cc",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -2371,8 +2842,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2382,7 +2863,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2392,6 +2883,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
 ]
 
 [[package]]
@@ -2497,6 +3047,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http 1.4.0",
  "http-body",
@@ -2508,6 +3059,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -2518,12 +3070,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -2535,6 +3089,12 @@ checksum = "21918d6644020c6f6ef1993242989bf6d4952d2e025617744f184c02df51c356"
 dependencies = [
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
 name = "ring"
@@ -2563,7 +3123,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -2582,7 +3142,7 @@ dependencies = [
  "http 0.2.12",
  "mime",
  "mime_guess",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
 ]
 
@@ -2839,7 +3399,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
 ]
 
 [[package]]
@@ -3013,7 +3588,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
@@ -3053,7 +3628,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -3246,6 +3821,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -3630,6 +4219,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3747,6 +4347,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3755,6 +4368,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
@@ -4098,6 +4717,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4211,3 +4836,42 @@ name = "zmij"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
+dependencies = [
+ "zune-core 0.5.1",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,13 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono", "uu
 lettre = { version = "0.11", features = ["tokio1-native-tls", "smtp-transport"] }
 
 # HTTP client
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "multipart", "stream"] }
+
+# Image generation
+image = "0.25"
+
+# Base64 encoding
+base64 = "0.22"
 
 # Regex
 regex = "1"

--- a/acteon-slack/Cargo.toml
+++ b/acteon-slack/Cargo.toml
@@ -17,6 +17,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+image = { workspace = true }
+base64 = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/acteon-slack/src/image_gen.rs
+++ b/acteon-slack/src/image_gen.rs
@@ -1,0 +1,355 @@
+//! Simple image generation for Slack uploads.
+//!
+//! Provides procedural image generation that can be used with the
+//! `upload_image` action type. Generated images are returned as PNG bytes
+//! ready for upload.
+
+use image::{ImageBuffer, Rgba, RgbaImage};
+use std::io::Cursor;
+
+use crate::error::SlackError;
+
+/// Supported image generation styles.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ImageSpec {
+    /// A solid color rectangle.
+    SolidColor {
+        width: u32,
+        height: u32,
+        /// Color as hex string, e.g. "#FF5733" or "FF5733".
+        color: String,
+    },
+    /// A horizontal gradient between two colors.
+    Gradient {
+        width: u32,
+        height: u32,
+        /// Start color as hex string.
+        from_color: String,
+        /// End color as hex string.
+        to_color: String,
+    },
+    /// A checkerboard pattern.
+    Checkerboard {
+        width: u32,
+        height: u32,
+        /// Size of each square in pixels.
+        square_size: u32,
+        /// First color as hex string.
+        color_a: String,
+        /// Second color as hex string.
+        color_b: String,
+    },
+    /// A simple bar chart rendered as an image.
+    BarChart {
+        width: u32,
+        height: u32,
+        /// Data values for each bar.
+        values: Vec<f64>,
+        /// Bar color as hex string.
+        bar_color: String,
+        /// Background color as hex string.
+        #[serde(default = "default_bg_color")]
+        background_color: String,
+    },
+}
+
+fn default_bg_color() -> String {
+    "#FFFFFF".to_owned()
+}
+
+/// Parse a hex color string into RGBA.
+fn parse_hex_color(hex: &str) -> Result<Rgba<u8>, SlackError> {
+    let hex = hex.trim_start_matches('#');
+    if hex.len() != 6 {
+        return Err(SlackError::InvalidPayload(format!(
+            "invalid hex color: expected 6 hex digits, got '{hex}'"
+        )));
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16)
+        .map_err(|_| SlackError::InvalidPayload(format!("invalid hex color: '{hex}'")))?;
+    let g = u8::from_str_radix(&hex[2..4], 16)
+        .map_err(|_| SlackError::InvalidPayload(format!("invalid hex color: '{hex}'")))?;
+    let b = u8::from_str_radix(&hex[4..6], 16)
+        .map_err(|_| SlackError::InvalidPayload(format!("invalid hex color: '{hex}'")))?;
+    Ok(Rgba([r, g, b, 255]))
+}
+
+/// Linearly interpolate between two RGBA colors.
+fn lerp_color(a: Rgba<u8>, b: Rgba<u8>, t: f64) -> Rgba<u8> {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let mix = |a: u8, b: u8| -> u8 {
+        let v = f64::from(a) * (1.0 - t) + f64::from(b) * t;
+        v.clamp(0.0, 255.0) as u8
+    };
+    Rgba([mix(a[0], b[0]), mix(a[1], b[1]), mix(a[2], b[2]), 255])
+}
+
+/// Validate image dimensions to prevent excessive memory allocation.
+fn validate_dimensions(width: u32, height: u32) -> Result<(), SlackError> {
+    const MAX_DIMENSION: u32 = 4096;
+    const MAX_PIXELS: u64 = 16_777_216; // 4096 * 4096
+
+    if width == 0 || height == 0 {
+        return Err(SlackError::InvalidPayload(
+            "image dimensions must be greater than zero".into(),
+        ));
+    }
+    if width > MAX_DIMENSION || height > MAX_DIMENSION {
+        return Err(SlackError::InvalidPayload(format!(
+            "image dimensions must not exceed {MAX_DIMENSION}x{MAX_DIMENSION}"
+        )));
+    }
+    if u64::from(width) * u64::from(height) > MAX_PIXELS {
+        return Err(SlackError::InvalidPayload(format!(
+            "total pixel count must not exceed {MAX_PIXELS}"
+        )));
+    }
+    Ok(())
+}
+
+/// Generate a PNG image from the given specification.
+///
+/// Returns the raw PNG bytes.
+pub fn generate_image(spec: &ImageSpec) -> Result<Vec<u8>, SlackError> {
+    let img = match spec {
+        ImageSpec::SolidColor {
+            width,
+            height,
+            color,
+        } => {
+            validate_dimensions(*width, *height)?;
+            let rgba = parse_hex_color(color)?;
+            ImageBuffer::from_fn(*width, *height, |_, _| rgba)
+        }
+        ImageSpec::Gradient {
+            width,
+            height,
+            from_color,
+            to_color,
+        } => {
+            validate_dimensions(*width, *height)?;
+            let from = parse_hex_color(from_color)?;
+            let to = parse_hex_color(to_color)?;
+            ImageBuffer::from_fn(*width, *height, |x, _| {
+                let t = if *width > 1 {
+                    f64::from(x) / f64::from(*width - 1)
+                } else {
+                    0.0
+                };
+                lerp_color(from, to, t)
+            })
+        }
+        ImageSpec::Checkerboard {
+            width,
+            height,
+            square_size,
+            color_a,
+            color_b,
+        } => {
+            validate_dimensions(*width, *height)?;
+            let sq = (*square_size).max(1);
+            let a = parse_hex_color(color_a)?;
+            let b = parse_hex_color(color_b)?;
+            ImageBuffer::from_fn(*width, *height, |x, y| {
+                if ((x / sq) + (y / sq)) % 2 == 0 {
+                    a
+                } else {
+                    b
+                }
+            })
+        }
+        ImageSpec::BarChart {
+            width,
+            height,
+            values,
+            bar_color,
+            background_color,
+        } => {
+            validate_dimensions(*width, *height)?;
+            generate_bar_chart(*width, *height, values, bar_color, background_color)?
+        }
+    };
+
+    encode_png(&img)
+}
+
+/// Generate a bar chart image.
+fn generate_bar_chart(
+    width: u32,
+    height: u32,
+    values: &[f64],
+    bar_color: &str,
+    background_color: &str,
+) -> Result<RgbaImage, SlackError> {
+    let bar_rgba = parse_hex_color(bar_color)?;
+    let bg_rgba = parse_hex_color(background_color)?;
+
+    let mut img = ImageBuffer::from_fn(width, height, |_, _| bg_rgba);
+
+    if values.is_empty() {
+        return Ok(img);
+    }
+
+    let max_val = values
+        .iter()
+        .copied()
+        .fold(f64::NEG_INFINITY, f64::max)
+        .max(0.001);
+
+    let padding = 4u32;
+    #[allow(clippy::cast_possible_truncation)]
+    let n = values.len() as u32;
+    let usable_width = width.saturating_sub(padding * 2);
+    let bar_width = usable_width / n;
+    if bar_width == 0 {
+        return Ok(img);
+    }
+    let gap = (bar_width / 5).clamp(1, 4);
+    let actual_bar = bar_width.saturating_sub(gap);
+
+    let usable_height = height.saturating_sub(padding * 2);
+
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    for (i, &val) in values.iter().enumerate() {
+        let bar_height = ((val / max_val) * f64::from(usable_height)).round() as u32;
+        let bar_height = bar_height.min(usable_height);
+        let x_start = padding + (i as u32) * bar_width;
+        let y_start = padding + usable_height - bar_height;
+
+        for y in y_start..y_start + bar_height {
+            for x in x_start..x_start + actual_bar {
+                if x < width && y < height {
+                    img.put_pixel(x, y, bar_rgba);
+                }
+            }
+        }
+    }
+
+    Ok(img)
+}
+
+/// Encode an RGBA image as PNG bytes.
+fn encode_png(img: &RgbaImage) -> Result<Vec<u8>, SlackError> {
+    let mut buf = Cursor::new(Vec::new());
+    img.write_to(&mut buf, image::ImageFormat::Png)
+        .map_err(|e| SlackError::InvalidPayload(format!("failed to encode PNG: {e}")))?;
+    Ok(buf.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_hex_color_with_hash() {
+        let c = parse_hex_color("#FF5733").unwrap();
+        assert_eq!(c, Rgba([255, 87, 51, 255]));
+    }
+
+    #[test]
+    fn parse_hex_color_without_hash() {
+        let c = parse_hex_color("00FF00").unwrap();
+        assert_eq!(c, Rgba([0, 255, 0, 255]));
+    }
+
+    #[test]
+    fn parse_hex_color_invalid() {
+        assert!(parse_hex_color("ZZZ").is_err());
+        assert!(parse_hex_color("#12345").is_err());
+    }
+
+    #[test]
+    fn generate_solid_color() {
+        let spec = ImageSpec::SolidColor {
+            width: 10,
+            height: 10,
+            color: "#FF0000".into(),
+        };
+        let png = generate_image(&spec).unwrap();
+        assert!(!png.is_empty());
+        // PNG magic bytes
+        assert_eq!(&png[..4], &[137, 80, 78, 71]);
+    }
+
+    #[test]
+    fn generate_gradient() {
+        let spec = ImageSpec::Gradient {
+            width: 100,
+            height: 50,
+            from_color: "#000000".into(),
+            to_color: "#FFFFFF".into(),
+        };
+        let png = generate_image(&spec).unwrap();
+        assert!(!png.is_empty());
+    }
+
+    #[test]
+    fn generate_checkerboard() {
+        let spec = ImageSpec::Checkerboard {
+            width: 64,
+            height: 64,
+            square_size: 8,
+            color_a: "#000000".into(),
+            color_b: "#FFFFFF".into(),
+        };
+        let png = generate_image(&spec).unwrap();
+        assert!(!png.is_empty());
+    }
+
+    #[test]
+    fn generate_bar_chart() {
+        let spec = ImageSpec::BarChart {
+            width: 200,
+            height: 100,
+            values: vec![10.0, 25.0, 15.0, 30.0, 20.0],
+            bar_color: "#3366CC".into(),
+            background_color: "#FFFFFF".into(),
+        };
+        let png = generate_image(&spec).unwrap();
+        assert!(!png.is_empty());
+    }
+
+    #[test]
+    fn generate_bar_chart_empty_values() {
+        let spec = ImageSpec::BarChart {
+            width: 200,
+            height: 100,
+            values: vec![],
+            bar_color: "#3366CC".into(),
+            background_color: "#FFFFFF".into(),
+        };
+        let png = generate_image(&spec).unwrap();
+        assert!(!png.is_empty());
+    }
+
+    #[test]
+    fn reject_zero_dimensions() {
+        let spec = ImageSpec::SolidColor {
+            width: 0,
+            height: 10,
+            color: "#FF0000".into(),
+        };
+        assert!(generate_image(&spec).is_err());
+    }
+
+    #[test]
+    fn reject_oversized_dimensions() {
+        let spec = ImageSpec::SolidColor {
+            width: 10000,
+            height: 10000,
+            color: "#FF0000".into(),
+        };
+        assert!(generate_image(&spec).is_err());
+    }
+
+    #[test]
+    fn lerp_color_midpoint() {
+        let a = Rgba([0, 0, 0, 255]);
+        let b = Rgba([200, 100, 50, 255]);
+        let mid = lerp_color(a, b, 0.5);
+        assert_eq!(mid[0], 100);
+        assert_eq!(mid[1], 50);
+        assert_eq!(mid[2], 25);
+    }
+}

--- a/acteon-slack/src/lib.rs
+++ b/acteon-slack/src/lib.rs
@@ -16,10 +16,16 @@
 
 pub mod config;
 pub mod error;
+pub mod image_gen;
 pub mod provider;
 pub mod types;
 
 pub use config::SlackConfig;
 pub use error::SlackError;
+pub use image_gen::ImageSpec;
 pub use provider::SlackProvider;
-pub use types::{SlackApiResponse, SlackAuthTestResponse, SlackPostMessageRequest};
+pub use types::{
+    SlackApiResponse, SlackAuthTestResponse, SlackCompleteUploadRequest,
+    SlackCompleteUploadResponse, SlackFileReference, SlackGetUploadUrlRequest,
+    SlackGetUploadUrlResponse, SlackPostMessageRequest,
+};

--- a/acteon-slack/src/provider.rs
+++ b/acteon-slack/src/provider.rs
@@ -6,12 +6,23 @@ use tracing::{debug, instrument, warn};
 
 use crate::config::SlackConfig;
 use crate::error::SlackError;
-use crate::types::{SlackApiResponse, SlackAuthTestResponse, SlackPostMessageRequest};
+use crate::image_gen::{self, ImageSpec};
+use crate::types::{
+    SlackApiResponse, SlackAuthTestResponse, SlackCompleteUploadRequest,
+    SlackCompleteUploadResponse, SlackFileReference, SlackGetUploadUrlResponse,
+    SlackPostMessageRequest,
+};
 
-/// Slack provider that sends messages via the Slack Web API.
+/// Slack provider that sends messages and uploads files via the Slack Web API.
 ///
 /// Implements the [`Provider`] trait so it can be registered in the provider
 /// registry and used by the action executor.
+///
+/// # Supported action types
+///
+/// - `send_message` — posts a message via `chat.postMessage`
+/// - `upload_image` — generates (or accepts) an image and uploads it via
+///   the Slack files.uploadV2 flow
 pub struct SlackProvider {
     config: SlackConfig,
     client: Client,
@@ -23,6 +34,23 @@ struct MessagePayload {
     channel: Option<String>,
     text: Option<String>,
     blocks: Option<serde_json::Value>,
+}
+
+/// Fields extracted from an action payload for image upload.
+#[derive(Debug, Deserialize)]
+struct ImageUploadPayload {
+    /// Target channel to share the uploaded file to.
+    channel: Option<String>,
+    /// Filename for the upload (defaults to "image.png").
+    filename: Option<String>,
+    /// Optional title for the file in Slack.
+    title: Option<String>,
+    /// Optional initial comment when sharing.
+    initial_comment: Option<String>,
+    /// Base64-encoded PNG image data. If provided, `generate` is ignored.
+    image_base64: Option<String>,
+    /// Image generation specification. Used when `image_base64` is absent.
+    generate: Option<ImageSpec>,
 }
 
 impl SlackProvider {
@@ -103,16 +131,12 @@ impl SlackProvider {
 
         Ok(api_response)
     }
-}
 
-impl Provider for SlackProvider {
-    #[allow(clippy::unnecessary_literal_bound)]
-    fn name(&self) -> &str {
-        "slack"
-    }
-
-    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "slack"))]
-    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+    /// Execute the `send_message` action type.
+    async fn execute_send_message(
+        &self,
+        action: &Action,
+    ) -> Result<ProviderResponse, ProviderError> {
         let payload: MessagePayload = serde_json::from_value(action.payload.clone())
             .map_err(|e| SlackError::InvalidPayload(format!("failed to parse payload: {e}")))?;
 
@@ -140,6 +164,243 @@ impl Provider for SlackProvider {
         });
 
         Ok(ProviderResponse::success(body))
+    }
+
+    /// Execute the `upload_image` action type.
+    ///
+    /// Uses the Slack files.uploadV2 three-step flow:
+    /// 1. `files.getUploadURLExternal` — obtain a presigned upload URL
+    /// 2. POST file bytes to the presigned URL
+    /// 3. `files.completeUploadExternal` — finalize and share the file
+    async fn execute_upload_image(
+        &self,
+        action: &Action,
+    ) -> Result<ProviderResponse, ProviderError> {
+        let payload: ImageUploadPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| SlackError::InvalidPayload(format!("failed to parse payload: {e}")))?;
+
+        let channel = self.resolve_channel(payload.channel.as_deref())?;
+        let filename = payload
+            .filename
+            .unwrap_or_else(|| "image.png".to_owned());
+
+        // Obtain image bytes: either from base64 or by generating.
+        let image_bytes = if let Some(b64) = &payload.image_base64 {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD
+                .decode(b64)
+                .map_err(|e| {
+                    SlackError::InvalidPayload(format!("invalid base64 image data: {e}"))
+                })?
+        } else if let Some(spec) = &payload.generate {
+            image_gen::generate_image(spec)?
+        } else {
+            return Err(SlackError::InvalidPayload(
+                "payload must contain either 'image_base64' or 'generate' specification".into(),
+            )
+            .into());
+        };
+
+        debug!(
+            filename = %filename,
+            bytes = image_bytes.len(),
+            channel = %channel,
+            "uploading image to Slack"
+        );
+
+        // Step 1: Get upload URL.
+        let upload_url_resp = self.get_upload_url(&filename, image_bytes.len() as u64).await?;
+
+        let presigned_url = upload_url_resp.upload_url.ok_or_else(|| {
+            SlackError::Api("files.getUploadURLExternal returned no upload_url".into())
+        })?;
+        let file_id = upload_url_resp.file_id.ok_or_else(|| {
+            SlackError::Api("files.getUploadURLExternal returned no file_id".into())
+        })?;
+
+        // Step 2: Upload file bytes to the presigned URL.
+        self.upload_to_presigned_url(&presigned_url, &image_bytes, &filename)
+            .await?;
+
+        // Step 3: Complete the upload and share to channel.
+        let complete_resp = self
+            .complete_upload(
+                &file_id,
+                payload.title.as_deref().or(Some(&filename)),
+                Some(&channel),
+                payload.initial_comment.as_deref(),
+            )
+            .await?;
+
+        let file_ids: Vec<String> = complete_resp
+            .files
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|f| f.id.clone())
+            .collect();
+
+        let body = serde_json::json!({
+            "ok": true,
+            "file_id": file_id,
+            "file_ids": file_ids,
+            "channel": channel,
+        });
+
+        Ok(ProviderResponse::success(body))
+    }
+
+    /// Step 1: Call `files.getUploadURLExternal` to obtain a presigned upload URL.
+    async fn get_upload_url(
+        &self,
+        filename: &str,
+        length: u64,
+    ) -> Result<SlackGetUploadUrlResponse, SlackError> {
+        let url = self.api_url("files.getUploadURLExternal");
+
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.config.token)
+            .form(&[
+                ("filename", filename.to_owned()),
+                ("length", length.to_string()),
+            ])
+            .send()
+            .await?;
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(SlackError::RateLimited);
+        }
+
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(SlackError::Api(format!(
+                "files.getUploadURLExternal HTTP {status}: {body}"
+            )));
+        }
+
+        let resp: SlackGetUploadUrlResponse = response.json().await?;
+
+        if !resp.ok {
+            let err = resp.error.unwrap_or_else(|| "unknown_error".into());
+            return Err(SlackError::Api(format!(
+                "files.getUploadURLExternal failed: {err}"
+            )));
+        }
+
+        Ok(resp)
+    }
+
+    /// Step 2: Upload file bytes to the presigned URL via multipart form.
+    async fn upload_to_presigned_url(
+        &self,
+        presigned_url: &str,
+        data: &[u8],
+        filename: &str,
+    ) -> Result<(), SlackError> {
+        let part = reqwest::multipart::Part::bytes(data.to_vec())
+            .file_name(filename.to_owned())
+            .mime_str("image/png")
+            .map_err(|e| SlackError::InvalidPayload(format!("invalid mime type: {e}")))?;
+
+        let form = reqwest::multipart::Form::new().part("file", part);
+
+        let response = self
+            .client
+            .post(presigned_url)
+            .multipart(form)
+            .send()
+            .await?;
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(SlackError::RateLimited);
+        }
+
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(SlackError::Api(format!(
+                "file upload to presigned URL failed HTTP {status}: {body}"
+            )));
+        }
+
+        debug!("file bytes uploaded to presigned URL successfully");
+        Ok(())
+    }
+
+    /// Step 3: Call `files.completeUploadExternal` to finalize the upload
+    /// and share it to a channel.
+    async fn complete_upload(
+        &self,
+        file_id: &str,
+        title: Option<&str>,
+        channel_id: Option<&str>,
+        initial_comment: Option<&str>,
+    ) -> Result<SlackCompleteUploadResponse, SlackError> {
+        let url = self.api_url("files.completeUploadExternal");
+
+        let request = SlackCompleteUploadRequest {
+            files: vec![SlackFileReference {
+                id: file_id.to_owned(),
+                title: title.map(str::to_owned),
+            }],
+            channel_id: channel_id.map(str::to_owned),
+            initial_comment: initial_comment.map(str::to_owned),
+        };
+
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.config.token)
+            .json(&request)
+            .send()
+            .await?;
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(SlackError::RateLimited);
+        }
+
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(SlackError::Api(format!(
+                "files.completeUploadExternal HTTP {status}: {body}"
+            )));
+        }
+
+        let resp: SlackCompleteUploadResponse = response.json().await?;
+
+        if !resp.ok {
+            let err = resp.error.unwrap_or_else(|| "unknown_error".into());
+            return Err(SlackError::Api(format!(
+                "files.completeUploadExternal failed: {err}"
+            )));
+        }
+
+        debug!(file_id = %file_id, "file upload completed successfully");
+        Ok(resp)
+    }
+}
+
+impl Provider for SlackProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "slack"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "slack"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        match action.action_type.as_str() {
+            "send_message" => self.execute_send_message(action).await,
+            "upload_image" => self.execute_upload_image(action).await,
+            other => Err(ProviderError::ExecutionFailed(format!(
+                "unsupported action type: '{other}' (supported: send_message, upload_image)"
+            ))),
+        }
     }
 
     #[instrument(skip(self), fields(provider = "slack"))]
@@ -246,12 +507,101 @@ mod tests {
         }
     }
 
+    /// A mock server that handles the three-step file upload flow.
+    struct MockUploadServer {
+        listener: tokio::net::TcpListener,
+        base_url: String,
+    }
+
+    impl MockUploadServer {
+        async fn start() -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("failed to bind mock upload server");
+            let port = listener.local_addr().unwrap().port();
+            let base_url = format!("http://127.0.0.1:{port}");
+            Self { listener, base_url }
+        }
+
+        /// Handle the three sequential requests of the upload flow.
+        async fn handle_upload_flow(self) {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+            // Request 1: files.getUploadURLExternal
+            let (mut stream, _) = self.listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 8192];
+            let _ = stream.read(&mut buf).await.unwrap();
+
+            let upload_url = format!("{}/upload-target", self.base_url);
+            let body = format!(
+                r#"{{"ok":true,"upload_url":"{upload_url}","file_id":"F_MOCK_123"}}"#
+            );
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 {body}",
+                body.len()
+            );
+            stream.write_all(resp.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+
+            // Request 2: Upload to presigned URL
+            let (mut stream, _) = self.listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 65536];
+            let _ = stream.read(&mut buf).await.unwrap();
+
+            let body = "OK";
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: text/plain\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 {body}",
+                body.len()
+            );
+            stream.write_all(resp.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+
+            // Request 3: files.completeUploadExternal
+            let (mut stream, _) = self.listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 8192];
+            let _ = stream.read(&mut buf).await.unwrap();
+
+            let body = r#"{"ok":true,"files":[{"id":"F_MOCK_123","title":"image.png"}]}"#;
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 {body}",
+                body.len()
+            );
+            stream.write_all(resp.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+        }
+    }
+
     fn make_action(payload: serde_json::Value) -> Action {
         Action::new(
             "notifications",
             "tenant-1",
             "slack",
             "send_message",
+            payload,
+        )
+    }
+
+    fn make_upload_action(payload: serde_json::Value) -> Action {
+        Action::new(
+            "notifications",
+            "tenant-1",
+            "slack",
+            "upload_image",
             payload,
         )
     }
@@ -408,6 +758,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_unsupported_action_type() {
+        let config = SlackConfig::new("xoxb-test").with_api_base_url("http://localhost:1");
+        let provider = SlackProvider::new(config);
+
+        let action = Action::new(
+            "notifications",
+            "tenant-1",
+            "slack",
+            "delete_channel",
+            serde_json::json!({}),
+        );
+
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[tokio::test]
     async fn health_check_success() {
         let server = MockSlackServer::start().await;
         let config = SlackConfig::new("xoxb-test").with_api_base_url(&server.base_url);
@@ -457,5 +824,131 @@ mod tests {
 
         assert!(matches!(err, ProviderError::RateLimited));
         assert!(err.is_retryable());
+    }
+
+    // ─── Image upload tests ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn upload_image_with_generate() {
+        let server = MockUploadServer::start().await;
+        let config = SlackConfig::new("xoxb-test").with_api_base_url(&server.base_url);
+        let provider = SlackProvider::new(config);
+
+        let action = make_upload_action(serde_json::json!({
+            "channel": "#general",
+            "filename": "chart.png",
+            "title": "My Chart",
+            "generate": {
+                "type": "solid_color",
+                "width": 10,
+                "height": 10,
+                "color": "#FF0000"
+            }
+        }));
+
+        let server_handle = tokio::spawn(async move {
+            server.handle_upload_flow().await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        let response = result.expect("upload_image should succeed");
+        assert_eq!(response.status, acteon_core::ResponseStatus::Success);
+        assert_eq!(response.body["ok"], true);
+        assert_eq!(response.body["file_id"], "F_MOCK_123");
+        assert_eq!(response.body["channel"], "#general");
+    }
+
+    #[tokio::test]
+    async fn upload_image_with_base64() {
+        let server = MockUploadServer::start().await;
+        let config = SlackConfig::new("xoxb-test").with_api_base_url(&server.base_url);
+        let provider = SlackProvider::new(config);
+
+        // Create a tiny valid PNG via the image generator, then base64 it.
+        let png_bytes = image_gen::generate_image(&ImageSpec::SolidColor {
+            width: 2,
+            height: 2,
+            color: "#00FF00".into(),
+        })
+        .unwrap();
+        use base64::Engine;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&png_bytes);
+
+        let action = make_upload_action(serde_json::json!({
+            "channel": "#general",
+            "image_base64": b64,
+        }));
+
+        let server_handle = tokio::spawn(async move {
+            server.handle_upload_flow().await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        let response = result.expect("upload_image with base64 should succeed");
+        assert_eq!(response.status, acteon_core::ResponseStatus::Success);
+        assert_eq!(response.body["ok"], true);
+    }
+
+    #[tokio::test]
+    async fn upload_image_missing_source() {
+        let config = SlackConfig::new("xoxb-test").with_api_base_url("http://localhost:1");
+        let provider = SlackProvider::new(config);
+
+        let action = make_upload_action(serde_json::json!({
+            "channel": "#general",
+        }));
+
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+    }
+
+    #[tokio::test]
+    async fn upload_image_invalid_base64() {
+        let config = SlackConfig::new("xoxb-test").with_api_base_url("http://localhost:1");
+        let provider = SlackProvider::new(config);
+
+        let action = make_upload_action(serde_json::json!({
+            "channel": "#general",
+            "image_base64": "not-valid-base64!!!",
+        }));
+
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+    }
+
+    #[tokio::test]
+    async fn upload_image_with_bar_chart() {
+        let server = MockUploadServer::start().await;
+        let config = SlackConfig::new("xoxb-test").with_api_base_url(&server.base_url);
+        let provider = SlackProvider::new(config);
+
+        let action = make_upload_action(serde_json::json!({
+            "channel": "#metrics",
+            "filename": "metrics.png",
+            "title": "Weekly Metrics",
+            "initial_comment": "Here are this week's metrics!",
+            "generate": {
+                "type": "bar_chart",
+                "width": 400,
+                "height": 200,
+                "values": [10.0, 25.0, 15.0, 30.0, 20.0],
+                "bar_color": "#3366CC",
+                "background_color": "#FFFFFF"
+            }
+        }));
+
+        let server_handle = tokio::spawn(async move {
+            server.handle_upload_flow().await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        let response = result.expect("bar chart upload should succeed");
+        assert_eq!(response.status, acteon_core::ResponseStatus::Success);
     }
 }

--- a/acteon-slack/src/types.rs
+++ b/acteon-slack/src/types.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+// ─── chat.postMessage ────────────────────────────────────────────────
+
 /// Request body for the Slack `chat.postMessage` API.
 #[derive(Debug, Clone, Serialize)]
 pub struct SlackPostMessageRequest {
@@ -15,6 +17,8 @@ pub struct SlackPostMessageRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blocks: Option<serde_json::Value>,
 }
+
+// ─── API Responses ───────────────────────────────────────────────────
 
 /// Envelope returned by all Slack Web API methods.
 #[derive(Debug, Clone, Deserialize)]
@@ -46,6 +50,69 @@ pub struct SlackAuthTestResponse {
 
     /// Authenticated team ID.
     pub team_id: Option<String>,
+}
+
+// ─── files.getUploadURLExternal ──────────────────────────────────────
+
+/// Request body for the Slack `files.getUploadURLExternal` API.
+#[derive(Debug, Clone, Serialize)]
+pub struct SlackGetUploadUrlRequest {
+    /// The name of the file to upload.
+    pub filename: String,
+    /// Length of the file in bytes.
+    pub length: u64,
+}
+
+/// Response from `files.getUploadURLExternal`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SlackGetUploadUrlResponse {
+    pub ok: bool,
+    pub error: Option<String>,
+    /// Presigned URL to upload the file data to.
+    pub upload_url: Option<String>,
+    /// Opaque file ID used to complete the upload.
+    pub file_id: Option<String>,
+}
+
+// ─── files.completeUploadExternal ────────────────────────────────────
+
+/// Request body for the Slack `files.completeUploadExternal` API.
+#[derive(Debug, Clone, Serialize)]
+pub struct SlackCompleteUploadRequest {
+    /// Files to complete, each with their `id` and optional `title`.
+    pub files: Vec<SlackFileReference>,
+    /// Channel to share the file in (optional).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel_id: Option<String>,
+    /// Initial comment to post with the file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initial_comment: Option<String>,
+}
+
+/// A reference to a file being completed, containing its ID.
+#[derive(Debug, Clone, Serialize)]
+pub struct SlackFileReference {
+    /// The file ID returned from `getUploadURLExternal`.
+    pub id: String,
+    /// Optional title for the file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
+/// Response from `files.completeUploadExternal`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SlackCompleteUploadResponse {
+    pub ok: bool,
+    pub error: Option<String>,
+    /// Completed file objects.
+    pub files: Option<Vec<SlackFileObject>>,
+}
+
+/// Minimal representation of a Slack file object.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SlackFileObject {
+    pub id: Option<String>,
+    pub title: Option<String>,
 }
 
 #[cfg(test)]
@@ -102,5 +169,55 @@ mod tests {
         assert!(resp.ok);
         assert_eq!(resp.user_id.as_deref(), Some("U123"));
         assert_eq!(resp.team_id.as_deref(), Some("T456"));
+    }
+
+    #[test]
+    fn get_upload_url_request_serializes() {
+        let req = SlackGetUploadUrlRequest {
+            filename: "chart.png".into(),
+            length: 1024,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["filename"], "chart.png");
+        assert_eq!(json["length"], 1024);
+    }
+
+    #[test]
+    fn get_upload_url_response_deserializes() {
+        let json = r#"{"ok":true,"upload_url":"https://files.slack.com/upload/xxx","file_id":"F123"}"#;
+        let resp: SlackGetUploadUrlResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.ok);
+        assert_eq!(
+            resp.upload_url.as_deref(),
+            Some("https://files.slack.com/upload/xxx")
+        );
+        assert_eq!(resp.file_id.as_deref(), Some("F123"));
+    }
+
+    #[test]
+    fn complete_upload_request_serializes() {
+        let req = SlackCompleteUploadRequest {
+            files: vec![SlackFileReference {
+                id: "F123".into(),
+                title: Some("My Chart".into()),
+            }],
+            channel_id: Some("C456".into()),
+            initial_comment: None,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["files"][0]["id"], "F123");
+        assert_eq!(json["files"][0]["title"], "My Chart");
+        assert_eq!(json["channel_id"], "C456");
+        assert!(json.get("initial_comment").is_none());
+    }
+
+    #[test]
+    fn complete_upload_response_deserializes() {
+        let json = r#"{"ok":true,"files":[{"id":"F123","title":"chart.png"}]}"#;
+        let resp: SlackCompleteUploadResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.ok);
+        let files = resp.files.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].id.as_deref(), Some("F123"));
     }
 }


### PR DESCRIPTION
Extend the Slack provider with a new `upload_image` action type that can generate images procedurally and upload them to Slack channels using the modern files.uploadV2 three-step flow (getUploadURLExternal → upload → completeUploadExternal).

New capabilities:
- Image generation module supporting solid colors, gradients, checkerboards, and bar charts
- Base64 image upload for pre-existing images
- Multipart file upload to Slack presigned URLs
- Full test coverage with mock upload server (44 tests passing)

https://claude.ai/code/session_01RrAnqhP1hfS8t3XBqiK8JC