### PR TITLE
Chain ready index, concurrent advances, step idempotency

### DIFF
--- a/crates/audit/audit/src/record.rs
+++ b/crates/audit/audit/src/record.rs
@@ -11,6 +11,9 @@ pub struct AuditRecord {
     // -- Action fields (denormalized) --
     /// The action's unique identifier.
     pub action_id: String,
+    /// Chain execution ID, if this record is part of a chain lifecycle.
+    #[serde(default)]
+    pub chain_id: Option<String>,
     /// Namespace the action belongs to.
     pub namespace: String,
     /// Tenant that owns the action.
@@ -80,6 +83,8 @@ pub struct AuditQuery {
     pub matched_rule: Option<String>,
     /// Filter by caller identity.
     pub caller_id: Option<String>,
+    /// Filter by chain execution ID.
+    pub chain_id: Option<String>,
     /// Only records dispatched at or after this time.
     pub from: Option<DateTime<Utc>>,
     /// Only records dispatched at or before this time.

--- a/crates/audit/clickhouse/src/migrations.rs
+++ b/crates/audit/clickhouse/src/migrations.rs
@@ -55,5 +55,10 @@ pub async fn run_migrations(
         client.query(stmt).execute().await?;
     }
 
+    // Add chain_id column (idempotent).
+    let chain_id_stmt =
+        format!("ALTER TABLE {table} ADD COLUMN IF NOT EXISTS chain_id Nullable(String)");
+    client.query(&chain_id_stmt).execute().await?;
+
     Ok(())
 }

--- a/crates/audit/clickhouse/src/store.rs
+++ b/crates/audit/clickhouse/src/store.rs
@@ -17,6 +17,7 @@ use crate::migrations;
 struct AuditInsertRow {
     id: String,
     action_id: String,
+    chain_id: Option<String>,
     namespace: String,
     tenant: String,
     provider: String,
@@ -48,6 +49,7 @@ struct AuditInsertRow {
 struct AuditSelectRow {
     id: String,
     action_id: String,
+    chain_id: Option<String>,
     namespace: String,
     tenant: String,
     provider: String,
@@ -76,6 +78,7 @@ impl From<AuditRecord> for AuditInsertRow {
         Self {
             id: r.id,
             action_id: r.action_id,
+            chain_id: r.chain_id,
             namespace: r.namespace,
             tenant: r.tenant,
             provider: r.provider,
@@ -104,6 +107,7 @@ impl From<AuditSelectRow> for AuditRecord {
         Self {
             id: row.id,
             action_id: row.action_id,
+            chain_id: row.chain_id,
             namespace: row.namespace,
             tenant: row.tenant,
             provider: row.provider,
@@ -141,7 +145,7 @@ fn millis_to_datetime(ms: i64) -> DateTime<Utc> {
 /// The explicit column list used in SELECT statements so that column ordering
 /// is deterministic and matches the `AuditSelectRow` field order.
 const SELECT_COLUMNS: &str = "\
-    id, action_id, namespace, tenant, provider, action_type, verdict, \
+    id, action_id, chain_id, namespace, tenant, provider, action_type, verdict, \
     matched_rule, outcome, action_payload, verdict_details, outcome_details, \
     metadata, dispatched_at, completed_at, duration_ms, expires_at, \
     caller_id, auth_method";
@@ -167,6 +171,7 @@ fn build_where_clause(query: &AuditQuery) -> String {
         (&query.verdict, "verdict"),
         (&query.matched_rule, "matched_rule"),
         (&query.caller_id, "caller_id"),
+        (&query.chain_id, "chain_id"),
     ];
 
     for (value, col) in string_filters {

--- a/crates/audit/elasticsearch/src/store.rs
+++ b/crates/audit/elasticsearch/src/store.rs
@@ -68,6 +68,7 @@ impl ElasticsearchAuditStore {
                 "properties": {
                     "id":               { "type": "keyword" },
                     "action_id":        { "type": "keyword" },
+                    "chain_id":         { "type": "keyword" },
                     "namespace":        { "type": "keyword" },
                     "tenant":           { "type": "keyword" },
                     "provider":         { "type": "keyword" },
@@ -343,6 +344,7 @@ fn build_es_query(query: &AuditQuery) -> serde_json::Value {
         (&query.verdict, "verdict"),
         (&query.matched_rule, "matched_rule"),
         (&query.caller_id, "caller_id"),
+        (&query.chain_id, "chain_id"),
     ];
 
     for (value, field) in fields {

--- a/crates/audit/memory/src/store.rs
+++ b/crates/audit/memory/src/store.rs
@@ -102,6 +102,11 @@ impl AuditStore for MemoryAuditStore {
                 {
                     return None;
                 }
+                if let Some(ref cid) = query.chain_id
+                    && rec.chain_id.as_deref() != Some(cid.as_str())
+                {
+                    return None;
+                }
                 if let Some(ref from) = query.from
                     && rec.dispatched_at < *from
                 {
@@ -186,6 +191,7 @@ mod tests {
         AuditRecord {
             id: id.to_owned(),
             action_id: action_id.to_owned(),
+            chain_id: None,
             namespace: "ns".to_owned(),
             tenant: "t1".to_owned(),
             provider: "email".to_owned(),

--- a/crates/audit/postgres/src/store.rs
+++ b/crates/audit/postgres/src/store.rs
@@ -50,17 +50,17 @@ impl AuditStore for PostgresAuditStore {
         let sql = format!(
             r"
             INSERT INTO {} (
-                id, action_id, namespace, tenant, provider, action_type,
+                id, action_id, chain_id, namespace, tenant, provider, action_type,
                 verdict, matched_rule, outcome,
                 action_payload, verdict_details, outcome_details, metadata,
                 dispatched_at, completed_at, duration_ms, expires_at,
                 caller_id, auth_method
             ) VALUES (
-                $1, $2, $3, $4, $5, $6,
-                $7, $8, $9,
-                $10, $11, $12, $13,
-                $14, $15, $16, $17,
-                $18, $19
+                $1, $2, $3, $4, $5, $6, $7,
+                $8, $9, $10,
+                $11, $12, $13, $14,
+                $15, $16, $17, $18,
+                $19, $20
             )
             ",
             self.table
@@ -72,6 +72,7 @@ impl AuditStore for PostgresAuditStore {
         sqlx::query(&sql)
             .bind(&entry.id)
             .bind(&entry.action_id)
+            .bind(&entry.chain_id)
             .bind(&entry.namespace)
             .bind(&entry.tenant)
             .bind(&entry.provider)
@@ -215,6 +216,7 @@ fn build_where_clause(query: &AuditQuery) -> (String, Vec<String>, Option<u32>, 
         (&query.verdict, "verdict"),
         (&query.matched_rule, "matched_rule"),
         (&query.caller_id, "caller_id"),
+        (&query.chain_id, "chain_id"),
     ];
 
     for (value, col) in fields {
@@ -257,6 +259,7 @@ fn build_where_clause(query: &AuditQuery) -> (String, Vec<String>, Option<u32>, 
 struct AuditRow {
     id: String,
     action_id: String,
+    chain_id: Option<String>,
     namespace: String,
     tenant: String,
     provider: String,
@@ -284,6 +287,7 @@ impl From<AuditRow> for AuditRecord {
         Self {
             id: row.id,
             action_id: row.action_id,
+            chain_id: row.chain_id,
             namespace: row.namespace,
             tenant: row.tenant,
             provider: row.provider,

--- a/crates/core/src/chain.rs
+++ b/crates/core/src/chain.rs
@@ -1,0 +1,309 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Failure policy applied at the chain level when a step fails.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChainFailurePolicy {
+    /// Abort the chain and mark it as failed.
+    #[default]
+    Abort,
+    /// Abort the chain without sending the failure to the DLQ.
+    AbortNoDlq,
+}
+
+/// Per-step failure policy override.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StepFailurePolicy {
+    /// Abort the chain on this step's failure.
+    Abort,
+    /// Skip this step and continue to the next.
+    Skip,
+    /// Push the failure to the DLQ and abort the chain.
+    Dlq,
+}
+
+/// Configuration for a single step in a task chain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChainStepConfig {
+    /// Name of this step (used for `{{steps.NAME.*}}` references).
+    pub name: String,
+    /// Provider to execute this step with.
+    pub provider: String,
+    /// Action type for the synthetic action.
+    pub action_type: String,
+    /// Template for the step payload. Supports `{{origin.*}}`, `{{prev.*}}`,
+    /// `{{steps.NAME.*}}`, `{{chain_id}}`, `{{step_index}}`.
+    pub payload_template: serde_json::Value,
+    /// Optional per-step failure policy override.
+    #[serde(default)]
+    pub on_failure: Option<StepFailurePolicy>,
+    /// Optional delay in seconds before executing this step.
+    ///
+    /// When set, the chain will wait this many seconds before the step becomes
+    /// eligible for execution. The delay is relative to when the previous step
+    /// completes.
+    #[serde(default)]
+    pub delay_seconds: Option<u64>,
+}
+
+impl ChainStepConfig {
+    /// Create a new step configuration.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        provider: impl Into<String>,
+        action_type: impl Into<String>,
+        payload_template: serde_json::Value,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            provider: provider.into(),
+            action_type: action_type.into(),
+            payload_template,
+            on_failure: None,
+            delay_seconds: None,
+        }
+    }
+
+    /// Set the per-step failure policy.
+    #[must_use]
+    pub fn with_on_failure(mut self, policy: StepFailurePolicy) -> Self {
+        self.on_failure = Some(policy);
+        self
+    }
+
+    /// Set a delay (in seconds) before this step becomes eligible for execution.
+    #[must_use]
+    pub fn with_delay(mut self, seconds: u64) -> Self {
+        self.delay_seconds = Some(seconds);
+        self
+    }
+}
+
+/// Target for outbound notifications dispatched when a chain is cancelled.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChainNotificationTarget {
+    /// Provider to dispatch the notification through.
+    pub provider: String,
+    /// Action type for the notification action.
+    pub action_type: String,
+}
+
+/// Configuration for a task chain — a sequence of steps executed in order.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChainConfig {
+    /// Unique name for this chain (referenced from rules).
+    pub name: String,
+    /// Ordered list of steps to execute.
+    pub steps: Vec<ChainStepConfig>,
+    /// Chain-level failure policy.
+    #[serde(default)]
+    pub on_failure: ChainFailurePolicy,
+    /// Optional timeout in seconds for the entire chain.
+    pub timeout_seconds: Option<u64>,
+    /// Optional notification target dispatched when the chain is cancelled.
+    #[serde(default)]
+    pub on_cancel: Option<ChainNotificationTarget>,
+}
+
+impl ChainConfig {
+    /// Create a new chain configuration with the given name.
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            steps: Vec::new(),
+            on_failure: ChainFailurePolicy::default(),
+            timeout_seconds: None,
+            on_cancel: None,
+        }
+    }
+
+    /// Add a step to the chain.
+    #[must_use]
+    pub fn with_step(mut self, step: ChainStepConfig) -> Self {
+        self.steps.push(step);
+        self
+    }
+
+    /// Set the chain-level failure policy.
+    #[must_use]
+    pub fn with_on_failure(mut self, policy: ChainFailurePolicy) -> Self {
+        self.on_failure = policy;
+        self
+    }
+
+    /// Set the chain timeout in seconds.
+    #[must_use]
+    pub fn with_timeout(mut self, seconds: u64) -> Self {
+        self.timeout_seconds = Some(seconds);
+        self
+    }
+
+    /// Set the notification target dispatched when the chain is cancelled.
+    #[must_use]
+    pub fn with_on_cancel(mut self, target: ChainNotificationTarget) -> Self {
+        self.on_cancel = Some(target);
+        self
+    }
+}
+
+/// Status of a chain execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChainStatus {
+    /// Chain is currently executing steps.
+    Running,
+    /// All steps completed successfully.
+    Completed,
+    /// A step failed and the chain was aborted.
+    Failed,
+    /// The chain was explicitly cancelled.
+    Cancelled,
+    /// The chain exceeded its timeout.
+    TimedOut,
+}
+
+/// Result of a single chain step execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StepResult {
+    /// Name of the step.
+    pub step_name: String,
+    /// Whether the step completed successfully.
+    pub success: bool,
+    /// Response body from the provider (if successful).
+    pub response_body: Option<serde_json::Value>,
+    /// Error message (if failed).
+    pub error: Option<String>,
+    /// When this step completed.
+    pub completed_at: DateTime<Utc>,
+}
+
+/// Runtime state of a chain execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChainState {
+    /// Unique identifier for this chain execution.
+    pub chain_id: String,
+    /// Name of the chain configuration.
+    pub chain_name: String,
+    /// The original action that triggered the chain.
+    pub origin_action: crate::Action,
+    /// Index of the current step being executed (0-based).
+    pub current_step: usize,
+    /// Total number of steps in the chain.
+    pub total_steps: usize,
+    /// Current execution status.
+    pub status: ChainStatus,
+    /// Results for each completed step (indexed by step position).
+    pub step_results: Vec<Option<StepResult>>,
+    /// When the chain execution started.
+    pub started_at: DateTime<Utc>,
+    /// When the chain state was last updated.
+    pub updated_at: DateTime<Utc>,
+    /// When the chain will time out (if a timeout is configured).
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Namespace of the originating action.
+    pub namespace: String,
+    /// Tenant of the originating action.
+    pub tenant: String,
+    /// Reason for cancellation (if cancelled).
+    #[serde(default)]
+    pub cancel_reason: Option<String>,
+    /// Who cancelled the chain (if cancelled).
+    #[serde(default)]
+    pub cancelled_by: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chain_config_builder() {
+        let config = ChainConfig::new("my-chain")
+            .with_step(ChainStepConfig::new(
+                "step1",
+                "provider-a",
+                "do_thing",
+                serde_json::json!({"key": "value"}),
+            ))
+            .with_step(
+                ChainStepConfig::new("step2", "provider-b", "do_other", serde_json::json!({}))
+                    .with_on_failure(StepFailurePolicy::Skip),
+            )
+            .with_on_failure(ChainFailurePolicy::AbortNoDlq)
+            .with_timeout(300);
+
+        assert_eq!(config.name, "my-chain");
+        assert_eq!(config.steps.len(), 2);
+        assert_eq!(config.steps[0].name, "step1");
+        assert_eq!(config.steps[1].on_failure, Some(StepFailurePolicy::Skip));
+        assert_eq!(config.on_failure, ChainFailurePolicy::AbortNoDlq);
+        assert_eq!(config.timeout_seconds, Some(300));
+    }
+
+    #[test]
+    fn default_failure_policy_is_abort() {
+        assert_eq!(ChainFailurePolicy::default(), ChainFailurePolicy::Abort);
+    }
+
+    #[test]
+    fn chain_config_serde_roundtrip() {
+        let config = ChainConfig::new("test-chain")
+            .with_step(ChainStepConfig::new(
+                "search",
+                "search-api",
+                "web_search",
+                serde_json::json!({"query": "{{origin.payload.query}}"}),
+            ))
+            .with_timeout(120);
+
+        let json = serde_json::to_string(&config).unwrap();
+        let back: ChainConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.name, "test-chain");
+        assert_eq!(back.steps.len(), 1);
+        assert_eq!(back.timeout_seconds, Some(120));
+    }
+
+    #[test]
+    fn chain_status_serde_roundtrip() {
+        let statuses = vec![
+            ChainStatus::Running,
+            ChainStatus::Completed,
+            ChainStatus::Failed,
+            ChainStatus::Cancelled,
+            ChainStatus::TimedOut,
+        ];
+        for status in &statuses {
+            let json = serde_json::to_string(status).unwrap();
+            let back: ChainStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(&back, status);
+        }
+    }
+
+    #[test]
+    fn chain_failure_policy_serde_roundtrip() {
+        let policies = vec![ChainFailurePolicy::Abort, ChainFailurePolicy::AbortNoDlq];
+        for policy in &policies {
+            let json = serde_json::to_string(policy).unwrap();
+            let back: ChainFailurePolicy = serde_json::from_str(&json).unwrap();
+            assert_eq!(&back, policy);
+        }
+    }
+
+    #[test]
+    fn step_failure_policy_serde_roundtrip() {
+        let policies = vec![
+            StepFailurePolicy::Abort,
+            StepFailurePolicy::Skip,
+            StepFailurePolicy::Dlq,
+        ];
+        for policy in &policies {
+            let json = serde_json::to_string(policy).unwrap();
+            let back: StepFailurePolicy = serde_json::from_str(&json).unwrap();
+            assert_eq!(&back, policy);
+        }
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod action;
 pub mod caller;
+pub mod chain;
 pub mod context;
 pub mod error;
 pub mod fingerprint;
@@ -11,6 +12,10 @@ pub mod types;
 
 pub use action::{Action, ActionMetadata};
 pub use caller::Caller;
+pub use chain::{
+    ChainConfig, ChainFailurePolicy, ChainNotificationTarget, ChainState, ChainStatus,
+    ChainStepConfig, StepFailurePolicy, StepResult,
+};
 pub use context::ActionContext;
 pub use error::ActeonError;
 pub use fingerprint::compute_fingerprint;

--- a/crates/core/src/outcome.rs
+++ b/crates/core/src/outcome.rs
@@ -60,6 +60,17 @@ pub enum ActionOutcome {
         /// Whether the notification was successfully sent to the human.
         notification_sent: bool,
     },
+    /// Action initiated a task chain execution.
+    ChainStarted {
+        /// Unique identifier for this chain execution.
+        chain_id: String,
+        /// Name of the chain configuration.
+        chain_name: String,
+        /// Total number of steps in the chain.
+        total_steps: usize,
+        /// Name of the first step to be executed.
+        first_step: String,
+    },
 }
 
 /// Response from a provider after executing an action.
@@ -182,6 +193,22 @@ mod tests {
         assert!(json.contains("approve_url"));
         assert!(json.contains("reject_url"));
         assert!(json.contains("notification_sent"));
+    }
+
+    #[test]
+    fn outcome_chain_started() {
+        let outcome = ActionOutcome::ChainStarted {
+            chain_id: "chain-abc".into(),
+            chain_name: "search-summarize-email".into(),
+            total_steps: 3,
+            first_step: "search".into(),
+        };
+        let json = serde_json::to_string(&outcome).unwrap();
+        assert!(json.contains("chain-abc"));
+        assert!(json.contains("search-summarize-email"));
+        assert!(json.contains("total_steps"));
+        let back: ActionOutcome = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, ActionOutcome::ChainStarted { .. }));
     }
 
     #[test]

--- a/crates/gateway/examples/basic.rs
+++ b/crates/gateway/examples/basic.rs
@@ -131,5 +131,6 @@ fn outcome_label(outcome: &ActionOutcome) -> &'static str {
         ActionOutcome::StateChanged { .. } => "StateChanged",
         ActionOutcome::Failed(_) => "Failed",
         ActionOutcome::PendingApproval { .. } => "PendingApproval",
+        ActionOutcome::ChainStarted { .. } => "ChainStarted",
     }
 }

--- a/crates/gateway/examples/multi_provider.rs
+++ b/crates/gateway/examples/multi_provider.rs
@@ -165,5 +165,10 @@ fn describe_outcome(outcome: &ActionOutcome) -> String {
             expires_at,
             ..
         } => format!("PendingApproval (id: {approval_id}, expires: {expires_at})"),
+        ActionOutcome::ChainStarted {
+            chain_id,
+            chain_name,
+            ..
+        } => format!("ChainStarted (id: {chain_id}, chain: {chain_name})"),
     }
 }

--- a/crates/gateway/src/chain.rs
+++ b/crates/gateway/src/chain.rs
@@ -1,0 +1,416 @@
+use acteon_core::Action;
+use acteon_core::chain::{ChainStepConfig, StepResult};
+
+/// Resolve template variables in a chain step's payload.
+///
+/// Supported variable patterns:
+/// - `{{origin.payload.X}}`, `{{origin.namespace}}`, `{{origin.tenant}}`,
+///   `{{origin.action_type}}`, `{{origin.metadata.X}}`
+/// - `{{prev.body.X}}`, `{{prev.body}}` — previous step's response body
+/// - `{{steps.NAME.body.X}}` — named step's response body
+/// - `{{chain_id}}`, `{{step_index}}`
+///
+/// If the entire string value is a single `{{expr}}`, the original JSON type
+/// from the referenced value is preserved. Otherwise, patterns are replaced
+/// inline as strings. Missing paths resolve to `null`.
+pub fn resolve_template(
+    template: &serde_json::Value,
+    origin: &Action,
+    step_results: &[Option<StepResult>],
+    steps_config: &[ChainStepConfig],
+    chain_id: &str,
+    step_index: usize,
+) -> serde_json::Value {
+    match template {
+        serde_json::Value::String(s) => {
+            resolve_string(s, origin, step_results, steps_config, chain_id, step_index)
+        }
+        serde_json::Value::Object(map) => {
+            let mut result = serde_json::Map::new();
+            for (k, v) in map {
+                result.insert(
+                    k.clone(),
+                    resolve_template(v, origin, step_results, steps_config, chain_id, step_index),
+                );
+            }
+            serde_json::Value::Object(result)
+        }
+        serde_json::Value::Array(arr) => serde_json::Value::Array(
+            arr.iter()
+                .map(|v| {
+                    resolve_template(v, origin, step_results, steps_config, chain_id, step_index)
+                })
+                .collect(),
+        ),
+        // Primitives pass through unchanged.
+        other => other.clone(),
+    }
+}
+
+/// Resolve a single string value, handling both full-replacement and inline substitution.
+fn resolve_string(
+    s: &str,
+    origin: &Action,
+    step_results: &[Option<StepResult>],
+    steps_config: &[ChainStepConfig],
+    chain_id: &str,
+    step_index: usize,
+) -> serde_json::Value {
+    let trimmed = s.trim();
+
+    // If the entire string is a single {{expr}}, preserve the JSON type.
+    if trimmed.starts_with("{{") && trimmed.ends_with("}}") && count_patterns(trimmed) == 1 {
+        let expr = &trimmed[2..trimmed.len() - 2];
+        return resolve_expr(
+            expr,
+            origin,
+            step_results,
+            steps_config,
+            chain_id,
+            step_index,
+        );
+    }
+
+    // Otherwise, do inline string replacement for all {{...}} patterns.
+    let mut result = s.to_string();
+    while let Some(start) = result.find("{{") {
+        let Some(end) = result[start..].find("}}") else {
+            break;
+        };
+        let full_end = start + end + 2;
+        let expr = &result[start + 2..start + end];
+        let value = resolve_expr(
+            expr,
+            origin,
+            step_results,
+            steps_config,
+            chain_id,
+            step_index,
+        );
+        let replacement = json_to_inline_string(&value);
+        result.replace_range(start..full_end, &replacement);
+    }
+
+    serde_json::Value::String(result)
+}
+
+/// Count the number of `{{...}}` patterns in a string.
+fn count_patterns(s: &str) -> usize {
+    let mut count = 0;
+    let mut pos = 0;
+    while let Some(start) = s[pos..].find("{{") {
+        if let Some(end) = s[pos + start..].find("}}") {
+            count += 1;
+            pos = pos + start + end + 2;
+        } else {
+            break;
+        }
+    }
+    count
+}
+
+/// Resolve a single expression like `origin.payload.query` or `prev.body.results`.
+fn resolve_expr(
+    expr: &str,
+    origin: &Action,
+    step_results: &[Option<StepResult>],
+    steps_config: &[ChainStepConfig],
+    chain_id: &str,
+    step_index: usize,
+) -> serde_json::Value {
+    let parts: Vec<&str> = expr.split('.').collect();
+
+    match parts.first().copied() {
+        Some("origin") => resolve_origin(&parts[1..], origin),
+        Some("prev") => resolve_prev(&parts[1..], step_results, step_index),
+        Some("steps") => resolve_named_step(&parts[1..], step_results, steps_config),
+        Some("chain_id") => serde_json::Value::String(chain_id.to_owned()),
+        Some("step_index") => serde_json::json!(step_index),
+        _ => serde_json::Value::Null,
+    }
+}
+
+/// Resolve `origin.*` paths.
+fn resolve_origin(path: &[&str], origin: &Action) -> serde_json::Value {
+    match path.first().copied() {
+        Some("payload") => navigate_json(&origin.payload, &path[1..]),
+        Some("namespace") => serde_json::Value::String(origin.namespace.to_string()),
+        Some("tenant") => serde_json::Value::String(origin.tenant.to_string()),
+        Some("action_type") => serde_json::Value::String(origin.action_type.clone()),
+        Some("provider") => serde_json::Value::String(origin.provider.to_string()),
+        Some("id") => serde_json::Value::String(origin.id.to_string()),
+        Some("metadata") => {
+            if let Some(key) = path.get(1) {
+                origin
+                    .metadata
+                    .labels
+                    .get(*key)
+                    .map_or(serde_json::Value::Null, |v| {
+                        serde_json::Value::String(v.clone())
+                    })
+            } else {
+                serde_json::to_value(&origin.metadata.labels).unwrap_or(serde_json::Value::Null)
+            }
+        }
+        _ => serde_json::Value::Null,
+    }
+}
+
+/// Resolve `prev.body.*` paths — the previous step's response body.
+fn resolve_prev(
+    path: &[&str],
+    step_results: &[Option<StepResult>],
+    step_index: usize,
+) -> serde_json::Value {
+    if step_index == 0 {
+        return serde_json::Value::Null;
+    }
+    let prev_result = step_results.get(step_index - 1).and_then(|r| r.as_ref());
+
+    match path.first().copied() {
+        Some("body") => {
+            if let Some(result) = prev_result {
+                let body = result
+                    .response_body
+                    .clone()
+                    .unwrap_or(serde_json::Value::Null);
+                navigate_json(&body, &path[1..])
+            } else {
+                serde_json::Value::Null
+            }
+        }
+        _ => serde_json::Value::Null,
+    }
+}
+
+/// Resolve `steps.NAME.body.*` paths — a named step's response body.
+fn resolve_named_step(
+    path: &[&str],
+    step_results: &[Option<StepResult>],
+    steps_config: &[ChainStepConfig],
+) -> serde_json::Value {
+    let Some(name) = path.first().copied() else {
+        return serde_json::Value::Null;
+    };
+
+    // Find the step index by name.
+    let Some(idx) = steps_config.iter().position(|s| s.name == name) else {
+        return serde_json::Value::Null;
+    };
+
+    let Some(Some(result)) = step_results.get(idx) else {
+        return serde_json::Value::Null;
+    };
+
+    match path.get(1).copied() {
+        Some("body") => {
+            let body = result
+                .response_body
+                .clone()
+                .unwrap_or(serde_json::Value::Null);
+            navigate_json(&body, &path[2..])
+        }
+        _ => serde_json::Value::Null,
+    }
+}
+
+/// Navigate into a JSON value by a dot-separated path.
+fn navigate_json(value: &serde_json::Value, path: &[&str]) -> serde_json::Value {
+    let mut current = value.clone();
+    for &segment in path {
+        match current {
+            serde_json::Value::Object(ref map) => {
+                current = map.get(segment).cloned().unwrap_or(serde_json::Value::Null);
+            }
+            serde_json::Value::Array(ref arr) => {
+                if let Ok(idx) = segment.parse::<usize>() {
+                    current = arr.get(idx).cloned().unwrap_or(serde_json::Value::Null);
+                } else {
+                    return serde_json::Value::Null;
+                }
+            }
+            _ => return serde_json::Value::Null,
+        }
+    }
+    current
+}
+
+/// Convert a JSON value to a string for inline template replacement.
+fn json_to_inline_string(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Null => "null".to_owned(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn test_origin() -> Action {
+        Action::new(
+            "ns",
+            "tenant",
+            "search-api",
+            "web_search",
+            serde_json::json!({
+                "query": "rust async",
+                "limit": 10,
+                "nested": {"key": "deep_value"}
+            }),
+        )
+    }
+
+    fn test_steps_config() -> Vec<ChainStepConfig> {
+        vec![
+            ChainStepConfig::new("search", "search-api", "web_search", serde_json::json!({})),
+            ChainStepConfig::new("summarize", "llm", "summarize", serde_json::json!({})),
+            ChainStepConfig::new("email", "email", "send_email", serde_json::json!({})),
+        ]
+    }
+
+    fn step_result(name: &str, body: serde_json::Value) -> Option<StepResult> {
+        Some(StepResult {
+            step_name: name.to_owned(),
+            success: true,
+            response_body: Some(body),
+            error: None,
+            completed_at: Utc::now(),
+        })
+    }
+
+    #[test]
+    fn resolve_origin_payload() {
+        let origin = test_origin();
+        let steps = test_steps_config();
+        let template = serde_json::json!({"q": "{{origin.payload.query}}"});
+        let result = resolve_template(&template, &origin, &[], &steps, "c1", 0);
+        assert_eq!(result, serde_json::json!({"q": "rust async"}));
+    }
+
+    #[test]
+    fn resolve_origin_fields() {
+        let origin = test_origin();
+        let steps = test_steps_config();
+        let template = serde_json::json!({
+            "ns": "{{origin.namespace}}",
+            "t": "{{origin.tenant}}",
+            "at": "{{origin.action_type}}"
+        });
+        let result = resolve_template(&template, &origin, &[], &steps, "c1", 0);
+        assert_eq!(result["ns"], "ns");
+        assert_eq!(result["t"], "tenant");
+        assert_eq!(result["at"], "web_search");
+    }
+
+    #[test]
+    fn resolve_prev_body() {
+        let origin = test_origin();
+        let steps = test_steps_config();
+        let results = vec![step_result(
+            "search",
+            serde_json::json!({"results": "some data"}),
+        )];
+        let template = serde_json::json!({"text": "{{prev.body.results}}"});
+        let result = resolve_template(&template, &origin, &results, &steps, "c1", 1);
+        assert_eq!(result, serde_json::json!({"text": "some data"}));
+    }
+
+    #[test]
+    fn resolve_prev_at_step_zero_is_null() {
+        let origin = test_origin();
+        let steps = test_steps_config();
+        let template = serde_json::json!({"text": "{{prev.body}}"});
+        let result = resolve_template(&template, &origin, &[], &steps, "c1", 0);
+        assert_eq!(result["text"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn resolve_named_step() {
+        let origin = test_origin();
+        let steps = test_steps_config();
+        let results = vec![
+            step_result("search", serde_json::json!({"results": "search data"})),
+            step_result("summarize", serde_json::json!({"summary": "brief"})),
+        ];
+        let template = serde_json::json!({"s": "{{steps.search.body.results}}"});
+        let result = resolve_template(&template, &origin, &results, &steps, "c1", 2);
+        assert_eq!(result, serde_json::json!({"s": "search data"}));
+    }
+
+    #[test]
+    fn resolve_chain_id_and_step_index() {
+        let origin = test_origin();
+        let steps = test_steps_config();
+        let template = serde_json::json!({
+            "id": "{{chain_id}}",
+            "idx": "{{step_index}}"
+        });
+        let result = resolve_template(&template, &origin, &[], &steps, "chain-42", 2);
+        assert_eq!(result["id"], "chain-42");
+        // step_index is a single {{expr}} so it preserves the JSON integer type.
+        assert_eq!(result["idx"], serde_json::json!(2));
+    }
+
+    #[test]
+    fn resolve_full_value_preserves_type() {
+        let origin = test_origin();
+        let steps = test_steps_config();
+        // When the entire value is a single {{expr}} pointing to a number, preserve the type.
+        let template = serde_json::json!({"limit": "{{origin.payload.limit}}"});
+        let result = resolve_template(&template, &origin, &[], &steps, "c1", 0);
+        assert_eq!(result["limit"], serde_json::json!(10));
+    }
+
+    #[test]
+    fn resolve_missing_path_returns_null() {
+        let origin = test_origin();
+        let steps = test_steps_config();
+        let template = serde_json::json!({"x": "{{origin.payload.nonexistent}}"});
+        let result = resolve_template(&template, &origin, &[], &steps, "c1", 0);
+        assert_eq!(result["x"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn resolve_nested_json_path() {
+        let origin = test_origin();
+        let steps = test_steps_config();
+        let template = serde_json::json!({"deep": "{{origin.payload.nested.key}}"});
+        let result = resolve_template(&template, &origin, &[], &steps, "c1", 0);
+        assert_eq!(result["deep"], "deep_value");
+    }
+
+    #[test]
+    fn resolve_inline_multiple_patterns() {
+        let origin = test_origin();
+        let steps = test_steps_config();
+        let template = serde_json::json!({
+            "msg": "Search for {{origin.payload.query}} in {{origin.namespace}}"
+        });
+        let result = resolve_template(&template, &origin, &[], &steps, "c1", 0);
+        assert_eq!(result["msg"], "Search for rust async in ns");
+    }
+
+    #[test]
+    fn resolve_array_templates() {
+        let origin = test_origin();
+        let steps = test_steps_config();
+        let template = serde_json::json!(["{{origin.payload.query}}", "literal"]);
+        let result = resolve_template(&template, &origin, &[], &steps, "c1", 0);
+        assert_eq!(result[0], "rust async");
+        assert_eq!(result[1], "literal");
+    }
+
+    #[test]
+    fn resolve_passthrough_primitives() {
+        let origin = test_origin();
+        let steps = test_steps_config();
+        let template = serde_json::json!(42);
+        let result = resolve_template(&template, &origin, &[], &steps, "c1", 0);
+        assert_eq!(result, serde_json::json!(42));
+    }
+}

--- a/crates/gateway/src/error.rs
+++ b/crates/gateway/src/error.rs
@@ -34,4 +34,8 @@ pub enum GatewayError {
     /// The approval has already been approved or rejected.
     #[error("approval already decided: {0}")]
     ApprovalAlreadyDecided(String),
+
+    /// An error occurred during chain execution.
+    #[error("chain error: {0}")]
+    ChainError(String),
 }

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod background;
 pub mod builder;
+pub mod chain;
 pub mod error;
 pub mod gateway;
 pub mod group_manager;
@@ -9,7 +10,7 @@ pub mod watcher;
 pub use acteon_executor::{DeadLetterEntry, DeadLetterQueue, DeadLetterSink};
 pub use background::{
     ApprovalRetryEvent, BackgroundConfig, BackgroundProcessor, BackgroundProcessorBuilder,
-    GroupFlushEvent, TimeoutEvent,
+    ChainAdvanceEvent, GroupFlushEvent, TimeoutEvent,
 };
 pub use builder::GatewayBuilder;
 pub use error::GatewayError;

--- a/crates/gateway/src/metrics.rs
+++ b/crates/gateway/src/metrics.rs
@@ -28,6 +28,14 @@ pub struct GatewayMetrics {
     pub llm_guardrail_denied: AtomicU64,
     /// LLM guardrail evaluation errors.
     pub llm_guardrail_errors: AtomicU64,
+    /// Task chains started.
+    pub chains_started: AtomicU64,
+    /// Task chains completed successfully.
+    pub chains_completed: AtomicU64,
+    /// Task chains failed.
+    pub chains_failed: AtomicU64,
+    /// Task chains cancelled.
+    pub chains_cancelled: AtomicU64,
 }
 
 impl GatewayMetrics {
@@ -86,6 +94,26 @@ impl GatewayMetrics {
         self.llm_guardrail_errors.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Increment the chains started counter.
+    pub fn increment_chains_started(&self) {
+        self.chains_started.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the chains completed counter.
+    pub fn increment_chains_completed(&self) {
+        self.chains_completed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the chains failed counter.
+    pub fn increment_chains_failed(&self) {
+        self.chains_failed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the chains cancelled counter.
+    pub fn increment_chains_cancelled(&self) {
+        self.chains_cancelled.fetch_add(1, Ordering::Relaxed);
+    }
+
     /// Take a consistent point-in-time snapshot of all counters.
     pub fn snapshot(&self) -> MetricsSnapshot {
         MetricsSnapshot {
@@ -100,6 +128,10 @@ impl GatewayMetrics {
             llm_guardrail_allowed: self.llm_guardrail_allowed.load(Ordering::Relaxed),
             llm_guardrail_denied: self.llm_guardrail_denied.load(Ordering::Relaxed),
             llm_guardrail_errors: self.llm_guardrail_errors.load(Ordering::Relaxed),
+            chains_started: self.chains_started.load(Ordering::Relaxed),
+            chains_completed: self.chains_completed.load(Ordering::Relaxed),
+            chains_failed: self.chains_failed.load(Ordering::Relaxed),
+            chains_cancelled: self.chains_cancelled.load(Ordering::Relaxed),
         }
     }
 }
@@ -129,6 +161,14 @@ pub struct MetricsSnapshot {
     pub llm_guardrail_denied: u64,
     /// LLM guardrail evaluation errors.
     pub llm_guardrail_errors: u64,
+    /// Task chains started.
+    pub chains_started: u64,
+    /// Task chains completed successfully.
+    pub chains_completed: u64,
+    /// Task chains failed.
+    pub chains_failed: u64,
+    /// Task chains cancelled.
+    pub chains_cancelled: u64,
 }
 
 #[cfg(test)]
@@ -150,6 +190,10 @@ mod tests {
         assert_eq!(snap.llm_guardrail_allowed, 0);
         assert_eq!(snap.llm_guardrail_denied, 0);
         assert_eq!(snap.llm_guardrail_errors, 0);
+        assert_eq!(snap.chains_started, 0);
+        assert_eq!(snap.chains_completed, 0);
+        assert_eq!(snap.chains_failed, 0);
+        assert_eq!(snap.chains_cancelled, 0);
     }
 
     #[test]
@@ -167,6 +211,10 @@ mod tests {
         m.increment_llm_guardrail_allowed();
         m.increment_llm_guardrail_denied();
         m.increment_llm_guardrail_errors();
+        m.increment_chains_started();
+        m.increment_chains_completed();
+        m.increment_chains_failed();
+        m.increment_chains_cancelled();
 
         let snap = m.snapshot();
         assert_eq!(snap.dispatched, 2);
@@ -180,5 +228,9 @@ mod tests {
         assert_eq!(snap.llm_guardrail_allowed, 1);
         assert_eq!(snap.llm_guardrail_denied, 1);
         assert_eq!(snap.llm_guardrail_errors, 1);
+        assert_eq!(snap.chains_started, 1);
+        assert_eq!(snap.chains_completed, 1);
+        assert_eq!(snap.chains_failed, 1);
+        assert_eq!(snap.chains_cancelled, 1);
     }
 }

--- a/crates/rules/cel/src/frontend.rs
+++ b/crates/rules/cel/src/frontend.rs
@@ -79,6 +79,11 @@ enum CelAction {
         /// JSON value describing the modifications.
         changes: serde_json::Value,
     },
+    /// Execute action through a task chain.
+    Chain {
+        /// Name of the chain configuration to use.
+        chain: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -164,6 +169,9 @@ fn compile_action(action: &CelAction) -> RuleAction {
         },
         CelAction::Modify { changes } => RuleAction::Modify {
             changes: changes.clone(),
+        },
+        CelAction::Chain { chain } => RuleAction::Chain {
+            chain: chain.clone(),
         },
     }
 }

--- a/crates/rules/rules/src/ir/action.rs
+++ b/crates/rules/rules/src/ir/action.rs
@@ -53,6 +53,11 @@ impl RuleAction {
         matches!(self, Self::RequestApproval { .. })
     }
 
+    /// Returns `true` if this action triggers a task chain.
+    pub fn is_chain(&self) -> bool {
+        matches!(self, Self::Chain { .. })
+    }
+
     /// Returns a human-readable label for the action kind.
     pub fn kind_label(&self) -> &'static str {
         match self {
@@ -67,6 +72,7 @@ impl RuleAction {
             Self::StateMachine { .. } => "state_machine",
             Self::Group { .. } => "group",
             Self::RequestApproval { .. } => "request_approval",
+            Self::Chain { .. } => "chain",
         }
     }
 }
@@ -163,6 +169,16 @@ mod tests {
             .kind_label(),
             "group"
         );
+    }
+
+    #[test]
+    fn chain_predicates() {
+        let chain = RuleAction::Chain {
+            chain: "my-chain".into(),
+        };
+        assert!(chain.is_chain());
+        assert!(!chain.is_allow());
+        assert_eq!(chain.kind_label(), "chain");
     }
 
     #[test]

--- a/crates/rules/rules/src/ir/rule.rs
+++ b/crates/rules/rules/src/ir/rule.rs
@@ -71,6 +71,11 @@ pub enum RuleAction {
         /// Optional message to include in the approval notification.
         message: Option<String>,
     },
+    /// Execute action as the first step of a named task chain.
+    Chain {
+        /// Name of the chain configuration to use.
+        chain: String,
+    },
 }
 
 /// Where a rule was loaded from.
@@ -256,6 +261,9 @@ mod tests {
                 notify_provider: "email".into(),
                 timeout_seconds: 86400,
                 message: Some("Requires approval".into()),
+            },
+            RuleAction::Chain {
+                chain: "search-summarize-email".into(),
             },
         ];
 

--- a/crates/rules/yaml/src/frontend.rs
+++ b/crates/rules/yaml/src/frontend.rs
@@ -291,6 +291,9 @@ fn compile_action(action: &YamlAction) -> RuleAction {
             timeout_seconds: *timeout_seconds,
             message: message.clone(),
         },
+        YamlAction::Chain { chain } => RuleAction::Chain {
+            chain: chain.clone(),
+        },
     }
 }
 

--- a/crates/rules/yaml/src/parser.rs
+++ b/crates/rules/yaml/src/parser.rs
@@ -201,6 +201,11 @@ pub enum YamlAction {
         /// Optional message to include in the approval notification.
         message: Option<String>,
     },
+    /// Execute action through a task chain.
+    Chain {
+        /// Name of the chain configuration to use.
+        chain: String,
+    },
 }
 
 #[cfg(test)]

--- a/crates/server/src/api/audit.rs
+++ b/crates/server/src/api/audit.rs
@@ -25,6 +25,7 @@ use super::schemas::ErrorResponse;
         ("outcome" = Option<String>, Query, description = "Filter by outcome"),
         ("verdict" = Option<String>, Query, description = "Filter by verdict"),
         ("matched_rule" = Option<String>, Query, description = "Filter by matched rule name"),
+        ("chain_id" = Option<String>, Query, description = "Filter by chain execution ID"),
         ("from" = Option<String>, Query, description = "Start of time range (RFC 3339)"),
         ("to" = Option<String>, Query, description = "End of time range (RFC 3339)"),
         ("limit" = Option<u32>, Query, description = "Max records to return (default 50, max 1000)"),

--- a/crates/server/src/api/chains.rs
+++ b/crates/server/src/api/chains.rs
@@ -1,0 +1,346 @@
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+
+use acteon_core::ChainStatus;
+
+use super::AppState;
+use super::schemas::ErrorResponse;
+
+/// Query parameters for listing chain executions.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ChainQueryParams {
+    /// Namespace to filter by.
+    pub namespace: String,
+    /// Tenant to filter by.
+    pub tenant: String,
+    /// Optional status filter: `"running"`, `"completed"`, `"failed"`, `"cancelled"`, `"timed_out"`.
+    pub status: Option<String>,
+}
+
+/// Namespace/tenant query for chain detail endpoints.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ChainNamespaceParams {
+    /// Namespace.
+    pub namespace: String,
+    /// Tenant.
+    pub tenant: String,
+}
+
+/// Request body for cancelling a chain.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ChainCancelRequest {
+    /// Namespace of the chain.
+    pub namespace: String,
+    /// Tenant of the chain.
+    pub tenant: String,
+    /// Optional reason for cancellation.
+    #[serde(default)]
+    pub reason: Option<String>,
+    /// Optional identifier of who cancelled the chain.
+    #[serde(default)]
+    pub cancelled_by: Option<String>,
+}
+
+/// Summary of a chain execution for list responses.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ChainSummary {
+    /// Unique chain execution ID.
+    pub chain_id: String,
+    /// Name of the chain configuration.
+    pub chain_name: String,
+    /// Current status.
+    pub status: String,
+    /// Current step index (0-based).
+    pub current_step: usize,
+    /// Total number of steps.
+    pub total_steps: usize,
+    /// When the chain started.
+    pub started_at: DateTime<Utc>,
+    /// When the chain was last updated.
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Response for listing chain executions.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListChainsResponse {
+    /// List of chain execution summaries.
+    pub chains: Vec<ChainSummary>,
+}
+
+/// Detailed status of a single chain step.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ChainStepStatus {
+    /// Step name.
+    pub name: String,
+    /// Provider used for this step.
+    pub provider: String,
+    /// Step status: `"pending"`, `"completed"`, `"failed"`, `"skipped"`.
+    pub status: String,
+    /// Response body from the provider (if completed).
+    #[schema(value_type = Option<Object>)]
+    pub response_body: Option<serde_json::Value>,
+    /// Error message (if failed).
+    pub error: Option<String>,
+    /// When this step completed.
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+/// Full detail response for a chain execution.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ChainDetailResponse {
+    /// Unique chain execution ID.
+    pub chain_id: String,
+    /// Name of the chain configuration.
+    pub chain_name: String,
+    /// Current status.
+    pub status: String,
+    /// Current step index (0-based).
+    pub current_step: usize,
+    /// Total number of steps.
+    pub total_steps: usize,
+    /// Per-step status details.
+    pub steps: Vec<ChainStepStatus>,
+    /// When the chain started.
+    pub started_at: DateTime<Utc>,
+    /// When the chain was last updated.
+    pub updated_at: DateTime<Utc>,
+    /// When the chain will time out.
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Reason for cancellation (if cancelled).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancel_reason: Option<String>,
+    /// Who cancelled the chain (if cancelled).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancelled_by: Option<String>,
+}
+
+fn parse_status_filter(s: &str) -> Option<ChainStatus> {
+    match s {
+        "running" => Some(ChainStatus::Running),
+        "completed" => Some(ChainStatus::Completed),
+        "failed" => Some(ChainStatus::Failed),
+        "cancelled" => Some(ChainStatus::Cancelled),
+        "timed_out" => Some(ChainStatus::TimedOut),
+        _ => None,
+    }
+}
+
+fn status_to_string(s: &ChainStatus) -> String {
+    match s {
+        ChainStatus::Running => "running".into(),
+        ChainStatus::Completed => "completed".into(),
+        ChainStatus::Failed => "failed".into(),
+        ChainStatus::Cancelled => "cancelled".into(),
+        ChainStatus::TimedOut => "timed_out".into(),
+    }
+}
+
+/// `GET /v1/chains` -- list chain executions.
+#[utoipa::path(
+    get,
+    path = "/v1/chains",
+    tag = "Chains",
+    summary = "List chain executions",
+    description = "Returns chain executions filtered by namespace, tenant, and optional status.",
+    params(ChainQueryParams),
+    responses(
+        (status = 200, description = "Chain list", body = ListChainsResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+    )
+)]
+pub async fn list_chains(
+    State(state): State<AppState>,
+    Query(params): Query<ChainQueryParams>,
+) -> impl IntoResponse {
+    let gw = state.gateway.read().await;
+    let status_filter = params.status.as_deref().and_then(parse_status_filter);
+
+    match gw
+        .list_chains(&params.namespace, &params.tenant, status_filter.as_ref())
+        .await
+    {
+        Ok(chains) => {
+            let summaries: Vec<ChainSummary> = chains
+                .iter()
+                .map(|c| ChainSummary {
+                    chain_id: c.chain_id.clone(),
+                    chain_name: c.chain_name.clone(),
+                    status: status_to_string(&c.status),
+                    current_step: c.current_step,
+                    total_steps: c.total_steps,
+                    started_at: c.started_at,
+                    updated_at: c.updated_at,
+                })
+                .collect();
+            (
+                StatusCode::OK,
+                Json(ListChainsResponse { chains: summaries }),
+            )
+                .into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+/// `GET /v1/chains/{chain_id}` -- get chain execution details.
+#[utoipa::path(
+    get,
+    path = "/v1/chains/{chain_id}",
+    tag = "Chains",
+    summary = "Get chain execution status",
+    description = "Returns full details of a chain execution including step results.",
+    params(
+        ("chain_id" = String, Path, description = "Chain execution ID"),
+        ChainNamespaceParams,
+    ),
+    responses(
+        (status = 200, description = "Chain details", body = ChainDetailResponse),
+        (status = 404, description = "Chain not found", body = ErrorResponse),
+    )
+)]
+pub async fn get_chain(
+    State(state): State<AppState>,
+    Path(chain_id): Path<String>,
+    Query(params): Query<ChainNamespaceParams>,
+) -> impl IntoResponse {
+    let gw = state.gateway.read().await;
+
+    match gw
+        .get_chain_status(&params.namespace, &params.tenant, &chain_id)
+        .await
+    {
+        Ok(Some(chain_state)) => {
+            // Build per-step status from the chain config and results.
+            let steps: Vec<ChainStepStatus> = (0..chain_state.total_steps)
+                .map(|i| {
+                    let result = chain_state.step_results.get(i).and_then(|r| r.as_ref());
+                    let step_name =
+                        result.map_or_else(|| format!("step-{i}"), |r| r.step_name.clone());
+                    let (status, resp_body, error, completed) = if let Some(r) = result {
+                        let s = if r.success { "completed" } else { "failed" };
+                        (
+                            s.to_string(),
+                            r.response_body.clone(),
+                            r.error.clone(),
+                            Some(r.completed_at),
+                        )
+                    } else {
+                        ("pending".to_string(), None, None, None)
+                    };
+                    ChainStepStatus {
+                        name: step_name,
+                        provider: String::new(),
+                        status,
+                        response_body: resp_body,
+                        error,
+                        completed_at: completed,
+                    }
+                })
+                .collect();
+
+            let detail = ChainDetailResponse {
+                chain_id: chain_state.chain_id,
+                chain_name: chain_state.chain_name,
+                status: status_to_string(&chain_state.status),
+                current_step: chain_state.current_step,
+                total_steps: chain_state.total_steps,
+                steps,
+                started_at: chain_state.started_at,
+                updated_at: chain_state.updated_at,
+                expires_at: chain_state.expires_at,
+                cancel_reason: chain_state.cancel_reason,
+                cancelled_by: chain_state.cancelled_by,
+            };
+            (StatusCode::OK, Json(detail)).into_response()
+        }
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("chain not found: {chain_id}"),
+            }),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+/// `POST /v1/chains/{chain_id}/cancel` -- cancel a running chain.
+#[utoipa::path(
+    post,
+    path = "/v1/chains/{chain_id}/cancel",
+    tag = "Chains",
+    summary = "Cancel a running chain",
+    description = "Cancels a running chain execution. Returns an error if already completed/failed.",
+    params(("chain_id" = String, Path, description = "Chain execution ID")),
+    responses(
+        (status = 200, description = "Chain cancelled", body = ChainDetailResponse),
+        (status = 404, description = "Chain not found", body = ErrorResponse),
+        (status = 409, description = "Chain already finished", body = ErrorResponse),
+    )
+)]
+pub async fn cancel_chain(
+    State(state): State<AppState>,
+    Path(chain_id): Path<String>,
+    Json(params): Json<ChainCancelRequest>,
+) -> impl IntoResponse {
+    let gw = state.gateway.read().await;
+
+    match gw
+        .cancel_chain(
+            &params.namespace,
+            &params.tenant,
+            &chain_id,
+            params.reason,
+            params.cancelled_by,
+        )
+        .await
+    {
+        Ok(chain_state) => {
+            let detail = ChainDetailResponse {
+                chain_id: chain_state.chain_id,
+                chain_name: chain_state.chain_name,
+                status: status_to_string(&chain_state.status),
+                current_step: chain_state.current_step,
+                total_steps: chain_state.total_steps,
+                steps: Vec::new(),
+                started_at: chain_state.started_at,
+                updated_at: chain_state.updated_at,
+                expires_at: chain_state.expires_at,
+                cancel_reason: chain_state.cancel_reason,
+                cancelled_by: chain_state.cancelled_by,
+            };
+            (StatusCode::OK, Json(detail)).into_response()
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("not found") {
+                (StatusCode::NOT_FOUND, Json(ErrorResponse { error: msg })).into_response()
+            } else if msg.contains("not running") {
+                (StatusCode::CONFLICT, Json(ErrorResponse { error: msg })).into_response()
+            } else {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse { error: msg }),
+                )
+                    .into_response()
+            }
+        }
+    }
+}

--- a/crates/server/src/api/health.rs
+++ b/crates/server/src/api/health.rs
@@ -34,6 +34,10 @@ pub async fn health(State(state): State<AppState>) -> impl IntoResponse {
             llm_guardrail_allowed: snap.llm_guardrail_allowed,
             llm_guardrail_denied: snap.llm_guardrail_denied,
             llm_guardrail_errors: snap.llm_guardrail_errors,
+            chains_started: snap.chains_started,
+            chains_completed: snap.chains_completed,
+            chains_failed: snap.chains_failed,
+            chains_cancelled: snap.chains_cancelled,
         },
     };
 
@@ -66,6 +70,10 @@ pub async fn metrics(State(state): State<AppState>) -> impl IntoResponse {
         llm_guardrail_allowed: snap.llm_guardrail_allowed,
         llm_guardrail_denied: snap.llm_guardrail_denied,
         llm_guardrail_errors: snap.llm_guardrail_errors,
+        chains_started: snap.chains_started,
+        chains_completed: snap.chains_completed,
+        chains_failed: snap.chains_failed,
+        chains_cancelled: snap.chains_cancelled,
     };
 
     (StatusCode::OK, Json(body))

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -1,6 +1,7 @@
 pub mod approvals;
 pub mod audit;
 pub mod auth;
+pub mod chains;
 pub mod dispatch;
 pub mod dlq;
 pub mod events;
@@ -90,6 +91,10 @@ pub fn router(state: AppState) -> Router {
         .route("/v1/groups", get(groups::list_groups))
         .route("/v1/groups/{group_key}", get(groups::get_group))
         .route("/v1/groups/{group_key}", delete(groups::flush_group))
+        // Chains (task chain orchestration)
+        .route("/v1/chains", get(chains::list_chains))
+        .route("/v1/chains/{chain_id}", get(chains::get_chain))
+        .route("/v1/chains/{chain_id}/cancel", post(chains::cancel_chain))
         // Approvals (list requires auth)
         .route("/v1/approvals", get(approvals::list_approvals))
         // Logout (requires auth)

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -8,6 +8,9 @@ use acteon_core::{
 use super::approvals::{
     ApprovalActionResponse, ApprovalQueryParams, ApprovalStatusResponse, ListApprovalsResponse,
 };
+use super::chains::{
+    ChainCancelRequest, ChainDetailResponse, ChainStepStatus, ChainSummary, ListChainsResponse,
+};
 use super::dlq::{DlqDrainResponse, DlqEntry, DlqStatsResponse};
 use super::events::{
     EventStateResponse, ListEventsResponse, TransitionRequest, TransitionResponse,
@@ -34,7 +37,8 @@ use super::schemas::{
         (name = "DLQ", description = "Dead-letter queue for failed actions"),
         (name = "Events", description = "Event lifecycle state management"),
         (name = "Groups", description = "Event group management for batched notifications"),
-        (name = "Approvals", description = "Human-in-the-loop approval workflow")
+        (name = "Approvals", description = "Human-in-the-loop approval workflow"),
+        (name = "Chains", description = "Task chain orchestration")
     ),
     paths(
         super::health::health,
@@ -58,6 +62,9 @@ use super::schemas::{
         super::approvals::reject,
         super::approvals::get_approval,
         super::approvals::list_approvals,
+        super::chains::list_chains,
+        super::chains::get_chain,
+        super::chains::cancel_chain,
     ),
     components(schemas(
         Action, ActionOutcome, ProviderResponse, ResponseStatus, ActionError,
@@ -70,6 +77,7 @@ use super::schemas::{
         EventStateResponse, ListEventsResponse, TransitionRequest, TransitionResponse,
         GroupSummary, ListGroupsResponse, GroupDetailResponse, FlushGroupResponse,
         ApprovalActionResponse, ApprovalStatusResponse, ApprovalQueryParams, ListApprovalsResponse,
+        ChainSummary, ListChainsResponse, ChainDetailResponse, ChainStepStatus, ChainCancelRequest,
     ))
 )]
 pub struct ApiDoc;

--- a/crates/server/src/api/schemas.rs
+++ b/crates/server/src/api/schemas.rs
@@ -44,6 +44,18 @@ pub struct MetricsResponse {
     /// LLM guardrail evaluation errors.
     #[schema(example = 0)]
     pub llm_guardrail_errors: u64,
+    /// Task chains started.
+    #[schema(example = 0)]
+    pub chains_started: u64,
+    /// Task chains completed successfully.
+    #[schema(example = 0)]
+    pub chains_completed: u64,
+    /// Task chains failed.
+    #[schema(example = 0)]
+    pub chains_failed: u64,
+    /// Task chains cancelled.
+    #[schema(example = 0)]
+    pub chains_cancelled: u64,
 }
 
 /// Summary of a loaded rule.

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -73,6 +73,10 @@ name = "postgres_simulation"
 required-features = ["postgres"]
 
 [[example]]
+name = "postgres_chain_simulation"
+required-features = ["postgres"]
+
+[[example]]
 name = "clickhouse_simulation"
 required-features = ["clickhouse"]
 

--- a/crates/simulation/examples/chain_simulation.rs
+++ b/crates/simulation/examples/chain_simulation.rs
@@ -1,0 +1,828 @@
+//! Simulation of task chains with audit trail verification.
+//!
+//! Demonstrates:
+//! 1. A successful multi-step chain (search -> summarize -> email)
+//! 2. A chain with a failing step and Abort policy
+//! 3. A chain with a failing step and Skip policy
+//! 4. Chain cancellation
+//! 5. Chain audit trail queries (step + terminal records)
+//!
+//! Run with: `cargo run -p acteon-simulation --example chain_simulation`
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use acteon_audit::record::AuditQuery;
+use acteon_audit::store::AuditStore;
+use acteon_audit_memory::MemoryAuditStore;
+use acteon_core::chain::{ChainConfig, ChainStepConfig, StepFailurePolicy};
+use acteon_core::{Action, ActionOutcome};
+use acteon_gateway::GatewayBuilder;
+use acteon_rules::Rule;
+use acteon_rules_yaml::YamlFrontend;
+use acteon_simulation::prelude::*;
+use acteon_state_memory::{MemoryDistributedLock, MemoryStateStore};
+
+const CHAIN_RULE: &str = r#"
+rules:
+  - name: research-pipeline
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "research"
+    action:
+      type: chain
+      chain: search-summarize-email
+"#;
+
+fn parse_rules(yaml: &str) -> Vec<Rule> {
+    let frontend = YamlFrontend;
+    acteon_rules::RuleFrontend::parse(&frontend, yaml).expect("failed to parse rules")
+}
+
+#[tokio::main]
+#[allow(clippy::too_many_lines)]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("==================================================================");
+    println!("           ACTEON CHAIN SIMULATION");
+    println!("==================================================================\n");
+
+    // =========================================================================
+    // DEMO 1: Successful Multi-Step Chain
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DEMO 1: SUCCESSFUL MULTI-STEP CHAIN");
+    println!("------------------------------------------------------------------\n");
+
+    let state: Arc<dyn acteon_state::StateStore> = Arc::new(MemoryStateStore::new());
+    let lock: Arc<dyn acteon_state::DistributedLock> = Arc::new(MemoryDistributedLock::new());
+    let audit: Arc<dyn AuditStore> = Arc::new(MemoryAuditStore::new());
+
+    let search_provider = Arc::new(RecordingProvider::new("search-api").with_response_fn(|_| {
+        Ok(acteon_core::ProviderResponse::success(serde_json::json!({
+            "results": [
+                {"title": "Rust async primer", "url": "https://example.com/1"},
+                {"title": "Tokio guide", "url": "https://example.com/2"},
+            ]
+        })))
+    }));
+    let summarize_provider = Arc::new(RecordingProvider::new("llm-api").with_response_fn(|_| {
+        Ok(acteon_core::ProviderResponse::success(serde_json::json!({
+            "summary": "Rust's async model uses Futures with Tokio as the primary runtime."
+        })))
+    }));
+    let email_provider = Arc::new(RecordingProvider::new("email"));
+
+    let chain_config = ChainConfig::new("search-summarize-email")
+        .with_step(ChainStepConfig::new(
+            "search",
+            "search-api",
+            "web_search",
+            serde_json::json!({"query": "{{origin.payload.query}}"}),
+        ))
+        .with_step(ChainStepConfig::new(
+            "summarize",
+            "llm-api",
+            "summarize",
+            serde_json::json!({
+                "text": "{{prev.response_body}}",
+                "max_length": 200
+            }),
+        ))
+        .with_step(ChainStepConfig::new(
+            "notify",
+            "email",
+            "send_email",
+            serde_json::json!({
+                "to": "{{origin.payload.email}}",
+                "subject": "Research results for: {{origin.payload.query}}",
+                "body": "{{prev.response_body.summary}}"
+            }),
+        ))
+        .with_timeout(60);
+
+    let rules = parse_rules(CHAIN_RULE);
+
+    let gateway = GatewayBuilder::new()
+        .state(Arc::clone(&state))
+        .lock(Arc::clone(&lock))
+        .rules(rules)
+        .provider(Arc::clone(&search_provider) as Arc<dyn acteon_provider::DynProvider>)
+        .provider(Arc::clone(&summarize_provider) as Arc<dyn acteon_provider::DynProvider>)
+        .provider(Arc::clone(&email_provider) as Arc<dyn acteon_provider::DynProvider>)
+        .audit(Arc::clone(&audit))
+        .audit_store_payload(true)
+        .chain(chain_config)
+        .completed_chain_ttl(Duration::from_secs(3600))
+        .build()?;
+
+    let action = Action::new(
+        "research",
+        "tenant-1",
+        "search-api",
+        "research",
+        serde_json::json!({
+            "query": "rust async programming",
+            "email": "dev@example.com"
+        }),
+    );
+
+    println!("  Dispatching research action...");
+    let outcome = gateway.dispatch(action, None).await?;
+
+    let chain_id = match &outcome {
+        ActionOutcome::ChainStarted {
+            chain_id,
+            chain_name,
+            total_steps,
+            first_step,
+        } => {
+            println!("  Chain started: {chain_name}");
+            println!("    chain_id:    {chain_id}");
+            println!("    total_steps: {total_steps}");
+            println!("    first_step:  {first_step}");
+            chain_id.clone()
+        }
+        other => {
+            println!("  Unexpected outcome: {other:?}");
+            return Ok(());
+        }
+    };
+
+    // Advance through all 3 steps.
+    for step in 0..3 {
+        gateway
+            .advance_chain("research", "tenant-1", &chain_id)
+            .await?;
+        println!("  Step {step} advanced");
+    }
+
+    // Wait for async audit writes.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify providers were called.
+    println!("\n  Provider call counts:");
+    println!("    search-api: {}", search_provider.call_count());
+    println!("    llm-api:    {}", summarize_provider.call_count());
+    println!("    email:      {}", email_provider.call_count());
+
+    // Query audit records for this chain.
+    let page = audit
+        .query(&AuditQuery {
+            chain_id: Some(chain_id.clone()),
+            ..Default::default()
+        })
+        .await?;
+
+    println!("\n  Audit records for chain {chain_id}: {}", page.total);
+    for rec in &page.records {
+        println!(
+            "    [{:>22}] provider={:<12} outcome={}",
+            rec.outcome, rec.provider, rec.action_type
+        );
+    }
+
+    // Verify the chain status.
+    let chain_state = gateway
+        .get_chain_status("research", "tenant-1", &chain_id)
+        .await?
+        .expect("chain state should exist");
+    println!("\n  Final chain status: {:?}", chain_state.status);
+    assert_eq!(
+        chain_state.status,
+        acteon_core::chain::ChainStatus::Completed
+    );
+
+    // Verify we have step + terminal audit records.
+    let step_records: Vec<_> = page
+        .records
+        .iter()
+        .filter(|r| r.outcome.starts_with("chain_step"))
+        .collect();
+    let terminal_records: Vec<_> = page
+        .records
+        .iter()
+        .filter(|r| {
+            r.outcome == "chain_completed"
+                || r.outcome == "chain_failed"
+                || r.outcome == "chain_timed_out"
+                || r.outcome == "chain_cancelled"
+        })
+        .collect();
+    println!("  Step audit records:     {}", step_records.len());
+    println!("  Terminal audit records:  {}", terminal_records.len());
+    assert_eq!(step_records.len(), 3, "expected 3 step records");
+    assert_eq!(terminal_records.len(), 1, "expected 1 terminal record");
+    assert_eq!(terminal_records[0].outcome, "chain_completed");
+
+    gateway.shutdown().await;
+    println!("\n  PASSED\n");
+
+    // =========================================================================
+    // DEMO 2: Chain with Failing Step (Abort)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DEMO 2: CHAIN WITH FAILING STEP (ABORT POLICY)");
+    println!("------------------------------------------------------------------\n");
+
+    let state: Arc<dyn acteon_state::StateStore> = Arc::new(MemoryStateStore::new());
+    let lock: Arc<dyn acteon_state::DistributedLock> = Arc::new(MemoryDistributedLock::new());
+    let audit: Arc<dyn AuditStore> = Arc::new(MemoryAuditStore::new());
+
+    let ok_provider = Arc::new(RecordingProvider::new("step-ok").with_response_fn(|_| {
+        Ok(acteon_core::ProviderResponse::success(
+            serde_json::json!({"ok": true}),
+        ))
+    }));
+    let fail_provider =
+        Arc::new(RecordingProvider::new("step-fail").with_failure_mode(FailureMode::Always));
+    let unreachable_provider = Arc::new(RecordingProvider::new("step-unreachable"));
+
+    let chain_config = ChainConfig::new("abort-chain")
+        .with_step(ChainStepConfig::new(
+            "first",
+            "step-ok",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_step(ChainStepConfig::new(
+            "second-fails",
+            "step-fail",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_step(ChainStepConfig::new(
+            "third-unreachable",
+            "step-unreachable",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_timeout(30);
+
+    let abort_rule: &str = r#"
+rules:
+  - name: trigger-abort-chain
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "trigger_abort"
+    action:
+      type: chain
+      chain: abort-chain
+"#;
+    let rules = parse_rules(abort_rule);
+
+    let gateway = GatewayBuilder::new()
+        .state(Arc::clone(&state))
+        .lock(Arc::clone(&lock))
+        .rules(rules)
+        .provider(Arc::clone(&ok_provider) as Arc<dyn acteon_provider::DynProvider>)
+        .provider(Arc::clone(&fail_provider) as Arc<dyn acteon_provider::DynProvider>)
+        .provider(Arc::clone(&unreachable_provider) as Arc<dyn acteon_provider::DynProvider>)
+        .audit(Arc::clone(&audit))
+        .audit_store_payload(true)
+        .chain(chain_config)
+        .completed_chain_ttl(Duration::from_secs(3600))
+        .build()?;
+
+    let action = Action::new(
+        "test",
+        "tenant-1",
+        "step-ok",
+        "trigger_abort",
+        serde_json::json!({}),
+    );
+
+    println!("  Dispatching action to trigger abort-chain...");
+    let outcome = gateway.dispatch(action, None).await?;
+    let chain_id = match &outcome {
+        ActionOutcome::ChainStarted { chain_id, .. } => chain_id.clone(),
+        other => {
+            println!("  Unexpected outcome: {other:?}");
+            return Ok(());
+        }
+    };
+
+    // Advance step 0 (succeeds), then step 1 (fails -> abort).
+    gateway.advance_chain("test", "tenant-1", &chain_id).await?;
+    println!("  Step 0 (first): advanced OK");
+    gateway.advance_chain("test", "tenant-1", &chain_id).await?;
+    println!("  Step 1 (second-fails): failed -> chain aborted");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let chain_state = gateway
+        .get_chain_status("test", "tenant-1", &chain_id)
+        .await?
+        .expect("chain state should exist");
+    println!("\n  Final chain status: {:?}", chain_state.status);
+    assert_eq!(chain_state.status, acteon_core::chain::ChainStatus::Failed);
+
+    println!("  Provider call counts:");
+    println!("    step-ok:          {}", ok_provider.call_count());
+    println!("    step-fail:        {}", fail_provider.call_count());
+    println!(
+        "    step-unreachable: {} (never reached)",
+        unreachable_provider.call_count()
+    );
+    unreachable_provider.assert_not_called();
+
+    let page = audit
+        .query(&AuditQuery {
+            chain_id: Some(chain_id.clone()),
+            ..Default::default()
+        })
+        .await?;
+    println!("\n  Audit records for chain: {}", page.total);
+    for rec in &page.records {
+        println!(
+            "    [{:>22}] provider={:<16} action_type={}",
+            rec.outcome, rec.provider, rec.action_type
+        );
+    }
+
+    let failed_records: Vec<_> = page
+        .records
+        .iter()
+        .filter(|r| r.outcome == "chain_failed")
+        .collect();
+    assert_eq!(
+        failed_records.len(),
+        1,
+        "expected 1 chain_failed terminal record"
+    );
+
+    gateway.shutdown().await;
+    println!("\n  PASSED\n");
+
+    // =========================================================================
+    // DEMO 3: Chain with Failing Step (Skip)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DEMO 3: CHAIN WITH FAILING STEP (SKIP POLICY)");
+    println!("------------------------------------------------------------------\n");
+
+    let state: Arc<dyn acteon_state::StateStore> = Arc::new(MemoryStateStore::new());
+    let lock: Arc<dyn acteon_state::DistributedLock> = Arc::new(MemoryDistributedLock::new());
+    let audit: Arc<dyn AuditStore> = Arc::new(MemoryAuditStore::new());
+
+    let ok_provider = Arc::new(RecordingProvider::new("step-a").with_response_fn(|_| {
+        Ok(acteon_core::ProviderResponse::success(
+            serde_json::json!({"result": "done"}),
+        ))
+    }));
+    let fail_provider =
+        Arc::new(RecordingProvider::new("step-b").with_failure_mode(FailureMode::Always));
+    let final_provider = Arc::new(RecordingProvider::new("step-c").with_response_fn(|_| {
+        Ok(acteon_core::ProviderResponse::success(
+            serde_json::json!({"final": true}),
+        ))
+    }));
+
+    let chain_config = ChainConfig::new("skip-chain")
+        .with_step(ChainStepConfig::new(
+            "first",
+            "step-a",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_step(
+            ChainStepConfig::new(
+                "second-skippable",
+                "step-b",
+                "do_thing",
+                serde_json::json!({}),
+            )
+            .with_on_failure(StepFailurePolicy::Skip),
+        )
+        .with_step(ChainStepConfig::new(
+            "third",
+            "step-c",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_timeout(30);
+
+    let skip_rule: &str = r#"
+rules:
+  - name: trigger-skip-chain
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "trigger_skip"
+    action:
+      type: chain
+      chain: skip-chain
+"#;
+    let rules = parse_rules(skip_rule);
+
+    let gateway = GatewayBuilder::new()
+        .state(Arc::clone(&state))
+        .lock(Arc::clone(&lock))
+        .rules(rules)
+        .provider(Arc::clone(&ok_provider) as Arc<dyn acteon_provider::DynProvider>)
+        .provider(Arc::clone(&fail_provider) as Arc<dyn acteon_provider::DynProvider>)
+        .provider(Arc::clone(&final_provider) as Arc<dyn acteon_provider::DynProvider>)
+        .audit(Arc::clone(&audit))
+        .audit_store_payload(true)
+        .chain(chain_config)
+        .completed_chain_ttl(Duration::from_secs(3600))
+        .build()?;
+
+    let action = Action::new(
+        "test",
+        "tenant-1",
+        "step-a",
+        "trigger_skip",
+        serde_json::json!({}),
+    );
+
+    println!("  Dispatching action to trigger skip-chain...");
+    let outcome = gateway.dispatch(action, None).await?;
+    let chain_id = match &outcome {
+        ActionOutcome::ChainStarted { chain_id, .. } => chain_id.clone(),
+        other => {
+            println!("  Unexpected outcome: {other:?}");
+            return Ok(());
+        }
+    };
+
+    // Advance all 3 steps: step 0 OK, step 1 fails but skips, step 2 OK.
+    for i in 0..3 {
+        gateway.advance_chain("test", "tenant-1", &chain_id).await?;
+        println!("  Step {i} advanced");
+    }
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let chain_state = gateway
+        .get_chain_status("test", "tenant-1", &chain_id)
+        .await?
+        .expect("chain state should exist");
+    println!("\n  Final chain status: {:?}", chain_state.status);
+    assert_eq!(
+        chain_state.status,
+        acteon_core::chain::ChainStatus::Completed
+    );
+
+    println!("  Provider call counts:");
+    println!("    step-a: {}", ok_provider.call_count());
+    println!(
+        "    step-b: {} (failed, skipped)",
+        fail_provider.call_count()
+    );
+    println!(
+        "    step-c: {} (still reached)",
+        final_provider.call_count()
+    );
+    assert_eq!(
+        final_provider.call_count(),
+        1,
+        "step-c should be reached after skip"
+    );
+
+    let page = audit
+        .query(&AuditQuery {
+            chain_id: Some(chain_id.clone()),
+            ..Default::default()
+        })
+        .await?;
+    println!("\n  Audit records for chain: {}", page.total);
+    for rec in &page.records {
+        println!(
+            "    [{:>22}] provider={:<10} action_type={}",
+            rec.outcome, rec.provider, rec.action_type
+        );
+    }
+
+    let skipped: Vec<_> = page
+        .records
+        .iter()
+        .filter(|r| r.outcome == "chain_step_skipped")
+        .collect();
+    assert_eq!(skipped.len(), 1, "expected 1 chain_step_skipped record");
+
+    let terminal: Vec<_> = page
+        .records
+        .iter()
+        .filter(|r| r.outcome == "chain_completed")
+        .collect();
+    assert_eq!(
+        terminal.len(),
+        1,
+        "chain should complete despite skipped step"
+    );
+
+    gateway.shutdown().await;
+    println!("\n  PASSED\n");
+
+    // =========================================================================
+    // DEMO 4: Chain Cancellation
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DEMO 4: CHAIN CANCELLATION");
+    println!("------------------------------------------------------------------\n");
+
+    let state: Arc<dyn acteon_state::StateStore> = Arc::new(MemoryStateStore::new());
+    let lock: Arc<dyn acteon_state::DistributedLock> = Arc::new(MemoryDistributedLock::new());
+    let audit: Arc<dyn AuditStore> = Arc::new(MemoryAuditStore::new());
+
+    // Use a provider with a delay to simulate slow steps.
+    let slow_provider = Arc::new(RecordingProvider::new("slow-svc"));
+    let webhook_provider = Arc::new(RecordingProvider::new("webhook"));
+
+    let chain_config = ChainConfig::new("cancellable-chain")
+        .with_step(ChainStepConfig::new(
+            "step-1",
+            "slow-svc",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_step(ChainStepConfig::new(
+            "step-2",
+            "slow-svc",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_step(ChainStepConfig::new(
+            "step-3",
+            "slow-svc",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_timeout(120);
+
+    let cancel_rule: &str = r#"
+rules:
+  - name: trigger-cancel-chain
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "trigger_cancel"
+    action:
+      type: chain
+      chain: cancellable-chain
+"#;
+    let rules = parse_rules(cancel_rule);
+
+    let gateway = GatewayBuilder::new()
+        .state(Arc::clone(&state))
+        .lock(Arc::clone(&lock))
+        .rules(rules)
+        .provider(Arc::clone(&slow_provider) as Arc<dyn acteon_provider::DynProvider>)
+        .provider(Arc::clone(&webhook_provider) as Arc<dyn acteon_provider::DynProvider>)
+        .audit(Arc::clone(&audit))
+        .audit_store_payload(true)
+        .chain(chain_config)
+        .completed_chain_ttl(Duration::from_secs(3600))
+        .build()?;
+
+    let action = Action::new(
+        "test",
+        "tenant-1",
+        "slow-svc",
+        "trigger_cancel",
+        serde_json::json!({}),
+    );
+
+    println!("  Dispatching action to trigger cancellable-chain...");
+    let outcome = gateway.dispatch(action, None).await?;
+    let chain_id = match &outcome {
+        ActionOutcome::ChainStarted { chain_id, .. } => chain_id.clone(),
+        other => {
+            println!("  Unexpected outcome: {other:?}");
+            return Ok(());
+        }
+    };
+
+    // Advance step 0 so chain is partially complete.
+    gateway.advance_chain("test", "tenant-1", &chain_id).await?;
+    println!("  Step 0 advanced");
+
+    // Cancel the chain while step 1 is pending.
+    println!("  Cancelling chain...");
+    let cancelled_state = gateway
+        .cancel_chain(
+            "test",
+            "tenant-1",
+            &chain_id,
+            Some("user requested cancellation".into()),
+            Some("admin@example.com".into()),
+        )
+        .await?;
+
+    println!("  Chain status after cancel: {:?}", cancelled_state.status);
+    println!("  Cancel reason: {:?}", cancelled_state.cancel_reason);
+    println!("  Cancelled by: {:?}", cancelled_state.cancelled_by);
+    assert_eq!(
+        cancelled_state.status,
+        acteon_core::chain::ChainStatus::Cancelled
+    );
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let page = audit
+        .query(&AuditQuery {
+            chain_id: Some(chain_id.clone()),
+            ..Default::default()
+        })
+        .await?;
+    println!("\n  Audit records for chain: {}", page.total);
+    for rec in &page.records {
+        println!(
+            "    [{:>22}] provider={:<10} action_type={}",
+            rec.outcome, rec.provider, rec.action_type
+        );
+    }
+
+    let cancelled: Vec<_> = page
+        .records
+        .iter()
+        .filter(|r| r.outcome == "chain_cancelled")
+        .collect();
+    assert_eq!(
+        cancelled.len(),
+        1,
+        "expected 1 chain_cancelled terminal record"
+    );
+
+    // Verify terminal record has cancel details.
+    let terminal_rec = cancelled[0];
+    let details = &terminal_rec.outcome_details;
+    assert_eq!(
+        details["cancel_reason"].as_str(),
+        Some("user requested cancellation")
+    );
+    assert_eq!(details["cancelled_by"].as_str(), Some("admin@example.com"));
+
+    gateway.shutdown().await;
+    println!("\n  PASSED\n");
+
+    // =========================================================================
+    // DEMO 5: Audit Trail Filter by chain_id
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DEMO 5: AUDIT TRAIL QUERIES");
+    println!("------------------------------------------------------------------\n");
+
+    let state: Arc<dyn acteon_state::StateStore> = Arc::new(MemoryStateStore::new());
+    let lock: Arc<dyn acteon_state::DistributedLock> = Arc::new(MemoryDistributedLock::new());
+    let audit: Arc<dyn AuditStore> = Arc::new(MemoryAuditStore::new());
+
+    let provider_a = Arc::new(RecordingProvider::new("svc-a"));
+    let provider_b = Arc::new(RecordingProvider::new("svc-b"));
+
+    let chain_a = ChainConfig::new("chain-alpha")
+        .with_step(ChainStepConfig::new(
+            "step1",
+            "svc-a",
+            "task",
+            serde_json::json!({}),
+        ))
+        .with_step(ChainStepConfig::new(
+            "step2",
+            "svc-a",
+            "task",
+            serde_json::json!({}),
+        ))
+        .with_timeout(30);
+
+    let chain_b = ChainConfig::new("chain-beta")
+        .with_step(ChainStepConfig::new(
+            "step1",
+            "svc-b",
+            "task",
+            serde_json::json!({}),
+        ))
+        .with_timeout(30);
+
+    let multi_rule: &str = r#"
+rules:
+  - name: trigger-alpha
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "alpha"
+    action:
+      type: chain
+      chain: chain-alpha
+  - name: trigger-beta
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "beta"
+    action:
+      type: chain
+      chain: chain-beta
+"#;
+    let rules = parse_rules(multi_rule);
+
+    let gateway = GatewayBuilder::new()
+        .state(Arc::clone(&state))
+        .lock(Arc::clone(&lock))
+        .rules(rules)
+        .provider(Arc::clone(&provider_a) as Arc<dyn acteon_provider::DynProvider>)
+        .provider(Arc::clone(&provider_b) as Arc<dyn acteon_provider::DynProvider>)
+        .audit(Arc::clone(&audit))
+        .audit_store_payload(true)
+        .chain(chain_a)
+        .chain(chain_b)
+        .completed_chain_ttl(Duration::from_secs(3600))
+        .build()?;
+
+    // Dispatch chain-alpha.
+    let action_a = Action::new("test", "tenant-1", "svc-a", "alpha", serde_json::json!({}));
+    let outcome_a = gateway.dispatch(action_a, None).await?;
+    let chain_id_a = match &outcome_a {
+        ActionOutcome::ChainStarted { chain_id, .. } => chain_id.clone(),
+        other => panic!("unexpected: {other:?}"),
+    };
+
+    // Dispatch chain-beta.
+    let action_b = Action::new("test", "tenant-1", "svc-b", "beta", serde_json::json!({}));
+    let outcome_b = gateway.dispatch(action_b, None).await?;
+    let chain_id_b = match &outcome_b {
+        ActionOutcome::ChainStarted { chain_id, .. } => chain_id.clone(),
+        other => panic!("unexpected: {other:?}"),
+    };
+
+    // Advance both chains.
+    for _ in 0..2 {
+        gateway
+            .advance_chain("test", "tenant-1", &chain_id_a)
+            .await?;
+    }
+    gateway
+        .advance_chain("test", "tenant-1", &chain_id_b)
+        .await?;
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Query all audit records.
+    let all_page = audit.query(&AuditQuery::default()).await?;
+    println!("  Total audit records (all chains): {}", all_page.total);
+
+    // Query only chain-alpha records.
+    let alpha_page = audit
+        .query(&AuditQuery {
+            chain_id: Some(chain_id_a.clone()),
+            ..Default::default()
+        })
+        .await?;
+    println!(
+        "  Records for chain-alpha ({}): {}",
+        chain_id_a, alpha_page.total
+    );
+    for rec in &alpha_page.records {
+        println!(
+            "    [{:>22}] provider={:<10} action_type={}",
+            rec.outcome, rec.provider, rec.action_type
+        );
+    }
+
+    // Query only chain-beta records.
+    let beta_page = audit
+        .query(&AuditQuery {
+            chain_id: Some(chain_id_b.clone()),
+            ..Default::default()
+        })
+        .await?;
+    println!(
+        "  Records for chain-beta  ({}): {}",
+        chain_id_b, beta_page.total
+    );
+    for rec in &beta_page.records {
+        println!(
+            "    [{:>22}] provider={:<10} action_type={}",
+            rec.outcome, rec.provider, rec.action_type
+        );
+    }
+
+    // chain-alpha: 1 dispatch + 2 steps + 1 terminal = 4 records.
+    // chain-beta:  1 dispatch + 1 step  + 1 terminal = 3 records.
+    assert_eq!(
+        alpha_page.total, 4,
+        "chain-alpha: 1 dispatch + 2 step + 1 terminal"
+    );
+    assert_eq!(
+        beta_page.total, 3,
+        "chain-beta: 1 dispatch + 1 step + 1 terminal"
+    );
+
+    // Verify no cross-contamination.
+    for rec in &alpha_page.records {
+        assert_eq!(rec.chain_id.as_deref(), Some(chain_id_a.as_str()));
+    }
+    for rec in &beta_page.records {
+        assert_eq!(rec.chain_id.as_deref(), Some(chain_id_b.as_str()));
+    }
+
+    gateway.shutdown().await;
+    println!("\n  PASSED\n");
+
+    println!("==================================================================");
+    println!("           ALL CHAIN SIMULATIONS PASSED");
+    println!("==================================================================");
+
+    Ok(())
+}

--- a/crates/simulation/examples/postgres_chain_simulation.rs
+++ b/crates/simulation/examples/postgres_chain_simulation.rs
@@ -199,7 +199,10 @@ rules:
         })
         .await?;
 
-    println!("\n  Audit records in Postgres for chain {chain_id}: {}", page.total);
+    println!(
+        "\n  Audit records in Postgres for chain {chain_id}: {}",
+        page.total
+    );
     for rec in &page.records {
         println!(
             "    [{:>22}] provider={:<12} action_type={}",

--- a/crates/simulation/examples/postgres_chain_simulation.rs
+++ b/crates/simulation/examples/postgres_chain_simulation.rs
@@ -1,0 +1,841 @@
+//! Chain lifecycle simulation against a real `PostgreSQL` backend.
+//!
+//! Exercises chain dispatch, step advancement, failure policies,
+//! cancellation, and `chain_id`-filtered audit queries — all persisted
+//! to `PostgreSQL`.
+//!
+//! Prerequisites:
+//! ```sh
+//! docker run -d --name acteon-postgres -p 5433:5432 \
+//!   -e POSTGRES_PASSWORD=postgres -e POSTGRES_USER=postgres \
+//!   -e POSTGRES_DB=acteon_test postgres:16-alpine
+//! ```
+//!
+//! Run with:
+//! ```sh
+//! DATABASE_URL=postgres://postgres:postgres@localhost:5433/acteon_test \
+//!   cargo run -p acteon-simulation --example postgres_chain_simulation --features postgres
+//! ```
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use acteon_audit::record::AuditQuery;
+use acteon_audit::store::AuditStore;
+use acteon_audit_postgres::{PostgresAuditConfig, PostgresAuditStore};
+use acteon_core::chain::{ChainConfig, ChainStepConfig, StepFailurePolicy};
+use acteon_core::{Action, ActionOutcome};
+use acteon_gateway::GatewayBuilder;
+use acteon_provider::DynProvider;
+use acteon_rules::Rule;
+use acteon_rules_yaml::YamlFrontend;
+use acteon_simulation::prelude::*;
+use acteon_state_postgres::{PostgresConfig, PostgresDistributedLock, PostgresStateStore};
+
+fn parse_rules(yaml: &str) -> Vec<Rule> {
+    let frontend = YamlFrontend;
+    acteon_rules::RuleFrontend::parse(&frontend, yaml).expect("failed to parse rules")
+}
+
+/// Build a Postgres state + audit configuration pair from `DATABASE_URL`.
+fn pg_configs(prefix: &str) -> (PostgresConfig, PostgresAuditConfig) {
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5433/acteon_test".to_string());
+
+    let state_config = PostgresConfig {
+        url: database_url.clone(),
+        pool_size: 10,
+        schema: "public".to_string(),
+        table_prefix: prefix.to_string(),
+    };
+
+    let audit_config = PostgresAuditConfig::new(&database_url).with_prefix(prefix);
+
+    (state_config, audit_config)
+}
+
+#[tokio::main]
+#[allow(clippy::too_many_lines)]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("==================================================================");
+    println!("    ACTEON CHAIN SIMULATION — POSTGRESQL BACKEND");
+    println!("==================================================================\n");
+
+    // =========================================================================
+    // DEMO 1: Successful Multi-Step Chain
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DEMO 1: SUCCESSFUL MULTI-STEP CHAIN (PostgreSQL)");
+    println!("------------------------------------------------------------------\n");
+
+    let (state_cfg, audit_cfg) = pg_configs("chain_sim1_");
+
+    let state = Arc::new(PostgresStateStore::new(state_cfg.clone()).await?);
+    let lock = Arc::new(PostgresDistributedLock::new(state_cfg).await?);
+    let audit = Arc::new(PostgresAuditStore::new(&audit_cfg).await?);
+
+    let search_provider = Arc::new(RecordingProvider::new("search-api").with_response_fn(|_| {
+        Ok(acteon_core::ProviderResponse::success(serde_json::json!({
+            "results": [
+                {"title": "Rust async primer", "url": "https://example.com/1"},
+                {"title": "Tokio guide", "url": "https://example.com/2"},
+            ]
+        })))
+    }));
+    let summarize_provider = Arc::new(RecordingProvider::new("llm-api").with_response_fn(|_| {
+        Ok(acteon_core::ProviderResponse::success(serde_json::json!({
+            "summary": "Rust's async model uses Futures with Tokio as the primary runtime."
+        })))
+    }));
+    let email_provider = Arc::new(RecordingProvider::new("email"));
+
+    let chain_config = ChainConfig::new("search-summarize-email")
+        .with_step(ChainStepConfig::new(
+            "search",
+            "search-api",
+            "web_search",
+            serde_json::json!({"query": "{{origin.payload.query}}"}),
+        ))
+        .with_step(ChainStepConfig::new(
+            "summarize",
+            "llm-api",
+            "summarize",
+            serde_json::json!({
+                "text": "{{prev.response_body}}",
+                "max_length": 200
+            }),
+        ))
+        .with_step(ChainStepConfig::new(
+            "notify",
+            "email",
+            "send_email",
+            serde_json::json!({
+                "to": "{{origin.payload.email}}",
+                "subject": "Research results for: {{origin.payload.query}}",
+                "body": "{{prev.response_body.summary}}"
+            }),
+        ))
+        .with_timeout(60);
+
+    let rules = parse_rules(
+        r#"
+rules:
+  - name: research-pipeline
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "research"
+    action:
+      type: chain
+      chain: search-summarize-email
+"#,
+    );
+
+    let gateway = GatewayBuilder::new()
+        .state(state.clone() as Arc<dyn acteon_state::StateStore>)
+        .lock(lock.clone() as Arc<dyn acteon_state::DistributedLock>)
+        .rules(rules)
+        .provider(Arc::clone(&search_provider) as Arc<dyn DynProvider>)
+        .provider(Arc::clone(&summarize_provider) as Arc<dyn DynProvider>)
+        .provider(Arc::clone(&email_provider) as Arc<dyn DynProvider>)
+        .audit(audit.clone() as Arc<dyn AuditStore>)
+        .audit_store_payload(true)
+        .audit_ttl_seconds(3600)
+        .chain(chain_config)
+        .completed_chain_ttl(Duration::from_secs(3600))
+        .build()?;
+
+    println!("  Connected to PostgreSQL");
+
+    let action = Action::new(
+        "research",
+        "tenant-1",
+        "search-api",
+        "research",
+        serde_json::json!({
+            "query": "rust async programming",
+            "email": "dev@example.com"
+        }),
+    );
+
+    println!("  Dispatching research action...");
+    let outcome = gateway.dispatch(action, None).await?;
+
+    let chain_id = match &outcome {
+        ActionOutcome::ChainStarted {
+            chain_id,
+            chain_name,
+            total_steps,
+            first_step,
+        } => {
+            println!("  Chain started: {chain_name}");
+            println!("    chain_id:    {chain_id}");
+            println!("    total_steps: {total_steps}");
+            println!("    first_step:  {first_step}");
+            chain_id.clone()
+        }
+        other => panic!("Expected ChainStarted, got: {other:?}"),
+    };
+
+    for step in 0..3 {
+        gateway
+            .advance_chain("research", "tenant-1", &chain_id)
+            .await?;
+        println!("  Step {step} advanced");
+    }
+
+    // Wait for async audit writes to flush to Postgres.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    println!("\n  Provider call counts:");
+    println!("    search-api: {}", search_provider.call_count());
+    println!("    llm-api:    {}", summarize_provider.call_count());
+    println!("    email:      {}", email_provider.call_count());
+
+    let page = audit
+        .query(&AuditQuery {
+            chain_id: Some(chain_id.clone()),
+            ..Default::default()
+        })
+        .await?;
+
+    println!("\n  Audit records in Postgres for chain {chain_id}: {}", page.total);
+    for rec in &page.records {
+        println!(
+            "    [{:>22}] provider={:<12} action_type={}",
+            rec.outcome, rec.provider, rec.action_type
+        );
+    }
+
+    let step_records: Vec<_> = page
+        .records
+        .iter()
+        .filter(|r| r.outcome.starts_with("chain_step"))
+        .collect();
+    let terminal_records: Vec<_> = page
+        .records
+        .iter()
+        .filter(|r| {
+            r.outcome == "chain_completed"
+                || r.outcome == "chain_failed"
+                || r.outcome == "chain_timed_out"
+                || r.outcome == "chain_cancelled"
+        })
+        .collect();
+    println!("  Step audit records:     {}", step_records.len());
+    println!("  Terminal audit records:  {}", terminal_records.len());
+    assert_eq!(step_records.len(), 3, "expected 3 step records");
+    assert_eq!(terminal_records.len(), 1, "expected 1 terminal record");
+    assert_eq!(terminal_records[0].outcome, "chain_completed");
+
+    let chain_state = gateway
+        .get_chain_status("research", "tenant-1", &chain_id)
+        .await?
+        .expect("chain state should exist");
+    assert_eq!(
+        chain_state.status,
+        acteon_core::chain::ChainStatus::Completed
+    );
+
+    gateway.shutdown().await;
+    println!("\n  PASSED\n");
+
+    // =========================================================================
+    // DEMO 2: Chain with Failing Step (Abort Policy)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DEMO 2: CHAIN WITH FAILING STEP — ABORT (PostgreSQL)");
+    println!("------------------------------------------------------------------\n");
+
+    let (state_cfg, audit_cfg) = pg_configs("chain_sim2_");
+
+    let state = Arc::new(PostgresStateStore::new(state_cfg.clone()).await?);
+    let lock = Arc::new(PostgresDistributedLock::new(state_cfg).await?);
+    let audit = Arc::new(PostgresAuditStore::new(&audit_cfg).await?);
+
+    let ok_provider = Arc::new(RecordingProvider::new("step-ok").with_response_fn(|_| {
+        Ok(acteon_core::ProviderResponse::success(
+            serde_json::json!({"ok": true}),
+        ))
+    }));
+    let fail_provider =
+        Arc::new(RecordingProvider::new("step-fail").with_failure_mode(FailureMode::Always));
+    let unreachable_provider = Arc::new(RecordingProvider::new("step-unreachable"));
+
+    let chain_config = ChainConfig::new("abort-chain")
+        .with_step(ChainStepConfig::new(
+            "first",
+            "step-ok",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_step(ChainStepConfig::new(
+            "second-fails",
+            "step-fail",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_step(ChainStepConfig::new(
+            "third-unreachable",
+            "step-unreachable",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_timeout(30);
+
+    let rules = parse_rules(
+        r#"
+rules:
+  - name: trigger-abort-chain
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "trigger_abort"
+    action:
+      type: chain
+      chain: abort-chain
+"#,
+    );
+
+    let gateway = GatewayBuilder::new()
+        .state(state.clone() as Arc<dyn acteon_state::StateStore>)
+        .lock(lock.clone() as Arc<dyn acteon_state::DistributedLock>)
+        .rules(rules)
+        .provider(Arc::clone(&ok_provider) as Arc<dyn DynProvider>)
+        .provider(Arc::clone(&fail_provider) as Arc<dyn DynProvider>)
+        .provider(Arc::clone(&unreachable_provider) as Arc<dyn DynProvider>)
+        .audit(audit.clone() as Arc<dyn AuditStore>)
+        .audit_store_payload(true)
+        .audit_ttl_seconds(3600)
+        .chain(chain_config)
+        .completed_chain_ttl(Duration::from_secs(3600))
+        .build()?;
+
+    let action = Action::new(
+        "test",
+        "tenant-1",
+        "step-ok",
+        "trigger_abort",
+        serde_json::json!({}),
+    );
+
+    println!("  Dispatching action to trigger abort-chain...");
+    let outcome = gateway.dispatch(action, None).await?;
+    let chain_id = match &outcome {
+        ActionOutcome::ChainStarted { chain_id, .. } => chain_id.clone(),
+        other => panic!("Expected ChainStarted, got: {other:?}"),
+    };
+
+    gateway.advance_chain("test", "tenant-1", &chain_id).await?;
+    println!("  Step 0 (first): advanced OK");
+    gateway.advance_chain("test", "tenant-1", &chain_id).await?;
+    println!("  Step 1 (second-fails): failed -> chain aborted");
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let chain_state = gateway
+        .get_chain_status("test", "tenant-1", &chain_id)
+        .await?
+        .expect("chain state should exist");
+    println!("\n  Final chain status: {:?}", chain_state.status);
+    assert_eq!(chain_state.status, acteon_core::chain::ChainStatus::Failed);
+
+    println!("  Provider call counts:");
+    println!("    step-ok:          {}", ok_provider.call_count());
+    println!("    step-fail:        {}", fail_provider.call_count());
+    println!(
+        "    step-unreachable: {} (never reached)",
+        unreachable_provider.call_count()
+    );
+    unreachable_provider.assert_not_called();
+
+    let page = audit
+        .query(&AuditQuery {
+            chain_id: Some(chain_id.clone()),
+            ..Default::default()
+        })
+        .await?;
+    println!("\n  Audit records in Postgres for chain: {}", page.total);
+    for rec in &page.records {
+        println!(
+            "    [{:>22}] provider={:<16} action_type={}",
+            rec.outcome, rec.provider, rec.action_type
+        );
+    }
+
+    let failed_records: Vec<_> = page
+        .records
+        .iter()
+        .filter(|r| r.outcome == "chain_failed")
+        .collect();
+    assert_eq!(
+        failed_records.len(),
+        1,
+        "expected 1 chain_failed terminal record"
+    );
+
+    gateway.shutdown().await;
+    println!("\n  PASSED\n");
+
+    // =========================================================================
+    // DEMO 3: Chain with Failing Step (Skip Policy)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DEMO 3: CHAIN WITH FAILING STEP — SKIP (PostgreSQL)");
+    println!("------------------------------------------------------------------\n");
+
+    let (state_cfg, audit_cfg) = pg_configs("chain_sim3_");
+
+    let state = Arc::new(PostgresStateStore::new(state_cfg.clone()).await?);
+    let lock = Arc::new(PostgresDistributedLock::new(state_cfg).await?);
+    let audit = Arc::new(PostgresAuditStore::new(&audit_cfg).await?);
+
+    let ok_provider = Arc::new(RecordingProvider::new("step-a").with_response_fn(|_| {
+        Ok(acteon_core::ProviderResponse::success(
+            serde_json::json!({"result": "done"}),
+        ))
+    }));
+    let fail_provider =
+        Arc::new(RecordingProvider::new("step-b").with_failure_mode(FailureMode::Always));
+    let final_provider = Arc::new(RecordingProvider::new("step-c").with_response_fn(|_| {
+        Ok(acteon_core::ProviderResponse::success(
+            serde_json::json!({"final": true}),
+        ))
+    }));
+
+    let chain_config = ChainConfig::new("skip-chain")
+        .with_step(ChainStepConfig::new(
+            "first",
+            "step-a",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_step(
+            ChainStepConfig::new(
+                "second-skippable",
+                "step-b",
+                "do_thing",
+                serde_json::json!({}),
+            )
+            .with_on_failure(StepFailurePolicy::Skip),
+        )
+        .with_step(ChainStepConfig::new(
+            "third",
+            "step-c",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_timeout(30);
+
+    let rules = parse_rules(
+        r#"
+rules:
+  - name: trigger-skip-chain
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "trigger_skip"
+    action:
+      type: chain
+      chain: skip-chain
+"#,
+    );
+
+    let gateway = GatewayBuilder::new()
+        .state(state.clone() as Arc<dyn acteon_state::StateStore>)
+        .lock(lock.clone() as Arc<dyn acteon_state::DistributedLock>)
+        .rules(rules)
+        .provider(Arc::clone(&ok_provider) as Arc<dyn DynProvider>)
+        .provider(Arc::clone(&fail_provider) as Arc<dyn DynProvider>)
+        .provider(Arc::clone(&final_provider) as Arc<dyn DynProvider>)
+        .audit(audit.clone() as Arc<dyn AuditStore>)
+        .audit_store_payload(true)
+        .audit_ttl_seconds(3600)
+        .chain(chain_config)
+        .completed_chain_ttl(Duration::from_secs(3600))
+        .build()?;
+
+    let action = Action::new(
+        "test",
+        "tenant-1",
+        "step-a",
+        "trigger_skip",
+        serde_json::json!({}),
+    );
+
+    println!("  Dispatching action to trigger skip-chain...");
+    let outcome = gateway.dispatch(action, None).await?;
+    let chain_id = match &outcome {
+        ActionOutcome::ChainStarted { chain_id, .. } => chain_id.clone(),
+        other => panic!("Expected ChainStarted, got: {other:?}"),
+    };
+
+    for i in 0..3 {
+        gateway.advance_chain("test", "tenant-1", &chain_id).await?;
+        println!("  Step {i} advanced");
+    }
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let chain_state = gateway
+        .get_chain_status("test", "tenant-1", &chain_id)
+        .await?
+        .expect("chain state should exist");
+    println!("\n  Final chain status: {:?}", chain_state.status);
+    assert_eq!(
+        chain_state.status,
+        acteon_core::chain::ChainStatus::Completed
+    );
+
+    assert_eq!(
+        final_provider.call_count(),
+        1,
+        "step-c should be reached after skip"
+    );
+
+    let page = audit
+        .query(&AuditQuery {
+            chain_id: Some(chain_id.clone()),
+            ..Default::default()
+        })
+        .await?;
+    println!("\n  Audit records in Postgres for chain: {}", page.total);
+    for rec in &page.records {
+        println!(
+            "    [{:>22}] provider={:<10} action_type={}",
+            rec.outcome, rec.provider, rec.action_type
+        );
+    }
+
+    let skipped: Vec<_> = page
+        .records
+        .iter()
+        .filter(|r| r.outcome == "chain_step_skipped")
+        .collect();
+    assert_eq!(skipped.len(), 1, "expected 1 chain_step_skipped record");
+
+    let terminal: Vec<_> = page
+        .records
+        .iter()
+        .filter(|r| r.outcome == "chain_completed")
+        .collect();
+    assert_eq!(
+        terminal.len(),
+        1,
+        "chain should complete despite skipped step"
+    );
+
+    gateway.shutdown().await;
+    println!("\n  PASSED\n");
+
+    // =========================================================================
+    // DEMO 4: Chain Cancellation
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DEMO 4: CHAIN CANCELLATION (PostgreSQL)");
+    println!("------------------------------------------------------------------\n");
+
+    let (state_cfg, audit_cfg) = pg_configs("chain_sim4_");
+
+    let state = Arc::new(PostgresStateStore::new(state_cfg.clone()).await?);
+    let lock = Arc::new(PostgresDistributedLock::new(state_cfg).await?);
+    let audit = Arc::new(PostgresAuditStore::new(&audit_cfg).await?);
+
+    let slow_provider = Arc::new(RecordingProvider::new("slow-svc"));
+
+    let chain_config = ChainConfig::new("cancellable-chain")
+        .with_step(ChainStepConfig::new(
+            "step-1",
+            "slow-svc",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_step(ChainStepConfig::new(
+            "step-2",
+            "slow-svc",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_step(ChainStepConfig::new(
+            "step-3",
+            "slow-svc",
+            "do_thing",
+            serde_json::json!({}),
+        ))
+        .with_timeout(120);
+
+    let rules = parse_rules(
+        r#"
+rules:
+  - name: trigger-cancel-chain
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "trigger_cancel"
+    action:
+      type: chain
+      chain: cancellable-chain
+"#,
+    );
+
+    let gateway = GatewayBuilder::new()
+        .state(state.clone() as Arc<dyn acteon_state::StateStore>)
+        .lock(lock.clone() as Arc<dyn acteon_state::DistributedLock>)
+        .rules(rules)
+        .provider(Arc::clone(&slow_provider) as Arc<dyn DynProvider>)
+        .audit(audit.clone() as Arc<dyn AuditStore>)
+        .audit_store_payload(true)
+        .audit_ttl_seconds(3600)
+        .chain(chain_config)
+        .completed_chain_ttl(Duration::from_secs(3600))
+        .build()?;
+
+    let action = Action::new(
+        "test",
+        "tenant-1",
+        "slow-svc",
+        "trigger_cancel",
+        serde_json::json!({}),
+    );
+
+    println!("  Dispatching action to trigger cancellable-chain...");
+    let outcome = gateway.dispatch(action, None).await?;
+    let chain_id = match &outcome {
+        ActionOutcome::ChainStarted { chain_id, .. } => chain_id.clone(),
+        other => panic!("Expected ChainStarted, got: {other:?}"),
+    };
+
+    gateway.advance_chain("test", "tenant-1", &chain_id).await?;
+    println!("  Step 0 advanced");
+
+    println!("  Cancelling chain...");
+    let cancelled_state = gateway
+        .cancel_chain(
+            "test",
+            "tenant-1",
+            &chain_id,
+            Some("operator requested cancellation".into()),
+            Some("admin@example.com".into()),
+        )
+        .await?;
+
+    println!("  Chain status after cancel: {:?}", cancelled_state.status);
+    println!("  Cancel reason: {:?}", cancelled_state.cancel_reason);
+    println!("  Cancelled by: {:?}", cancelled_state.cancelled_by);
+    assert_eq!(
+        cancelled_state.status,
+        acteon_core::chain::ChainStatus::Cancelled
+    );
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let page = audit
+        .query(&AuditQuery {
+            chain_id: Some(chain_id.clone()),
+            ..Default::default()
+        })
+        .await?;
+    println!("\n  Audit records in Postgres for chain: {}", page.total);
+    for rec in &page.records {
+        println!(
+            "    [{:>22}] provider={:<10} action_type={}",
+            rec.outcome, rec.provider, rec.action_type
+        );
+    }
+
+    let cancelled: Vec<_> = page
+        .records
+        .iter()
+        .filter(|r| r.outcome == "chain_cancelled")
+        .collect();
+    assert_eq!(
+        cancelled.len(),
+        1,
+        "expected 1 chain_cancelled terminal record"
+    );
+
+    let terminal_rec = cancelled[0];
+    let details = &terminal_rec.outcome_details;
+    assert_eq!(
+        details["cancel_reason"].as_str(),
+        Some("operator requested cancellation")
+    );
+    assert_eq!(details["cancelled_by"].as_str(), Some("admin@example.com"));
+
+    gateway.shutdown().await;
+    println!("\n  PASSED\n");
+
+    // =========================================================================
+    // DEMO 5: Two Concurrent Chains with chain_id Audit Filtering
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DEMO 5: CONCURRENT CHAINS + AUDIT FILTERING (PostgreSQL)");
+    println!("------------------------------------------------------------------\n");
+
+    let (state_cfg, audit_cfg) = pg_configs("chain_sim5_");
+
+    let state = Arc::new(PostgresStateStore::new(state_cfg.clone()).await?);
+    let lock = Arc::new(PostgresDistributedLock::new(state_cfg).await?);
+    let audit = Arc::new(PostgresAuditStore::new(&audit_cfg).await?);
+
+    let provider_a = Arc::new(RecordingProvider::new("svc-a"));
+    let provider_b = Arc::new(RecordingProvider::new("svc-b"));
+
+    let chain_a = ChainConfig::new("chain-alpha")
+        .with_step(ChainStepConfig::new(
+            "step1",
+            "svc-a",
+            "task",
+            serde_json::json!({}),
+        ))
+        .with_step(ChainStepConfig::new(
+            "step2",
+            "svc-a",
+            "task",
+            serde_json::json!({}),
+        ))
+        .with_timeout(30);
+
+    let chain_b = ChainConfig::new("chain-beta")
+        .with_step(ChainStepConfig::new(
+            "step1",
+            "svc-b",
+            "task",
+            serde_json::json!({}),
+        ))
+        .with_timeout(30);
+
+    let rules = parse_rules(
+        r#"
+rules:
+  - name: trigger-alpha
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "alpha"
+    action:
+      type: chain
+      chain: chain-alpha
+  - name: trigger-beta
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "beta"
+    action:
+      type: chain
+      chain: chain-beta
+"#,
+    );
+
+    let gateway = GatewayBuilder::new()
+        .state(state.clone() as Arc<dyn acteon_state::StateStore>)
+        .lock(lock.clone() as Arc<dyn acteon_state::DistributedLock>)
+        .rules(rules)
+        .provider(Arc::clone(&provider_a) as Arc<dyn DynProvider>)
+        .provider(Arc::clone(&provider_b) as Arc<dyn DynProvider>)
+        .audit(audit.clone() as Arc<dyn AuditStore>)
+        .audit_store_payload(true)
+        .audit_ttl_seconds(3600)
+        .chain(chain_a)
+        .chain(chain_b)
+        .completed_chain_ttl(Duration::from_secs(3600))
+        .build()?;
+
+    let action_a = Action::new("test", "tenant-1", "svc-a", "alpha", serde_json::json!({}));
+    let outcome_a = gateway.dispatch(action_a, None).await?;
+    let chain_id_a = match &outcome_a {
+        ActionOutcome::ChainStarted { chain_id, .. } => chain_id.clone(),
+        other => panic!("Expected ChainStarted, got: {other:?}"),
+    };
+
+    let action_b = Action::new("test", "tenant-1", "svc-b", "beta", serde_json::json!({}));
+    let outcome_b = gateway.dispatch(action_b, None).await?;
+    let chain_id_b = match &outcome_b {
+        ActionOutcome::ChainStarted { chain_id, .. } => chain_id.clone(),
+        other => panic!("Expected ChainStarted, got: {other:?}"),
+    };
+
+    println!("  chain-alpha: {chain_id_a}");
+    println!("  chain-beta:  {chain_id_b}");
+
+    for _ in 0..2 {
+        gateway
+            .advance_chain("test", "tenant-1", &chain_id_a)
+            .await?;
+    }
+    gateway
+        .advance_chain("test", "tenant-1", &chain_id_b)
+        .await?;
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let all_page = audit.query(&AuditQuery::default()).await?;
+    println!("\n  Total audit records (all chains): {}", all_page.total);
+
+    let alpha_page = audit
+        .query(&AuditQuery {
+            chain_id: Some(chain_id_a.clone()),
+            ..Default::default()
+        })
+        .await?;
+    println!(
+        "  Records for chain-alpha: {} (expected 4: 1 dispatch + 2 step + 1 terminal)",
+        alpha_page.total
+    );
+    for rec in &alpha_page.records {
+        println!(
+            "    [{:>22}] provider={:<10} action_type={}",
+            rec.outcome, rec.provider, rec.action_type
+        );
+    }
+
+    let beta_page = audit
+        .query(&AuditQuery {
+            chain_id: Some(chain_id_b.clone()),
+            ..Default::default()
+        })
+        .await?;
+    println!(
+        "  Records for chain-beta:  {} (expected 3: 1 dispatch + 1 step + 1 terminal)",
+        beta_page.total
+    );
+    for rec in &beta_page.records {
+        println!(
+            "    [{:>22}] provider={:<10} action_type={}",
+            rec.outcome, rec.provider, rec.action_type
+        );
+    }
+
+    // chain-alpha: 1 dispatch + 2 steps + 1 terminal = 4.
+    // chain-beta:  1 dispatch + 1 step  + 1 terminal = 3.
+    assert_eq!(
+        alpha_page.total, 4,
+        "chain-alpha: 1 dispatch + 2 step + 1 terminal"
+    );
+    assert_eq!(
+        beta_page.total, 3,
+        "chain-beta: 1 dispatch + 1 step + 1 terminal"
+    );
+
+    // Verify no cross-contamination.
+    for rec in &alpha_page.records {
+        assert_eq!(rec.chain_id.as_deref(), Some(chain_id_a.as_str()));
+    }
+    for rec in &beta_page.records {
+        assert_eq!(rec.chain_id.as_deref(), Some(chain_id_b.as_str()));
+    }
+
+    println!("\n  SQL you can run to inspect the audit trail:");
+    println!("    SELECT chain_id, outcome, provider, action_type, dispatched_at");
+    println!("    FROM public.chain_sim5_audit");
+    println!("    ORDER BY dispatched_at DESC LIMIT 20;");
+
+    gateway.shutdown().await;
+    println!("\n  PASSED\n");
+
+    println!("==================================================================");
+    println!("    ALL POSTGRESQL CHAIN SIMULATIONS PASSED");
+    println!("==================================================================");
+
+    Ok(())
+}

--- a/crates/state/clickhouse/src/config.rs
+++ b/crates/state/clickhouse/src/config.rs
@@ -36,6 +36,11 @@ impl ClickHouseConfig {
     pub(crate) fn timeout_index_table(&self) -> String {
         format!("{}timeout_index", self.table_prefix)
     }
+
+    /// Return the chain ready index table name (`{prefix}chain_ready_index`).
+    pub(crate) fn chain_ready_index_table(&self) -> String {
+        format!("{}chain_ready_index", self.table_prefix)
+    }
 }
 
 #[cfg(test)]

--- a/crates/state/postgres/src/config.rs
+++ b/crates/state/postgres/src/config.rs
@@ -40,6 +40,11 @@ impl PostgresConfig {
     pub(crate) fn timeout_index_table(&self) -> String {
         format!("{}.{}timeout_index", self.schema, self.table_prefix)
     }
+
+    /// Return the fully-qualified chain ready index table name (`schema.prefix_chain_ready_index`).
+    pub(crate) fn chain_ready_index_table(&self) -> String {
+        format!("{}.{}chain_ready_index", self.schema, self.table_prefix)
+    }
 }
 
 #[cfg(test)]

--- a/crates/state/state/src/key.rs
+++ b/crates/state/state/src/key.rs
@@ -26,6 +26,10 @@ pub enum KeyKind {
     Approval,
     /// Index of pending approvals by action ID.
     PendingApprovals,
+    /// Task chain execution state.
+    Chain,
+    /// Index of pending chain steps awaiting advancement.
+    PendingChains,
     Custom(String),
 }
 
@@ -47,6 +51,8 @@ impl KeyKind {
             Self::ActiveEvents => "active_events",
             Self::Approval => "approval",
             Self::PendingApprovals => "pending_approvals",
+            Self::Chain => "chain",
+            Self::PendingChains => "pending_chains",
             Self::Custom(s) => s.as_str(),
         }
     }
@@ -130,6 +136,8 @@ mod tests {
         assert_eq!(KeyKind::ActiveEvents.as_str(), "active_events");
         assert_eq!(KeyKind::Approval.as_str(), "approval");
         assert_eq!(KeyKind::PendingApprovals.as_str(), "pending_approvals");
+        assert_eq!(KeyKind::Chain.as_str(), "chain");
+        assert_eq!(KeyKind::PendingChains.as_str(), "pending_chains");
         assert_eq!(KeyKind::Custom("foo".into()).as_str(), "foo");
     }
 

--- a/crates/state/state/src/store.rs
+++ b/crates/state/state/src/store.rs
@@ -104,4 +104,30 @@ pub trait StateStore: Send + Sync {
     /// Returns a list of canonical key strings. This is O(log N + M) where M is
     /// the number of expired keys, compared to O(N) for scanning all timeouts.
     async fn get_expired_timeouts(&self, now_ms: i64) -> Result<Vec<String>, StateError>;
+
+    /// Add a chain to the ready index with a `ready_at` timestamp (ms).
+    ///
+    /// Chains with `ready_at <= now` will be returned by [`get_ready_chains`].
+    async fn index_chain_ready(&self, key: &StateKey, ready_at_ms: i64) -> Result<(), StateError> {
+        let _ = (key, ready_at_ms);
+        Ok(())
+    }
+
+    /// Remove a chain from the ready index.
+    async fn remove_chain_ready_index(&self, key: &StateKey) -> Result<(), StateError> {
+        let _ = key;
+        Ok(())
+    }
+
+    /// Get all chains that are ready for advancement (`ready_at <= now_ms`).
+    ///
+    /// Returns canonical key strings. The default implementation falls back to
+    /// [`scan_keys_by_kind`] with `PendingChains` (O(N)).
+    async fn get_ready_chains(&self, now_ms: i64) -> Result<Vec<String>, StateError> {
+        let _ = now_ms;
+        let entries = self
+            .scan_keys_by_kind(crate::key::KeyKind::PendingChains)
+            .await?;
+        Ok(entries.into_iter().map(|(k, _)| k).collect())
+    }
 }

--- a/crates/state/state/src/store.rs
+++ b/crates/state/state/src/store.rs
@@ -107,10 +107,10 @@ pub trait StateStore: Send + Sync {
 
     /// Add a chain to the ready index with a `ready_at` timestamp (ms).
     ///
-    /// Chains with `ready_at <= now` will be returned by [`get_ready_chains`].
+    /// Chains with `ready_at <= now` will be returned by [`StateStore::get_ready_chains`].
     ///
     /// The default implementation stores the timestamp as a
-    /// `Custom("chain_ready_at")` key so that [`get_ready_chains`] can filter
+    /// `Custom("chain_ready_at")` key so that [`StateStore::get_ready_chains`] can filter
     /// by time. Backends with native sorted-set support (Memory, Redis) should
     /// override this for O(log N) performance.
     async fn index_chain_ready(&self, key: &StateKey, ready_at_ms: i64) -> Result<(), StateError> {
@@ -126,7 +126,7 @@ pub trait StateStore: Send + Sync {
     /// Remove a chain from the ready index.
     ///
     /// The default implementation deletes the `Custom("chain_ready_at")` key
-    /// written by [`index_chain_ready`].
+    /// written by [`StateStore::index_chain_ready`].
     async fn remove_chain_ready_index(&self, key: &StateKey) -> Result<(), StateError> {
         let ready_key = StateKey::new(
             key.namespace.clone(),


### PR DESCRIPTION
## Summary

- **Sorted-set ready index** replaces O(N) `scan_keys_by_kind(PendingChains)` with O(log N + M) lookups via `index_chain_ready` / `get_ready_chains`. Memory backend uses `BTreeMap`, Redis uses `ZRANGEBYSCORE`. Postgres/DynamoDB/ClickHouse fall back to the existing scan.
- **Semaphore-bounded concurrency** for chain advancement — each advance event spawns its own tokio task, gated by a configurable semaphore (`max_concurrent_advances`, default 16). One slow chain step no longer blocks others.
- **Step idempotency** via dedup keys (`chain-step:{chain_id}:{step_idx}`). Prevents double-execution on crash recovery: detects whether a previously-dispatched step completed (skip) or was interrupted (fail + abort).
- **Terminal chain state TTL** (`completed_chain_ttl_seconds`, default 7 days) — completed/failed/cancelled/timed-out chain records auto-expire instead of accumulating forever.
- **Step delays** (`delay_seconds` on step config) — the ready-index score is set to `now_ms + delay_ms`, so the background processor defers the step until the delay elapses.

## Files changed

| Area | Files | What |
|------|-------|------|
| State trait | `state/state/src/store.rs` | 3 new trait methods with defaults |
| Memory backend | `state/memory/src/store.rs` | BTreeMap index + 3 impls |
| Redis backend | `state/redis/src/store.rs` | ZADD/ZREM/ZRANGEBYSCORE impls |
| Gateway | `gateway/src/gateway.rs`, `gateway/src/builder.rs` | Index wiring, idempotency check, TTL, delay scoring |
| Background | `gateway/src/background.rs` | `get_ready_chains` replaces scan + JSON parse |
| Config | `server/src/config.rs` | `max_concurrent_advances`, `completed_chain_ttl_seconds`, `delay_seconds` |
| Server | `server/src/main.rs` | Semaphore consumer, delay/TTL wiring |
| Core IR | `core/src/chain.rs` | `delay_seconds` field on `ChainStepConfig` |

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace --no-deps -- -D warnings` passes
- [x] `cargo test --workspace` passes (0 failures)
- [x] `cargo build --workspace` succeeds
- [ ] Manual: verify chain with `delay_seconds: 10` on step 2 defers execution ~10s
- [ ] Manual: verify completed chain state expires after configured TTL
- [ ] Manual: verify concurrent chain advances don't exceed semaphore limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)