### PR TITLE
Add PagerDuty provider integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "acteon-crypto"
+version = "0.1.0"
+dependencies = [
+ "aes-gcm",
+ "base64",
+ "hex",
+ "regex",
+ "secrecy",
+ "thiserror 2.0.18",
+ "zeroize",
+]
+
+[[package]]
 name = "acteon-email"
 version = "0.1.0"
 dependencies = [
@@ -170,6 +183,7 @@ name = "acteon-pagerduty"
 version = "0.1.0"
 dependencies = [
  "acteon-core",
+ "acteon-crypto",
  "acteon-provider",
  "reqwest",
  "serde",
@@ -250,6 +264,7 @@ dependencies = [
  "acteon-audit-memory",
  "acteon-audit-postgres",
  "acteon-core",
+ "acteon-crypto",
  "acteon-executor",
  "acteon-gateway",
  "acteon-llm",
@@ -262,12 +277,10 @@ dependencies = [
  "acteon-state-memory",
  "acteon-state-postgres",
  "acteon-state-redis",
- "aes-gcm",
  "argon2",
  "async-trait",
  "axum 0.8.8",
  "axum-test",
- "base64",
  "chrono",
  "clap",
  "hex",
@@ -3811,6 +3824,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5461,6 +5484,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "acteon-pagerduty"
+version = "0.1.0"
+dependencies = [
+ "acteon-core",
+ "acteon-provider",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "acteon-provider"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     # Integrations
     "crates/integrations/email",
     "crates/integrations/slack",
+    "crates/integrations/pagerduty",
 ]
 
 [workspace.package]
@@ -81,6 +82,7 @@ acteon-llm = { path = "crates/llm" }
 # Integrations
 acteon-email = { path = "crates/integrations/email" }
 acteon-slack = { path = "crates/integrations/slack" }
+acteon-pagerduty = { path = "crates/integrations/pagerduty" }
 
 # Parsing
 nom = "7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/simulation",
     "crates/executor",
     "crates/provider",
+    "crates/crypto",
 
     # State backends
     "crates/state/state",
@@ -55,6 +56,7 @@ acteon-gateway = { path = "crates/gateway" }
 acteon-simulation = { path = "crates/simulation" }
 acteon-executor = { path = "crates/executor" }
 acteon-provider = { path = "crates/provider" }
+acteon-crypto = { path = "crates/crypto" }
 
 # State backends
 acteon-state = { path = "crates/state/state" }
@@ -169,6 +171,8 @@ hmac = "0.12"
 hex = "0.4"
 aes-gcm = "0.10"
 base64 = "0.22"
+secrecy = { version = "0.8", features = ["serde"] }
+zeroize = { version = "1", features = ["derive"] }
 
 # Tracing subscriber
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ All crates are organized under `crates/` with logical groupings:
 |-------|-------------|
 | `crates/integrations/email` | Email/SMTP provider |
 | `crates/integrations/slack` | Slack provider |
+| `crates/integrations/pagerduty` | PagerDuty Events API v2 provider |
 
 ## Running locally
 

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "acteon-crypto"
+description = "Shared AES-256-GCM encryption utilities for Acteon config secrets"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+aes-gcm = { workspace = true }
+base64 = { workspace = true }
+hex = { workspace = true }
+regex = { workspace = true }
+secrecy = { workspace = true }
+thiserror = { workspace = true }
+zeroize = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -1,0 +1,271 @@
+//! Shared AES-256-GCM encryption utilities for Acteon config secrets.
+//!
+//! Values are stored in the format:
+//! `ENC[AES256-GCM,data:<b64>,iv:<b64>,tag:<b64>]`
+//!
+//! Decrypted values are returned as [`SecretString`] to prevent accidental
+//! logging. The [`MasterKey`] wrapper zeroizes key material on drop.
+
+use std::fmt;
+use std::sync::LazyLock;
+
+use aes_gcm::aead::{Aead, KeyInit, OsRng};
+use aes_gcm::{Aes256Gcm, Nonce};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as B64;
+use regex::Regex;
+use thiserror::Error;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+// Re-export for consumers so they don't need a direct `secrecy` dependency.
+pub use secrecy::{ExposeSecret, Secret, SecretString};
+
+/// Compiled regex for parsing `ENC[AES256-GCM,data:<b64>,iv:<b64>,tag:<b64>]`.
+///
+/// Captures three groups: data, iv, and tag (all base64-encoded).
+static ENC_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^ENC\[AES256-GCM,data:([A-Za-z0-9+/=]+),iv:([A-Za-z0-9+/=]+),tag:([A-Za-z0-9+/=]+)\]$",
+    )
+    .expect("ENC regex is valid")
+});
+
+/// A 32-byte AES-256 master key that is zeroized when dropped.
+///
+/// Prevents key material from lingering in memory after the key is no longer
+/// needed. The [`Debug`] implementation is redacted to avoid accidental logging.
+///
+/// Raw bytes are not accessible outside this crate — all cryptographic
+/// operations go through the functions in this module.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+pub struct MasterKey([u8; 32]);
+
+impl MasterKey {
+    /// Access the raw key bytes (crate-internal only).
+    pub(crate) fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for MasterKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("MasterKey([REDACTED])")
+    }
+}
+
+/// Errors that can occur during encryption/decryption operations.
+#[derive(Debug, Error)]
+pub enum CryptoError {
+    /// The provided master key is not valid (wrong length or encoding).
+    #[error("invalid master key: {0}")]
+    InvalidKey(String),
+
+    /// The encrypted value format is malformed.
+    #[error("invalid encrypted value: {0}")]
+    InvalidFormat(String),
+
+    /// Decryption failed — wrong key or corrupted data.
+    #[error("decryption failed (wrong key or corrupted data)")]
+    DecryptionFailed,
+
+    /// Encryption failed.
+    #[error("encryption failed: {0}")]
+    EncryptionFailed(String),
+}
+
+/// Parse a 32-byte master key from hex or base64.
+///
+/// Accepts either 64 hex characters or a base64 string that decodes to exactly
+/// 32 bytes. The returned [`MasterKey`] is zeroized on drop.
+pub fn parse_master_key(raw: &str) -> Result<MasterKey, CryptoError> {
+    let trimmed = raw.trim();
+    // Try hex first (64 hex chars = 32 bytes).
+    if trimmed.len() == 64
+        && let Ok(bytes) = hex::decode(trimmed)
+        && bytes.len() == 32
+    {
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&bytes);
+        return Ok(MasterKey(key));
+    }
+    // Try base64.
+    if let Ok(bytes) = B64.decode(trimmed)
+        && bytes.len() == 32
+    {
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&bytes);
+        return Ok(MasterKey(key));
+    }
+    Err(CryptoError::InvalidKey(
+        "must be 32 bytes encoded as 64 hex chars or base64".to_owned(),
+    ))
+}
+
+/// Returns `true` if `value` looks like an encrypted `ENC[AES256-GCM,...]` marker.
+#[must_use]
+pub fn is_encrypted(value: &str) -> bool {
+    ENC_RE.is_match(value.trim())
+}
+
+/// If `value` starts with `ENC[AES256-GCM,...]`, decrypt it using the master
+/// key. Otherwise return the value unchanged (pass-through).
+///
+/// Returns a [`SecretString`] to prevent accidental logging of decrypted
+/// secrets.
+pub fn decrypt_value(value: &str, master_key: &MasterKey) -> Result<SecretString, CryptoError> {
+    let trimmed = value.trim();
+
+    let Some(caps) = ENC_RE.captures(trimmed) else {
+        // Not an ENC[...] envelope — pass through unchanged.
+        return Ok(SecretString::new(value.to_owned()));
+    };
+
+    let data = B64
+        .decode(&caps[1])
+        .map_err(|e| CryptoError::InvalidFormat(format!("invalid base64 in data: {e}")))?;
+    let iv = B64
+        .decode(&caps[2])
+        .map_err(|e| CryptoError::InvalidFormat(format!("invalid base64 in iv: {e}")))?;
+    let tag = B64
+        .decode(&caps[3])
+        .map_err(|e| CryptoError::InvalidFormat(format!("invalid base64 in tag: {e}")))?;
+
+    if iv.len() != 12 {
+        return Err(CryptoError::InvalidFormat(format!(
+            "IV must be 12 bytes, got {}",
+            iv.len()
+        )));
+    }
+    if tag.len() != 16 {
+        return Err(CryptoError::InvalidFormat(format!(
+            "tag must be 16 bytes, got {}",
+            tag.len()
+        )));
+    }
+
+    // AES-GCM ciphertext = data || tag
+    let mut ciphertext = data;
+    ciphertext.extend_from_slice(&tag);
+
+    let cipher = Aes256Gcm::new_from_slice(master_key.as_bytes())
+        .map_err(|e| CryptoError::InvalidKey(format!("invalid AES key: {e}")))?;
+    let nonce = Nonce::from_slice(&iv);
+
+    let plaintext = cipher
+        .decrypt(nonce, ciphertext.as_ref())
+        .map_err(|_| CryptoError::DecryptionFailed)?;
+
+    let s = String::from_utf8(plaintext)
+        .map_err(|e| CryptoError::InvalidFormat(format!("decrypted value is not UTF-8: {e}")))?;
+
+    Ok(SecretString::new(s))
+}
+
+/// Encrypt a plaintext string, producing an `ENC[AES256-GCM,...]` marker.
+///
+/// The returned string is the encrypted envelope (not secret itself — it is
+/// meant to be stored in configuration files).
+pub fn encrypt_value(plaintext: &str, master_key: &MasterKey) -> Result<String, CryptoError> {
+    use aes_gcm::AeadCore;
+
+    let cipher = Aes256Gcm::new_from_slice(master_key.as_bytes())
+        .map_err(|e| CryptoError::InvalidKey(format!("invalid AES key: {e}")))?;
+    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+
+    let ciphertext = cipher
+        .encrypt(&nonce, plaintext.as_bytes())
+        .map_err(|e| CryptoError::EncryptionFailed(e.to_string()))?;
+
+    // AES-GCM output = ciphertext_data || 16-byte tag
+    let (data, tag) = ciphertext.split_at(ciphertext.len() - 16);
+
+    Ok(format!(
+        "ENC[AES256-GCM,data:{},iv:{},tag:{}]",
+        B64.encode(data),
+        B64.encode(nonce.as_slice()),
+        B64.encode(tag),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_key() -> MasterKey {
+        parse_master_key(&"42".repeat(32)).unwrap()
+    }
+
+    #[test]
+    fn roundtrip_encrypt_decrypt() {
+        let key = test_key();
+        let plaintext = "my-secret-value";
+        let encrypted = encrypt_value(plaintext, &key).unwrap();
+        assert!(encrypted.starts_with("ENC[AES256-GCM,"));
+        let decrypted = decrypt_value(&encrypted, &key).unwrap();
+        assert_eq!(decrypted.expose_secret(), plaintext);
+    }
+
+    #[test]
+    fn passthrough_plain_value() {
+        let key = test_key();
+        let plain = "not-encrypted";
+        let result = decrypt_value(plain, &key).unwrap();
+        assert_eq!(result.expose_secret(), plain);
+    }
+
+    #[test]
+    fn parse_hex_key() {
+        let hex_key = "aa".repeat(32);
+        let key = parse_master_key(&hex_key).unwrap();
+        assert_eq!(key.as_bytes(), &[0xaa; 32]);
+    }
+
+    #[test]
+    fn parse_base64_key() {
+        let raw = [0xbbu8; 32];
+        let b64 = B64.encode(raw);
+        let key = parse_master_key(&b64).unwrap();
+        assert_eq!(key.as_bytes(), &[0xbb; 32]);
+    }
+
+    #[test]
+    fn is_encrypted_detects_enc_prefix() {
+        assert!(is_encrypted("ENC[AES256-GCM,data:abc,iv:def,tag:ghi]"));
+        assert!(!is_encrypted("plain-text-value"));
+        assert!(!is_encrypted("ENC[AES256-GCM,incomplete"));
+    }
+
+    #[test]
+    fn decrypt_invalid_format_missing_data() {
+        let key = test_key();
+        // Missing data field — regex won't match, so it'll pass through.
+        // Use a value that looks like ENC but has bad structure:
+        let bad = "ENC[AES256-GCM,data:AAAA,iv:AAAA,tag:AAAA]";
+        // The regex matches, but the decoded iv/tag have wrong lengths.
+        let err = decrypt_value(bad, &key).unwrap_err();
+        assert!(matches!(err, CryptoError::InvalidFormat(_)));
+    }
+
+    #[test]
+    fn parse_master_key_rejects_short() {
+        let err = parse_master_key("too-short").unwrap_err();
+        assert!(matches!(err, CryptoError::InvalidKey(_)));
+    }
+
+    #[test]
+    fn master_key_debug_is_redacted() {
+        let key = test_key();
+        let debug = format!("{key:?}");
+        assert_eq!(debug, "MasterKey([REDACTED])");
+        assert!(!debug.contains("42"));
+    }
+
+    #[test]
+    fn malformed_enc_passes_through() {
+        let key = test_key();
+        // Looks like ENC but doesn't match the regex — treated as plain value.
+        let malformed = "ENC[AES256-GCM,garbage]";
+        let result = decrypt_value(malformed, &key).unwrap();
+        assert_eq!(result.expose_secret(), malformed);
+    }
+}

--- a/crates/integrations/pagerduty/Cargo.toml
+++ b/crates/integrations/pagerduty/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "acteon-pagerduty"
+description = "PagerDuty provider for Acteon — sends events via the PagerDuty Events API v2"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+
+[dependencies]
+acteon-core = { workspace = true }
+acteon-provider = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/integrations/pagerduty/Cargo.toml
+++ b/crates/integrations/pagerduty/Cargo.toml
@@ -11,6 +11,7 @@ default = []
 
 [dependencies]
 acteon-core = { workspace = true }
+acteon-crypto = { workspace = true }
 acteon-provider = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/crates/integrations/pagerduty/src/config.rs
+++ b/crates/integrations/pagerduty/src/config.rs
@@ -1,0 +1,95 @@
+/// Configuration for the `PagerDuty` provider.
+#[derive(Debug, Clone)]
+pub struct PagerDutyConfig {
+    /// Integration routing key used to authenticate events.
+    pub routing_key: String,
+
+    /// Base URL for the `PagerDuty` Events API. Override this for testing
+    /// against a mock server.
+    pub api_base_url: String,
+
+    /// Default severity when not specified in the event payload.
+    pub default_severity: String,
+
+    /// Default source when not specified in the event payload.
+    pub default_source: Option<String>,
+}
+
+impl PagerDutyConfig {
+    /// Create a new configuration with the given routing key.
+    ///
+    /// Uses the default `PagerDuty` Events API base URL
+    /// (`https://events.pagerduty.com`) and severity `"error"`.
+    pub fn new(routing_key: impl Into<String>) -> Self {
+        Self {
+            routing_key: routing_key.into(),
+            api_base_url: "https://events.pagerduty.com".to_owned(),
+            default_severity: "error".to_owned(),
+            default_source: None,
+        }
+    }
+
+    /// Override the API base URL (useful for testing).
+    #[must_use]
+    pub fn with_api_base_url(mut self, url: impl Into<String>) -> Self {
+        self.api_base_url = url.into();
+        self
+    }
+
+    /// Set the default severity for trigger events.
+    #[must_use]
+    pub fn with_default_severity(mut self, severity: impl Into<String>) -> Self {
+        self.default_severity = severity.into();
+        self
+    }
+
+    /// Set the default source for trigger events.
+    #[must_use]
+    pub fn with_default_source(mut self, source: impl Into<String>) -> Self {
+        self.default_source = Some(source.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_values() {
+        let config = PagerDutyConfig::new("test-routing-key");
+        assert_eq!(config.routing_key, "test-routing-key");
+        assert_eq!(config.api_base_url, "https://events.pagerduty.com");
+        assert_eq!(config.default_severity, "error");
+        assert!(config.default_source.is_none());
+    }
+
+    #[test]
+    fn with_api_base_url() {
+        let config = PagerDutyConfig::new("key").with_api_base_url("http://localhost:9999");
+        assert_eq!(config.api_base_url, "http://localhost:9999");
+    }
+
+    #[test]
+    fn with_default_severity() {
+        let config = PagerDutyConfig::new("key").with_default_severity("critical");
+        assert_eq!(config.default_severity, "critical");
+    }
+
+    #[test]
+    fn with_default_source() {
+        let config = PagerDutyConfig::new("key").with_default_source("monitoring");
+        assert_eq!(config.default_source.as_deref(), Some("monitoring"));
+    }
+
+    #[test]
+    fn builder_chain() {
+        let config = PagerDutyConfig::new("key")
+            .with_api_base_url("http://localhost:1234")
+            .with_default_severity("warning")
+            .with_default_source("acteon");
+        assert_eq!(config.api_base_url, "http://localhost:1234");
+        assert_eq!(config.default_severity, "warning");
+        assert_eq!(config.default_source.as_deref(), Some("acteon"));
+    }
+}

--- a/crates/integrations/pagerduty/src/config.rs
+++ b/crates/integrations/pagerduty/src/config.rs
@@ -1,8 +1,20 @@
+use std::collections::HashMap;
+
+use acteon_crypto::ExposeSecret;
+
+use crate::error::PagerDutyError;
+
 /// Configuration for the `PagerDuty` provider.
+///
+/// Supports multiple `PagerDuty` services, each identified by a service ID and
+/// mapped to an integration routing key.
 #[derive(Debug, Clone)]
 pub struct PagerDutyConfig {
-    /// Integration routing key used to authenticate events.
-    pub routing_key: String,
+    /// Map of `PagerDuty` service ID → integration routing key.
+    services: HashMap<String, String>,
+
+    /// Fallback service when payload omits `service_id`.
+    default_service_id: Option<String>,
 
     /// Base URL for the `PagerDuty` Events API. Override this for testing
     /// against a mock server.
@@ -16,17 +28,54 @@ pub struct PagerDutyConfig {
 }
 
 impl PagerDutyConfig {
-    /// Create a new configuration with the given routing key.
+    /// Create an empty configuration with no services.
     ///
     /// Uses the default `PagerDuty` Events API base URL
     /// (`https://events.pagerduty.com`) and severity `"error"`.
-    pub fn new(routing_key: impl Into<String>) -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         Self {
-            routing_key: routing_key.into(),
+            services: HashMap::new(),
+            default_service_id: None,
             api_base_url: "https://events.pagerduty.com".to_owned(),
             default_severity: "error".to_owned(),
             default_source: None,
         }
+    }
+
+    /// Create a configuration with a single service, set as the default.
+    ///
+    /// This is a convenience shorthand for the common single-service case.
+    #[must_use]
+    pub fn single_service(service_id: impl Into<String>, routing_key: impl Into<String>) -> Self {
+        let service_id = service_id.into();
+        let mut services = HashMap::new();
+        services.insert(service_id.clone(), routing_key.into());
+        Self {
+            services,
+            default_service_id: Some(service_id),
+            api_base_url: "https://events.pagerduty.com".to_owned(),
+            default_severity: "error".to_owned(),
+            default_source: None,
+        }
+    }
+
+    /// Add a service to the configuration.
+    #[must_use]
+    pub fn with_service(
+        mut self,
+        service_id: impl Into<String>,
+        routing_key: impl Into<String>,
+    ) -> Self {
+        self.services.insert(service_id.into(), routing_key.into());
+        self
+    }
+
+    /// Set the default service ID used when a payload omits `service_id`.
+    #[must_use]
+    pub fn with_default_service(mut self, service_id: impl Into<String>) -> Self {
+        self.default_service_id = Some(service_id.into());
+        self
     }
 
     /// Override the API base URL (useful for testing).
@@ -49,6 +98,67 @@ impl PagerDutyConfig {
         self.default_source = Some(source.into());
         self
     }
+
+    /// Decrypt any `ENC[...]` routing keys in the services map.
+    ///
+    /// Plain-text values pass through unchanged.
+    #[must_use = "returns the config with decrypted secrets"]
+    pub fn decrypt_secrets(
+        mut self,
+        master_key: &acteon_crypto::MasterKey,
+    ) -> Result<Self, PagerDutyError> {
+        for routing_key in self.services.values_mut() {
+            routing_key.clone_from(
+                acteon_crypto::decrypt_value(routing_key, master_key)
+                    .map_err(|e| {
+                        PagerDutyError::InvalidPayload(format!(
+                            "failed to decrypt routing key: {e}"
+                        ))
+                    })?
+                    .expose_secret(),
+            );
+        }
+        Ok(self)
+    }
+
+    /// Resolve a routing key from the services map.
+    ///
+    /// Resolution order:
+    /// 1. Explicit `service_id` → look up in map
+    /// 2. No `service_id` + default configured → use default
+    /// 3. No `service_id` + no default + exactly 1 service → use it implicitly
+    /// 4. Otherwise → error
+    pub(crate) fn resolve_routing_key(
+        &self,
+        service_id: Option<&str>,
+    ) -> Result<&str, PagerDutyError> {
+        match service_id {
+            Some(sid) => self
+                .services
+                .get(sid)
+                .map(String::as_str)
+                .ok_or_else(|| PagerDutyError::UnknownService(sid.to_owned())),
+            None => {
+                if let Some(default_sid) = &self.default_service_id {
+                    self.services
+                        .get(default_sid.as_str())
+                        .map(String::as_str)
+                        .ok_or_else(|| PagerDutyError::UnknownService(default_sid.clone()))
+                } else if self.services.len() == 1 {
+                    // Implicit single-service fallback.
+                    Ok(self.services.values().next().unwrap().as_str())
+                } else {
+                    Err(PagerDutyError::NoDefaultService)
+                }
+            }
+        }
+    }
+}
+
+impl Default for PagerDutyConfig {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[cfg(test)]
@@ -56,40 +166,129 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_values() {
-        let config = PagerDutyConfig::new("test-routing-key");
-        assert_eq!(config.routing_key, "test-routing-key");
+    fn single_service_defaults() {
+        let config = PagerDutyConfig::single_service("PABC123", "rk-abc");
         assert_eq!(config.api_base_url, "https://events.pagerduty.com");
         assert_eq!(config.default_severity, "error");
         assert!(config.default_source.is_none());
+        assert_eq!(config.default_service_id.as_deref(), Some("PABC123"));
+        assert_eq!(config.services.get("PABC123").unwrap(), "rk-abc");
     }
 
     #[test]
-    fn with_api_base_url() {
-        let config = PagerDutyConfig::new("key").with_api_base_url("http://localhost:9999");
-        assert_eq!(config.api_base_url, "http://localhost:9999");
+    fn new_creates_empty() {
+        let config = PagerDutyConfig::new();
+        assert!(config.services.is_empty());
+        assert!(config.default_service_id.is_none());
     }
 
     #[test]
-    fn with_default_severity() {
-        let config = PagerDutyConfig::new("key").with_default_severity("critical");
-        assert_eq!(config.default_severity, "critical");
+    fn with_service_adds_entry() {
+        let config = PagerDutyConfig::new().with_service("PSVC1", "key-1");
+        assert_eq!(config.services.get("PSVC1").unwrap(), "key-1");
     }
 
     #[test]
-    fn with_default_source() {
-        let config = PagerDutyConfig::new("key").with_default_source("monitoring");
-        assert_eq!(config.default_source.as_deref(), Some("monitoring"));
+    fn with_default_service() {
+        let config = PagerDutyConfig::new()
+            .with_service("PSVC1", "key-1")
+            .with_default_service("PSVC1");
+        assert_eq!(config.default_service_id.as_deref(), Some("PSVC1"));
     }
 
     #[test]
     fn builder_chain() {
-        let config = PagerDutyConfig::new("key")
+        let config = PagerDutyConfig::new()
+            .with_service("PSVC1", "key-1")
+            .with_service("PSVC2", "key-2")
+            .with_default_service("PSVC1")
             .with_api_base_url("http://localhost:1234")
             .with_default_severity("warning")
             .with_default_source("acteon");
+        assert_eq!(config.services.len(), 2);
         assert_eq!(config.api_base_url, "http://localhost:1234");
         assert_eq!(config.default_severity, "warning");
         assert_eq!(config.default_source.as_deref(), Some("acteon"));
+    }
+
+    #[test]
+    fn resolve_explicit_service() {
+        let config = PagerDutyConfig::new()
+            .with_service("PSVC1", "key-1")
+            .with_service("PSVC2", "key-2");
+        assert_eq!(config.resolve_routing_key(Some("PSVC2")).unwrap(), "key-2");
+    }
+
+    #[test]
+    fn resolve_unknown_service() {
+        let config = PagerDutyConfig::new().with_service("PSVC1", "key-1");
+        let err = config.resolve_routing_key(Some("PSVC999")).unwrap_err();
+        assert!(matches!(err, PagerDutyError::UnknownService(ref s) if s == "PSVC999"));
+    }
+
+    #[test]
+    fn resolve_uses_default() {
+        let config = PagerDutyConfig::new()
+            .with_service("PSVC1", "key-1")
+            .with_service("PSVC2", "key-2")
+            .with_default_service("PSVC1");
+        assert_eq!(config.resolve_routing_key(None).unwrap(), "key-1");
+    }
+
+    #[test]
+    fn resolve_implicit_single() {
+        let config = PagerDutyConfig::new().with_service("PSVC1", "key-1");
+        assert_eq!(config.resolve_routing_key(None).unwrap(), "key-1");
+    }
+
+    #[test]
+    fn resolve_no_default_multiple() {
+        let config = PagerDutyConfig::new()
+            .with_service("PSVC1", "key-1")
+            .with_service("PSVC2", "key-2");
+        let err = config.resolve_routing_key(None).unwrap_err();
+        assert!(matches!(err, PagerDutyError::NoDefaultService));
+    }
+
+    fn test_master_key() -> acteon_crypto::MasterKey {
+        acteon_crypto::parse_master_key(&"42".repeat(32)).unwrap()
+    }
+
+    #[test]
+    fn decrypt_secrets_roundtrip() {
+        let master_key = test_master_key();
+        let original = "my-routing-key";
+        let encrypted = acteon_crypto::encrypt_value(original, &master_key).unwrap();
+
+        let config = PagerDutyConfig::new()
+            .with_service("PSVC1", &encrypted)
+            .decrypt_secrets(&master_key)
+            .unwrap();
+
+        assert_eq!(config.resolve_routing_key(Some("PSVC1")).unwrap(), original);
+    }
+
+    #[test]
+    fn decrypt_secrets_passthrough() {
+        let master_key = test_master_key();
+        let config = PagerDutyConfig::new()
+            .with_service("PSVC1", "plain-key")
+            .decrypt_secrets(&master_key)
+            .unwrap();
+
+        assert_eq!(
+            config.resolve_routing_key(Some("PSVC1")).unwrap(),
+            "plain-key"
+        );
+    }
+
+    #[test]
+    fn decrypt_secrets_invalid() {
+        let master_key = test_master_key();
+        let config =
+            PagerDutyConfig::new().with_service("PSVC1", "ENC[AES256-GCM,data:bad,iv:bad,tag:bad]");
+
+        let err = config.decrypt_secrets(&master_key).unwrap_err();
+        assert!(matches!(err, PagerDutyError::InvalidPayload(_)));
     }
 }

--- a/crates/integrations/pagerduty/src/error.rs
+++ b/crates/integrations/pagerduty/src/error.rs
@@ -1,0 +1,75 @@
+use acteon_provider::ProviderError;
+use thiserror::Error;
+
+/// Errors specific to the `PagerDuty` provider.
+///
+/// These are internal errors that get converted into [`ProviderError`] at the
+/// public API boundary.
+#[derive(Debug, Error)]
+pub enum PagerDutyError {
+    /// An HTTP-level transport error occurred.
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// The `PagerDuty` API returned a non-success response.
+    #[error("PagerDuty API error: {0}")]
+    Api(String),
+
+    /// The action payload is missing required fields or has invalid structure.
+    #[error("invalid payload: {0}")]
+    InvalidPayload(String),
+
+    /// The provider received an HTTP 429 (Too Many Requests) response.
+    #[error("rate limited by PagerDuty")]
+    RateLimited,
+}
+
+impl From<PagerDutyError> for ProviderError {
+    fn from(err: PagerDutyError) -> Self {
+        match err {
+            PagerDutyError::Http(e) => ProviderError::Connection(e.to_string()),
+            PagerDutyError::Api(msg) => ProviderError::ExecutionFailed(msg),
+            PagerDutyError::InvalidPayload(msg) => ProviderError::Serialization(msg),
+            PagerDutyError::RateLimited => ProviderError::RateLimited,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limited_maps_to_retryable() {
+        let provider_err: ProviderError = PagerDutyError::RateLimited.into();
+        assert!(provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::RateLimited));
+    }
+
+    #[test]
+    fn api_error_maps_to_non_retryable() {
+        let provider_err: ProviderError = PagerDutyError::Api("bad request".into()).into();
+        assert!(!provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn invalid_payload_maps_to_serialization() {
+        let provider_err: ProviderError =
+            PagerDutyError::InvalidPayload("missing summary".into()).into();
+        assert!(!provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::Serialization(_)));
+    }
+
+    #[test]
+    fn display_messages() {
+        let err = PagerDutyError::Api("invalid routing key".into());
+        assert_eq!(err.to_string(), "PagerDuty API error: invalid routing key");
+
+        let err = PagerDutyError::InvalidPayload("missing dedup_key".into());
+        assert_eq!(err.to_string(), "invalid payload: missing dedup_key");
+
+        let err = PagerDutyError::RateLimited;
+        assert_eq!(err.to_string(), "rate limited by PagerDuty");
+    }
+}

--- a/crates/integrations/pagerduty/src/lib.rs
+++ b/crates/integrations/pagerduty/src/lib.rs
@@ -9,9 +9,17 @@
 //! ```rust,no_run
 //! use acteon_pagerduty::{PagerDutyConfig, PagerDutyProvider};
 //!
-//! let config = PagerDutyConfig::new("your-routing-key")
+//! // Single service
+//! let config = PagerDutyConfig::single_service("PABC123", "your-routing-key")
 //!     .with_default_severity("critical")
 //!     .with_default_source("monitoring");
+//! let provider = PagerDutyProvider::new(config);
+//!
+//! // Multiple services
+//! let config = PagerDutyConfig::new()
+//!     .with_service("PABC123", "routing-key-1")
+//!     .with_service("PXYZ789", "routing-key-2")
+//!     .with_default_service("PABC123");
 //! let provider = PagerDutyProvider::new(config);
 //! ```
 

--- a/crates/integrations/pagerduty/src/lib.rs
+++ b/crates/integrations/pagerduty/src/lib.rs
@@ -1,0 +1,28 @@
+//! `PagerDuty` provider for the Acteon notification gateway.
+//!
+//! This crate implements the [`Provider`](acteon_provider::Provider) trait,
+//! enabling Acteon to send events through the
+//! [PagerDuty Events API v2](https://developer.pagerduty.com/docs/events-api-v2/overview/).
+//!
+//! # Quick start
+//!
+//! ```rust,no_run
+//! use acteon_pagerduty::{PagerDutyConfig, PagerDutyProvider};
+//!
+//! let config = PagerDutyConfig::new("your-routing-key")
+//!     .with_default_severity("critical")
+//!     .with_default_source("monitoring");
+//! let provider = PagerDutyProvider::new(config);
+//! ```
+
+pub mod config;
+pub mod error;
+pub mod provider;
+pub mod types;
+
+pub use config::PagerDutyConfig;
+pub use error::PagerDutyError;
+pub use provider::PagerDutyProvider;
+pub use types::{
+    PagerDutyApiResponse, PagerDutyEvent, PagerDutyImage, PagerDutyLink, PagerDutyPayload,
+};

--- a/crates/integrations/pagerduty/src/provider.rs
+++ b/crates/integrations/pagerduty/src/provider.rs
@@ -1,0 +1,521 @@
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::{Provider, ProviderError};
+use reqwest::Client;
+use serde::Deserialize;
+use tracing::{debug, instrument, warn};
+
+use crate::config::PagerDutyConfig;
+use crate::error::PagerDutyError;
+use crate::types::{
+    PagerDutyApiResponse, PagerDutyEvent, PagerDutyImage, PagerDutyLink, PagerDutyPayload,
+};
+
+/// `PagerDuty` provider that sends events via the `PagerDuty` Events API v2.
+///
+/// Implements the [`Provider`] trait so it can be registered in the provider
+/// registry and used by the action executor.
+pub struct PagerDutyProvider {
+    config: PagerDutyConfig,
+    client: Client,
+}
+
+/// Fields extracted from an action payload.
+#[derive(Debug, Deserialize)]
+struct EventPayload {
+    event_action: String,
+    summary: Option<String>,
+    severity: Option<String>,
+    source: Option<String>,
+    component: Option<String>,
+    group: Option<String>,
+    class: Option<String>,
+    dedup_key: Option<String>,
+    custom_details: Option<serde_json::Value>,
+    images: Option<Vec<PagerDutyImage>>,
+    links: Option<Vec<PagerDutyLink>>,
+}
+
+impl PagerDutyProvider {
+    /// Create a new `PagerDuty` provider with the given configuration.
+    ///
+    /// Uses a default `reqwest::Client` with reasonable timeouts.
+    pub fn new(config: PagerDutyConfig) -> Self {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("failed to build HTTP client");
+        Self { config, client }
+    }
+
+    /// Create a new `PagerDuty` provider with a custom HTTP client.
+    ///
+    /// Useful for testing or for sharing a connection pool across providers.
+    pub fn with_client(config: PagerDutyConfig, client: Client) -> Self {
+        Self { config, client }
+    }
+
+    /// Build the full URL for the Events API v2 enqueue endpoint.
+    fn enqueue_url(&self) -> String {
+        format!("{}/v2/enqueue", self.config.api_base_url)
+    }
+
+    /// Send an event to the `PagerDuty` Events API v2 and interpret the
+    /// response.
+    async fn send_event(
+        &self,
+        event: &PagerDutyEvent,
+    ) -> Result<PagerDutyApiResponse, PagerDutyError> {
+        let url = self.enqueue_url();
+
+        debug!(event_action = %event.event_action, "sending event to PagerDuty");
+
+        let response = self.client.post(&url).json(event).send().await?;
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            warn!("PagerDuty API rate limit hit");
+            return Err(PagerDutyError::RateLimited);
+        }
+
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(PagerDutyError::Api(format!("HTTP {status}: {body}")));
+        }
+
+        let api_response: PagerDutyApiResponse = response.json().await?;
+
+        Ok(api_response)
+    }
+
+    /// Build a [`PagerDutyEvent`] from the deserialized action payload,
+    /// applying config defaults where appropriate.
+    fn build_event(&self, payload: EventPayload) -> Result<PagerDutyEvent, PagerDutyError> {
+        match payload.event_action.as_str() {
+            "trigger" => {
+                let summary = payload.summary.ok_or_else(|| {
+                    PagerDutyError::InvalidPayload(
+                        "trigger events require a 'summary' field".into(),
+                    )
+                })?;
+
+                let severity = payload
+                    .severity
+                    .unwrap_or_else(|| self.config.default_severity.clone());
+
+                let source = payload
+                    .source
+                    .or_else(|| self.config.default_source.clone())
+                    .unwrap_or_else(|| "acteon".to_owned());
+
+                Ok(PagerDutyEvent {
+                    routing_key: self.config.routing_key.clone(),
+                    event_action: "trigger".into(),
+                    dedup_key: payload.dedup_key,
+                    payload: Some(PagerDutyPayload {
+                        summary,
+                        source,
+                        severity,
+                        component: payload.component,
+                        group: payload.group,
+                        class: payload.class,
+                        custom_details: payload.custom_details,
+                    }),
+                    images: payload.images,
+                    links: payload.links,
+                })
+            }
+            "acknowledge" | "resolve" => {
+                let dedup_key = payload.dedup_key.ok_or_else(|| {
+                    PagerDutyError::InvalidPayload(format!(
+                        "{} events require a 'dedup_key' field",
+                        payload.event_action,
+                    ))
+                })?;
+
+                Ok(PagerDutyEvent {
+                    routing_key: self.config.routing_key.clone(),
+                    event_action: payload.event_action,
+                    dedup_key: Some(dedup_key),
+                    payload: None,
+                    images: None,
+                    links: None,
+                })
+            }
+            other => Err(PagerDutyError::InvalidPayload(format!(
+                "invalid event_action '{other}': must be 'trigger', 'acknowledge', or 'resolve'",
+            ))),
+        }
+    }
+}
+
+impl Provider for PagerDutyProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "pagerduty"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "pagerduty"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        let payload: EventPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| PagerDutyError::InvalidPayload(format!("failed to parse payload: {e}")))?;
+
+        let event = self.build_event(payload)?;
+        let api_response = self.send_event(&event).await?;
+
+        let body = serde_json::json!({
+            "status": api_response.status,
+            "message": api_response.message,
+            "dedup_key": api_response.dedup_key,
+        });
+
+        Ok(ProviderResponse::success(body))
+    }
+
+    #[instrument(skip(self), fields(provider = "pagerduty"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        let url = self.enqueue_url();
+
+        debug!("performing PagerDuty health check");
+
+        // POST an empty JSON body — any HTTP response (even 400) means the
+        // endpoint is reachable. Only a connection failure is an error.
+        let response = self
+            .client
+            .post(&url)
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .map_err(|e| ProviderError::Connection(e.to_string()))?;
+
+        debug!(status = %response.status(), "PagerDuty health check response");
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use acteon_core::Action;
+    use acteon_provider::{Provider, ProviderError};
+
+    use super::*;
+    use crate::config::PagerDutyConfig;
+
+    /// A minimal mock HTTP server built on tokio that returns canned responses.
+    struct MockPagerDutyServer {
+        listener: tokio::net::TcpListener,
+        base_url: String,
+    }
+
+    impl MockPagerDutyServer {
+        async fn start() -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("failed to bind mock server");
+            let port = listener.local_addr().unwrap().port();
+            let base_url = format!("http://127.0.0.1:{port}");
+            Self { listener, base_url }
+        }
+
+        /// Accept one connection and respond with the given status code and JSON
+        /// body, then shut down.
+        async fn respond_once(self, status_code: u16, body: &str) {
+            let body = body.to_owned();
+            let (mut stream, _) = self.listener.accept().await.unwrap();
+
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+            // Read the full request (we don't parse it -- just drain it).
+            let mut buf = vec![0u8; 8192];
+            let _ = stream.read(&mut buf).await.unwrap();
+
+            let response = format!(
+                "HTTP/1.1 {status_code} OK\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 {body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+        }
+
+        /// Accept one connection and respond with HTTP 429 (rate limited).
+        async fn respond_rate_limited(self) {
+            let body = r#"{"status":"throttle event creation","message":"Rate limit reached","dedup_key":null}"#;
+            self.respond_once(429, body).await;
+        }
+    }
+
+    fn make_action(payload: serde_json::Value) -> Action {
+        Action::new("incidents", "tenant-1", "pagerduty", "send_event", payload)
+    }
+
+    #[test]
+    fn provider_name() {
+        let config = PagerDutyConfig::new("test-routing-key");
+        let provider = PagerDutyProvider::new(config);
+        assert_eq!(provider.name(), "pagerduty");
+    }
+
+    #[tokio::test]
+    async fn execute_trigger_success() {
+        let server = MockPagerDutyServer::start().await;
+        let config = PagerDutyConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = PagerDutyProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "summary": "CPU usage exceeded 90%",
+            "severity": "critical",
+            "source": "monitoring",
+            "dedup_key": "web-01/cpu-high"
+        }));
+
+        let response_body =
+            r#"{"status":"success","message":"Event processed","dedup_key":"web-01/cpu-high"}"#;
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(202, response_body).await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        let response = result.expect("execute should succeed");
+        assert_eq!(response.status, acteon_core::ResponseStatus::Success);
+        assert_eq!(response.body["status"], "success");
+        assert_eq!(response.body["dedup_key"], "web-01/cpu-high");
+    }
+
+    #[tokio::test]
+    async fn execute_trigger_with_images_and_links() {
+        let server = MockPagerDutyServer::start().await;
+        let config = PagerDutyConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = PagerDutyProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "summary": "CPU usage high",
+            "images": [
+                {
+                    "src": "https://example.com/chart.png",
+                    "href": "https://example.com/dashboard",
+                    "alt": "CPU Chart"
+                }
+            ],
+            "links": [
+                {
+                    "href": "https://example.com/runbook",
+                    "text": "Runbook"
+                }
+            ]
+        }));
+
+        let response_body = r#"{"status":"success","message":"Event processed","dedup_key":"abc"}"#;
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(202, response_body).await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn execute_acknowledge_success() {
+        let server = MockPagerDutyServer::start().await;
+        let config = PagerDutyConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = PagerDutyProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "event_action": "acknowledge",
+            "dedup_key": "web-01/cpu-high"
+        }));
+
+        let response_body =
+            r#"{"status":"success","message":"Event processed","dedup_key":"web-01/cpu-high"}"#;
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(202, response_body).await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        let response = result.expect("execute should succeed");
+        assert_eq!(response.status, acteon_core::ResponseStatus::Success);
+        assert_eq!(response.body["message"], "Event processed");
+    }
+
+    #[tokio::test]
+    async fn execute_resolve_success() {
+        let server = MockPagerDutyServer::start().await;
+        let config = PagerDutyConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = PagerDutyProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "event_action": "resolve",
+            "dedup_key": "web-01/cpu-high"
+        }));
+
+        let response_body =
+            r#"{"status":"success","message":"Event processed","dedup_key":"web-01/cpu-high"}"#;
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(202, response_body).await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        let response = result.expect("execute should succeed");
+        assert_eq!(response.status, acteon_core::ResponseStatus::Success);
+    }
+
+    #[tokio::test]
+    async fn execute_trigger_uses_config_defaults() {
+        let server = MockPagerDutyServer::start().await;
+        let config = PagerDutyConfig::new("test-key")
+            .with_api_base_url(&server.base_url)
+            .with_default_severity("warning")
+            .with_default_source("acteon-test");
+        let provider = PagerDutyProvider::new(config);
+
+        // Payload without severity or source — should use config defaults.
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "summary": "Disk space low"
+        }));
+
+        let response_body =
+            r#"{"status":"success","message":"Event processed","dedup_key":"generated-key"}"#;
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(202, response_body).await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn execute_trigger_missing_summary() {
+        let config = PagerDutyConfig::new("test-key").with_api_base_url("http://localhost:1");
+        let provider = PagerDutyProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "severity": "critical"
+        }));
+
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_invalid_event_action() {
+        let config = PagerDutyConfig::new("test-key").with_api_base_url("http://localhost:1");
+        let provider = PagerDutyProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "event_action": "invalid_action",
+            "summary": "test"
+        }));
+
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_ack_missing_dedup_key() {
+        let config = PagerDutyConfig::new("test-key").with_api_base_url("http://localhost:1");
+        let provider = PagerDutyProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "event_action": "acknowledge"
+        }));
+
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_rate_limited() {
+        let server = MockPagerDutyServer::start().await;
+        let config = PagerDutyConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = PagerDutyProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "summary": "test event"
+        }));
+
+        let server_handle = tokio::spawn(async move {
+            server.respond_rate_limited().await;
+        });
+
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+
+        assert!(matches!(err, ProviderError::RateLimited));
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_api_error() {
+        let server = MockPagerDutyServer::start().await;
+        let config = PagerDutyConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = PagerDutyProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "summary": "test event"
+        }));
+
+        let response_body = r#"{"status":"invalid event","message":"Event object is invalid"}"#;
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(400, response_body).await;
+        });
+
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+
+        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn health_check_success() {
+        let server = MockPagerDutyServer::start().await;
+        let config = PagerDutyConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = PagerDutyProvider::new(config);
+
+        // Even a 400 response means the endpoint is reachable.
+        let response_body = r#"{"status":"invalid event","message":"Event object is invalid"}"#;
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(400, response_body).await;
+        });
+
+        let result = provider.health_check().await;
+        server_handle.await.unwrap();
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn health_check_connection_failure() {
+        // Point to a port that nothing is listening on.
+        let config = PagerDutyConfig::new("test-key").with_api_base_url("http://127.0.0.1:1");
+        let provider = PagerDutyProvider::new(config);
+
+        let err = provider.health_check().await.unwrap_err();
+        assert!(matches!(err, ProviderError::Connection(_)));
+        assert!(err.is_retryable());
+    }
+}

--- a/crates/integrations/pagerduty/src/types.rs
+++ b/crates/integrations/pagerduty/src/types.rs
@@ -1,0 +1,203 @@
+use serde::{Deserialize, Serialize};
+
+/// A link to display in the `PagerDuty` incident.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PagerDutyLink {
+    /// The URL of the link.
+    pub href: String,
+    /// Optional text to display for the link.
+    pub text: Option<String>,
+}
+
+/// An image to display in the `PagerDuty` incident.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PagerDutyImage {
+    /// The URL of the image.
+    pub src: String,
+    /// Optional URL to make the image a link.
+    pub href: Option<String>,
+    /// Optional alternative text for the image.
+    pub alt: Option<String>,
+}
+
+/// Request body for the `PagerDuty` Events API v2.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PagerDutyEvent {
+    /// Integration routing key.
+    pub routing_key: String,
+
+    /// Event action: `"trigger"`, `"acknowledge"`, or `"resolve"`.
+    pub event_action: String,
+
+    /// Deduplication key for correlating trigger/ack/resolve events.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dedup_key: Option<String>,
+
+    /// Event payload (required for trigger events).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<PagerDutyPayload>,
+
+    /// Images to display in the `PagerDuty` incident.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub images: Option<Vec<PagerDutyImage>>,
+
+    /// Links to display in the `PagerDuty` incident.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<PagerDutyLink>>,
+}
+
+/// Payload section of a `PagerDuty` trigger event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PagerDutyPayload {
+    /// Brief description of the event.
+    pub summary: String,
+
+    /// The source of the event (e.g. hostname or service name).
+    pub source: String,
+
+    /// Severity level: `"critical"`, `"error"`, `"warning"`, or `"info"`.
+    pub severity: String,
+
+    /// Logical grouping component (e.g. `"web-01"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component: Option<String>,
+
+    /// Logical grouping (e.g. `"production"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
+
+    /// Event class/type (e.g. `"cpu"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub class: Option<String>,
+
+    /// Arbitrary key-value details.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom_details: Option<serde_json::Value>,
+}
+
+/// Response from the `PagerDuty` Events API v2.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PagerDutyApiResponse {
+    /// Status string (`"success"` on success).
+    pub status: String,
+
+    /// Human-readable message.
+    pub message: String,
+
+    /// Deduplication key assigned by `PagerDuty` (present on success).
+    pub dedup_key: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_serializes_trigger_with_payload() {
+        let event = PagerDutyEvent {
+            routing_key: "R123".into(),
+            event_action: "trigger".into(),
+            dedup_key: Some("dedup-1".into()),
+            payload: Some(PagerDutyPayload {
+                summary: "High CPU".into(),
+                source: "web-01".into(),
+                severity: "critical".into(),
+                component: Some("cpu".into()),
+                group: None,
+                class: None,
+                custom_details: None,
+            }),
+            images: None,
+            links: None,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["routing_key"], "R123");
+        assert_eq!(json["event_action"], "trigger");
+        assert_eq!(json["dedup_key"], "dedup-1");
+        assert_eq!(json["payload"]["summary"], "High CPU");
+        assert_eq!(json["payload"]["severity"], "critical");
+        assert!(json["payload"].get("group").is_none());
+    }
+
+    #[test]
+    fn event_serializes_acknowledge_without_payload() {
+        let event = PagerDutyEvent {
+            routing_key: "R123".into(),
+            event_action: "acknowledge".into(),
+            dedup_key: Some("dedup-1".into()),
+            payload: None,
+            images: None,
+            links: None,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["event_action"], "acknowledge");
+        assert_eq!(json["dedup_key"], "dedup-1");
+        assert!(json.get("payload").is_none());
+    }
+
+    #[test]
+    fn api_response_deserializes_success() {
+        let json = r#"{"status":"success","message":"Event processed","dedup_key":"abc123"}"#;
+        let resp: PagerDutyApiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.status, "success");
+        assert_eq!(resp.message, "Event processed");
+        assert_eq!(resp.dedup_key.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn api_response_deserializes_error() {
+        let json =
+            r#"{"status":"invalid event","message":"Event object is invalid","dedup_key":null}"#;
+        let resp: PagerDutyApiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.status, "invalid event");
+        assert!(resp.dedup_key.is_none());
+    }
+
+    #[test]
+    fn payload_omits_none_fields() {
+        let payload = PagerDutyPayload {
+            summary: "test".into(),
+            source: "src".into(),
+            severity: "info".into(),
+            component: None,
+            group: None,
+            class: None,
+            custom_details: None,
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert!(json.get("component").is_none());
+        assert!(json.get("group").is_none());
+        assert!(json.get("class").is_none());
+        assert!(json.get("custom_details").is_none());
+    }
+
+    #[test]
+    fn event_serializes_with_images_and_links() {
+        let event = PagerDutyEvent {
+            routing_key: "R123".into(),
+            event_action: "trigger".into(),
+            dedup_key: None,
+            payload: Some(PagerDutyPayload {
+                summary: "test".into(),
+                source: "src".into(),
+                severity: "info".into(),
+                component: None,
+                group: None,
+                class: None,
+                custom_details: None,
+            }),
+            images: Some(vec![PagerDutyImage {
+                src: "https://example.com/image.png".into(),
+                href: Some("https://example.com/".into()),
+                alt: Some("alt text".into()),
+            }]),
+            links: Some(vec![PagerDutyLink {
+                href: "https://example.com/".into(),
+                text: Some("link text".into()),
+            }]),
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["images"][0]["src"], "https://example.com/image.png");
+        assert_eq!(json["links"][0]["href"], "https://example.com/");
+    }
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -42,6 +42,7 @@ acteon-provider = { workspace = true }
 acteon-executor = { workspace = true }
 acteon-gateway = { workspace = true }
 acteon-llm = { workspace = true }
+acteon-crypto = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
 chrono = { workspace = true }
@@ -64,8 +65,6 @@ jsonwebtoken = { workspace = true }
 argon2 = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
-aes-gcm = { workspace = true }
-base64 = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/crates/server/src/auth/api_key.rs
+++ b/crates/server/src/auth/api_key.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use sha2::{Digest, Sha256};
 
 use super::config::{ApiKeyConfig, Grant};
+use super::crypto::ExposeSecret;
 use super::identity::CallerIdentity;
 use super::role::Role;
 
@@ -22,7 +23,7 @@ pub fn build_api_key_table(configs: &[ApiKeyConfig]) -> HashMap<String, ApiKeyEn
     for cfg in configs {
         let role = Role::from_str_loose(&cfg.role).unwrap_or(Role::Viewer);
         map.insert(
-            cfg.key_hash.clone(),
+            cfg.key_hash.expose_secret().clone(),
             ApiKeyEntry {
                 name: cfg.name.clone(),
                 role,

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use super::crypto::SecretString;
+
 /// Top-level schema for `auth.toml`.
 #[derive(Debug, Deserialize)]
 pub struct AuthFileConfig {
@@ -14,7 +16,9 @@ pub struct AuthFileConfig {
 #[derive(Debug, Deserialize)]
 pub struct AuthSettings {
     /// JWT signing secret (may be `ENC[...]` before decryption).
-    pub jwt_secret: String,
+    ///
+    /// Wrapped in [`SecretString`] so it is redacted in logs.
+    pub jwt_secret: SecretString,
     /// JWT token lifetime in seconds.
     #[serde(default = "default_jwt_expiry")]
     pub jwt_expiry_seconds: u64,
@@ -29,7 +33,9 @@ fn default_jwt_expiry() -> u64 {
 pub struct UserConfig {
     pub username: String,
     /// Argon2 password hash (may be `ENC[...]` before decryption).
-    pub password_hash: String,
+    ///
+    /// Wrapped in [`SecretString`] so it is redacted in logs.
+    pub password_hash: SecretString,
     /// Role: `"admin"`, `"operator"`, or `"viewer"`.
     pub role: String,
     #[serde(default)]
@@ -52,7 +58,9 @@ pub struct Grant {
 pub struct ApiKeyConfig {
     pub name: String,
     /// SHA-256 hash of the raw key (may be `ENC[...]` before decryption).
-    pub key_hash: String,
+    ///
+    /// Wrapped in [`SecretString`] so it is redacted in logs.
+    pub key_hash: SecretString,
     /// Role: `"admin"`, `"operator"`, or `"viewer"`.
     pub role: String,
     #[serde(default)]

--- a/crates/server/src/auth/crypto.rs
+++ b/crates/server/src/auth/crypto.rs
@@ -1,162 +1,26 @@
-use aes_gcm::aead::{Aead, KeyInit, OsRng};
-use aes_gcm::{Aes256Gcm, Nonce};
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD as B64;
-
-/// A 32-byte AES-256 master key for encrypting/decrypting sensitive config values.
-pub type MasterKey = [u8; 32];
-
-/// Parse a 32-byte master key from hex or base64.
-pub fn parse_master_key(raw: &str) -> Result<[u8; 32], String> {
-    let trimmed = raw.trim();
-    // Try hex first (64 hex chars = 32 bytes).
-    if trimmed.len() == 64
-        && let Ok(bytes) = hex::decode(trimmed)
-        && bytes.len() == 32
-    {
-        let mut key = [0u8; 32];
-        key.copy_from_slice(&bytes);
-        return Ok(key);
-    }
-    // Try base64.
-    if let Ok(bytes) = B64.decode(trimmed)
-        && bytes.len() == 32
-    {
-        let mut key = [0u8; 32];
-        key.copy_from_slice(&bytes);
-        return Ok(key);
-    }
-    Err("ACTEON_AUTH_KEY must be 32 bytes encoded as 64 hex chars or base64".to_owned())
-}
-
-/// If `value` starts with `ENC[AES256-GCM,...]`, decrypt it using the master
-/// key. Otherwise return the value unchanged.
-pub fn decrypt_value(value: &str, master_key: &[u8; 32]) -> Result<String, String> {
-    let trimmed = value.trim();
-    if !trimmed.starts_with("ENC[AES256-GCM,") || !trimmed.ends_with(']') {
-        return Ok(value.to_owned());
-    }
-
-    let inner = &trimmed["ENC[AES256-GCM,".len()..trimmed.len() - 1];
-    let mut data_b64 = None;
-    let mut iv_b64 = None;
-    let mut tag_b64 = None;
-
-    for part in inner.split(',') {
-        let part = part.trim();
-        if let Some(v) = part.strip_prefix("data:") {
-            data_b64 = Some(v);
-        } else if let Some(v) = part.strip_prefix("iv:") {
-            iv_b64 = Some(v);
-        } else if let Some(v) = part.strip_prefix("tag:") {
-            tag_b64 = Some(v);
-        }
-    }
-
-    let data = B64
-        .decode(data_b64.ok_or("missing data field in ENC[...]")?)
-        .map_err(|e| format!("invalid base64 in data: {e}"))?;
-    let iv = B64
-        .decode(iv_b64.ok_or("missing iv field in ENC[...]")?)
-        .map_err(|e| format!("invalid base64 in iv: {e}"))?;
-    let tag = B64
-        .decode(tag_b64.ok_or("missing tag field in ENC[...]")?)
-        .map_err(|e| format!("invalid base64 in tag: {e}"))?;
-
-    if iv.len() != 12 {
-        return Err(format!("IV must be 12 bytes, got {}", iv.len()));
-    }
-    if tag.len() != 16 {
-        return Err(format!("tag must be 16 bytes, got {}", tag.len()));
-    }
-
-    // AES-GCM ciphertext = data || tag
-    let mut ciphertext = data;
-    ciphertext.extend_from_slice(&tag);
-
-    let cipher =
-        Aes256Gcm::new_from_slice(master_key).map_err(|e| format!("invalid AES key: {e}"))?;
-    let nonce = Nonce::from_slice(&iv);
-
-    let plaintext = cipher
-        .decrypt(nonce, ciphertext.as_ref())
-        .map_err(|_| "decryption failed (wrong key or corrupted data)".to_owned())?;
-
-    String::from_utf8(plaintext).map_err(|e| format!("decrypted value is not UTF-8: {e}"))
-}
-
-/// Encrypt a plaintext string, producing an `ENC[AES256-GCM,...]` marker.
-pub fn encrypt_value(plaintext: &str, master_key: &[u8; 32]) -> Result<String, String> {
-    use aes_gcm::AeadCore;
-
-    let cipher =
-        Aes256Gcm::new_from_slice(master_key).map_err(|e| format!("invalid AES key: {e}"))?;
-    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
-
-    let ciphertext = cipher
-        .encrypt(&nonce, plaintext.as_bytes())
-        .map_err(|e| format!("encryption failed: {e}"))?;
-
-    // AES-GCM output = ciphertext_data || 16-byte tag
-    let (data, tag) = ciphertext.split_at(ciphertext.len() - 16);
-
-    Ok(format!(
-        "ENC[AES256-GCM,data:{},iv:{},tag:{}]",
-        B64.encode(data),
-        B64.encode(nonce.as_slice()),
-        B64.encode(tag),
-    ))
-}
+pub use acteon_crypto::{
+    CryptoError, ExposeSecret, MasterKey, SecretString, decrypt_value, encrypt_value, is_encrypted,
+    parse_master_key,
+};
 
 /// Decrypt all `ENC[...]` values in an [`super::config::AuthFileConfig`] in place.
+///
+/// Fields are already [`SecretString`], so decrypted values stay wrapped —
+/// no secrets are exposed during this operation.
 pub fn decrypt_auth_config(
     config: &mut super::config::AuthFileConfig,
-    master_key: &[u8; 32],
+    master_key: &MasterKey,
 ) -> Result<(), String> {
-    config.settings.jwt_secret = decrypt_value(&config.settings.jwt_secret, master_key)?;
+    config.settings.jwt_secret =
+        decrypt_value(config.settings.jwt_secret.expose_secret(), master_key)
+            .map_err(|e| e.to_string())?;
     for user in &mut config.users {
-        user.password_hash = decrypt_value(&user.password_hash, master_key)?;
+        user.password_hash = decrypt_value(user.password_hash.expose_secret(), master_key)
+            .map_err(|e| e.to_string())?;
     }
     for key in &mut config.api_keys {
-        key.key_hash = decrypt_value(&key.key_hash, master_key)?;
+        key.key_hash =
+            decrypt_value(key.key_hash.expose_secret(), master_key).map_err(|e| e.to_string())?;
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn roundtrip_encrypt_decrypt() {
-        let key = [0x42u8; 32];
-        let plaintext = "my-secret-value";
-        let encrypted = encrypt_value(plaintext, &key).unwrap();
-        assert!(encrypted.starts_with("ENC[AES256-GCM,"));
-        let decrypted = decrypt_value(&encrypted, &key).unwrap();
-        assert_eq!(decrypted, plaintext);
-    }
-
-    #[test]
-    fn passthrough_plain_value() {
-        let key = [0x42u8; 32];
-        let plain = "not-encrypted";
-        let result = decrypt_value(plain, &key).unwrap();
-        assert_eq!(result, plain);
-    }
-
-    #[test]
-    fn parse_hex_key() {
-        let hex_key = "aa".repeat(32);
-        let key = parse_master_key(&hex_key).unwrap();
-        assert_eq!(key, [0xaa; 32]);
-    }
-
-    #[test]
-    fn parse_base64_key() {
-        let raw = [0xbbu8; 32];
-        let b64 = B64.encode(raw);
-        let key = parse_master_key(&b64).unwrap();
-        assert_eq!(key, [0xbb; 32]);
-    }
 }

--- a/docs/book/concepts/providers.md
+++ b/docs/book/concepts/providers.md
@@ -163,11 +163,31 @@ The `acteon-slack` crate provides a Slack messaging provider.
 
 The `acteon-pagerduty` crate provides a PagerDuty Events API v2 provider for incident management. It supports triggering, acknowledging, and resolving incidents.
 
+**Configuration:**
+
+Single service (routing key only):
+
+```rust
+let config = PagerDutyConfig::single_service("PABC123", "your-routing-key");
+```
+
+Multiple services:
+
+```rust
+let config = PagerDutyConfig::new()
+    .with_service("PABC123", "routing-key-1")
+    .with_service("PXYZ789", "routing-key-2")
+    .with_default_service("PABC123");
+```
+
+When multiple services are configured, each action payload can specify a `service_id` to target a specific service. If omitted, the default service is used. With a single service, `service_id` is optional.
+
 **Trigger payload:**
 
 ```json
 {
   "event_action": "trigger",
+  "service_id": "PABC123",
   "summary": "CPU usage exceeded 90% on web-01",
   "severity": "critical",
   "source": "monitoring",
@@ -193,6 +213,7 @@ The `acteon-pagerduty` crate provides a PagerDuty Events API v2 provider for inc
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `event_action` | Yes | — | `"trigger"`, `"acknowledge"`, or `"resolve"` |
+| `service_id` | No | Config default | PagerDuty service ID to route the event to |
 | `summary` | Trigger only | — | Brief description of the event |
 | `severity` | No | Config default | `"critical"`, `"error"`, `"warning"`, or `"info"` |
 | `source` | No | Config default | Event source (e.g. hostname or service) |

--- a/docs/book/concepts/providers.md
+++ b/docs/book/concepts/providers.md
@@ -9,6 +9,7 @@ flowchart LR
     G[Gateway] --> R[Provider Registry]
     R --> E[Email SMTP]
     R --> S[Slack]
+    R --> P[PagerDuty]
     R --> W[Webhook]
     R --> C[Custom Provider]
 ```
@@ -115,6 +116,7 @@ use std::sync::Arc;
 let gateway = GatewayBuilder::new()
     .provider(Arc::new(EmailProvider::new(smtp_config)))
     .provider(Arc::new(SlackProvider::new(slack_token)))
+    .provider(Arc::new(PagerDutyProvider::new(pagerduty_config)))
     .provider(Arc::new(MyWebhookProvider {
         client: reqwest::Client::new(),
         base_url: "https://api.example.com".into(),
@@ -156,6 +158,51 @@ The `acteon-slack` crate provides a Slack messaging provider.
   "blocks": []
 }
 ```
+
+### PagerDuty
+
+The `acteon-pagerduty` crate provides a PagerDuty Events API v2 provider for incident management. It supports triggering, acknowledging, and resolving incidents.
+
+**Trigger payload:**
+
+```json
+{
+  "event_action": "trigger",
+  "summary": "CPU usage exceeded 90% on web-01",
+  "severity": "critical",
+  "source": "monitoring",
+  "component": "web-01",
+  "group": "production",
+  "class": "cpu",
+  "dedup_key": "web-01/cpu-high",
+  "custom_details": { "cpu_percent": 95.2 },
+  "images": [{ "src": "https://example.com/graph.png", "alt": "CPU graph" }],
+  "links": [{ "href": "https://example.com/runbook", "text": "Runbook" }]
+}
+```
+
+**Acknowledge/resolve payload:**
+
+```json
+{
+  "event_action": "acknowledge",
+  "dedup_key": "web-01/cpu-high"
+}
+```
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `event_action` | Yes | — | `"trigger"`, `"acknowledge"`, or `"resolve"` |
+| `summary` | Trigger only | — | Brief description of the event |
+| `severity` | No | Config default | `"critical"`, `"error"`, `"warning"`, or `"info"` |
+| `source` | No | Config default | Event source (e.g. hostname or service) |
+| `dedup_key` | Ack/resolve | — | Deduplication key for correlating events |
+| `component` | No | — | Logical grouping component |
+| `group` | No | — | Logical grouping (e.g. `"production"`) |
+| `class` | No | — | Event class/type (e.g. `"cpu"`) |
+| `custom_details` | No | — | Arbitrary key-value details |
+| `images` | No | — | Images to display in the incident |
+| `links` | No | — | Links to display in the incident |
 
 ## Provider Errors
 


### PR DESCRIPTION
## Summary

- **New `acteon-pagerduty` crate** implementing the `Provider` trait for PagerDuty Events API v2 (trigger, acknowledge, resolve)
- **Config** with routing key, default severity/source, and API base URL override for testing
- **Images/links support** on trigger events per PagerDuty API spec
- **Error mapping** — HTTP→Connection (retryable), 429→RateLimited (retryable), API errors→ExecutionFailed, invalid payloads→Serialization
- **Health check** — POST empty body to endpoint; any HTTP response confirms connectivity
- **28 unit tests + 1 doc-test** covering all event types, config defaults, validation errors, rate limiting, and mock server scenarios
- **Simulation scenarios** added to `demo_simulation` (incident escalation with dedup) and `grouping_simulation` (critical→PagerDuty escalation + service-based grouping)

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy -p acteon-pagerduty --no-deps -- -D warnings` passes
- [x] `cargo test -p acteon-pagerduty` — 28 tests + 1 doc-test pass
- [x] `cargo test --workspace` — full workspace passes
- [x] `cargo run -p acteon-simulation --example demo_simulation` — Demo 6 (PagerDuty escalation) runs correctly
- [x] `cargo run -p acteon-simulation --example grouping_simulation` — Scenario 9 (PagerDuty + grouping) runs correctly
- [x] `cargo doc -p acteon-pagerduty --no-deps` generates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)