### PR TITLE
Add semantic routing with embedding-based rule matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "acteon-embedding"
+version = "0.1.0"
+dependencies = [
+ "acteon-rules",
+ "async-trait",
+ "moka",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "acteon-executor"
 version = "0.1.0"
 dependencies = [
@@ -265,6 +280,7 @@ dependencies = [
  "acteon-audit-postgres",
  "acteon-core",
  "acteon-crypto",
+ "acteon-embedding",
  "acteon-executor",
  "acteon-gateway",
  "acteon-llm",
@@ -629,6 +645,17 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1638,6 +1665,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +1919,16 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -2950,6 +2996,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3332,6 +3398,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -4404,6 +4476,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ members = [
     # LLM
     "crates/llm",
 
+    # Embedding
+    "crates/embedding",
+
     # Integrations
     "crates/integrations/email",
     "crates/integrations/slack",
@@ -81,6 +84,9 @@ acteon-rules-cel = { path = "crates/rules/cel" }
 # LLM
 acteon-llm = { path = "crates/llm" }
 
+# Embedding
+acteon-embedding = { path = "crates/embedding" }
+
 # Integrations
 acteon-email = { path = "crates/integrations/email" }
 acteon-slack = { path = "crates/integrations/slack" }
@@ -119,6 +125,7 @@ bytes = "1"
 
 # Concurrent data structures
 dashmap = "6"
+moka = { version = "0.12", features = ["future"] }
 
 # Redis
 redis = { version = "0.27", features = ["tokio-comp", "connection-manager", "script"] }

--- a/crates/embedding/Cargo.toml
+++ b/crates/embedding/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "acteon-embedding"
+description = "Embedding provider for semantic routing in Acteon"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+acteon-rules = { workspace = true }
+async-trait = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+moka = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/embedding/src/bridge.rs
+++ b/crates/embedding/src/bridge.rs
@@ -1,0 +1,202 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tracing::warn;
+
+use acteon_rules::EmbeddingEvalSupport;
+use acteon_rules::error::RuleError;
+
+use crate::cache::{CacheTier, EmbeddingCache};
+use crate::config::EmbeddingBridgeConfig;
+use crate::cosine::cosine_similarity;
+use crate::metrics::EmbeddingMetrics;
+use crate::provider::EmbeddingProvider;
+
+/// Bridge between the `acteon-embedding` provider layer and the
+/// `EmbeddingEvalSupport` trait expected by the rule engine.
+///
+/// It caches both topic and text embeddings and computes their cosine
+/// similarity. When `fail_open` is enabled (the default), embedding errors
+/// return similarity `0.0` instead of propagating to the caller — this
+/// means `semantic_match` rules evaluate to `false` on API failure rather
+/// than killing the entire dispatch pipeline.
+pub struct EmbeddingBridge {
+    topic_cache: EmbeddingCache,
+    text_cache: EmbeddingCache,
+    fail_open: bool,
+    metrics: Arc<EmbeddingMetrics>,
+}
+
+impl std::fmt::Debug for EmbeddingBridge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EmbeddingBridge")
+            .field("fail_open", &self.fail_open)
+            .finish_non_exhaustive()
+    }
+}
+
+impl EmbeddingBridge {
+    /// Create a new bridge wrapping the given embedding provider.
+    pub fn new(provider: Arc<dyn EmbeddingProvider>, config: EmbeddingBridgeConfig) -> Self {
+        let metrics = Arc::new(EmbeddingMetrics::default());
+        let topic_cache = EmbeddingCache::new(
+            Arc::clone(&provider),
+            config.topic_cache_capacity,
+            Duration::from_secs(config.topic_cache_ttl_seconds),
+            Arc::clone(&metrics),
+            CacheTier::Topic,
+        );
+        let text_cache = EmbeddingCache::new(
+            provider,
+            config.text_cache_capacity,
+            Duration::from_secs(config.text_cache_ttl_seconds),
+            Arc::clone(&metrics),
+            CacheTier::Text,
+        );
+        Self {
+            topic_cache,
+            text_cache,
+            fail_open: config.fail_open,
+            metrics,
+        }
+    }
+
+    /// Return a shared handle to the embedding metrics counters.
+    ///
+    /// Use this to expose cache hit/miss rates and error counts to
+    /// monitoring endpoints. The returned `Arc` can be stored separately
+    /// from the bridge (e.g. in `AppState`) so metrics remain accessible
+    /// even when the bridge is behind a trait object.
+    pub fn metrics(&self) -> Arc<EmbeddingMetrics> {
+        Arc::clone(&self.metrics)
+    }
+
+    /// Pre-warm the topic cache with the given topic strings.
+    ///
+    /// Call this after loading rules to avoid cold-start latency on the
+    /// first requests. Errors for individual topics are logged and skipped.
+    pub async fn warm_topics(&self, topics: &[&str]) {
+        for topic in topics {
+            if let Err(e) = self.topic_cache.get(topic).await {
+                tracing::warn!(
+                    topic = topic,
+                    error = %e,
+                    "failed to pre-warm topic embedding"
+                );
+            }
+        }
+    }
+
+    /// Compute cosine similarity between a text and a topic embedding.
+    async fn compute_similarity(&self, text: &str, topic: &str) -> Result<f64, RuleError> {
+        let topic_vec = self
+            .topic_cache
+            .get(topic)
+            .await
+            .map_err(|e| RuleError::Evaluation(format!("embedding error (topic): {e}")))?;
+
+        let text_vec = self
+            .text_cache
+            .get(text)
+            .await
+            .map_err(|e| RuleError::Evaluation(format!("embedding error (text): {e}")))?;
+
+        Ok(f64::from(cosine_similarity(&text_vec, &topic_vec)))
+    }
+}
+
+#[async_trait]
+impl EmbeddingEvalSupport for EmbeddingBridge {
+    async fn similarity(&self, text: &str, topic: &str) -> Result<f64, RuleError> {
+        match self.compute_similarity(text, topic).await {
+            Ok(sim) => Ok(sim),
+            Err(e) if self.fail_open => {
+                self.metrics.increment_errors();
+                self.metrics.increment_fail_open();
+                warn!(
+                    text = text,
+                    topic = topic,
+                    error = %e,
+                    "embedding similarity failed, returning 0.0 (fail-open)"
+                );
+                Ok(0.0)
+            }
+            Err(e) => {
+                self.metrics.increment_errors();
+                Err(e)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::EmbeddingBridgeConfig;
+    use crate::mock::{FailingEmbeddingProvider, MockEmbeddingProvider};
+
+    #[tokio::test]
+    async fn bridge_computes_similarity() {
+        // Mock returns the same vector for all inputs -> similarity = 1.0
+        let provider = Arc::new(MockEmbeddingProvider::new(vec![1.0, 0.0, 0.0]));
+        let bridge = EmbeddingBridge::new(provider, EmbeddingBridgeConfig::default());
+
+        let sim = bridge.similarity("hello", "world").await.unwrap();
+        assert!((sim - 1.0).abs() < 1e-6);
+    }
+
+    #[tokio::test]
+    async fn bridge_caches_text_embeddings() {
+        let provider = Arc::new(MockEmbeddingProvider::new(vec![1.0, 0.0]));
+        let bridge =
+            EmbeddingBridge::new(Arc::clone(&provider) as _, EmbeddingBridgeConfig::default());
+
+        // Call twice with the same text + topic.
+        bridge.similarity("hello", "world").await.unwrap();
+        bridge.similarity("hello", "world").await.unwrap();
+
+        // topic "world" = 1 call, text "hello" = 1 call -> 2 total (not 4).
+        assert_eq!(provider.call_count(), 2);
+
+        let snap = bridge.metrics().snapshot();
+        assert_eq!(snap.topic_cache_misses, 1);
+        assert_eq!(snap.topic_cache_hits, 1);
+        assert_eq!(snap.text_cache_misses, 1);
+        assert_eq!(snap.text_cache_hits, 1);
+    }
+
+    #[tokio::test]
+    async fn fail_open_returns_zero_and_records_metrics() {
+        let provider: Arc<dyn EmbeddingProvider> = Arc::new(FailingEmbeddingProvider);
+        let config = EmbeddingBridgeConfig {
+            fail_open: true,
+            ..EmbeddingBridgeConfig::default()
+        };
+        let bridge = EmbeddingBridge::new(provider, config);
+
+        let sim = bridge.similarity("hello", "world").await.unwrap();
+        assert!((sim - 0.0).abs() < 1e-6);
+
+        let snap = bridge.metrics().snapshot();
+        assert_eq!(snap.errors, 1);
+        assert_eq!(snap.fail_open_count, 1);
+    }
+
+    #[tokio::test]
+    async fn fail_closed_propagates_error_and_records_metrics() {
+        let provider: Arc<dyn EmbeddingProvider> = Arc::new(FailingEmbeddingProvider);
+        let config = EmbeddingBridgeConfig {
+            fail_open: false,
+            ..EmbeddingBridgeConfig::default()
+        };
+        let bridge = EmbeddingBridge::new(provider, config);
+
+        let result = bridge.similarity("hello", "world").await;
+        assert!(result.is_err());
+
+        let snap = bridge.metrics().snapshot();
+        assert_eq!(snap.errors, 1);
+        assert_eq!(snap.fail_open_count, 0);
+    }
+}

--- a/crates/embedding/src/cache.rs
+++ b/crates/embedding/src/cache.rs
@@ -1,0 +1,150 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use moka::future::Cache;
+
+use crate::error::EmbeddingError;
+use crate::metrics::EmbeddingMetrics;
+use crate::provider::EmbeddingProvider;
+
+/// Which cache tier this instance represents (used to increment the correct
+/// metric counters).
+#[derive(Debug, Clone, Copy)]
+pub enum CacheTier {
+    /// Topic embeddings (long TTL, large capacity).
+    Topic,
+    /// Text embeddings (short TTL, small capacity).
+    Text,
+}
+
+/// A bounded, TTL-based embedding cache backed by [`moka`].
+///
+/// Uses `try_get_with` to coalesce concurrent requests for the same key
+/// (thundering herd protection). Works for both topic embeddings (long TTL,
+/// large capacity) and text embeddings (short TTL, small capacity).
+pub struct EmbeddingCache {
+    provider: Arc<dyn EmbeddingProvider>,
+    cache: Cache<String, Vec<f32>>,
+    metrics: Arc<EmbeddingMetrics>,
+    tier: CacheTier,
+}
+
+impl EmbeddingCache {
+    /// Create a new cache backed by the given embedding provider.
+    pub fn new(
+        provider: Arc<dyn EmbeddingProvider>,
+        max_capacity: u64,
+        ttl: Duration,
+        metrics: Arc<EmbeddingMetrics>,
+        tier: CacheTier,
+    ) -> Self {
+        let cache = Cache::builder()
+            .max_capacity(max_capacity)
+            .time_to_live(ttl)
+            .build();
+        Self {
+            provider,
+            cache,
+            metrics,
+            tier,
+        }
+    }
+
+    /// Get the embedding for a key, computing it via the provider on cache miss.
+    ///
+    /// Concurrent callers for the same key will coalesce into a single provider
+    /// call. Hit/miss counters are approximate under high concurrency (a small
+    /// number of concurrent requests for the same uncached key may all count as
+    /// misses even though only one provider call is made).
+    pub async fn get(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        // Check cache first for metrics tracking. This is racy with
+        // try_get_with but acceptable for operational counters.
+        if let Some(val) = self.cache.get(text).await {
+            self.record_hit();
+            return Ok(val);
+        }
+
+        self.record_miss();
+        let provider = Arc::clone(&self.provider);
+        let key = text.to_owned();
+        self.cache
+            .try_get_with(key, async move { provider.embed(text).await })
+            .await
+            .map_err(|e| EmbeddingError::ApiError(e.to_string()))
+    }
+
+    fn record_hit(&self) {
+        match self.tier {
+            CacheTier::Topic => self.metrics.increment_topic_hit(),
+            CacheTier::Text => self.metrics.increment_text_hit(),
+        }
+    }
+
+    fn record_miss(&self) {
+        match self.tier {
+            CacheTier::Topic => self.metrics.increment_topic_miss(),
+            CacheTier::Text => self.metrics.increment_text_miss(),
+        }
+    }
+}
+
+impl std::fmt::Debug for EmbeddingCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EmbeddingCache")
+            .field("tier", &self.tier)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mock::MockEmbeddingProvider;
+
+    fn test_metrics() -> Arc<EmbeddingMetrics> {
+        Arc::new(EmbeddingMetrics::default())
+    }
+
+    #[tokio::test]
+    async fn caches_embeddings() {
+        let metrics = test_metrics();
+        let provider = Arc::new(MockEmbeddingProvider::new(vec![0.1, 0.2, 0.3]));
+        let cache = EmbeddingCache::new(
+            Arc::clone(&provider) as _,
+            100,
+            Duration::from_secs(60),
+            Arc::clone(&metrics),
+            CacheTier::Topic,
+        );
+
+        let first = cache.get("test topic").await.unwrap();
+        let second = cache.get("test topic").await.unwrap();
+        assert_eq!(first, second);
+        assert_eq!(provider.call_count(), 1);
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.topic_cache_misses, 1);
+        assert_eq!(snap.topic_cache_hits, 1);
+    }
+
+    #[tokio::test]
+    async fn different_keys_call_provider() {
+        let metrics = test_metrics();
+        let provider = Arc::new(MockEmbeddingProvider::new(vec![1.0]));
+        let cache = EmbeddingCache::new(
+            Arc::clone(&provider) as _,
+            100,
+            Duration::from_secs(60),
+            Arc::clone(&metrics),
+            CacheTier::Text,
+        );
+
+        cache.get("a").await.unwrap();
+        cache.get("b").await.unwrap();
+        assert_eq!(provider.call_count(), 2);
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.text_cache_misses, 2);
+        assert_eq!(snap.text_cache_hits, 0);
+    }
+}

--- a/crates/embedding/src/config.rs
+++ b/crates/embedding/src/config.rs
@@ -1,0 +1,59 @@
+use serde::Deserialize;
+
+/// Configuration for an HTTP-based embedding provider.
+#[derive(Debug, Clone, Deserialize)]
+pub struct EmbeddingConfig {
+    /// The API endpoint (e.g., `https://api.openai.com/v1/embeddings`).
+    pub endpoint: String,
+    /// The model name (e.g., `text-embedding-3-small`).
+    pub model: String,
+    /// API key for authentication.
+    pub api_key: String,
+    /// Request timeout in seconds.
+    pub timeout_seconds: u64,
+}
+
+/// Configuration for the [`EmbeddingBridge`](crate::EmbeddingBridge) caching
+/// and resilience behaviour.
+///
+/// # Memory footprint
+///
+/// Each cached embedding is a `Vec<f32>` whose size depends on the model
+/// dimension. For a 1536-dimensional model (`text-embedding-3-small`), one
+/// vector is ~6 KB. With the defaults below the worst-case memory usage is:
+///
+/// - Topic cache: 10 000 x 6 KB = ~60 MB
+/// - Text cache:   1 000 x 6 KB = ~6 MB
+///
+/// Adjust `topic_cache_capacity` and `text_cache_capacity` for your
+/// environment. Monitor hit rates via the `/metrics` endpoint.
+#[derive(Debug, Clone, Copy)]
+pub struct EmbeddingBridgeConfig {
+    /// Maximum number of topic embeddings to cache.
+    pub topic_cache_capacity: u64,
+    /// TTL in seconds for cached topic embeddings.
+    pub topic_cache_ttl_seconds: u64,
+    /// Maximum number of text embeddings to cache.
+    pub text_cache_capacity: u64,
+    /// TTL in seconds for cached text embeddings.
+    pub text_cache_ttl_seconds: u64,
+    /// Whether to fail open (return similarity `0.0`) on embedding errors.
+    ///
+    /// When `true` (the default), embedding API failures cause
+    /// `semantic_match` rules to evaluate to `false` (no match) rather
+    /// than killing the dispatch pipeline. This mirrors the `llm_fail_open`
+    /// behaviour.
+    pub fail_open: bool,
+}
+
+impl Default for EmbeddingBridgeConfig {
+    fn default() -> Self {
+        Self {
+            topic_cache_capacity: 10_000,
+            topic_cache_ttl_seconds: 3600,
+            text_cache_capacity: 1_000,
+            text_cache_ttl_seconds: 60,
+            fail_open: true,
+        }
+    }
+}

--- a/crates/embedding/src/cosine.rs
+++ b/crates/embedding/src/cosine.rs
@@ -1,0 +1,79 @@
+/// Compute the cosine similarity between two vectors.
+///
+/// Returns a value in `[-1.0, 1.0]`. For normalized embeddings, this is
+/// typically in `[0.0, 1.0]`.
+///
+/// Returns `0.0` if either vector has zero magnitude or the vectors differ
+/// in length.
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+
+    let mut dot = 0.0_f32;
+    let mut mag_a = 0.0_f32;
+    let mut mag_b = 0.0_f32;
+
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        mag_a += x * x;
+        mag_b += y * y;
+    }
+
+    let denom = mag_a.sqrt() * mag_b.sqrt();
+    if denom == 0.0 {
+        return 0.0;
+    }
+
+    dot / denom
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_vectors() {
+        let v = vec![1.0, 2.0, 3.0];
+        let sim = cosine_similarity(&v, &v);
+        assert!((sim - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn orthogonal_vectors() {
+        let a = vec![1.0, 0.0];
+        let b = vec![0.0, 1.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!(sim.abs() < 1e-6);
+    }
+
+    #[test]
+    fn opposite_vectors() {
+        let a = vec![1.0, 0.0];
+        let b = vec![-1.0, 0.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!((sim + 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn empty_vectors() {
+        let sim = cosine_similarity(&[], &[]);
+        assert_eq!(sim, 0.0);
+    }
+
+    #[test]
+    fn different_lengths() {
+        let a = vec![1.0, 2.0];
+        let b = vec![1.0, 2.0, 3.0];
+        let sim = cosine_similarity(&a, &b);
+        assert_eq!(sim, 0.0);
+    }
+
+    #[test]
+    fn zero_vector() {
+        let a = vec![0.0, 0.0];
+        let b = vec![1.0, 2.0];
+        let sim = cosine_similarity(&a, &b);
+        assert_eq!(sim, 0.0);
+    }
+}

--- a/crates/embedding/src/error.rs
+++ b/crates/embedding/src/error.rs
@@ -1,0 +1,21 @@
+use thiserror::Error;
+
+/// Errors that can occur during embedding operations.
+#[derive(Debug, Error)]
+pub enum EmbeddingError {
+    /// An HTTP request failed.
+    #[error("HTTP error: {0}")]
+    HttpError(String),
+
+    /// The request timed out.
+    #[error("embedding request timed out")]
+    Timeout,
+
+    /// Failed to parse the API response.
+    #[error("parse error: {0}")]
+    ParseError(String),
+
+    /// The API returned an error.
+    #[error("API error: {0}")]
+    ApiError(String),
+}

--- a/crates/embedding/src/http.rs
+++ b/crates/embedding/src/http.rs
@@ -1,0 +1,101 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use crate::config::EmbeddingConfig;
+use crate::error::EmbeddingError;
+use crate::provider::EmbeddingProvider;
+
+/// An embedding provider that calls an OpenAI-compatible `/v1/embeddings` API.
+pub struct HttpEmbeddingProvider {
+    client: reqwest::Client,
+    endpoint: String,
+    model: String,
+    api_key: String,
+}
+
+impl HttpEmbeddingProvider {
+    /// Create a new HTTP embedding provider from the given configuration.
+    pub fn new(config: EmbeddingConfig) -> Result<Self, EmbeddingError> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(config.timeout_seconds))
+            .build()
+            .map_err(|e| EmbeddingError::HttpError(e.to_string()))?;
+
+        Ok(Self {
+            client,
+            endpoint: config.endpoint,
+            model: config.model,
+            api_key: config.api_key,
+        })
+    }
+}
+
+/// `OpenAI` embeddings API request body.
+#[derive(Serialize)]
+struct EmbeddingRequest<'a> {
+    model: &'a str,
+    input: &'a str,
+}
+
+/// `OpenAI` embeddings API response.
+#[derive(Deserialize)]
+struct EmbeddingResponse {
+    data: Vec<EmbeddingData>,
+}
+
+/// A single embedding result.
+#[derive(Deserialize)]
+struct EmbeddingData {
+    embedding: Vec<f32>,
+}
+
+#[async_trait]
+impl EmbeddingProvider for HttpEmbeddingProvider {
+    async fn embed(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        debug!(model = %self.model, text_len = text.len(), "requesting embedding");
+
+        let request_body = EmbeddingRequest {
+            model: &self.model,
+            input: text,
+        };
+
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .json(&request_body)
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_timeout() {
+                    EmbeddingError::Timeout
+                } else {
+                    EmbeddingError::HttpError(e.to_string())
+                }
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "failed to read body".to_owned());
+            return Err(EmbeddingError::ApiError(format!("status {status}: {body}")));
+        }
+
+        let result: EmbeddingResponse = response
+            .json()
+            .await
+            .map_err(|e| EmbeddingError::ParseError(e.to_string()))?;
+
+        result
+            .data
+            .into_iter()
+            .next()
+            .map(|d| d.embedding)
+            .ok_or_else(|| EmbeddingError::ParseError("empty response data".to_owned()))
+    }
+}

--- a/crates/embedding/src/lib.rs
+++ b/crates/embedding/src/lib.rs
@@ -1,0 +1,17 @@
+pub mod bridge;
+pub mod cache;
+pub mod config;
+pub mod cosine;
+pub mod error;
+pub mod http;
+pub mod metrics;
+pub mod mock;
+pub mod provider;
+
+pub use bridge::EmbeddingBridge;
+pub use config::{EmbeddingBridgeConfig, EmbeddingConfig};
+pub use error::EmbeddingError;
+pub use http::HttpEmbeddingProvider;
+pub use metrics::{EmbeddingMetrics, EmbeddingMetricsSnapshot};
+pub use mock::{FailingEmbeddingProvider, MappingEmbeddingProvider, MockEmbeddingProvider};
+pub use provider::EmbeddingProvider;

--- a/crates/embedding/src/metrics.rs
+++ b/crates/embedding/src/metrics.rs
@@ -1,0 +1,120 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Atomic counters tracking embedding cache and provider behaviour.
+///
+/// All counters use relaxed ordering for maximum throughput. For a
+/// consistent point-in-time view, call [`snapshot`](Self::snapshot).
+#[derive(Debug, Default)]
+pub struct EmbeddingMetrics {
+    /// Topic cache hits (embedding already cached).
+    pub topic_cache_hits: AtomicU64,
+    /// Topic cache misses (required provider call).
+    pub topic_cache_misses: AtomicU64,
+    /// Text cache hits.
+    pub text_cache_hits: AtomicU64,
+    /// Text cache misses.
+    pub text_cache_misses: AtomicU64,
+    /// Total embedding provider errors.
+    pub errors: AtomicU64,
+    /// Times fail-open returned `0.0` instead of propagating an error.
+    pub fail_open_count: AtomicU64,
+}
+
+impl EmbeddingMetrics {
+    /// Increment the topic cache hit counter.
+    pub fn increment_topic_hit(&self) {
+        self.topic_cache_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the topic cache miss counter.
+    pub fn increment_topic_miss(&self) {
+        self.topic_cache_misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the text cache hit counter.
+    pub fn increment_text_hit(&self) {
+        self.text_cache_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the text cache miss counter.
+    pub fn increment_text_miss(&self) {
+        self.text_cache_misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the error counter.
+    pub fn increment_errors(&self) {
+        self.errors.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the fail-open activation counter.
+    pub fn increment_fail_open(&self) {
+        self.fail_open_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Take a consistent point-in-time snapshot of all counters.
+    pub fn snapshot(&self) -> EmbeddingMetricsSnapshot {
+        EmbeddingMetricsSnapshot {
+            topic_cache_hits: self.topic_cache_hits.load(Ordering::Relaxed),
+            topic_cache_misses: self.topic_cache_misses.load(Ordering::Relaxed),
+            text_cache_hits: self.text_cache_hits.load(Ordering::Relaxed),
+            text_cache_misses: self.text_cache_misses.load(Ordering::Relaxed),
+            errors: self.errors.load(Ordering::Relaxed),
+            fail_open_count: self.fail_open_count.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// A plain data snapshot of [`EmbeddingMetrics`] at a point in time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingMetricsSnapshot {
+    /// Topic cache hits.
+    pub topic_cache_hits: u64,
+    /// Topic cache misses.
+    pub topic_cache_misses: u64,
+    /// Text cache hits.
+    pub text_cache_hits: u64,
+    /// Text cache misses.
+    pub text_cache_misses: u64,
+    /// Total embedding provider errors.
+    pub errors: u64,
+    /// Times fail-open returned `0.0` instead of propagating an error.
+    pub fail_open_count: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_metrics_are_zero() {
+        let m = EmbeddingMetrics::default();
+        let snap = m.snapshot();
+        assert_eq!(snap.topic_cache_hits, 0);
+        assert_eq!(snap.topic_cache_misses, 0);
+        assert_eq!(snap.text_cache_hits, 0);
+        assert_eq!(snap.text_cache_misses, 0);
+        assert_eq!(snap.errors, 0);
+        assert_eq!(snap.fail_open_count, 0);
+    }
+
+    #[test]
+    fn increment_and_snapshot() {
+        let m = EmbeddingMetrics::default();
+        m.increment_topic_hit();
+        m.increment_topic_hit();
+        m.increment_topic_miss();
+        m.increment_text_hit();
+        m.increment_text_miss();
+        m.increment_text_miss();
+        m.increment_errors();
+        m.increment_fail_open();
+
+        let snap = m.snapshot();
+        assert_eq!(snap.topic_cache_hits, 2);
+        assert_eq!(snap.topic_cache_misses, 1);
+        assert_eq!(snap.text_cache_hits, 1);
+        assert_eq!(snap.text_cache_misses, 2);
+        assert_eq!(snap.errors, 1);
+        assert_eq!(snap.fail_open_count, 1);
+    }
+}

--- a/crates/embedding/src/mock.rs
+++ b/crates/embedding/src/mock.rs
@@ -1,0 +1,118 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+
+use crate::error::EmbeddingError;
+use crate::provider::EmbeddingProvider;
+
+/// A mock embedding provider that always returns the same fixed vector.
+///
+/// Tracks the number of calls via an atomic counter so tests can verify
+/// caching behaviour.
+pub struct MockEmbeddingProvider {
+    vector: Vec<f32>,
+    calls: AtomicUsize,
+}
+
+impl MockEmbeddingProvider {
+    /// Create a mock provider returning the given fixed vector.
+    pub fn new(vector: Vec<f32>) -> Self {
+        Self {
+            vector,
+            calls: AtomicUsize::new(0),
+        }
+    }
+
+    /// Number of times [`embed`](EmbeddingProvider::embed) was called.
+    pub fn call_count(&self) -> usize {
+        self.calls.load(Ordering::Relaxed)
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for MockEmbeddingProvider {
+    async fn embed(&self, _text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        Ok(self.vector.clone())
+    }
+}
+
+/// A mock embedding provider that maps specific text to specific vectors.
+///
+/// Unknown texts receive a zero vector of the configured dimension.
+pub struct MappingEmbeddingProvider {
+    mappings: HashMap<String, Vec<f32>>,
+    dimension: usize,
+}
+
+impl MappingEmbeddingProvider {
+    /// Create a mapping provider with the given text-to-vector mappings.
+    pub fn new(mappings: HashMap<String, Vec<f32>>, dimension: usize) -> Self {
+        Self {
+            mappings,
+            dimension,
+        }
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for MappingEmbeddingProvider {
+    async fn embed(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        Ok(self
+            .mappings
+            .get(text)
+            .cloned()
+            .unwrap_or_else(|| vec![0.0; self.dimension]))
+    }
+}
+
+/// A mock embedding provider that always returns an error.
+pub struct FailingEmbeddingProvider;
+
+#[async_trait]
+impl EmbeddingProvider for FailingEmbeddingProvider {
+    async fn embed(&self, _text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        Err(EmbeddingError::ApiError("mock failure".to_owned()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mock_returns_fixed_vector() {
+        let provider = MockEmbeddingProvider::new(vec![1.0, 2.0, 3.0]);
+        let result = provider.embed("anything").await.unwrap();
+        assert_eq!(result, vec![1.0, 2.0, 3.0]);
+    }
+
+    #[tokio::test]
+    async fn mock_tracks_call_count() {
+        let provider = MockEmbeddingProvider::new(vec![1.0]);
+        assert_eq!(provider.call_count(), 0);
+        provider.embed("a").await.unwrap();
+        provider.embed("b").await.unwrap();
+        assert_eq!(provider.call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn mapping_returns_known_vector() {
+        let mut mappings = HashMap::new();
+        mappings.insert("hello".to_owned(), vec![0.5, 0.5]);
+        let provider = MappingEmbeddingProvider::new(mappings, 2);
+
+        let result = provider.embed("hello").await.unwrap();
+        assert_eq!(result, vec![0.5, 0.5]);
+
+        let result = provider.embed("unknown").await.unwrap();
+        assert_eq!(result, vec![0.0, 0.0]);
+    }
+
+    #[tokio::test]
+    async fn failing_always_errors() {
+        let provider = FailingEmbeddingProvider;
+        assert!(provider.embed("anything").await.is_err());
+    }
+}

--- a/crates/embedding/src/provider.rs
+++ b/crates/embedding/src/provider.rs
@@ -1,0 +1,24 @@
+use async_trait::async_trait;
+
+use crate::error::EmbeddingError;
+
+/// Trait for computing text embeddings.
+///
+/// Implementations call an external service (e.g., `OpenAI`) to convert text
+/// into a dense vector representation.
+#[async_trait]
+pub trait EmbeddingProvider: Send + Sync {
+    /// Embed a single text string into a vector.
+    async fn embed(&self, text: &str) -> Result<Vec<f32>, EmbeddingError>;
+
+    /// Embed multiple texts in a single batch.
+    ///
+    /// The default implementation calls [`embed`](Self::embed) sequentially.
+    async fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        let mut results = Vec::with_capacity(texts.len());
+        for text in texts {
+            results.push(self.embed(text).await?);
+        }
+        Ok(results)
+    }
+}

--- a/crates/gateway/src/builder.rs
+++ b/crates/gateway/src/builder.rs
@@ -45,6 +45,7 @@ pub struct GatewayBuilder {
     llm_fail_open: bool,
     chains: HashMap<String, ChainConfig>,
     completed_chain_ttl: Option<Duration>,
+    embedding: Option<Arc<dyn acteon_rules::EmbeddingEvalSupport>>,
 }
 
 impl GatewayBuilder {
@@ -73,6 +74,7 @@ impl GatewayBuilder {
             llm_fail_open: true,
             chains: HashMap::new(),
             completed_chain_ttl: None,
+            embedding: None,
         }
     }
 
@@ -269,6 +271,16 @@ impl GatewayBuilder {
         self
     }
 
+    /// Set the embedding support for semantic matching in rule conditions.
+    #[must_use]
+    pub fn embedding_support(
+        mut self,
+        support: Arc<dyn acteon_rules::EmbeddingEvalSupport>,
+    ) -> Self {
+        self.embedding = Some(support);
+        self
+    }
+
     /// Consume the builder and produce a configured [`Gateway`].
     ///
     /// Returns a [`GatewayError::Configuration`] if required fields
@@ -340,6 +352,7 @@ impl GatewayBuilder {
             llm_fail_open: self.llm_fail_open,
             chains: self.chains,
             completed_chain_ttl: self.completed_chain_ttl,
+            embedding: self.embedding,
         })
     }
 }

--- a/crates/rules/rules/src/engine/context.rs
+++ b/crates/rules/rules/src/engine/context.rs
@@ -1,9 +1,27 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 
 use acteon_core::Action;
 use acteon_state::StateStore;
+
+use crate::error::RuleError;
+
+/// Trait for providing embedding-based similarity evaluation.
+///
+/// Implementations compute the cosine similarity between a text string and a
+/// topic description using vector embeddings. The trait is defined in
+/// `acteon-rules` so the rule engine can call it without depending on any
+/// specific embedding provider.
+#[async_trait]
+pub trait EmbeddingEvalSupport: Send + Sync + std::fmt::Debug {
+    /// Compute the similarity between `text` and `topic`.
+    ///
+    /// Returns a value in `[0.0, 1.0]` where higher means more similar.
+    async fn similarity(&self, text: &str, topic: &str) -> Result<f64, RuleError>;
+}
 
 /// The evaluation context supplied to the rule engine when evaluating expressions.
 ///
@@ -19,6 +37,8 @@ pub struct EvalContext<'a> {
     pub environment: &'a HashMap<String, String>,
     /// The current timestamp for time-based evaluations.
     pub now: DateTime<Utc>,
+    /// Optional embedding support for semantic matching.
+    pub embedding: Option<Arc<dyn EmbeddingEvalSupport>>,
 }
 
 impl<'a> EvalContext<'a> {
@@ -33,6 +53,7 @@ impl<'a> EvalContext<'a> {
             state,
             environment,
             now: Utc::now(),
+            embedding: None,
         }
     }
 
@@ -40,6 +61,13 @@ impl<'a> EvalContext<'a> {
     #[must_use]
     pub fn with_now(mut self, now: DateTime<Utc>) -> Self {
         self.now = now;
+        self
+    }
+
+    /// Set the embedding support for semantic matching.
+    #[must_use]
+    pub fn with_embedding(mut self, embedding: Arc<dyn EmbeddingEvalSupport>) -> Self {
+        self.embedding = Some(embedding);
         self
     }
 }

--- a/crates/rules/rules/src/engine/mod.rs
+++ b/crates/rules/rules/src/engine/mod.rs
@@ -2,5 +2,5 @@ pub mod builtins;
 pub mod context;
 pub mod executor;
 
-pub use context::EvalContext;
+pub use context::{EmbeddingEvalSupport, EvalContext};
 pub use executor::{RuleEngine, RuleVerdict};

--- a/crates/rules/rules/src/lib.rs
+++ b/crates/rules/rules/src/lib.rs
@@ -3,7 +3,7 @@ pub mod error;
 pub mod frontend;
 pub mod ir;
 
-pub use engine::{EvalContext, RuleEngine, RuleVerdict};
+pub use engine::{EmbeddingEvalSupport, EvalContext, RuleEngine, RuleVerdict};
 pub use error::RuleError;
 pub use frontend::RuleFrontend;
 pub use ir::expr::Expr;

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -42,6 +42,7 @@ acteon-provider = { workspace = true }
 acteon-executor = { workspace = true }
 acteon-gateway = { workspace = true }
 acteon-llm = { workspace = true }
+acteon-embedding = { workspace = true }
 acteon-crypto = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }

--- a/crates/server/src/api/embeddings.rs
+++ b/crates/server/src/api/embeddings.rs
@@ -1,0 +1,116 @@
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::auth::identity::CallerIdentity;
+use crate::auth::role::Permission;
+use crate::error::ServerError;
+use crate::ratelimit::config::RateLimitTier;
+
+use super::AppState;
+use super::schemas::ErrorResponse;
+
+/// Request body for the similarity endpoint.
+#[derive(Deserialize, ToSchema)]
+pub struct SimilarityRequest {
+    /// The text to compare.
+    pub text: String,
+    /// The topic to compare against.
+    pub topic: String,
+}
+
+/// Response body for the similarity endpoint.
+#[derive(Serialize, ToSchema)]
+pub struct SimilarityResponse {
+    /// Cosine similarity score in `[0.0, 1.0]`.
+    pub similarity: f64,
+    /// The topic that was compared.
+    pub topic: String,
+}
+
+/// Tight rate limit tier for embedding similarity requests: 5 per minute.
+const EMBEDDING_RATE_LIMIT: RateLimitTier = RateLimitTier {
+    requests_per_window: 5,
+    window_seconds: 60,
+};
+
+/// `POST /v1/embeddings/similarity` -- compute cosine similarity between text and a topic.
+///
+/// Returns the similarity score from the configured embedding provider.
+/// Rate-limited to 5 requests per minute per caller.
+#[utoipa::path(
+    post,
+    path = "/v1/embeddings/similarity",
+    tag = "Embeddings",
+    summary = "Compute embedding similarity",
+    description = "Computes cosine similarity between the given text and topic using the configured embedding provider. Rate-limited to 5 requests/minute per caller.",
+    request_body(content = SimilarityRequest, description = "Text and topic to compare"),
+    responses(
+        (status = 200, description = "Similarity computed", body = SimilarityResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Embedding provider not configured", body = ErrorResponse),
+        (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    )
+)]
+pub async fn similarity(
+    State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Json(req): Json<SimilarityRequest>,
+) -> Result<impl IntoResponse, ServerError> {
+    // Check role permission (reuse Dispatch permission).
+    if !identity.role.has_permission(Permission::Dispatch) {
+        return Ok((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!(ErrorResponse {
+                error:
+                    "insufficient permissions: embedding similarity requires admin or operator role"
+                        .into(),
+            })),
+        ));
+    }
+
+    // Apply tight per-caller rate limit for embedding requests.
+    if let Some(ref limiter) = state.rate_limiter {
+        let bucket = format!("embedding:{}", identity.id);
+        if let Err(e) = limiter
+            .check_custom_limit(&bucket, &EMBEDDING_RATE_LIMIT)
+            .await
+        {
+            return Err(ServerError::RateLimited {
+                retry_after: e.retry_after,
+            });
+        }
+    }
+
+    // Check that embedding support is configured.
+    let Some(ref embedding) = state.embedding else {
+        return Ok((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!(ErrorResponse {
+                error: "embedding provider is not configured".into(),
+            })),
+        ));
+    };
+
+    // Compute similarity.
+    match embedding.similarity(&req.text, &req.topic).await {
+        Ok(score) => Ok((
+            StatusCode::OK,
+            Json(serde_json::json!(SimilarityResponse {
+                similarity: score,
+                topic: req.topic,
+            })),
+        )),
+        Err(e) => Ok((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!(ErrorResponse {
+                error: format!("embedding similarity failed: {e}"),
+            })),
+        )),
+    }
+}

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -12,13 +12,14 @@ use super::chains::{
     ChainCancelRequest, ChainDetailResponse, ChainStepStatus, ChainSummary, ListChainsResponse,
 };
 use super::dlq::{DlqDrainResponse, DlqEntry, DlqStatsResponse};
+use super::embeddings::{SimilarityRequest, SimilarityResponse};
 use super::events::{
     EventStateResponse, ListEventsResponse, TransitionRequest, TransitionResponse,
 };
 use super::groups::{FlushGroupResponse, GroupDetailResponse, GroupSummary, ListGroupsResponse};
 use super::schemas::{
-    ErrorResponse, HealthResponse, MetricsResponse, ReloadRequest, ReloadResponse, RuleSummary,
-    SetEnabledRequest, SetEnabledResponse,
+    EmbeddingMetricsResponse, ErrorResponse, HealthResponse, MetricsResponse, ReloadRequest,
+    ReloadResponse, RuleSummary, SetEnabledRequest, SetEnabledResponse,
 };
 
 #[derive(utoipa::OpenApi)]
@@ -38,7 +39,8 @@ use super::schemas::{
         (name = "Events", description = "Event lifecycle state management"),
         (name = "Groups", description = "Event group management for batched notifications"),
         (name = "Approvals", description = "Human-in-the-loop approval workflow"),
-        (name = "Chains", description = "Task chain orchestration")
+        (name = "Chains", description = "Task chain orchestration"),
+        (name = "Embeddings", description = "Embedding similarity testing")
     ),
     paths(
         super::health::health,
@@ -65,6 +67,7 @@ use super::schemas::{
         super::chains::list_chains,
         super::chains::get_chain,
         super::chains::cancel_chain,
+        super::embeddings::similarity,
     ),
     components(schemas(
         Action, ActionOutcome, ProviderResponse, ResponseStatus, ActionError,
@@ -78,6 +81,8 @@ use super::schemas::{
         GroupSummary, ListGroupsResponse, GroupDetailResponse, FlushGroupResponse,
         ApprovalActionResponse, ApprovalStatusResponse, ApprovalQueryParams, ListApprovalsResponse,
         ChainSummary, ListChainsResponse, ChainDetailResponse, ChainStepStatus, ChainCancelRequest,
+        SimilarityRequest, SimilarityResponse,
+        EmbeddingMetricsResponse,
     ))
 )]
 pub struct ApiDoc;

--- a/crates/server/src/api/schemas.rs
+++ b/crates/server/src/api/schemas.rs
@@ -56,6 +56,36 @@ pub struct MetricsResponse {
     /// Task chains cancelled.
     #[schema(example = 0)]
     pub chains_cancelled: u64,
+    /// Embedding cache metrics (present when embedding provider is enabled).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub embedding: Option<EmbeddingMetricsResponse>,
+}
+
+/// Embedding cache and provider metrics.
+///
+/// Helps operators tune cache capacity and TTL settings. A low hit rate
+/// suggests the cache is too small or the TTL too short. A high
+/// `fail_open_count` indicates the embedding API is unreliable.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct EmbeddingMetricsResponse {
+    /// Topic cache hits.
+    #[schema(example = 500)]
+    pub topic_cache_hits: u64,
+    /// Topic cache misses (required provider API call).
+    #[schema(example = 10)]
+    pub topic_cache_misses: u64,
+    /// Text cache hits.
+    #[schema(example = 200)]
+    pub text_cache_hits: u64,
+    /// Text cache misses (required provider API call).
+    #[schema(example = 50)]
+    pub text_cache_misses: u64,
+    /// Total embedding provider errors.
+    #[schema(example = 0)]
+    pub errors: u64,
+    /// Times fail-open returned similarity `0.0` instead of an error.
+    #[schema(example = 0)]
+    pub fail_open_count: u64,
 }
 
 /// Summary of a loaded rule.

--- a/crates/server/src/ratelimit/limiter.rs
+++ b/crates/server/src/ratelimit/limiter.rs
@@ -113,6 +113,18 @@ impl RateLimiter {
             .unwrap_or(&self.config.tenants.default)
     }
 
+    /// Check and record a request for an arbitrary bucket with a custom tier.
+    ///
+    /// This is useful for endpoints that need their own tight rate limits
+    /// outside the normal caller/tenant tiers.
+    pub async fn check_custom_limit(
+        &self,
+        bucket: &str,
+        tier: &RateLimitTier,
+    ) -> Result<RateLimitResult, RateLimitExceeded> {
+        self.check_limit(bucket, tier).await
+    }
+
     /// Core rate limiting logic using the sliding window approximation algorithm.
     ///
     /// Algorithm (used by Cloudflare, has ~2% error margin):

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -81,6 +81,8 @@ fn build_test_state_with_audit(rules: Vec<Rule>, audit: Option<Arc<dyn AuditStor
         audit,
         auth: None,
         rate_limiter: None,
+        embedding: None,
+        embedding_metrics: None,
     }
 }
 
@@ -803,6 +805,8 @@ fn build_approval_state_with_providers(
         audit: None,
         auth: None,
         rate_limiter: None,
+        embedding: None,
+        embedding_metrics: None,
     }
 }
 

--- a/crates/simulation/examples/polyglot_client_simulation.rs
+++ b/crates/simulation/examples/polyglot_client_simulation.rs
@@ -61,6 +61,8 @@ impl TestServer {
             audit: Some(audit),
             auth: None,
             rate_limiter: None,
+            embedding: None,
+            embedding_metrics: None,
         };
 
         // Build router

--- a/docs/book/api/rest-api.md
+++ b/docs/book/api/rest-api.md
@@ -335,6 +335,51 @@ Force flush/close a group, triggering immediate notification.
 
 ---
 
+## Embeddings
+
+### `POST /v1/embeddings/similarity`
+
+Compute cosine similarity between a text and a topic using the configured embedding provider. Useful for testing semantic match thresholds before writing rules.
+
+**Rate limit:** 5 requests per minute per caller.
+
+**Required permission:** `Dispatch` (admin or operator role).
+
+**Request Body:**
+
+```json
+{
+  "text": "The database connection pool is exhausted and queries are timing out",
+  "topic": "Infrastructure issues, server problems"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `text` | string | Yes | The text to compare |
+| `topic` | string | Yes | The topic to compare against |
+
+**Response (200):**
+
+```json
+{
+  "similarity": 0.82,
+  "topic": "Infrastructure issues, server problems"
+}
+```
+
+**Error Responses:**
+
+| Status | Description |
+|--------|-------------|
+| `401` | Unauthorized |
+| `403` | Insufficient permissions |
+| `404` | Embedding provider not configured |
+| `429` | Rate limit exceeded |
+| `500` | Embedding computation failed |
+
+---
+
 ## Authentication
 
 ### `POST /v1/auth/login`
@@ -389,5 +434,6 @@ Revoke the current JWT token.
 | `GET` | `/v1/groups` | List groups |
 | `GET` | `/v1/groups/{group_key}` | Get group |
 | `DELETE` | `/v1/groups/{group_key}` | Flush group |
+| `POST` | `/v1/embeddings/similarity` | Compute embedding similarity |
 | `POST` | `/v1/auth/login` | Login |
 | `POST` | `/v1/auth/logout` | Logout |

--- a/docs/book/api/rule-reference.md
+++ b/docs/book/api/rule-reference.md
@@ -85,6 +85,38 @@ condition:
         eq: "true"
 ```
 
+### Semantic Match
+
+Match actions based on meaning using vector embeddings:
+
+```yaml
+condition:
+  semantic_match: "Infrastructure issues, server problems"
+  threshold: 0.75
+  text_field: action.payload.message
+```
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `semantic_match` | string | Yes | — | Topic description to match against |
+| `threshold` | float | No | `0.8` | Minimum cosine similarity (0.0 to 1.0) |
+| `text_field` | string | No | — | Field path for the text. When omitted, the entire payload is used |
+
+`semantic_match` can be used inside `all` / `any` blocks:
+
+```yaml
+condition:
+  all:
+    - field: action.payload.severity
+      eq: "critical"
+    - semantic_match: "Infrastructure and server issues"
+      threshold: 0.7
+      text_field: action.payload.description
+```
+
+!!! note
+    Requires the `[embedding]` section in `acteon.toml`. See [Semantic Routing](../features/semantic-routing.md) for configuration details.
+
 ### Expression Functions
 
 ```yaml

--- a/docs/book/features/index.md
+++ b/docs/book/features/index.md
@@ -69,6 +69,11 @@ AI-powered content evaluation and action gating.
 </div>
 
 <div class="card" markdown>
+### [Semantic Routing](semantic-routing.md)
+Route actions by meaning using vector embeddings and cosine similarity.
+</div>
+
+<div class="card" markdown>
 ### [Audit Trail](audit-trail.md)
 Comprehensive, searchable record of every action and its outcome.
 </div>

--- a/docs/book/features/semantic-routing.md
+++ b/docs/book/features/semantic-routing.md
@@ -1,0 +1,236 @@
+# Semantic Routing
+
+Semantic routing uses vector embeddings and cosine similarity to match actions by meaning rather than exact field values. Instead of writing rigid string comparisons, you describe the **topic** you care about in natural language and Acteon determines whether each action's content is semantically close enough.
+
+## How It Works
+
+```mermaid
+flowchart LR
+    A[Action] --> B{semantic_match rule?}
+    B -->|Match| C[Embed text + topic]
+    C --> D{similarity >= threshold?}
+    D -->|Yes| E[Apply rule action]
+    D -->|No| F[Skip rule]
+    B -->|No match| F
+```
+
+1. An action enters the rule engine and matches a `semantic_match` condition
+2. The action text (a specific field or the entire payload) is sent to the configured embedding API
+3. The topic description is embedded (or retrieved from cache)
+4. Cosine similarity is computed between the two vectors
+5. If similarity meets the threshold, the rule fires
+
+## Configuration
+
+### Server Configuration
+
+```toml title="acteon.toml"
+[embedding]
+enabled = true
+endpoint = "https://api.openai.com/v1/embeddings"
+model = "text-embedding-3-small"
+api_key = "ENC[AES256-GCM,...]"        # Use acteon-server encrypt
+timeout_seconds = 10
+fail_open = true                        # Return 0.0 on API failure
+
+# Cache tuning
+topic_cache_capacity = 10000            # Max cached topic embeddings
+topic_cache_ttl_seconds = 3600          # Topic cache TTL (1 hour)
+text_cache_capacity = 1000              # Max cached text embeddings
+text_cache_ttl_seconds = 60             # Text cache TTL (1 minute)
+```
+
+!!! tip "Secret Management"
+    Never store your embedding API key in plain text. Use `acteon-server encrypt`:
+
+    ```bash
+    export ACTEON_AUTH_KEY="<hex-encoded 256-bit key>"
+    echo -n "sk-..." | acteon-server encrypt
+    # Output: ENC[AES256-GCM,...]
+    ```
+
+    Paste the `ENC[...]` value into `api_key` in your `acteon.toml`.
+
+### Rule Configuration
+
+```yaml title="rules/semantic.yaml"
+rules:
+  - name: route-infra-alerts
+    priority: 5
+    description: "Route infrastructure alerts to the DevOps team"
+    condition:
+      semantic_match: "Infrastructure issues, server problems, outages"
+      threshold: 0.75
+      text_field: action.payload.message
+    action:
+      type: reroute
+      target_provider: devops-pagerduty
+```
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `semantic_match` | string | Yes | — | Topic description to match against |
+| `threshold` | float | No | `0.8` | Minimum cosine similarity (0.0 to 1.0) |
+| `text_field` | string | No | — | Dot-separated field path for the text to match. When omitted, the entire action payload is stringified |
+
+## Embedding Provider Interface
+
+```rust
+#[async_trait]
+pub trait EmbeddingEvalSupport: Send + Sync {
+    async fn similarity(&self, text: &str, topic: &str) -> Result<f64, RuleError>;
+}
+```
+
+The built-in `EmbeddingBridge` wraps any OpenAI-compatible embedding API and adds caching, fail-open resilience, and metrics.
+
+## Caching
+
+Embedding API calls are expensive and add latency. Acteon uses a two-tier cache to minimize external calls:
+
+| Tier | What it caches | Default capacity | Default TTL |
+|------|---------------|-----------------|-------------|
+| **Topic cache** | Embeddings for topic descriptions (from rule definitions) | 10,000 | 1 hour |
+| **Text cache** | Embeddings for action text (from payloads) | 1,000 | 1 minute |
+
+Topic embeddings change infrequently (only when rules change), so they get a long TTL and large capacity. Text embeddings are transient action data, so they get a short TTL.
+
+Both caches provide **thundering herd protection** — concurrent requests for the same key are coalesced into a single API call.
+
+### Cache Pre-warming
+
+On startup, Acteon walks all loaded rules and extracts every `semantic_match` topic. These topics are embedded immediately so the first requests don't pay cold-start latency.
+
+### Memory Footprint
+
+Each cached embedding is a `Vec<f32>` whose size depends on the model dimension. For `text-embedding-3-small` (1536 dimensions):
+
+| Cache | Worst case |
+|-------|-----------|
+| Topic cache (10,000 entries) | ~60 MB |
+| Text cache (1,000 entries) | ~6 MB |
+
+Adjust `topic_cache_capacity` and `text_cache_capacity` for your environment.
+
+## Fail-Open Behavior
+
+When `fail_open = true` (the default), embedding API failures return similarity `0.0` instead of propagating an error. This means `semantic_match` rules evaluate to **false** on API failure rather than killing the entire dispatch pipeline.
+
+When `fail_open = false`, embedding errors propagate and the action dispatch fails.
+
+!!! note
+    This mirrors the `fail_open` behavior of [LLM Guardrails](llm-guardrails.md).
+
+## Metrics
+
+Embedding cache and error metrics are exposed via the `/metrics` and `/health` endpoints when the embedding provider is configured:
+
+```json
+{
+  "embedding": {
+    "topic_cache_hits": 1500,
+    "topic_cache_misses": 10,
+    "text_cache_hits": 800,
+    "text_cache_misses": 200,
+    "errors": 2,
+    "fail_open_count": 2
+  }
+}
+```
+
+Monitor `text_cache_misses` and `errors` to tune your cache sizes and detect provider issues.
+
+## REST API
+
+The embedding subsystem also exposes a direct similarity endpoint for testing and debugging:
+
+```
+POST /v1/embeddings/similarity
+```
+
+See the [REST API Reference](../api/rest-api.md#post-v1embeddingssimilarity) for details.
+
+## Use Cases
+
+### Topic-Based Alert Routing
+
+Route alerts to the right team based on content meaning, not exact string matches:
+
+```yaml
+rules:
+  - name: route-infra
+    priority: 5
+    condition:
+      semantic_match: "Infrastructure issues, server outages, disk failures"
+      threshold: 0.75
+      text_field: action.payload.description
+    action:
+      type: reroute
+      target_provider: devops-pagerduty
+
+  - name: route-billing
+    priority: 5
+    condition:
+      semantic_match: "Billing problems, payment failures, subscription issues"
+      threshold: 0.75
+      text_field: action.payload.description
+    action:
+      type: reroute
+      target_provider: billing-team
+```
+
+### Content-Based Suppression
+
+Suppress noise alerts that match a known pattern:
+
+```yaml
+- name: suppress-maintenance-noise
+  priority: 1
+  condition:
+    all:
+      - field: action.action_type
+        eq: "alert"
+      - semantic_match: "Scheduled maintenance, planned downtime, maintenance window"
+        threshold: 0.8
+        text_field: action.payload.message
+  action:
+    type: suppress
+    reason: "Matches maintenance noise pattern"
+```
+
+### Semantic Deduplication
+
+Deduplicate alerts that say the same thing in different words:
+
+```yaml
+- name: dedup-similar-alerts
+  priority: 3
+  condition:
+    semantic_match: "Database connection pool exhausted"
+    threshold: 0.9
+    text_field: action.payload.summary
+  action:
+    type: deduplicate
+    ttl_seconds: 600
+```
+
+### Combining with Other Conditions
+
+`semantic_match` can be used inside `all` / `any` blocks alongside standard field conditions:
+
+```yaml
+- name: urgent-infra-to-pagerduty
+  priority: 2
+  condition:
+    all:
+      - field: action.payload.severity
+        eq: "critical"
+      - semantic_match: "Infrastructure and server issues"
+        threshold: 0.7
+        text_field: action.payload.description
+  action:
+    type: reroute
+    target_provider: pagerduty-urgent
+```

--- a/docs/book/getting-started/configuration.md
+++ b/docs/book/getting-started/configuration.md
@@ -124,6 +124,19 @@ action_type = "send_email"
 # policy = "block"                  # "block" | "flag"
 # temperature = 0.0
 # max_tokens = 256
+
+# ─── Embedding / Semantic Routing ────────────────────────
+[embedding]
+# enabled = false
+# endpoint = "https://api.openai.com/v1/embeddings"
+# model = "text-embedding-3-small"
+# api_key = ""                      # Supports ENC[...] encrypted values
+# timeout_seconds = 10
+# fail_open = true                  # Return similarity 0.0 on API failure
+# topic_cache_capacity = 10000      # Max cached topic embeddings
+# topic_cache_ttl_seconds = 3600    # Topic cache TTL (1 hour)
+# text_cache_capacity = 1000        # Max cached text embeddings
+# text_cache_ttl_seconds = 60       # Text cache TTL (1 minute)
 ```
 
 ## Section Details
@@ -226,12 +239,33 @@ See [Authentication](../api/authentication.md) for auth config file format.
 
 See [Task Chains](../features/chains.md) for detailed chain configuration.
 
+### `[embedding]`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable the embedding provider |
+| `endpoint` | string | `"https://api.openai.com/v1/embeddings"` | OpenAI-compatible embeddings API endpoint |
+| `model` | string | `"text-embedding-3-small"` | Embedding model name |
+| `api_key` | string | `""` | API key (supports `ENC[...]` encrypted values) |
+| `timeout_seconds` | u64 | `10` | Request timeout |
+| `fail_open` | bool | `true` | Return similarity `0.0` on API failure instead of erroring |
+| `topic_cache_capacity` | u64 | `10000` | Max cached topic embeddings |
+| `topic_cache_ttl_seconds` | u64 | `3600` | Topic cache TTL (1 hour) |
+| `text_cache_capacity` | u64 | `1000` | Max cached text embeddings |
+| `text_cache_ttl_seconds` | u64 | `60` | Text cache TTL (1 minute) |
+
+!!! tip "Secret Management"
+    The `api_key` field supports encrypted values. Set `ACTEON_AUTH_KEY` and use `acteon-server encrypt` to generate an `ENC[...]` token. See [Semantic Routing](../features/semantic-routing.md) for details.
+
+See [Semantic Routing](../features/semantic-routing.md) for feature documentation.
+
 ## Environment Variables
 
 | Variable | Description |
 |----------|-------------|
 | `RUST_LOG` | Log verbosity (`error`, `warn`, `info`, `debug`, `trace`) |
 | `OPENAI_API_KEY` | API key for LLM guardrail evaluations |
+| `ACTEON_AUTH_KEY` | Hex-encoded 256-bit master key for decrypting `ENC[...]` config values |
 
 ## Example Configurations
 

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -105,6 +105,16 @@ Use LLM-based evaluation to gate actions through AI-powered guardrails. Block or
 
 <div class="card" markdown>
 
+### Semantic Routing
+
+Route actions by meaning, not just field values. Use vector embeddings and cosine similarity to match actions against topic descriptions in natural language.
+
+[Learn more](features/semantic-routing.md)
+
+</div>
+
+<div class="card" markdown>
+
 ### Enterprise Ready
 
 Multi-tenant isolation, API key and JWT authentication, hot-reload for rules and auth config, graceful shutdown, and comprehensive audit trails.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
     - Human Approvals: features/approvals.md
     - Task Chains: features/chains.md
     - LLM Guardrails: features/llm-guardrails.md
+    - Semantic Routing: features/semantic-routing.md
     - Audit Trail: features/audit-trail.md
   - Backends:
     - backends/index.md


### PR DESCRIPTION
## Summary

- Introduces the `acteon-embedding` crate with an HTTP embedding provider, `moka`-backed two-tier cache (topic + text), fail-open resilience, and observability metrics (cache hits/misses, errors, fail-open count)
- Adds `semantic_match` condition type to the rule IR, YAML frontend, and CEL frontend — rules can now match actions by meaning using vector embeddings and cosine similarity
- Wires `EmbeddingEvalSupport` trait through the gateway and rule engine evaluation context
- Cache pre-warming on startup extracts all `SemanticMatch` topics from loaded rules via `Expr::semantic_topics()` AST walker
- New `POST /v1/embeddings/similarity` API endpoint for testing similarity thresholds before writing rules
- Server config `[embedding]` section with `ENC[...]` encrypted API key support
- Full documentation: feature page, rule reference syntax, REST API endpoint, configuration guide

## Highlights

| Area | Detail |
|------|--------|
| **Caching** | Two-tier moka cache: topics (10K, 1h TTL) + texts (1K, 1m TTL) with thundering herd protection |
| **Resilience** | `fail_open = true` (default) returns similarity 0.0 on API failure — semantic rules evaluate to false instead of crashing the pipeline |
| **Metrics** | `topic_cache_hits/misses`, `text_cache_hits/misses`, `errors`, `fail_open_count` exposed via `/metrics` and `/health` |
| **Pre-warming** | Topics extracted from rules at startup and embedded immediately to avoid cold-start latency |
| **Security** | API key supports `ENC[AES256-GCM,...]` via `ACTEON_AUTH_KEY` + `acteon-server encrypt` |

## Test plan

- [ ] `cargo fmt --all && cargo clippy --workspace --no-deps -- -D warnings && cargo test --workspace`
- [ ] Verify `semantic_match` YAML rule parsing with threshold and text_field
- [ ] Verify `semantic_match` CEL rule parsing
- [ ] Verify embedding cache hit/miss metrics via `/health` endpoint
- [ ] Verify fail-open behavior returns 0.0 on provider error
- [ ] Verify `POST /v1/embeddings/similarity` endpoint with valid and missing provider
- [ ] Review documentation renders correctly in MkDocs

🤖 Generated with [Claude Code](https://claude.com/claude-code)