### PR TITLE
Add dry-run mode for dispatch endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,22 @@ cargo run -p acteon-simulation --example postgres_simulation --features postgres
 - `acteon-audit-*` - Audit backend implementations
 - `acteon-rules-*` - Rule parsing frontends
 
+## Feature Implementation Steps
+
+When implementing a new feature (provider, capability, etc.), follow this layered approach:
+
+1. **Core types** – Add/modify types in `acteon-core` (e.g., new `ActionOutcome` variant, new config struct)
+2. **Crate implementation** – Create or modify the relevant crate under `crates/` (provider, gateway logic, etc.)
+3. **Register in workspace** – Add new crate to `Cargo.toml` workspace members and `[workspace.dependencies]`
+4. **Server integration** – Wire into `acteon-server` (routes, handlers, query params, OpenAPI annotations)
+5. **Gateway integration** – Update `acteon-gateway` dispatch pipeline if needed
+6. **Rust client** – Add helper methods to `acteon-client` (`crates/client/src/`)
+7. **Polyglot client SDKs** – Update Python, Node.js, Go, and Java clients in `clients/`
+8. **Tests** – Add unit tests in the crate, SDK tests, and simulation framework tests
+9. **Documentation** – Update `docs/book/` pages (concepts, API reference, examples)
+10. **Simulation example** – Add a simulation example in `crates/simulation/examples/`
+11. **Pre-commit checks** – Run `cargo fmt --all && cargo clippy --workspace --no-deps -- -D warnings && cargo test --workspace`
+
 ## Common Clippy Fixes
 
 - Use `#[must_use]` on builder methods returning `Self`

--- a/clients/java/src/main/java/com/acteon/client/models/ActionOutcome.java
+++ b/clients/java/src/main/java/com/acteon/client/models/ActionOutcome.java
@@ -16,9 +16,12 @@ public class ActionOutcome {
     private String newProvider;
     private Duration retryAfter;
     private ActionError error;
+    private String verdict;
+    private String matchedRule;
+    private String wouldBeProvider;
 
     public enum OutcomeType {
-        EXECUTED, DEDUPLICATED, SUPPRESSED, REROUTED, THROTTLED, FAILED
+        EXECUTED, DEDUPLICATED, SUPPRESSED, REROUTED, THROTTLED, FAILED, DRY_RUN
     }
 
     // Getters and setters
@@ -43,12 +46,22 @@ public class ActionOutcome {
     public ActionError getError() { return error; }
     public void setError(ActionError error) { this.error = error; }
 
+    public String getVerdict() { return verdict; }
+    public void setVerdict(String verdict) { this.verdict = verdict; }
+
+    public String getMatchedRule() { return matchedRule; }
+    public void setMatchedRule(String matchedRule) { this.matchedRule = matchedRule; }
+
+    public String getWouldBeProvider() { return wouldBeProvider; }
+    public void setWouldBeProvider(String wouldBeProvider) { this.wouldBeProvider = wouldBeProvider; }
+
     public boolean isExecuted() { return type == OutcomeType.EXECUTED; }
     public boolean isDeduplicated() { return type == OutcomeType.DEDUPLICATED; }
     public boolean isSuppressed() { return type == OutcomeType.SUPPRESSED; }
     public boolean isRerouted() { return type == OutcomeType.REROUTED; }
     public boolean isThrottled() { return type == OutcomeType.THROTTLED; }
     public boolean isFailed() { return type == OutcomeType.FAILED; }
+    public boolean isDryRun() { return type == OutcomeType.DRY_RUN; }
 
     /**
      * Parse an ActionOutcome from a raw JSON string.
@@ -114,6 +127,12 @@ public class ActionOutcome {
             outcome.type = OutcomeType.FAILED;
             Map<String, Object> failed = (Map<String, Object>) data.get("Failed");
             outcome.error = ActionError.fromMap(failed);
+        } else if (data.containsKey("DryRun")) {
+            outcome.type = OutcomeType.DRY_RUN;
+            Map<String, Object> dryRun = (Map<String, Object>) data.get("DryRun");
+            outcome.verdict = (String) dryRun.get("verdict");
+            outcome.matchedRule = (String) dryRun.get("matched_rule");
+            outcome.wouldBeProvider = (String) dryRun.get("would_be_provider");
         } else {
             outcome.type = OutcomeType.FAILED;
             outcome.error = new ActionError("UNKNOWN", "Unknown outcome", false, 0);

--- a/clients/nodejs/src/models.ts
+++ b/clients/nodejs/src/models.ts
@@ -102,7 +102,8 @@ export type ActionOutcome =
       response: ProviderResponse;
     }
   | { type: "throttled"; retryAfterSecs: number }
-  | { type: "failed"; error: ActionError };
+  | { type: "failed"; error: ActionError }
+  | { type: "dry_run"; verdict: string; matchedRule?: string; wouldBeProvider: string };
 
 /**
  * Error details when an action fails.
@@ -182,6 +183,16 @@ export function parseActionOutcome(data: unknown): ActionOutcome {
         retryable: (failed.retryable as boolean) ?? false,
         attempts: (failed.attempts as number) ?? 0,
       },
+    };
+  }
+
+  if ("DryRun" in obj) {
+    const dryRun = obj.DryRun as Record<string, unknown>;
+    return {
+      type: "dry_run",
+      verdict: (dryRun.verdict as string) ?? "",
+      matchedRule: dryRun.matched_rule as string | undefined,
+      wouldBeProvider: (dryRun.would_be_provider as string) ?? "",
     };
   }
 

--- a/crates/gateway/examples/basic.rs
+++ b/crates/gateway/examples/basic.rs
@@ -132,5 +132,6 @@ fn outcome_label(outcome: &ActionOutcome) -> &'static str {
         ActionOutcome::Failed(_) => "Failed",
         ActionOutcome::PendingApproval { .. } => "PendingApproval",
         ActionOutcome::ChainStarted { .. } => "ChainStarted",
+        ActionOutcome::DryRun { .. } => "DryRun",
     }
 }

--- a/crates/gateway/examples/multi_provider.rs
+++ b/crates/gateway/examples/multi_provider.rs
@@ -170,5 +170,10 @@ fn describe_outcome(outcome: &ActionOutcome) -> String {
             chain_name,
             ..
         } => format!("ChainStarted (id: {chain_id}, chain: {chain_name})"),
+        ActionOutcome::DryRun {
+            verdict,
+            would_be_provider,
+            ..
+        } => format!("DryRun (verdict: {verdict}, provider: {would_be_provider})"),
     }
 }

--- a/crates/simulation/examples/dry_run_simulation.rs
+++ b/crates/simulation/examples/dry_run_simulation.rs
@@ -1,0 +1,327 @@
+//! Demonstration of dry-run mode in the simulation framework.
+//!
+//! Dry-run evaluates the full rule pipeline and returns what *would* happen
+//! without executing the action, recording state, or emitting audit records.
+//!
+//! Run with: cargo run -p acteon-simulation --example dry_run_simulation
+
+use acteon_core::{Action, ActionOutcome};
+use acteon_simulation::prelude::*;
+
+const SUPPRESSION_RULE: &str = r#"
+rules:
+  - name: block-spam
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "spam"
+    action:
+      type: suppress
+"#;
+
+const REROUTE_RULE: &str = r#"
+rules:
+  - name: reroute-urgent
+    priority: 1
+    condition:
+      field: action.payload.priority
+      eq: "urgent"
+    action:
+      type: reroute
+      target_provider: sms
+"#;
+
+const DEDUP_RULE: &str = r#"
+rules:
+  - name: dedup-notifications
+    priority: 2
+    condition:
+      field: action.action_type
+      eq: "notify"
+    action:
+      type: deduplicate
+      ttl_seconds: 300
+"#;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("╔══════════════════════════════════════════════════════════════╗");
+    println!("║             DRY-RUN MODE SIMULATION DEMO                     ║");
+    println!("╚══════════════════════════════════════════════════════════════╝\n");
+
+    // =========================================================================
+    // DEMO 1: Dry-Run Allow Verdict
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  DEMO 1: DRY-RUN ALLOW VERDICT");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("email")
+            .add_rule_yaml(SUPPRESSION_RULE)
+            .build(),
+    )
+    .await?;
+
+    // Normal action with no matching suppression rule -> would be allowed.
+    let action = Action::new(
+        "notifications",
+        "tenant-1",
+        "email",
+        "send_email",
+        serde_json::json!({"to": "user@example.com", "subject": "Hello"}),
+    );
+
+    let outcome = harness.dispatch_dry_run(&action).await?;
+    println!("  Action: send_email via email provider");
+    println!("  Outcome: {outcome:?}");
+    outcome.assert_dry_run();
+
+    match &outcome {
+        ActionOutcome::DryRun {
+            verdict,
+            matched_rule,
+            would_be_provider,
+        } => {
+            println!("  Verdict: {verdict}");
+            println!("  Matched rule: {matched_rule:?}");
+            println!("  Would-be provider: {would_be_provider}");
+            assert_eq!(verdict, "allow");
+            assert!(matched_rule.is_none());
+            assert_eq!(would_be_provider, "email");
+        }
+        _ => panic!("expected DryRun"),
+    }
+
+    // Provider was NOT called.
+    harness.provider("email").unwrap().assert_not_called();
+    println!("  Provider calls: 0 (dry-run skips execution)");
+    println!();
+
+    harness.teardown().await?;
+
+    // =========================================================================
+    // DEMO 2: Dry-Run Suppression Verdict
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  DEMO 2: DRY-RUN SUPPRESSION VERDICT");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("email")
+            .add_rule_yaml(SUPPRESSION_RULE)
+            .build(),
+    )
+    .await?;
+
+    // This action matches the "block-spam" rule -> would be suppressed.
+    let spam_action = Action::new(
+        "notifications",
+        "tenant-1",
+        "email",
+        "spam",
+        serde_json::json!({"body": "buy now!"}),
+    );
+
+    let outcome = harness.dispatch_dry_run(&spam_action).await?;
+    println!("  Action: spam via email provider");
+    println!("  Outcome: {outcome:?}");
+    outcome.assert_dry_run();
+
+    match &outcome {
+        ActionOutcome::DryRun {
+            verdict,
+            matched_rule,
+            ..
+        } => {
+            println!("  Verdict: {verdict}");
+            println!("  Matched rule: {matched_rule:?}");
+            assert_eq!(verdict, "suppress");
+            assert_eq!(matched_rule.as_deref(), Some("block-spam"));
+        }
+        _ => panic!("expected DryRun"),
+    }
+
+    harness.provider("email").unwrap().assert_not_called();
+    println!("  Provider calls: 0 (dry-run skips execution)");
+    println!();
+
+    harness.teardown().await?;
+
+    // =========================================================================
+    // DEMO 3: Dry-Run Reroute Verdict
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  DEMO 3: DRY-RUN REROUTE VERDICT");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("email")
+            .add_recording_provider("sms")
+            .add_rule_yaml(REROUTE_RULE)
+            .build(),
+    )
+    .await?;
+
+    // Urgent action -> would be rerouted from email to sms.
+    let urgent_action = Action::new(
+        "notifications",
+        "tenant-1",
+        "email",
+        "alert",
+        serde_json::json!({"priority": "urgent", "message": "Server is down!"}),
+    );
+
+    let outcome = harness.dispatch_dry_run(&urgent_action).await?;
+    println!("  Action: alert via email provider (priority=urgent)");
+    println!("  Outcome: {outcome:?}");
+    outcome.assert_dry_run();
+
+    match &outcome {
+        ActionOutcome::DryRun {
+            verdict,
+            matched_rule,
+            would_be_provider,
+        } => {
+            println!("  Verdict: {verdict}");
+            println!("  Matched rule: {matched_rule:?}");
+            println!("  Would-be provider: {would_be_provider} (rerouted from email)");
+            assert_eq!(verdict, "reroute");
+            assert_eq!(matched_rule.as_deref(), Some("reroute-urgent"));
+            assert_eq!(would_be_provider, "sms");
+        }
+        _ => panic!("expected DryRun"),
+    }
+
+    // Neither provider was called.
+    harness.provider("email").unwrap().assert_not_called();
+    harness.provider("sms").unwrap().assert_not_called();
+    println!("  Email provider calls: 0");
+    println!("  SMS provider calls: 0");
+    println!();
+
+    harness.teardown().await?;
+
+    // =========================================================================
+    // DEMO 4: Dry-Run vs Normal Dispatch Comparison
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  DEMO 4: DRY-RUN vs NORMAL DISPATCH COMPARISON");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("email")
+            .add_rule_yaml(DEDUP_RULE)
+            .build(),
+    )
+    .await?;
+
+    let action = Action::new(
+        "notifications",
+        "tenant-1",
+        "email",
+        "notify",
+        serde_json::json!({"msg": "hello"}),
+    )
+    .with_dedup_key("dedup-key-1");
+
+    // Dry-run: shows "deduplicate" verdict, but does NOT record the dedup key.
+    let dry_outcome = harness.dispatch_dry_run(&action).await?;
+    println!("  Dry-run outcome: {dry_outcome:?}");
+    dry_outcome.assert_dry_run();
+    match &dry_outcome {
+        ActionOutcome::DryRun { verdict, .. } => {
+            println!("  Verdict: {verdict}");
+            assert_eq!(verdict, "deduplicate");
+        }
+        _ => panic!("expected DryRun"),
+    }
+    harness.provider("email").unwrap().assert_not_called();
+    println!("  Provider calls after dry-run: 0");
+
+    // Normal dispatch: the action is actually executed (first time with this dedup key).
+    let normal_outcome = harness.dispatch(&action).await?;
+    println!("  Normal outcome: {normal_outcome:?}");
+    normal_outcome.assert_executed();
+    harness.provider("email").unwrap().assert_called(1);
+    println!("  Provider calls after normal dispatch: 1");
+
+    // Second normal dispatch: now deduplicated because the key was recorded.
+    let dedup_outcome = harness.dispatch(&action).await?;
+    println!("  Second dispatch outcome: {dedup_outcome:?}");
+    dedup_outcome.assert_deduplicated();
+    harness.provider("email").unwrap().assert_called(1);
+    println!("  Provider calls (still 1, second was deduped): 1");
+    println!();
+
+    harness.teardown().await?;
+
+    // =========================================================================
+    // DEMO 5: Batch Dry-Run
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  DEMO 5: BATCH DRY-RUN");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("email")
+            .add_recording_provider("sms")
+            .add_rule_yaml(SUPPRESSION_RULE)
+            .add_rule_yaml(REROUTE_RULE)
+            .build(),
+    )
+    .await?;
+
+    let actions = vec![
+        // Would be allowed (no matching rule).
+        Action::new(
+            "ns",
+            "tenant-1",
+            "email",
+            "send_email",
+            serde_json::json!({}),
+        ),
+        // Would be suppressed by "block-spam".
+        Action::new("ns", "tenant-1", "email", "spam", serde_json::json!({})),
+        // Would be rerouted from email to sms by "reroute-urgent".
+        Action::new(
+            "ns",
+            "tenant-1",
+            "email",
+            "alert",
+            serde_json::json!({"priority": "urgent"}),
+        ),
+    ];
+
+    let outcomes = harness.dispatch_batch_dry_run(&actions).await;
+    println!("  Batch size: {}", actions.len());
+    for (i, outcome) in outcomes.iter().enumerate() {
+        let outcome = outcome.as_ref().unwrap();
+        println!("  Action {i}: {outcome:?}");
+        outcome.assert_dry_run();
+    }
+
+    // No providers were called.
+    harness.provider("email").unwrap().assert_not_called();
+    harness.provider("sms").unwrap().assert_not_called();
+    println!("  Total provider calls: 0 (batch dry-run)");
+    println!();
+
+    harness.teardown().await?;
+
+    println!("╔══════════════════════════════════════════════════════════════╗");
+    println!("║                  ALL DEMOS PASSED                            ║");
+    println!("╚══════════════════════════════════════════════════════════════╝");
+
+    Ok(())
+}

--- a/crates/simulation/src/assertions.rs
+++ b/crates/simulation/src/assertions.rs
@@ -184,6 +184,18 @@ impl SideEffectAssertions {
         }
     }
 
+    /// Assert that an outcome matches the `DryRun` variant.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the outcome is not `DryRun`.
+    pub fn assert_dry_run(outcome: &ActionOutcome) {
+        assert!(
+            matches!(outcome, ActionOutcome::DryRun { .. }),
+            "expected DryRun, got {outcome:?}"
+        );
+    }
+
     /// Assert that a state transition occurred to a specific state.
     ///
     /// # Panics
@@ -315,6 +327,9 @@ pub trait ActionOutcomeExt {
     /// Assert this outcome is `ChainStarted`.
     fn assert_chain_started(&self);
 
+    /// Assert this outcome is `DryRun`.
+    fn assert_dry_run(&self);
+
     /// Check if this outcome is `Executed`.
     fn is_executed(&self) -> bool;
 
@@ -341,6 +356,9 @@ pub trait ActionOutcomeExt {
 
     /// Check if this outcome is `ChainStarted`.
     fn is_chain_started(&self) -> bool;
+
+    /// Check if this outcome is `DryRun`.
+    fn is_dry_run(&self) -> bool;
 }
 
 impl ActionOutcomeExt for ActionOutcome {
@@ -380,6 +398,10 @@ impl ActionOutcomeExt for ActionOutcome {
         SideEffectAssertions::assert_chain_started(self);
     }
 
+    fn assert_dry_run(&self) {
+        SideEffectAssertions::assert_dry_run(self);
+    }
+
     fn is_executed(&self) -> bool {
         matches!(self, ActionOutcome::Executed(_))
     }
@@ -414,6 +436,10 @@ impl ActionOutcomeExt for ActionOutcome {
 
     fn is_chain_started(&self) -> bool {
         matches!(self, ActionOutcome::ChainStarted { .. })
+    }
+
+    fn is_dry_run(&self) -> bool {
+        matches!(self, ActionOutcome::DryRun { .. })
     }
 }
 
@@ -665,5 +691,27 @@ mod tests {
         };
         assert!(chain_started.is_chain_started());
         assert!(!chain_started.is_executed());
+    }
+
+    #[test]
+    fn assert_dry_run_passes() {
+        let outcome = ActionOutcome::DryRun {
+            verdict: "allow".into(),
+            matched_rule: None,
+            would_be_provider: "email".into(),
+        };
+        SideEffectAssertions::assert_dry_run(&outcome);
+        outcome.assert_dry_run();
+    }
+
+    #[test]
+    fn is_dry_run_works() {
+        let dry_run = ActionOutcome::DryRun {
+            verdict: "allow".into(),
+            matched_rule: None,
+            would_be_provider: "email".into(),
+        };
+        assert!(dry_run.is_dry_run());
+        assert!(!dry_run.is_executed());
     }
 }

--- a/crates/simulation/src/cluster/node.rs
+++ b/crates/simulation/src/cluster/node.rs
@@ -101,12 +101,25 @@ impl ServerNode {
         self.gateway.dispatch(action, None).await
     }
 
+    /// Dispatch an action through this node's gateway in dry-run mode.
+    pub async fn dispatch_dry_run(&self, action: Action) -> Result<ActionOutcome, GatewayError> {
+        self.gateway.dispatch_dry_run(action, None).await
+    }
+
     /// Dispatch a batch of actions through this node's gateway.
     pub async fn dispatch_batch(
         &self,
         actions: Vec<Action>,
     ) -> Vec<Result<ActionOutcome, GatewayError>> {
         self.gateway.dispatch_batch(actions, None).await
+    }
+
+    /// Dispatch a batch of actions through this node's gateway in dry-run mode.
+    pub async fn dispatch_batch_dry_run(
+        &self,
+        actions: Vec<Action>,
+    ) -> Vec<Result<ActionOutcome, GatewayError>> {
+        self.gateway.dispatch_batch_dry_run(actions, None).await
     }
 
     /// Gracefully stop this node.

--- a/docs/book/api/rest-api.md
+++ b/docs/book/api/rest-api.md
@@ -66,6 +66,12 @@ Dispatch counters only.
 
 Dispatch a single action through the gateway pipeline.
 
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `dry_run` | bool | `false` | When `true`, evaluates rules without executing. See [Dry-Run Mode](../features/dry-run.md). |
+
 **Request Body:**
 
 ```json
@@ -135,6 +141,12 @@ Dispatch a single action through the gateway pipeline.
 ### `POST /v1/dispatch/batch`
 
 Dispatch multiple actions in a single request.
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `dry_run` | bool | `false` | When `true`, evaluates rules without executing. See [Dry-Run Mode](../features/dry-run.md). |
 
 **Request Body:**
 

--- a/docs/book/examples/simulation.md
+++ b/docs/book/examples/simulation.md
@@ -148,6 +148,17 @@ harness.dispatch(&action).await.unwrap()
     .assert_state_changed(); // State transitioned
     .assert_pending_approval(); // Needs approval
     .assert_chain_started(); // Chain initiated
+    .assert_dry_run();       // Dry-run verdict returned
+```
+
+### Dry-Run Dispatch
+
+```rust
+// Dry-run: evaluate rules without executing
+let outcome = harness.dispatch_dry_run(&action).await.unwrap();
+outcome.assert_dry_run();
+// Provider was NOT called
+harness.provider("email").unwrap().assert_not_called();
 ```
 
 ## Test Scenarios
@@ -246,6 +257,20 @@ cargo run -p acteon-simulation --example postgres_simulation --features postgres
 cargo run -p acteon-simulation --example clickhouse_simulation --features clickhouse
 cargo run -p acteon-simulation --example dynamodb_simulation --features dynamodb
 ```
+
+### Dry-Run Simulation
+
+```bash
+cargo run -p acteon-simulation --example dry_run_simulation
+```
+
+Tests dry-run dispatch across multiple rule types:
+
+- **Allow verdict** — No rules match, action would be allowed
+- **Suppression verdict** — Rule would suppress the action
+- **Rerouting verdict** — Rule would reroute to a different provider
+- **Batch dry-run** — Multiple actions evaluated without executing
+- **Provider not called** — Verifies no side effects during dry-run
 
 ### Webhook Simulation
 

--- a/docs/book/features/dry-run.md
+++ b/docs/book/features/dry-run.md
@@ -1,0 +1,199 @@
+# Dry-Run Mode
+
+Dry-run mode lets you evaluate the full rule pipeline for an action without
+actually executing it, recording state changes, or emitting audit records.
+This is essential for:
+
+- **Testing rule changes** before deploying
+- **Debugging** why an action was suppressed, rerouted, or throttled
+- **Building rule-authoring tools** with instant feedback
+
+## How It Works
+
+Pass `?dry_run=true` as a query parameter on the dispatch endpoint:
+
+```
+POST /v1/dispatch?dry_run=true
+POST /v1/dispatch/batch?dry_run=true
+```
+
+The gateway will:
+
+1. Evaluate all rules (including CEL expressions) to produce a verdict
+2. Run the LLM guardrail check (if configured)
+3. Return a `DryRun` outcome describing what *would* happen
+
+The gateway will **skip**:
+
+- Distributed lock acquisition
+- Provider execution
+- State mutations (dedup keys, group state, chain state, etc.)
+- Audit record emission
+- Rate-limit counter updates
+
+## Response Format
+
+The `DryRun` outcome contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `verdict` | string | The verdict tag: `allow`, `suppress`, `deny`, `reroute`, `throttle`, `deduplicate`, `modify`, `group`, `state_machine`, `request_approval`, `chain` |
+| `matched_rule` | string? | Name of the matched rule, if any |
+| `would_be_provider` | string | The provider that would handle the action (reflects rerouting) |
+
+### Example: Action would be allowed
+
+```bash
+curl -X POST 'http://localhost:8080/v1/dispatch?dry_run=true' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "namespace": "notifications",
+    "tenant": "tenant-1",
+    "provider": "email",
+    "action_type": "send_email",
+    "payload": {"to": "user@example.com"}
+  }'
+```
+
+```json
+{
+  "DryRun": {
+    "verdict": "allow",
+    "matched_rule": null,
+    "would_be_provider": "email"
+  }
+}
+```
+
+### Example: Action would be suppressed
+
+```json
+{
+  "DryRun": {
+    "verdict": "suppress",
+    "matched_rule": "block-spam",
+    "would_be_provider": "email"
+  }
+}
+```
+
+### Example: Action would be rerouted
+
+```json
+{
+  "DryRun": {
+    "verdict": "reroute",
+    "matched_rule": "reroute-urgent",
+    "would_be_provider": "sms"
+  }
+}
+```
+
+## Client SDK Usage
+
+### Rust
+
+```rust
+use acteon_client::ActeonClient;
+use acteon_core::Action;
+
+let client = ActeonClient::new("http://localhost:8080");
+let action = Action::new("ns", "tenant", "email", "send", serde_json::json!({}));
+
+let outcome = client.dispatch_dry_run(&action).await?;
+println!("{:?}", outcome);
+```
+
+### Python
+
+```python
+from acteon_client import ActeonClient
+
+client = ActeonClient("http://localhost:8080")
+action = Action(namespace="ns", tenant="t1", provider="email",
+                action_type="send", payload={})
+outcome = client.dispatch(action, dry_run=True)
+if outcome.is_dry_run():
+    print(f"Verdict: {outcome.verdict_details['verdict']}")
+```
+
+### Node.js / TypeScript
+
+```typescript
+const outcome = await client.dispatch(action, { dryRun: true });
+if (outcome.type === "dry_run") {
+  console.log(`Verdict: ${outcome.verdict}`);
+}
+```
+
+### Go
+
+```go
+outcome, err := client.DispatchDryRun(ctx, action)
+if outcome.IsDryRun() {
+    fmt.Println("Verdict:", outcome.Verdict)
+}
+```
+
+### Java
+
+```java
+ActionOutcome outcome = client.dispatchDryRun(action);
+if (outcome.isDryRun()) {
+    System.out.println("Verdict: " + outcome.getVerdict());
+}
+```
+
+## Simulation Framework
+
+The simulation harness also supports dry-run mode:
+
+```rust
+use acteon_simulation::prelude::*;
+use acteon_core::Action;
+
+let harness = SimulationHarness::start(
+    SimulationConfig::builder()
+        .nodes(1)
+        .add_recording_provider("email")
+        .add_rule_yaml(r#"
+            rules:
+              - name: block-spam
+                priority: 1
+                condition:
+                  field: action.action_type
+                  eq: "spam"
+                action:
+                  type: suppress
+        "#)
+        .build()
+).await.unwrap();
+
+let action = Action::new("ns", "t1", "email", "spam", serde_json::json!({}));
+let outcome = harness.dispatch_dry_run(&action).await.unwrap();
+
+outcome.assert_dry_run();
+// Provider was NOT called
+harness.provider("email").unwrap().assert_not_called();
+```
+
+## Batch Dry-Run
+
+Batch dispatch also supports dry-run. All actions in the batch are evaluated
+independently and none are executed:
+
+```bash
+curl -X POST 'http://localhost:8080/v1/dispatch/batch?dry_run=true' \
+  -H 'Content-Type: application/json' \
+  -d '[
+    {"namespace": "ns", "tenant": "t1", "provider": "email", "action_type": "send", "payload": {}},
+    {"namespace": "ns", "tenant": "t1", "provider": "email", "action_type": "spam", "payload": {}}
+  ]'
+```
+
+```json
+[
+  {"DryRun": {"verdict": "allow", "matched_rule": null, "would_be_provider": "email"}},
+  {"DryRun": {"verdict": "suppress", "matched_rule": "block-spam", "would_be_provider": "email"}}
+]
+```

--- a/docs/book/features/index.md
+++ b/docs/book/features/index.md
@@ -78,4 +78,9 @@ Route actions by meaning using vector embeddings and cosine similarity.
 Comprehensive, searchable record of every action and its outcome.
 </div>
 
+<div class="card" markdown>
+### [Dry-Run Mode](dry-run.md)
+Test rules without executing actions — see what *would* happen before it happens.
+</div>
+
 </div>


### PR DESCRIPTION
Implement dry-run mode that evaluates the full rule pipeline (including LLM guardrails) and returns what *would* happen without executing the action, recording state, or emitting audit records. This is essential for testing rule changes, debugging suppression/routing, and building rule-authoring tools.

Changes across the full stack:
- Core: Add DryRun variant to ActionOutcome with verdict, matched_rule, and would_be_provider fields
- Gateway: Add dispatch_dry_run/dispatch_batch_dry_run methods that skip lock acquisition, execution, state mutation, and audit recording
- Server: Parse ?dry_run=true query parameter on dispatch endpoints
- Client: Add dispatch_dry_run/dispatch_batch_dry_run to Rust client
- SDKs: Update Python, Node.js, Go, and Java clients to parse DryRun
- Simulation: Add dispatch_dry_run to harness/node, assert_dry_run and is_dry_run to assertion helpers
- Tests: 8 gateway unit tests covering all verdict types, state isolation, and batch dry-run
- Docs: Feature page, REST API reference, simulation guide updates
- Example: 5-demo simulation covering allow/suppress/reroute/dedup verdicts, dry-run vs normal comparison, and batch dry-run

Also adds "Feature Implementation Steps" section to CLAUDE.md documenting the layered approach for future feature work.

https://claude.ai/code/session_01Ro9h4MbKYGM2sJL3Zs1vy8