### PR TITLE
Add circuit breaker admin API for manual trip/reset

### DIFF
--- a/crates/server/src/api/circuit_breakers.rs
+++ b/crates/server/src/api/circuit_breakers.rs
@@ -1,0 +1,238 @@
+use axum::Json;
+use axum::extract::{self, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+use utoipa::ToSchema;
+
+use crate::auth::identity::CallerIdentity;
+use crate::auth::role::Permission;
+
+use super::AppState;
+use super::schemas::ErrorResponse;
+
+/// Summary of a single circuit breaker's current state and configuration.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct CircuitBreakerStatus {
+    /// Provider name.
+    #[schema(example = "email")]
+    pub provider: String,
+    /// Current circuit state.
+    #[schema(example = "closed")]
+    pub state: String,
+    /// Number of consecutive failures before opening the circuit.
+    #[schema(example = 5)]
+    pub failure_threshold: u32,
+    /// Number of consecutive successes in half-open state to close the circuit.
+    #[schema(example = 2)]
+    pub success_threshold: u32,
+    /// Recovery timeout in seconds.
+    #[schema(example = 60)]
+    pub recovery_timeout_seconds: u64,
+    /// Optional fallback provider.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "sms")]
+    pub fallback_provider: Option<String>,
+}
+
+/// Response for listing all circuit breakers.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ListCircuitBreakersResponse {
+    /// List of circuit breaker statuses.
+    pub circuit_breakers: Vec<CircuitBreakerStatus>,
+}
+
+/// Response after tripping or resetting a circuit breaker.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct CircuitBreakerActionResponse {
+    /// Provider name.
+    #[schema(example = "email")]
+    pub provider: String,
+    /// New circuit state after the action.
+    #[schema(example = "open")]
+    pub state: String,
+    /// Human-readable status message.
+    #[schema(example = "circuit breaker tripped")]
+    pub message: String,
+}
+
+/// `GET /admin/circuit-breakers` -- list all circuit breakers with current state.
+#[utoipa::path(
+    get,
+    path = "/admin/circuit-breakers",
+    tag = "Circuit Breakers",
+    summary = "List circuit breakers",
+    description = "Returns all registered circuit breakers with their current state and configuration.",
+    responses(
+        (status = 200, description = "List of circuit breakers", body = ListCircuitBreakersResponse),
+        (status = 404, description = "Circuit breakers not enabled", body = ErrorResponse)
+    )
+)]
+pub async fn list_circuit_breakers(
+    State(state): State<AppState>,
+    axum::Extension(_identity): axum::Extension<CallerIdentity>,
+) -> impl IntoResponse {
+    let gw = state.gateway.read().await;
+    let Some(registry) = gw.circuit_breakers() else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!(ErrorResponse {
+                error: "circuit breakers are not enabled".into(),
+            })),
+        );
+    };
+
+    let mut breakers = Vec::new();
+    for name in registry.providers() {
+        if let Some(cb) = registry.get(name) {
+            let current_state = cb.state().await;
+            let config = cb.config();
+            breakers.push(CircuitBreakerStatus {
+                provider: name.to_owned(),
+                state: current_state.to_string(),
+                failure_threshold: config.failure_threshold,
+                success_threshold: config.success_threshold,
+                recovery_timeout_seconds: config.recovery_timeout.as_secs(),
+                fallback_provider: config.fallback_provider.clone(),
+            });
+        }
+    }
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!(ListCircuitBreakersResponse {
+            circuit_breakers: breakers,
+        })),
+    )
+}
+
+/// `POST /admin/circuit-breakers/{provider}/trip` -- force a circuit breaker open.
+#[utoipa::path(
+    post,
+    path = "/admin/circuit-breakers/{provider}/trip",
+    tag = "Circuit Breakers",
+    summary = "Trip circuit breaker",
+    description = "Force-opens a circuit breaker, immediately rejecting all requests to the provider.",
+    params(
+        ("provider" = String, Path, description = "Provider name")
+    ),
+    responses(
+        (status = 200, description = "Circuit breaker tripped", body = CircuitBreakerActionResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Circuit breaker not found", body = ErrorResponse)
+    )
+)]
+pub async fn trip_circuit_breaker(
+    State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
+    extract::Path(provider): extract::Path<String>,
+) -> impl IntoResponse {
+    if !identity
+        .role
+        .has_permission(Permission::CircuitBreakerManage)
+    {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!(ErrorResponse {
+                error: "insufficient permissions: circuit breaker management requires admin or operator role".into(),
+            })),
+        );
+    }
+
+    let gw = state.gateway.read().await;
+    let Some(registry) = gw.circuit_breakers() else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!(ErrorResponse {
+                error: "circuit breakers are not enabled".into(),
+            })),
+        );
+    };
+
+    let Some(cb) = registry.get(&provider) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!(ErrorResponse {
+                error: format!("circuit breaker not found: {provider}"),
+            })),
+        );
+    };
+
+    cb.trip().await;
+    info!(provider = %provider, "circuit breaker manually tripped");
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!(CircuitBreakerActionResponse {
+            provider,
+            state: "open".into(),
+            message: "circuit breaker tripped".into(),
+        })),
+    )
+}
+
+/// `POST /admin/circuit-breakers/{provider}/reset` -- force a circuit breaker closed.
+#[utoipa::path(
+    post,
+    path = "/admin/circuit-breakers/{provider}/reset",
+    tag = "Circuit Breakers",
+    summary = "Reset circuit breaker",
+    description = "Force-closes a circuit breaker, restoring normal request flow to the provider.",
+    params(
+        ("provider" = String, Path, description = "Provider name")
+    ),
+    responses(
+        (status = 200, description = "Circuit breaker reset", body = CircuitBreakerActionResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Circuit breaker not found", body = ErrorResponse)
+    )
+)]
+pub async fn reset_circuit_breaker(
+    State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
+    extract::Path(provider): extract::Path<String>,
+) -> impl IntoResponse {
+    if !identity
+        .role
+        .has_permission(Permission::CircuitBreakerManage)
+    {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!(ErrorResponse {
+                error: "insufficient permissions: circuit breaker management requires admin or operator role".into(),
+            })),
+        );
+    }
+
+    let gw = state.gateway.read().await;
+    let Some(registry) = gw.circuit_breakers() else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!(ErrorResponse {
+                error: "circuit breakers are not enabled".into(),
+            })),
+        );
+    };
+
+    let Some(cb) = registry.get(&provider) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!(ErrorResponse {
+                error: format!("circuit breaker not found: {provider}"),
+            })),
+        );
+    };
+
+    cb.reset().await;
+    info!(provider = %provider, "circuit breaker manually reset");
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!(CircuitBreakerActionResponse {
+            provider,
+            state: "closed".into(),
+            message: "circuit breaker reset".into(),
+        })),
+    )
+}

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -2,6 +2,7 @@ pub mod approvals;
 pub mod audit;
 pub mod auth;
 pub mod chains;
+pub mod circuit_breakers;
 pub mod dispatch;
 pub mod dlq;
 pub mod embeddings;
@@ -109,6 +110,19 @@ pub fn router(state: AppState) -> Router {
         .route("/v1/embeddings/similarity", post(embeddings::similarity))
         // Approvals (list requires auth)
         .route("/v1/approvals", get(approvals::list_approvals))
+        // Circuit breaker admin
+        .route(
+            "/admin/circuit-breakers",
+            get(circuit_breakers::list_circuit_breakers),
+        )
+        .route(
+            "/admin/circuit-breakers/{provider}/trip",
+            post(circuit_breakers::trip_circuit_breaker),
+        )
+        .route(
+            "/admin/circuit-breakers/{provider}/reset",
+            post(circuit_breakers::reset_circuit_breaker),
+        )
         // Logout (requires auth)
         .route("/v1/auth/logout", post(auth::logout))
         // Rate limiting runs after auth (so CallerIdentity is available)

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -11,6 +11,9 @@ use super::approvals::{
 use super::chains::{
     ChainCancelRequest, ChainDetailResponse, ChainStepStatus, ChainSummary, ListChainsResponse,
 };
+use super::circuit_breakers::{
+    CircuitBreakerActionResponse, CircuitBreakerStatus, ListCircuitBreakersResponse,
+};
 use super::dlq::{DlqDrainResponse, DlqEntry, DlqStatsResponse};
 use super::embeddings::{SimilarityRequest, SimilarityResponse};
 use super::events::{
@@ -41,7 +44,8 @@ use super::schemas::{
         (name = "Groups", description = "Event group management for batched notifications"),
         (name = "Approvals", description = "Human-in-the-loop approval workflow"),
         (name = "Chains", description = "Task chain orchestration"),
-        (name = "Embeddings", description = "Embedding similarity testing")
+        (name = "Embeddings", description = "Embedding similarity testing"),
+        (name = "Circuit Breakers", description = "Circuit breaker admin operations")
     ),
     paths(
         super::health::health,
@@ -71,6 +75,9 @@ use super::schemas::{
         super::chains::get_chain,
         super::chains::cancel_chain,
         super::embeddings::similarity,
+        super::circuit_breakers::list_circuit_breakers,
+        super::circuit_breakers::trip_circuit_breaker,
+        super::circuit_breakers::reset_circuit_breaker,
     ),
     components(schemas(
         Action, ActionOutcome, ProviderResponse, ResponseStatus, ActionError,
@@ -87,6 +94,7 @@ use super::schemas::{
         ChainSummary, ListChainsResponse, ChainDetailResponse, ChainStepStatus, ChainCancelRequest,
         SimilarityRequest, SimilarityResponse,
         EmbeddingMetricsResponse,
+        CircuitBreakerStatus, ListCircuitBreakersResponse, CircuitBreakerActionResponse,
     ))
 )]
 pub struct ApiDoc;

--- a/crates/server/src/auth/role.rs
+++ b/crates/server/src/auth/role.rs
@@ -25,7 +25,7 @@ impl Role {
     /// Check whether this role has a given permission.
     pub fn has_permission(self, perm: Permission) -> bool {
         match perm {
-            Permission::Dispatch | Permission::RulesManage => {
+            Permission::Dispatch | Permission::RulesManage | Permission::CircuitBreakerManage => {
                 matches!(self, Self::Admin | Self::Operator)
             }
             Permission::AuditRead | Permission::RulesRead => true,
@@ -50,4 +50,5 @@ pub enum Permission {
     AuditRead,
     RulesManage,
     RulesRead,
+    CircuitBreakerManage,
 }

--- a/docs/book/api/rest-api.md
+++ b/docs/book/api/rest-api.md
@@ -392,6 +392,78 @@ Compute cosine similarity between a text and a topic using the configured embedd
 
 ---
 
+## Circuit Breaker Admin
+
+These endpoints require the **admin** or **operator** role.
+
+### `GET /admin/circuit-breakers`
+
+List all circuit breakers with their current distributed state and configuration.
+
+**Response:**
+
+```json
+{
+  "circuit_breakers": [
+    {
+      "provider": "email",
+      "state": "closed",
+      "failure_threshold": 5,
+      "success_threshold": 2,
+      "recovery_timeout_seconds": 60,
+      "fallback_provider": "webhook"
+    }
+  ]
+}
+```
+
+| Status | Description |
+|--------|-------------|
+| `200` | List of circuit breakers |
+| `404` | Circuit breakers not enabled |
+
+### `POST /admin/circuit-breakers/{provider}/trip`
+
+Force-open a circuit breaker, immediately rejecting requests to the provider.
+
+**Response:**
+
+```json
+{
+  "provider": "email",
+  "state": "open",
+  "message": "circuit breaker tripped"
+}
+```
+
+| Status | Description |
+|--------|-------------|
+| `200` | Circuit breaker tripped |
+| `403` | Insufficient permissions |
+| `404` | Circuit breaker not found or not enabled |
+
+### `POST /admin/circuit-breakers/{provider}/reset`
+
+Force-close a circuit breaker, restoring normal request flow.
+
+**Response:**
+
+```json
+{
+  "provider": "email",
+  "state": "closed",
+  "message": "circuit breaker reset"
+}
+```
+
+| Status | Description |
+|--------|-------------|
+| `200` | Circuit breaker reset |
+| `403` | Insufficient permissions |
+| `404` | Circuit breaker not found or not enabled |
+
+---
+
 ## Authentication
 
 ### `POST /v1/auth/login`
@@ -447,5 +519,8 @@ Revoke the current JWT token.
 | `GET` | `/v1/groups/{group_key}` | Get group |
 | `DELETE` | `/v1/groups/{group_key}` | Flush group |
 | `POST` | `/v1/embeddings/similarity` | Compute embedding similarity |
+| `GET` | `/admin/circuit-breakers` | List circuit breakers |
+| `POST` | `/admin/circuit-breakers/{provider}/trip` | Force-open circuit breaker |
+| `POST` | `/admin/circuit-breakers/{provider}/reset` | Force-close circuit breaker |
 | `POST` | `/v1/auth/login` | Login |
 | `POST` | `/v1/auth/logout` | Logout |


### PR DESCRIPTION
## Summary

- Adds `GET /admin/circuit-breakers` to list all circuit breakers with current state and config
- Adds `POST /admin/circuit-breakers/{provider}/trip` to force-open a circuit breaker
- Adds `POST /admin/circuit-breakers/{provider}/reset` to force-close a circuit breaker
- Adds `CircuitBreaker::trip()` method to the gateway crate for programmatic force-open
- Adds `CircuitBreakerManage` permission (admin/operator roles only)
- Includes OpenAPI annotations and Swagger UI integration

Closes #21

## Test plan

- [x] New unit tests for `trip()` from closed and half-open states
- [x] All 69 existing circuit breaker tests pass
- [x] `cargo clippy --workspace --no-deps -- -D warnings` clean
- [x] `cargo test --workspace` passes
- [ ] Manual: start server with circuit breakers enabled, call `/admin/circuit-breakers` to list
- [ ] Manual: trip a provider via `/admin/circuit-breakers/{provider}/trip`, verify dispatch is rejected
- [ ] Manual: reset via `/admin/circuit-breakers/{provider}/reset`, verify dispatch resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)