### PR TITLE
Add delayed/scheduled actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/clients/java/src/main/java/com/acteon/client/models/ActionOutcome.java
+++ b/clients/java/src/main/java/com/acteon/client/models/ActionOutcome.java
@@ -19,9 +19,11 @@ public class ActionOutcome {
     private String verdict;
     private String matchedRule;
     private String wouldBeProvider;
+    private String actionId;
+    private String scheduledFor;
 
     public enum OutcomeType {
-        EXECUTED, DEDUPLICATED, SUPPRESSED, REROUTED, THROTTLED, FAILED, DRY_RUN
+        EXECUTED, DEDUPLICATED, SUPPRESSED, REROUTED, THROTTLED, FAILED, DRY_RUN, SCHEDULED
     }
 
     // Getters and setters
@@ -55,6 +57,12 @@ public class ActionOutcome {
     public String getWouldBeProvider() { return wouldBeProvider; }
     public void setWouldBeProvider(String wouldBeProvider) { this.wouldBeProvider = wouldBeProvider; }
 
+    public String getActionId() { return actionId; }
+    public void setActionId(String actionId) { this.actionId = actionId; }
+
+    public String getScheduledFor() { return scheduledFor; }
+    public void setScheduledFor(String scheduledFor) { this.scheduledFor = scheduledFor; }
+
     public boolean isExecuted() { return type == OutcomeType.EXECUTED; }
     public boolean isDeduplicated() { return type == OutcomeType.DEDUPLICATED; }
     public boolean isSuppressed() { return type == OutcomeType.SUPPRESSED; }
@@ -62,6 +70,7 @@ public class ActionOutcome {
     public boolean isThrottled() { return type == OutcomeType.THROTTLED; }
     public boolean isFailed() { return type == OutcomeType.FAILED; }
     public boolean isDryRun() { return type == OutcomeType.DRY_RUN; }
+    public boolean isScheduled() { return type == OutcomeType.SCHEDULED; }
 
     /**
      * Parse an ActionOutcome from a raw JSON string.
@@ -133,6 +142,11 @@ public class ActionOutcome {
             outcome.verdict = (String) dryRun.get("verdict");
             outcome.matchedRule = (String) dryRun.get("matched_rule");
             outcome.wouldBeProvider = (String) dryRun.get("would_be_provider");
+        } else if (data.containsKey("Scheduled")) {
+            outcome.type = OutcomeType.SCHEDULED;
+            Map<String, Object> scheduled = (Map<String, Object>) data.get("Scheduled");
+            outcome.actionId = (String) scheduled.get("action_id");
+            outcome.scheduledFor = (String) scheduled.get("scheduled_for");
         } else {
             outcome.type = OutcomeType.FAILED;
             outcome.error = new ActionError("UNKNOWN", "Unknown outcome", false, 0);

--- a/clients/nodejs/src/models.ts
+++ b/clients/nodejs/src/models.ts
@@ -103,7 +103,8 @@ export type ActionOutcome =
     }
   | { type: "throttled"; retryAfterSecs: number }
   | { type: "failed"; error: ActionError }
-  | { type: "dry_run"; verdict: string; matchedRule?: string; wouldBeProvider: string };
+  | { type: "dry_run"; verdict: string; matchedRule?: string; wouldBeProvider: string }
+  | { type: "scheduled"; actionId: string; scheduledFor: string };
 
 /**
  * Error details when an action fails.
@@ -193,6 +194,15 @@ export function parseActionOutcome(data: unknown): ActionOutcome {
       verdict: (dryRun.verdict as string) ?? "",
       matchedRule: dryRun.matched_rule as string | undefined,
       wouldBeProvider: (dryRun.would_be_provider as string) ?? "",
+    };
+  }
+
+  if ("Scheduled" in obj) {
+    const scheduled = obj.Scheduled as Record<string, unknown>;
+    return {
+      type: "scheduled",
+      actionId: (scheduled.action_id as string) ?? "",
+      scheduledFor: (scheduled.scheduled_for as string) ?? "",
     };
   }
 

--- a/clients/python/acteon_client/models.py
+++ b/clients/python/acteon_client/models.py
@@ -63,7 +63,8 @@ class ActionOutcome:
 
     Attributes:
         outcome_type: One of "executed", "deduplicated", "suppressed",
-                      "rerouted", "throttled", "failed", "dry_run".
+                      "rerouted", "throttled", "failed", "dry_run",
+                      "scheduled".
         response: Provider response (for executed/rerouted).
         rule: Rule name (for suppressed).
         original_provider: Original provider (for rerouted).
@@ -72,6 +73,8 @@ class ActionOutcome:
         error: Error details (for failed).
         verdict_details: Dry-run details including verdict, matched_rule,
                          and would_be_provider (for dry_run).
+        action_id: Scheduled action identifier (for scheduled).
+        scheduled_for: RFC 3339 timestamp for scheduled execution (for scheduled).
     """
     outcome_type: str
     response: Optional[ProviderResponse] = None
@@ -81,6 +84,8 @@ class ActionOutcome:
     retry_after_secs: Optional[float] = None
     error: Optional[dict[str, Any]] = None
     verdict_details: Optional[dict[str, Any]] = None
+    action_id: Optional[str] = None
+    scheduled_for: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ActionOutcome":
@@ -128,6 +133,13 @@ class ActionOutcome:
                     "would_be_provider": dry_run.get("would_be_provider"),
                 },
             )
+        elif "Scheduled" in data:
+            scheduled = data["Scheduled"]
+            return cls(
+                outcome_type="scheduled",
+                action_id=scheduled.get("action_id"),
+                scheduled_for=scheduled.get("scheduled_for"),
+            )
         else:
             return cls(outcome_type="unknown")
 
@@ -151,6 +163,9 @@ class ActionOutcome:
 
     def is_dry_run(self) -> bool:
         return self.outcome_type == "dry_run"
+
+    def is_scheduled(self) -> bool:
+        return self.outcome_type == "scheduled"
 
 
 @dataclass

--- a/crates/gateway/examples/basic.rs
+++ b/crates/gateway/examples/basic.rs
@@ -134,5 +134,6 @@ fn outcome_label(outcome: &ActionOutcome) -> &'static str {
         ActionOutcome::ChainStarted { .. } => "ChainStarted",
         ActionOutcome::DryRun { .. } => "DryRun",
         ActionOutcome::CircuitOpen { .. } => "CircuitOpen",
+        ActionOutcome::Scheduled { .. } => "Scheduled",
     }
 }

--- a/crates/gateway/examples/multi_provider.rs
+++ b/crates/gateway/examples/multi_provider.rs
@@ -179,5 +179,9 @@ fn describe_outcome(outcome: &ActionOutcome) -> String {
             provider,
             fallback_chain,
         } => format!("CircuitOpen (provider: {provider}, fallback_chain: {fallback_chain:?})"),
+        ActionOutcome::Scheduled {
+            action_id,
+            scheduled_for,
+        } => format!("Scheduled (id: {action_id}, for: {scheduled_for})"),
     }
 }

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -1276,10 +1276,11 @@ impl Gateway {
     /// Grace period added to the TTL of stored scheduled action data.
     ///
     /// The data TTL is `delay_seconds + GRACE_SECONDS` so that the background
-    /// processor has time to pick it up even if slightly delayed. If the data
+    /// processor has time to pick it up even if the processor is down for an
+    /// extended period. Set to 24 hours to survive longer outages. If the data
     /// expires before dispatch, the action is silently dropped (preferable to
     /// permanent orphaned state).
-    const SCHEDULE_GRACE_SECONDS: u64 = 300;
+    const SCHEDULE_GRACE_SECONDS: u64 = 86_400;
 
     /// Handle the schedule verdict: store the action for delayed execution.
     ///

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -352,6 +352,10 @@ impl Gateway {
                 .await?
             }
             RuleVerdict::Chain { rule: _, chain } => self.handle_chain(&action, chain).await?,
+            RuleVerdict::Schedule {
+                rule: _,
+                delay_seconds,
+            } => self.handle_schedule(&action, *delay_seconds).await?,
         };
 
         // 5. Emit audit record (tracked async task for graceful shutdown).
@@ -1259,6 +1263,126 @@ impl Gateway {
             group_id,
             group_size,
             notify_at,
+        })
+    }
+
+    /// Maximum allowed delay for scheduled actions (7 days).
+    ///
+    /// Prevents unbounded state store growth from actions scheduled far into the
+    /// future. Rules should use reasonable delays; anything longer than a week is
+    /// likely a misconfiguration.
+    const MAX_SCHEDULE_DELAY_SECONDS: u64 = 7 * 24 * 60 * 60;
+
+    /// Grace period added to the TTL of stored scheduled action data.
+    ///
+    /// The data TTL is `delay_seconds + GRACE_SECONDS` so that the background
+    /// processor has time to pick it up even if slightly delayed. If the data
+    /// expires before dispatch, the action is silently dropped (preferable to
+    /// permanent orphaned state).
+    const SCHEDULE_GRACE_SECONDS: u64 = 300;
+
+    /// Handle the schedule verdict: store the action for delayed execution.
+    ///
+    /// The action is persisted in the state store with a `ScheduledAction` key
+    /// and indexed in the `PendingScheduled` index for efficient polling by the
+    /// background processor. A TTL is set on the stored data so that orphaned
+    /// entries are automatically cleaned up.
+    #[instrument(
+        name = "gateway.handle_schedule",
+        skip(self, action),
+        fields(delay_seconds)
+    )]
+    async fn handle_schedule(
+        &self,
+        action: &Action,
+        delay_seconds: u64,
+    ) -> Result<ActionOutcome, GatewayError> {
+        // Validate delay bounds.
+        if delay_seconds == 0 {
+            return Err(GatewayError::Configuration(
+                "scheduled delay must be at least 1 second".to_string(),
+            ));
+        }
+        if delay_seconds > Self::MAX_SCHEDULE_DELAY_SECONDS {
+            return Err(GatewayError::Configuration(format!(
+                "scheduled delay {delay_seconds}s exceeds maximum of {}s (7 days)",
+                Self::MAX_SCHEDULE_DELAY_SECONDS
+            )));
+        }
+
+        // Reject re-scheduling of already-scheduled actions to prevent infinite loops.
+        if action
+            .payload
+            .get("_scheduled_dispatch")
+            .and_then(serde_json::Value::as_bool)
+            == Some(true)
+        {
+            warn!(
+                action_id = %action.id,
+                "rejecting re-schedule of already-scheduled action"
+            );
+            return Err(GatewayError::Configuration(
+                "cannot re-schedule an already-scheduled action".to_string(),
+            ));
+        }
+
+        let now = Utc::now();
+        #[allow(clippy::cast_possible_wrap)]
+        let scheduled_for = now + chrono::Duration::seconds(delay_seconds as i64);
+        let action_id = uuid::Uuid::new_v4().to_string();
+
+        // TTL = delay + grace period so orphaned entries self-clean.
+        let ttl = Some(Duration::from_secs(
+            delay_seconds + Self::SCHEDULE_GRACE_SECONDS,
+        ));
+
+        // Persist the scheduled action data.
+        let sched_key = StateKey::new(
+            action.namespace.as_str(),
+            action.tenant.as_str(),
+            KeyKind::ScheduledAction,
+            &action_id,
+        );
+        let sched_data = serde_json::json!({
+            "action_id": &action_id,
+            "action": action,
+            "scheduled_for": scheduled_for.to_rfc3339(),
+            "created_at": now.to_rfc3339(),
+        });
+        self.state
+            .set(&sched_key, &sched_data.to_string(), ttl)
+            .await?;
+
+        // Add to pending scheduled index using the timeout index mechanism.
+        let pending_key = StateKey::new(
+            action.namespace.as_str(),
+            action.tenant.as_str(),
+            KeyKind::PendingScheduled,
+            &action_id,
+        );
+        self.state
+            .set(
+                &pending_key,
+                &scheduled_for.timestamp_millis().to_string(),
+                ttl,
+            )
+            .await?;
+        self.state
+            .index_timeout(&pending_key, scheduled_for.timestamp_millis())
+            .await?;
+
+        self.metrics.increment_scheduled();
+
+        info!(
+            action_id = %action_id,
+            scheduled_for = %scheduled_for,
+            delay_seconds = delay_seconds,
+            "action scheduled for delayed execution"
+        );
+
+        Ok(ActionOutcome::Scheduled {
+            action_id,
+            scheduled_for,
         })
     }
 
@@ -2561,6 +2685,7 @@ fn verdict_tag(verdict: &RuleVerdict) -> &'static str {
         RuleVerdict::Group { .. } => "group",
         RuleVerdict::RequestApproval { .. } => "request_approval",
         RuleVerdict::Chain { .. } => "chain",
+        RuleVerdict::Schedule { .. } => "schedule",
     }
 }
 
@@ -2576,7 +2701,8 @@ fn matched_rule_name(verdict: &RuleVerdict) -> Option<String> {
         | RuleVerdict::StateMachine { rule, .. }
         | RuleVerdict::Group { rule, .. }
         | RuleVerdict::RequestApproval { rule, .. }
-        | RuleVerdict::Chain { rule, .. } => Some(rule.clone()),
+        | RuleVerdict::Chain { rule, .. }
+        | RuleVerdict::Schedule { rule, .. } => Some(rule.clone()),
     }
 }
 
@@ -2595,6 +2721,7 @@ fn outcome_tag(outcome: &ActionOutcome) -> &'static str {
         ActionOutcome::ChainStarted { .. } => "chain_started",
         ActionOutcome::DryRun { .. } => "dry_run",
         ActionOutcome::CircuitOpen { .. } => "circuit_open",
+        ActionOutcome::Scheduled { .. } => "scheduled",
     }
 }
 
@@ -2725,6 +2852,13 @@ fn build_audit_record(
         } => serde_json::json!({
             "provider": provider,
             "fallback_chain": fallback_chain,
+        }),
+        ActionOutcome::Scheduled {
+            action_id,
+            scheduled_for,
+        } => serde_json::json!({
+            "action_id": action_id,
+            "scheduled_for": scheduled_for.to_rfc3339(),
         }),
     };
 
@@ -4760,6 +4894,264 @@ mod tests {
             }
             other => panic!("expected ActionDispatched, got {other:?}"),
         }
+    }
+
+    // -- Scheduled action tests ------------------------------------------------
+
+    #[tokio::test]
+    async fn dispatch_schedule_returns_scheduled_outcome() {
+        let rules = vec![Rule::new(
+            "delay-send",
+            Expr::Bool(true),
+            RuleAction::Schedule { delay_seconds: 60 },
+        )];
+        let gw = build_gateway(rules);
+        let outcome = gw.dispatch(test_action(), None).await.unwrap();
+        match outcome {
+            ActionOutcome::Scheduled {
+                ref action_id,
+                scheduled_for,
+            } => {
+                assert!(!action_id.is_empty(), "action_id should not be empty");
+                // scheduled_for should be roughly 60 seconds in the future
+                let now = chrono::Utc::now();
+                let diff = (scheduled_for - now).num_seconds();
+                assert!(
+                    (55..=65).contains(&diff),
+                    "scheduled_for should be ~60s in the future, got {diff}s"
+                );
+            }
+            other => panic!("expected Scheduled, got {other:?}"),
+        }
+
+        let snap = gw.metrics().snapshot();
+        assert_eq!(snap.dispatched, 1);
+        assert_eq!(snap.scheduled, 1);
+        assert_eq!(snap.executed, 0);
+    }
+
+    #[tokio::test]
+    async fn dispatch_schedule_stores_state() {
+        let store: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+        let lock: Arc<dyn DistributedLock> = Arc::new(MemoryDistributedLock::new());
+
+        let rules = vec![Rule::new(
+            "delay-send",
+            Expr::Bool(true),
+            RuleAction::Schedule { delay_seconds: 120 },
+        )];
+
+        let gw = GatewayBuilder::new()
+            .state(Arc::clone(&store))
+            .lock(lock)
+            .rules(rules)
+            .provider(Arc::new(MockProvider::new("email")))
+            .executor_config(ExecutorConfig {
+                max_retries: 0,
+                execution_timeout: Duration::from_secs(5),
+                max_concurrent: 10,
+                ..ExecutorConfig::default()
+            })
+            .build()
+            .expect("gateway should build");
+
+        let action = test_action();
+        let outcome = gw.dispatch(action.clone(), None).await.unwrap();
+
+        let action_id = match &outcome {
+            ActionOutcome::Scheduled { action_id, .. } => action_id.clone(),
+            other => panic!("expected Scheduled, got {other:?}"),
+        };
+
+        // Verify the scheduled action data was stored
+        let sched_key = acteon_state::StateKey::new(
+            "notifications",
+            "tenant-1",
+            acteon_state::KeyKind::ScheduledAction,
+            &action_id,
+        );
+        let data = store.get(&sched_key).await.unwrap();
+        assert!(
+            data.is_some(),
+            "scheduled action data should exist in state store"
+        );
+
+        let parsed: serde_json::Value = serde_json::from_str(&data.unwrap()).unwrap();
+        assert_eq!(parsed["action_id"].as_str().unwrap(), action_id);
+        assert!(parsed["action"].is_object());
+        assert!(parsed["scheduled_for"].is_string());
+        assert!(parsed["created_at"].is_string());
+
+        // Verify the pending scheduled index was stored
+        let pending_key = acteon_state::StateKey::new(
+            "notifications",
+            "tenant-1",
+            acteon_state::KeyKind::PendingScheduled,
+            &action_id,
+        );
+        let pending_data = store.get(&pending_key).await.unwrap();
+        assert!(
+            pending_data.is_some(),
+            "pending scheduled index should exist"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_schedule_zero_delay_errors() {
+        let rules = vec![Rule::new(
+            "bad-delay",
+            Expr::Bool(true),
+            RuleAction::Schedule { delay_seconds: 0 },
+        )];
+        let gw = build_gateway(rules);
+        let result = gw.dispatch(test_action(), None).await;
+        assert!(result.is_err(), "zero delay should produce an error");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("at least 1 second"),
+            "error should mention minimum delay: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_schedule_exceeds_max_delay_errors() {
+        // 8 days > 7 days max
+        let rules = vec![Rule::new(
+            "too-long",
+            Expr::Bool(true),
+            RuleAction::Schedule {
+                delay_seconds: 8 * 24 * 60 * 60,
+            },
+        )];
+        let gw = build_gateway(rules);
+        let result = gw.dispatch(test_action(), None).await;
+        assert!(
+            result.is_err(),
+            "exceeding max delay should produce an error"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("exceeds maximum"),
+            "error should mention maximum: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_schedule_max_boundary_succeeds() {
+        // Exactly 7 days should succeed
+        let rules = vec![Rule::new(
+            "max-delay",
+            Expr::Bool(true),
+            RuleAction::Schedule {
+                delay_seconds: 7 * 24 * 60 * 60,
+            },
+        )];
+        let gw = build_gateway(rules);
+        let outcome = gw.dispatch(test_action(), None).await.unwrap();
+        assert!(
+            matches!(outcome, ActionOutcome::Scheduled { .. }),
+            "exactly 7 days should succeed"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_schedule_prevents_reschedule() {
+        let rules = vec![Rule::new(
+            "delay",
+            Expr::Bool(true),
+            RuleAction::Schedule { delay_seconds: 60 },
+        )];
+        let gw = build_gateway(rules);
+
+        // Simulate an action that was already dispatched by the scheduler
+        let mut action = test_action();
+        let payload = action.payload.as_object_mut().unwrap();
+        payload.insert(
+            "_scheduled_dispatch".to_string(),
+            serde_json::Value::Bool(true),
+        );
+
+        let result = gw.dispatch(action, None).await;
+        assert!(
+            result.is_err(),
+            "re-scheduling an already-scheduled action should fail"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("re-schedule"),
+            "error should mention re-schedule: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_schedule_emits_stream_event() {
+        let rules = vec![Rule::new(
+            "delay-send",
+            Expr::Bool(true),
+            RuleAction::Schedule { delay_seconds: 30 },
+        )];
+        let gw = build_gateway(rules);
+        let mut rx = gw.stream_tx().subscribe();
+
+        let outcome = gw.dispatch(test_action(), None).await.unwrap();
+        assert!(matches!(outcome, ActionOutcome::Scheduled { .. }));
+
+        let event = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("should receive within timeout")
+            .expect("broadcast should not be closed");
+
+        match event.event_type {
+            acteon_core::StreamEventType::ActionDispatched { outcome, .. } => {
+                assert!(matches!(outcome, ActionOutcome::Scheduled { .. }));
+            }
+            other => panic!("expected ActionDispatched, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_schedule_unique_action_ids() {
+        let rules = vec![Rule::new(
+            "delay",
+            Expr::Bool(true),
+            RuleAction::Schedule { delay_seconds: 60 },
+        )];
+        let gw = build_gateway(rules);
+
+        let mut ids = Vec::new();
+        for _ in 0..10 {
+            let outcome = gw.dispatch(test_action(), None).await.unwrap();
+            if let ActionOutcome::Scheduled { action_id, .. } = outcome {
+                ids.push(action_id);
+            }
+        }
+        // All IDs should be unique
+        let unique: std::collections::HashSet<_> = ids.iter().collect();
+        assert_eq!(
+            unique.len(),
+            10,
+            "all scheduled action IDs should be unique"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_schedule_metrics_increment() {
+        let rules = vec![Rule::new(
+            "delay",
+            Expr::Bool(true),
+            RuleAction::Schedule { delay_seconds: 10 },
+        )];
+        let gw = build_gateway(rules);
+
+        for _ in 0..5 {
+            let _ = gw.dispatch(test_action(), None).await.unwrap();
+        }
+
+        let snap = gw.metrics().snapshot();
+        assert_eq!(snap.dispatched, 5);
+        assert_eq!(snap.scheduled, 5);
+        assert_eq!(snap.executed, 0);
+        assert_eq!(snap.suppressed, 0);
     }
 
     #[tokio::test]

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -19,6 +19,7 @@ reqwest = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod health;
+pub mod log;
 pub mod provider;
 pub mod registry;
 
@@ -7,6 +8,7 @@ pub mod registry;
 pub mod webhook;
 
 pub use error::ProviderError;
+pub use log::LogProvider;
 pub use provider::{DynProvider, Provider};
 pub use registry::ProviderRegistry;
 

--- a/crates/provider/src/log.rs
+++ b/crates/provider/src/log.rs
@@ -1,0 +1,72 @@
+use acteon_core::{Action, ProviderResponse};
+use tracing::info;
+
+use crate::error::ProviderError;
+use crate::provider::Provider;
+
+/// A provider that logs the action and returns success without performing any
+/// external I/O.
+///
+/// Useful for local development, simulations, and testing scenarios where you
+/// don't have (or need) a real provider endpoint.
+pub struct LogProvider {
+    name: String,
+}
+
+impl LogProvider {
+    /// Create a new `LogProvider` with the given name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+}
+
+impl Provider for LogProvider {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        info!(
+            provider = %self.name,
+            action_id = %action.id,
+            action_type = %action.action_type,
+            namespace = %action.namespace,
+            tenant = %action.tenant,
+            "log provider executed action"
+        );
+        Ok(ProviderResponse::success(serde_json::json!({
+            "provider": self.name,
+            "logged": true,
+        })))
+    }
+
+    #[allow(clippy::unused_async)]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_provider_name() {
+        let provider = LogProvider::new("test-log");
+        assert_eq!(Provider::name(&provider), "test-log");
+    }
+
+    #[tokio::test]
+    async fn log_provider_execute_returns_success() {
+        let provider = LogProvider::new("my-log");
+        let action = Action::new("ns", "t", "my-log", "do_thing", serde_json::Value::Null);
+        let resp = Provider::execute(&provider, &action).await.unwrap();
+        assert_eq!(resp.status, acteon_core::ResponseStatus::Success);
+    }
+
+    #[tokio::test]
+    async fn log_provider_health_check() {
+        let provider = LogProvider::new("my-log");
+        Provider::health_check(&provider).await.unwrap();
+    }
+}

--- a/crates/rules/rules/src/engine/verdict.rs
+++ b/crates/rules/rules/src/engine/verdict.rs
@@ -85,6 +85,13 @@ pub enum RuleVerdict {
         /// Name of the chain configuration to use.
         chain: String,
     },
+    /// Schedule the action for delayed execution.
+    Schedule {
+        /// Name of the rule that triggered scheduling.
+        rule: String,
+        /// Delay in seconds before the action is dispatched.
+        delay_seconds: u64,
+    },
 }
 
 impl RuleVerdict {
@@ -102,7 +109,8 @@ impl RuleVerdict {
             | Self::StateMachine { rule, .. }
             | Self::Group { rule, .. }
             | Self::RequestApproval { rule, .. }
-            | Self::Chain { rule, .. } => Some(rule),
+            | Self::Chain { rule, .. }
+            | Self::Schedule { rule, .. } => Some(rule),
         }
     }
 }
@@ -172,6 +180,10 @@ pub(crate) fn action_to_verdict(rule_name: &str, action: &RuleAction) -> RuleVer
         RuleAction::Chain { chain } => RuleVerdict::Chain {
             rule: rule_name.to_owned(),
             chain: chain.clone(),
+        },
+        RuleAction::Schedule { delay_seconds } => RuleVerdict::Schedule {
+            rule: rule_name.to_owned(),
+            delay_seconds: *delay_seconds,
         },
     }
 }

--- a/crates/rules/rules/src/ir/action.rs
+++ b/crates/rules/rules/src/ir/action.rs
@@ -58,6 +58,11 @@ impl RuleAction {
         matches!(self, Self::Chain { .. })
     }
 
+    /// Returns `true` if this action schedules the operation for delayed execution.
+    pub fn is_schedule(&self) -> bool {
+        matches!(self, Self::Schedule { .. })
+    }
+
     /// Returns a human-readable label for the action kind.
     pub fn kind_label(&self) -> &'static str {
         match self {
@@ -73,6 +78,7 @@ impl RuleAction {
             Self::Group { .. } => "group",
             Self::RequestApproval { .. } => "request_approval",
             Self::Chain { .. } => "chain",
+            Self::Schedule { .. } => "schedule",
         }
     }
 }
@@ -202,5 +208,30 @@ mod tests {
         };
         assert!(group.is_group());
         assert!(!group.is_state_machine());
+    }
+
+    #[test]
+    fn schedule_predicates() {
+        let schedule = RuleAction::Schedule { delay_seconds: 300 };
+        assert!(schedule.is_schedule());
+        assert!(!schedule.is_allow());
+        assert!(!schedule.is_deny());
+        assert!(!schedule.is_chain());
+        assert_eq!(schedule.kind_label(), "schedule");
+    }
+
+    #[test]
+    fn schedule_kind_label() {
+        assert_eq!(
+            RuleAction::Schedule { delay_seconds: 1 }.kind_label(),
+            "schedule"
+        );
+        assert_eq!(
+            RuleAction::Schedule {
+                delay_seconds: 604_800
+            }
+            .kind_label(),
+            "schedule"
+        );
     }
 }

--- a/crates/rules/rules/src/ir/rule.rs
+++ b/crates/rules/rules/src/ir/rule.rs
@@ -76,6 +76,11 @@ pub enum RuleAction {
         /// Name of the chain configuration to use.
         chain: String,
     },
+    /// Schedule the action for delayed execution.
+    Schedule {
+        /// Delay in seconds before the action is dispatched.
+        delay_seconds: u64,
+    },
 }
 
 /// Where a rule was loaded from.
@@ -279,6 +284,7 @@ mod tests {
             RuleAction::Chain {
                 chain: "search-summarize-email".into(),
             },
+            RuleAction::Schedule { delay_seconds: 300 },
         ];
 
         for action in &actions {

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -38,7 +38,7 @@ acteon-state-dynamodb = { workspace = true, optional = true }
 acteon-state-clickhouse = { workspace = true, optional = true }
 acteon-rules = { workspace = true }
 acteon-rules-yaml = { workspace = true }
-acteon-provider = { workspace = true }
+acteon-provider = { workspace = true, features = ["webhook"] }
 acteon-executor = { workspace = true }
 acteon-gateway = { workspace = true }
 acteon-llm = { workspace = true }

--- a/crates/server/src/api/stream.rs
+++ b/crates/server/src/api/stream.rs
@@ -429,6 +429,7 @@ fn stream_event_type_tag(event_type: &StreamEventType) -> &'static str {
         StreamEventType::Timeout { .. } => "timeout",
         StreamEventType::ChainAdvanced { .. } => "chain_advanced",
         StreamEventType::ApprovalRequired { .. } => "approval_required",
+        StreamEventType::ScheduledActionDue { .. } => "scheduled_action_due",
     }
 }
 

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -332,6 +332,12 @@ pub struct BackgroundProcessingConfig {
     /// Whether to retry failed approval notifications.
     #[serde(default = "default_enable_approval_retry")]
     pub enable_approval_retry: bool,
+    /// Whether to process scheduled actions.
+    #[serde(default)]
+    pub enable_scheduled_actions: bool,
+    /// How often to check for due scheduled actions (seconds).
+    #[serde(default = "default_scheduled_check_interval")]
+    pub scheduled_check_interval_seconds: u64,
     /// Namespace to scan for timeouts (required for timeout processing).
     #[serde(default)]
     pub namespace: String,
@@ -350,6 +356,8 @@ impl Default for BackgroundProcessingConfig {
             enable_group_flush: default_enable_group_flush(),
             enable_timeout_processing: default_enable_timeout_processing(),
             enable_approval_retry: default_enable_approval_retry(),
+            enable_scheduled_actions: false,
+            scheduled_check_interval_seconds: default_scheduled_check_interval(),
             namespace: String::new(),
             tenant: String::new(),
         }
@@ -382,6 +390,10 @@ fn default_enable_timeout_processing() -> bool {
 
 fn default_enable_approval_retry() -> bool {
     true
+}
+
+fn default_scheduled_check_interval() -> u64 {
+    5
 }
 
 /// Configuration for the optional LLM guardrail.

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -92,5 +92,9 @@ name = "polyglot_client_simulation"
 name = "otel_tracing_simulation"
 # No required-features - uses in-memory backends
 
+[[example]]
+name = "scheduled_actions_simulation"
+# No required-features - uses in-memory backends
+
 [lints]
 workspace = true

--- a/crates/simulation/examples/http_client_simulation.rs
+++ b/crates/simulation/examples/http_client_simulation.rs
@@ -4,10 +4,10 @@
 //! providing realistic integration testing.
 //!
 //! Prerequisites:
-//!   # Start the server with rules
-//!   cargo run -p acteon-server -- -c examples/redis.toml
+//!   # Start the server with the simulation config (log provider + rules)
+//!   cargo run -p acteon-server -- -c examples/simulation.toml
 //!
-//!   # Or with PostgreSQL for audit
+//!   # Or with a backend-specific config for audit persistence
 //!   docker compose --profile postgres up -d
 //!   cargo run -p acteon-server -- -c examples/postgres.toml
 //!

--- a/crates/simulation/examples/replay_simulation.rs
+++ b/crates/simulation/examples/replay_simulation.rs
@@ -4,7 +4,10 @@
 //! and replays selected actions to demonstrate the replay feature.
 //!
 //! Prerequisites:
-//!   # Start the server with audit enabled (e.g. with PostgreSQL)
+//!   # Start the server with the simulation config (log provider + audit)
+//!   cargo run -p acteon-server -- -c examples/simulation.toml
+//!
+//!   # Or with PostgreSQL for persistent audit
 //!   docker compose --profile postgres up -d
 //!   cargo run -p acteon-server -- -c examples/postgres.toml
 //!

--- a/crates/simulation/examples/scheduled_actions_simulation.rs
+++ b/crates/simulation/examples/scheduled_actions_simulation.rs
@@ -1,0 +1,714 @@
+//! Demonstration of Delayed/Scheduled Actions in the simulation framework.
+//!
+//! This example shows how rules with `type: schedule` defer action execution
+//! by persisting the action and scheduling it for later dispatch. The gateway
+//! returns `ActionOutcome::Scheduled` immediately, and a background processor
+//! picks up due actions when their scheduled time arrives.
+//!
+//! Scenarios demonstrated:
+//!   1. Delayed email reminder (welcome email scheduled after sign-up)
+//!   2. Off-peak retry (failed action rescheduled to quiet hours)
+//!   3. Escalation workflow (alert with delayed escalation)
+//!   4. Multi-tenant scheduling (independent delays per tenant)
+//!   5. Batch processing window (small actions batched via scheduling)
+//!
+//! Run with: `cargo run -p acteon-simulation --example scheduled_actions_simulation`
+
+use acteon_core::{Action, ActionOutcome};
+use acteon_simulation::prelude::*;
+
+// =============================================================================
+// Rule definitions
+// =============================================================================
+
+/// Schedule a welcome email 24 hours (86400s) after user sign-up.
+const WELCOME_EMAIL_RULE: &str = r#"
+rules:
+  - name: schedule-welcome-email
+    priority: 10
+    description: "Schedule welcome email 24h after sign-up"
+    condition:
+      field: action.action_type
+      eq: "welcome_email"
+    action:
+      type: schedule
+      delay_seconds: 86400
+"#;
+
+/// Schedule a cart-abandonment reminder 1 hour (3600s) after the event.
+const CART_REMINDER_RULE: &str = r#"
+rules:
+  - name: schedule-cart-reminder
+    priority: 10
+    description: "Schedule cart abandonment reminder in 1 hour"
+    condition:
+      field: action.action_type
+      eq: "cart_reminder"
+    action:
+      type: schedule
+      delay_seconds: 3600
+"#;
+
+/// Schedule a retry at off-peak time (simulated as 30-second delay).
+const OFF_PEAK_RETRY_RULE: &str = r#"
+rules:
+  - name: schedule-off-peak-retry
+    priority: 5
+    description: "Schedule failed sync for off-peak retry in 30s"
+    condition:
+      field: action.action_type
+      eq: "data_sync_retry"
+    action:
+      type: schedule
+      delay_seconds: 30
+"#;
+
+/// Schedule an escalation 30 minutes (1800s) after an alert fires.
+const ESCALATION_RULE: &str = r#"
+rules:
+  - name: schedule-escalation
+    priority: 10
+    description: "Schedule escalation 30 minutes after alert"
+    condition:
+      field: action.action_type
+      eq: "escalation"
+    action:
+      type: schedule
+      delay_seconds: 1800
+"#;
+
+/// Combined rule set: critical alerts fire immediately, non-critical are
+/// scheduled for a 5-minute delay.
+const COMBINED_ALERT_RULES: &str = r#"
+rules:
+  - name: critical-alert-immediate
+    priority: 1
+    description: "Critical alerts bypass scheduling and execute immediately"
+    condition:
+      all:
+        - field: action.action_type
+          eq: "alert"
+        - field: action.payload.severity
+          eq: "critical"
+    action:
+      type: reroute
+      target_provider: pagerduty
+
+  - name: schedule-non-critical-alert
+    priority: 10
+    description: "Non-critical alerts are scheduled for batch delivery"
+    condition:
+      field: action.action_type
+      eq: "alert"
+    action:
+      type: schedule
+      delay_seconds: 300
+"#;
+
+/// Short delay for batch processing window demonstration.
+const BATCH_WINDOW_RULE: &str = r#"
+rules:
+  - name: schedule-report-generation
+    priority: 10
+    description: "Schedule report generation for batch window"
+    condition:
+      field: action.action_type
+      eq: "generate_report"
+    action:
+      type: schedule
+      delay_seconds: 60
+"#;
+
+#[tokio::main]
+#[allow(clippy::too_many_lines)]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("╔══════════════════════════════════════════════════════════════╗");
+    println!("║       DELAYED / SCHEDULED ACTIONS SIMULATION DEMO            ║");
+    println!("╚══════════════════════════════════════════════════════════════╝\n");
+
+    // =========================================================================
+    // SCENARIO 1: Delayed Email Reminder
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  SCENARIO 1: DELAYED EMAIL REMINDER");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    println!("  When a user signs up, we schedule a welcome email for 24 hours");
+    println!("  later. A cart-abandonment reminder is scheduled for 1 hour.\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("email")
+            .add_rule_yaml(WELCOME_EMAIL_RULE)
+            .add_rule_yaml(CART_REMINDER_RULE)
+            .build(),
+    )
+    .await?;
+
+    println!("  Started simulation cluster");
+    println!("  Registered 'email' recording provider");
+    println!("  Loaded rules: schedule-welcome-email (24h), schedule-cart-reminder (1h)\n");
+
+    // Sign-up triggers welcome email -- should be scheduled, not executed yet
+    let welcome = Action::new(
+        "onboarding",
+        "saas-tenant",
+        "email",
+        "welcome_email",
+        serde_json::json!({
+            "to": "alice@example.com",
+            "subject": "Welcome to Acteon!",
+            "template": "welcome_v2",
+        }),
+    );
+
+    println!("  [dispatch] Welcome email for alice@example.com");
+    let outcome = harness.dispatch(&welcome).await?;
+    print_scheduled_outcome(&outcome, "welcome_email");
+
+    // Provider should NOT have been called yet -- action is scheduled
+    println!(
+        "  [verify]   Provider calls: {} (not yet executed -- scheduled for later)",
+        harness.provider("email").unwrap().call_count()
+    );
+    assert_eq!(harness.provider("email").unwrap().call_count(), 0);
+
+    // Cart abandonment -- also scheduled
+    let cart = Action::new(
+        "onboarding",
+        "saas-tenant",
+        "email",
+        "cart_reminder",
+        serde_json::json!({
+            "to": "bob@example.com",
+            "subject": "You left items in your cart",
+            "cart_value": "$49.99",
+        }),
+    );
+
+    println!("\n  [dispatch] Cart reminder for bob@example.com");
+    let outcome = harness.dispatch(&cart).await?;
+    print_scheduled_outcome(&outcome, "cart_reminder");
+
+    println!(
+        "  [verify]   Provider calls: {} (both emails deferred)",
+        harness.provider("email").unwrap().call_count()
+    );
+    assert_eq!(harness.provider("email").unwrap().call_count(), 0);
+
+    // Immediate email (action_type doesn't match schedule rules) goes through
+    let receipt = Action::new(
+        "onboarding",
+        "saas-tenant",
+        "email",
+        "order_receipt",
+        serde_json::json!({
+            "to": "alice@example.com",
+            "subject": "Your order confirmation",
+            "order_id": "ORD-12345",
+        }),
+    );
+
+    println!("\n  [dispatch] Order receipt for alice@example.com (no schedule rule)");
+    let outcome = harness.dispatch(&receipt).await?;
+    println!("  [result]   Outcome: {:?}", outcome_label(&outcome));
+    println!(
+        "  [verify]   Provider calls: {} (receipt sent immediately!)",
+        harness.provider("email").unwrap().call_count()
+    );
+    assert_eq!(harness.provider("email").unwrap().call_count(), 1);
+
+    harness.teardown().await?;
+    println!("\n  Simulation shut down\n");
+
+    // =========================================================================
+    // SCENARIO 2: Off-Peak Retry
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  SCENARIO 2: OFF-PEAK RETRY");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    println!("  A data synchronization that failed during peak hours is");
+    println!("  rescheduled for off-peak execution via a schedule rule.\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("data-pipeline")
+            .add_rule_yaml(OFF_PEAK_RETRY_RULE)
+            .build(),
+    )
+    .await?;
+
+    println!("  Started simulation cluster");
+    println!("  Loaded rule: schedule-off-peak-retry (30s delay)\n");
+
+    // The retry action matches the schedule rule
+    let retry = Action::new(
+        "data",
+        "analytics-tenant",
+        "data-pipeline",
+        "data_sync_retry",
+        serde_json::json!({
+            "source": "warehouse-prod",
+            "table": "events",
+            "failed_at": "2026-02-07T14:30:00Z",
+            "attempt": 2,
+            "error": "connection timeout during peak load",
+        }),
+    );
+
+    println!("  [dispatch] Data sync retry (attempt #2, failed during peak)");
+    let outcome = harness.dispatch(&retry).await?;
+    print_scheduled_outcome(&outcome, "data_sync_retry");
+
+    println!(
+        "  [verify]   Provider calls: {} (retry deferred to off-peak window)",
+        harness.provider("data-pipeline").unwrap().call_count()
+    );
+    assert_eq!(harness.provider("data-pipeline").unwrap().call_count(), 0);
+
+    // A different action type that doesn't match executes immediately
+    let immediate_sync = Action::new(
+        "data",
+        "analytics-tenant",
+        "data-pipeline",
+        "data_sync",
+        serde_json::json!({
+            "source": "warehouse-prod",
+            "table": "metrics",
+        }),
+    );
+
+    println!("\n  [dispatch] Fresh data sync (not a retry -- executes immediately)");
+    let outcome = harness.dispatch(&immediate_sync).await?;
+    println!("  [result]   Outcome: {:?}", outcome_label(&outcome));
+    println!(
+        "  [verify]   Provider calls: {} (fresh sync ran immediately)",
+        harness.provider("data-pipeline").unwrap().call_count()
+    );
+    assert_eq!(harness.provider("data-pipeline").unwrap().call_count(), 1);
+
+    harness.teardown().await?;
+    println!("\n  Simulation shut down\n");
+
+    // =========================================================================
+    // SCENARIO 3: Escalation Workflow
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  SCENARIO 3: ESCALATION WORKFLOW");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    println!("  An alert fires and an escalation is scheduled for 30 minutes.");
+    println!("  Critical alerts bypass scheduling entirely and go to PagerDuty.\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("slack")
+            .add_recording_provider("pagerduty")
+            .add_rule_yaml(COMBINED_ALERT_RULES)
+            .add_rule_yaml(ESCALATION_RULE)
+            .build(),
+    )
+    .await?;
+
+    println!("  Started simulation cluster");
+    println!("  Registered 'slack' and 'pagerduty' providers");
+    println!("  Loaded rules:");
+    println!("    - critical-alert-immediate (priority 1, reroute to pagerduty)");
+    println!("    - schedule-non-critical-alert (priority 10, 5-minute delay)");
+    println!("    - schedule-escalation (priority 10, 30-minute delay)\n");
+
+    // Non-critical alert gets scheduled
+    let warning_alert = Action::new(
+        "monitoring",
+        "acme-corp",
+        "slack",
+        "alert",
+        serde_json::json!({
+            "severity": "warning",
+            "source": "api-gateway",
+            "message": "Response latency above threshold (p99 > 500ms)",
+        }),
+    );
+
+    println!("  [dispatch] WARNING alert from api-gateway");
+    let outcome = harness.dispatch(&warning_alert).await?;
+    print_scheduled_outcome(&outcome, "non-critical alert");
+
+    // Critical alert bypasses scheduling
+    let critical_alert = Action::new(
+        "monitoring",
+        "acme-corp",
+        "slack",
+        "alert",
+        serde_json::json!({
+            "severity": "critical",
+            "source": "database",
+            "message": "Primary database unreachable",
+        }),
+    );
+
+    println!("\n  [dispatch] CRITICAL alert from database (bypasses scheduling)");
+    let outcome = harness.dispatch(&critical_alert).await?;
+    println!("  [result]   Outcome: {:?}", outcome_label(&outcome));
+    println!(
+        "  [verify]   PagerDuty calls: {} (critical alert escalated immediately!)",
+        harness.provider("pagerduty").unwrap().call_count()
+    );
+    assert_eq!(harness.provider("pagerduty").unwrap().call_count(), 1);
+
+    // Schedule an escalation for the warning alert
+    let escalation = Action::new(
+        "monitoring",
+        "acme-corp",
+        "pagerduty",
+        "escalation",
+        serde_json::json!({
+            "original_alert": "api-gateway latency",
+            "severity": "warning",
+            "message": "Escalating: latency issue unresolved after initial alert",
+            "escalation_level": 2,
+        }),
+    );
+
+    println!("\n  [dispatch] Escalation for warning alert (scheduled for 30 min)");
+    let outcome = harness.dispatch(&escalation).await?;
+    print_scheduled_outcome(&outcome, "escalation");
+
+    println!("\n  Final state:");
+    println!(
+        "    Slack calls: {} (warning alert was scheduled, not sent yet)",
+        harness.provider("slack").unwrap().call_count()
+    );
+    println!(
+        "    PagerDuty calls: {} (only the critical alert executed)",
+        harness.provider("pagerduty").unwrap().call_count()
+    );
+
+    harness.teardown().await?;
+    println!("\n  Simulation shut down\n");
+
+    // =========================================================================
+    // SCENARIO 4: Multi-Tenant Scheduling
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  SCENARIO 4: MULTI-TENANT SCHEDULING");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    println!("  Two tenants schedule actions independently. Each tenant's");
+    println!("  scheduled actions are isolated from the other.\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("email")
+            .add_rule_yaml(WELCOME_EMAIL_RULE)
+            .build(),
+    )
+    .await?;
+
+    println!("  Started simulation cluster");
+    println!("  Loaded rule: schedule-welcome-email (24h delay)\n");
+
+    // Tenant A schedules a welcome email
+    let tenant_a_action = Action::new(
+        "onboarding",
+        "tenant-alpha",
+        "email",
+        "welcome_email",
+        serde_json::json!({
+            "to": "user-a@alpha.com",
+            "subject": "Welcome to Alpha!",
+        }),
+    );
+
+    println!("  [dispatch] Tenant ALPHA: welcome email for user-a@alpha.com");
+    let outcome_a = harness.dispatch(&tenant_a_action).await?;
+    print_scheduled_outcome(&outcome_a, "tenant-alpha");
+
+    // Tenant B schedules a welcome email
+    let beta_action = Action::new(
+        "onboarding",
+        "tenant-beta",
+        "email",
+        "welcome_email",
+        serde_json::json!({
+            "to": "user-b@beta.com",
+            "subject": "Welcome to Beta!",
+        }),
+    );
+
+    println!("\n  [dispatch] Tenant BETA: welcome email for user-b@beta.com");
+    let outcome_b = harness.dispatch(&beta_action).await?;
+    print_scheduled_outcome(&outcome_b, "tenant-beta");
+
+    // Both are scheduled independently
+    println!(
+        "\n  [verify]   Provider calls: {} (both tenants' emails deferred)",
+        harness.provider("email").unwrap().call_count()
+    );
+    assert_eq!(harness.provider("email").unwrap().call_count(), 0);
+
+    // Verify that each tenant got a different action_id
+    if let (
+        ActionOutcome::Scheduled {
+            action_id: id_a, ..
+        },
+        ActionOutcome::Scheduled {
+            action_id: id_b, ..
+        },
+    ) = (&outcome_a, &outcome_b)
+    {
+        println!("  [verify]   Tenant ALPHA action_id: {id_a}");
+        println!("  [verify]   Tenant BETA  action_id: {id_b}");
+        assert_ne!(
+            id_a, id_b,
+            "each tenant should get a unique scheduled action ID"
+        );
+        println!("  [verify]   Unique action IDs confirmed (tenant isolation)");
+    }
+
+    // Tenant A sends a non-scheduled action -- only their immediate action runs
+    let tenant_a_immediate = Action::new(
+        "onboarding",
+        "tenant-alpha",
+        "email",
+        "password_reset",
+        serde_json::json!({
+            "to": "user-a@alpha.com",
+            "subject": "Reset your password",
+        }),
+    );
+
+    println!("\n  [dispatch] Tenant ALPHA: password reset (immediate)");
+    let outcome = harness.dispatch(&tenant_a_immediate).await?;
+    println!("  [result]   Outcome: {:?}", outcome_label(&outcome));
+    println!(
+        "  [verify]   Provider calls: {} (only the immediate action executed)",
+        harness.provider("email").unwrap().call_count()
+    );
+    assert_eq!(harness.provider("email").unwrap().call_count(), 1);
+
+    harness.teardown().await?;
+    println!("\n  Simulation shut down\n");
+
+    // =========================================================================
+    // SCENARIO 5: Batch Processing Window
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  SCENARIO 5: BATCH PROCESSING WINDOW");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    println!("  Multiple small report-generation requests arrive and are all");
+    println!("  scheduled for a batch processing window (60s delay). When the");
+    println!("  window arrives, the background processor dispatches them all.\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("report-engine")
+            .add_rule_yaml(BATCH_WINDOW_RULE)
+            .build(),
+    )
+    .await?;
+
+    println!("  Started simulation cluster");
+    println!("  Loaded rule: schedule-report-generation (60s batch window)\n");
+
+    let report_requests = vec![
+        ("acme-corp", "monthly-revenue", "January 2026"),
+        ("acme-corp", "user-growth", "January 2026"),
+        ("acme-corp", "churn-analysis", "Q4 2025"),
+        ("acme-corp", "api-usage", "Week 5"),
+        ("acme-corp", "cost-breakdown", "January 2026"),
+    ];
+
+    let mut scheduled_count = 0;
+    for (tenant, report_name, period) in &report_requests {
+        let action = Action::new(
+            "analytics",
+            *tenant,
+            "report-engine",
+            "generate_report",
+            serde_json::json!({
+                "report": report_name,
+                "period": period,
+                "format": "pdf",
+            }),
+        );
+
+        println!("  [dispatch] Report: {report_name} ({period})");
+        let outcome = harness.dispatch(&action).await?;
+
+        if matches!(outcome, ActionOutcome::Scheduled { .. }) {
+            scheduled_count += 1;
+            println!("  [result]   Scheduled for batch window");
+        } else {
+            println!("  [result]   Unexpected: {:?}", outcome_label(&outcome));
+        }
+    }
+
+    println!(
+        "\n  [summary]  {} of {} reports scheduled for batch processing",
+        scheduled_count,
+        report_requests.len()
+    );
+    println!(
+        "  [verify]   Provider calls: {} (nothing executed yet -- all batched)",
+        harness.provider("report-engine").unwrap().call_count()
+    );
+    assert_eq!(scheduled_count, report_requests.len());
+    assert_eq!(harness.provider("report-engine").unwrap().call_count(), 0);
+
+    println!("\n  When the 60-second batch window elapses, the background");
+    println!("  processor will dispatch all 5 reports to the report-engine");
+    println!("  provider in a single batch window.");
+
+    harness.teardown().await?;
+    println!("\n  Simulation shut down\n");
+
+    // =========================================================================
+    // SCENARIO 6: Dry-Run with Schedule Rules
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  SCENARIO 6: DRY-RUN WITH SCHEDULE RULES");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    println!("  Dry-run mode shows what *would* happen without persisting any");
+    println!("  scheduled action. Useful for testing rules before deployment.\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("email")
+            .add_rule_yaml(WELCOME_EMAIL_RULE)
+            .build(),
+    )
+    .await?;
+
+    let action = Action::new(
+        "onboarding",
+        "saas-tenant",
+        "email",
+        "welcome_email",
+        serde_json::json!({
+            "to": "test@example.com",
+            "subject": "Welcome!",
+        }),
+    );
+
+    println!("  [dry-run]  Welcome email for test@example.com");
+    let outcome = harness.dispatch_dry_run(&action).await?;
+    println!("  [result]   Outcome: {outcome:?}");
+
+    match &outcome {
+        ActionOutcome::DryRun {
+            verdict,
+            matched_rule,
+            would_be_provider,
+        } => {
+            println!("  [detail]   Verdict: {verdict}");
+            println!("  [detail]   Matched rule: {matched_rule:?}");
+            println!("  [detail]   Would-be provider: {would_be_provider}");
+        }
+        _ => {
+            println!(
+                "  [detail]   (non-DryRun outcome: {:?})",
+                outcome_label(&outcome)
+            );
+        }
+    }
+
+    println!(
+        "  [verify]   Provider calls: {} (dry-run never executes or schedules)",
+        harness.provider("email").unwrap().call_count()
+    );
+
+    harness.teardown().await?;
+    println!("\n  Simulation shut down\n");
+
+    // =========================================================================
+    // Summary
+    // =========================================================================
+    println!("╔══════════════════════════════════════════════════════════════╗");
+    println!("║              SCHEDULED ACTIONS DEMO COMPLETE                 ║");
+    println!("╠══════════════════════════════════════════════════════════════╣");
+    println!("║                                                              ║");
+    println!("║  Scenarios demonstrated:                                     ║");
+    println!("║                                                              ║");
+    println!("║  1. Delayed Email Reminder                                   ║");
+    println!("║     - Welcome email scheduled for 24h after sign-up          ║");
+    println!("║     - Cart reminder scheduled for 1h                         ║");
+    println!("║     - Immediate emails bypass scheduling                     ║");
+    println!("║                                                              ║");
+    println!("║  2. Off-Peak Retry                                           ║");
+    println!("║     - Failed sync retry deferred to quiet window             ║");
+    println!("║     - Fresh syncs execute immediately                        ║");
+    println!("║                                                              ║");
+    println!("║  3. Escalation Workflow                                      ║");
+    println!("║     - Critical alerts bypass scheduling (rerouted)           ║");
+    println!("║     - Non-critical alerts scheduled for batch delivery       ║");
+    println!("║     - Escalation scheduled for 30-minute follow-up           ║");
+    println!("║                                                              ║");
+    println!("║  4. Multi-Tenant Scheduling                                  ║");
+    println!("║     - Independent scheduling per tenant                      ║");
+    println!("║     - Unique action IDs per tenant (isolation)               ║");
+    println!("║                                                              ║");
+    println!("║  5. Batch Processing Window                                  ║");
+    println!("║     - 5 reports scheduled for 60s batch window               ║");
+    println!("║     - Zero provider calls until window elapses               ║");
+    println!("║                                                              ║");
+    println!("║  6. Dry-Run with Schedule Rules                              ║");
+    println!("║     - Preview scheduling behavior without side effects       ║");
+    println!("║                                                              ║");
+    println!("╚══════════════════════════════════════════════════════════════╝");
+
+    Ok(())
+}
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+/// Pretty-print a `Scheduled` outcome with context.
+fn print_scheduled_outcome(outcome: &ActionOutcome, label: &str) {
+    match outcome {
+        ActionOutcome::Scheduled {
+            action_id,
+            scheduled_for,
+        } => {
+            println!("  [result]   Outcome: Scheduled");
+            println!("  [detail]   Action ID: {action_id}");
+            println!("  [detail]   Scheduled for: {scheduled_for}");
+            println!("  [detail]   Label: {label}");
+        }
+        other => {
+            println!(
+                "  [result]   Unexpected outcome for {label}: {:?}",
+                outcome_label(other)
+            );
+        }
+    }
+}
+
+/// Return a short label for an outcome variant (for display purposes).
+fn outcome_label(outcome: &ActionOutcome) -> &'static str {
+    match outcome {
+        ActionOutcome::Executed(_) => "Executed",
+        ActionOutcome::Deduplicated => "Deduplicated",
+        ActionOutcome::Suppressed { .. } => "Suppressed",
+        ActionOutcome::Rerouted { .. } => "Rerouted",
+        ActionOutcome::Throttled { .. } => "Throttled",
+        ActionOutcome::Failed(_) => "Failed",
+        ActionOutcome::Grouped { .. } => "Grouped",
+        ActionOutcome::StateChanged { .. } => "StateChanged",
+        ActionOutcome::PendingApproval { .. } => "PendingApproval",
+        ActionOutcome::ChainStarted { .. } => "ChainStarted",
+        ActionOutcome::DryRun { .. } => "DryRun",
+        ActionOutcome::CircuitOpen { .. } => "CircuitOpen",
+        ActionOutcome::Scheduled { .. } => "Scheduled",
+    }
+}

--- a/crates/simulation/examples/sse_stream_simulation.rs
+++ b/crates/simulation/examples/sse_stream_simulation.rs
@@ -337,6 +337,7 @@ fn event_type_label(event_type: &StreamEventType) -> &'static str {
         StreamEventType::Timeout { .. } => "timeout",
         StreamEventType::ChainAdvanced { .. } => "chain_step",
         StreamEventType::ApprovalRequired { .. } => "approval",
+        StreamEventType::ScheduledActionDue { .. } => "scheduled",
     }
 }
 

--- a/crates/simulation/examples/stream_with_chains_simulation.rs
+++ b/crates/simulation/examples/stream_with_chains_simulation.rs
@@ -366,6 +366,7 @@ fn event_type_label(event_type: &StreamEventType) -> &'static str {
         StreamEventType::Timeout { .. } => "timeout",
         StreamEventType::ChainAdvanced { .. } => "chain_step",
         StreamEventType::ApprovalRequired { .. } => "approval",
+        StreamEventType::ScheduledActionDue { .. } => "scheduled",
     }
 }
 

--- a/crates/state/state/src/key.rs
+++ b/crates/state/state/src/key.rs
@@ -30,6 +30,10 @@ pub enum KeyKind {
     Chain,
     /// Index of pending chain steps awaiting advancement.
     PendingChains,
+    /// Scheduled action data awaiting delayed dispatch.
+    ScheduledAction,
+    /// Index of pending scheduled actions by dispatch time.
+    PendingScheduled,
     Custom(String),
 }
 
@@ -53,6 +57,8 @@ impl KeyKind {
             Self::PendingApprovals => "pending_approvals",
             Self::Chain => "chain",
             Self::PendingChains => "pending_chains",
+            Self::ScheduledAction => "scheduled_action",
+            Self::PendingScheduled => "pending_scheduled",
             Self::Custom(s) => s.as_str(),
         }
     }
@@ -138,6 +144,8 @@ mod tests {
         assert_eq!(KeyKind::PendingApprovals.as_str(), "pending_approvals");
         assert_eq!(KeyKind::Chain.as_str(), "chain");
         assert_eq!(KeyKind::PendingChains.as_str(), "pending_chains");
+        assert_eq!(KeyKind::ScheduledAction.as_str(), "scheduled_action");
+        assert_eq!(KeyKind::PendingScheduled.as_str(), "pending_scheduled");
         assert_eq!(KeyKind::Custom("foo".into()).as_str(), "foo");
     }
 

--- a/docs/book/api/rule-reference.md
+++ b/docs/book/api/rule-reference.md
@@ -296,6 +296,14 @@ action:
   chain_name: "pipeline-name"         # Required (references config)
 ```
 
+### Schedule
+
+```yaml
+action:
+  type: schedule
+  delay_seconds: 3600                   # Required (1–604800)
+```
+
 ### LLM Guardrail
 
 ```yaml

--- a/docs/book/features/index.md
+++ b/docs/book/features/index.md
@@ -31,6 +31,11 @@ Dynamically redirect actions to different providers based on priority, load, or 
 Transform action payloads before execution — redaction, enrichment, normalization.
 </div>
 
+<div class="card" markdown>
+### [Scheduled Actions](scheduled-actions.md)
+Delay action execution by a configurable duration — send reminders later, retry at off-peak times, or schedule escalations.
+</div>
+
 </div>
 
 ## Event Lifecycle

--- a/docs/book/features/scheduled-actions.md
+++ b/docs/book/features/scheduled-actions.md
@@ -1,0 +1,213 @@
+# Scheduled Actions
+
+Scheduled actions let you delay action execution by a configurable duration. Instead of dispatching immediately, Acteon stores the action and executes it after the specified delay. This is useful for:
+
+- **Delayed notifications** -- send a reminder email 24 hours after signup
+- **Off-peak retries** -- reschedule failed actions to run during low-traffic windows
+- **Escalation workflows** -- if an alert is not acknowledged within 30 minutes, escalate to the on-call manager
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant G as Gateway
+    participant S as State Store
+    participant BG as Background Processor
+    participant P as Provider
+
+    C->>G: Dispatch action (send_reminder)
+    G->>G: Evaluate rules
+    Note over G: Rule matches → schedule with 3600s delay
+    G->>S: Store action (due at now + 3600s)
+    G-->>C: Scheduled (action_id, scheduled_for)
+
+    Note over BG,S: 3600 seconds later...
+    BG->>S: Poll for due actions
+    S-->>BG: Action is due
+    BG->>P: Execute action
+    P-->>BG: Success
+    BG->>S: Mark completed
+```
+
+1. The client dispatches an action through the normal `POST /v1/dispatch` endpoint
+2. The gateway evaluates rules -- if a `schedule` rule matches, the action is stored for later
+3. The gateway returns an `ActionOutcome::Scheduled` response with the action ID and scheduled time
+4. A background processor polls the state store for due actions at a configurable interval
+5. When an action's scheduled time arrives, the background processor dispatches it to the provider
+
+## Rule Configuration
+
+### YAML
+
+```yaml title="rules/scheduled.yaml"
+rules:
+  - name: delay-reminders
+    priority: 10
+    description: "Send reminder emails after a 1-hour delay"
+    condition:
+      field: action.action_type
+      eq: "send_reminder"
+    action:
+      type: schedule
+      delay_seconds: 3600
+
+  - name: offpeak-batch-reports
+    priority: 15
+    description: "Delay batch reports by 6 hours to run off-peak"
+    condition:
+      all:
+        - field: action.action_type
+          eq: "generate_report"
+        - field: action.metadata.priority
+          eq: "low"
+    action:
+      type: schedule
+      delay_seconds: 21600
+```
+
+### CEL
+
+```cel
+// Delay reminders by 1 hour
+action.action_type == "send_reminder" ? schedule(3600) : allow()
+
+// Delay low-priority reports by 6 hours
+action.action_type == "generate_report" && action.metadata.priority == "low" ? schedule(21600) : allow()
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `delay_seconds` | u64 | Yes | Delay before execution, in seconds (1--604800) |
+
+The maximum delay is 604800 seconds (7 days).
+
+## Response
+
+When an action matches a `schedule` rule, the dispatch endpoint returns:
+
+```json
+{
+  "outcome": "scheduled",
+  "action_id": "019462a1-7b3e-7f00-a123-456789abcdef",
+  "scheduled_for": "2026-01-15T12:00:00Z"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `outcome` | string | Always `"scheduled"` |
+| `action_id` | string | Unique identifier for the scheduled action |
+| `scheduled_for` | string | RFC 3339 timestamp when the action will be dispatched |
+
+## Server Configuration
+
+Enable the background processor in `acteon.toml`:
+
+```toml
+[background]
+enable_scheduled_actions = true
+scheduled_check_interval = 5  # seconds
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enable_scheduled_actions` | bool | `false` | Enable the scheduled actions background processor |
+| `scheduled_check_interval` | u64 | `5` | How often to poll for due actions, in seconds |
+
+!!! warning
+    If `enable_scheduled_actions` is `false`, `schedule` rules will still match and store actions, but nothing will dispatch them. Always enable the background processor in production.
+
+## Client SDK Usage
+
+Scheduled actions work through the existing `dispatch()` API. No new client methods are needed -- just handle the new `Scheduled` outcome type in the response.
+
+### Rust
+
+```rust
+use acteon_client::ActeonClient;
+
+let client = ActeonClient::new("http://localhost:8080");
+
+let outcome = client.dispatch(&action).await?;
+match &outcome {
+    ActionOutcome::Scheduled { action_id, scheduled_for } => {
+        println!("Action {} scheduled for {}", action_id, scheduled_for);
+    }
+    ActionOutcome::Executed(resp) => {
+        println!("Executed immediately: {:?}", resp);
+    }
+    _ => {}
+}
+```
+
+### Python
+
+```python
+from acteon_client import ActeonClient
+
+client = ActeonClient("http://localhost:8080")
+
+outcome = client.dispatch(action)
+if outcome.is_scheduled():
+    print(f"Action {outcome.action_id} scheduled for {outcome.scheduled_for}")
+elif outcome.is_executed():
+    print(f"Executed immediately: {outcome.response}")
+```
+
+### Node.js / TypeScript
+
+```typescript
+const outcome = await client.dispatch(action);
+if (outcome.type === "scheduled") {
+  console.log(`Action ${outcome.actionId} scheduled for ${outcome.scheduledFor}`);
+} else if (outcome.type === "executed") {
+  console.log(`Executed immediately:`, outcome.response);
+}
+```
+
+### Go
+
+```go
+outcome, err := client.Dispatch(ctx, action)
+if err != nil {
+    log.Fatal(err)
+}
+if outcome.IsScheduled() {
+    fmt.Printf("Action %s scheduled for %s\n", outcome.ActionID, outcome.ScheduledFor)
+} else if outcome.IsExecuted() {
+    fmt.Println("Executed immediately:", outcome.Response)
+}
+```
+
+### Java
+
+```java
+ActionOutcome outcome = client.dispatch(action);
+if (outcome.isScheduled()) {
+    System.out.printf("Action %s scheduled for %s%n",
+        outcome.getActionId(), outcome.getScheduledFor());
+} else if (outcome.isExecuted()) {
+    System.out.println("Executed immediately: " + outcome.getResponse());
+}
+```
+
+## Reliability
+
+Scheduled actions use **at-least-once delivery** semantics:
+
+- Actions are persisted to the state store before the client receives a response
+- The background processor marks actions as "in-flight" before dispatching
+- If the processor crashes mid-dispatch, the action will be retried on the next poll
+- Successfully dispatched actions are marked as completed and will not be re-dispatched
+
+A **24-hour grace period** applies: actions that remain in the "in-flight" state for more than 24 hours are considered stale and will be retried. This handles cases where the processor crashes after picking up an action but before marking it complete.
+
+## Limitations
+
+- **Maximum delay**: 7 days (604800 seconds). Longer delays are rejected at rule evaluation time.
+- **No cancellation API**: Once an action is scheduled, it cannot be cancelled. A cancellation endpoint is planned for a future release.
+- **Polling latency**: The background processor polls at the configured interval (`scheduled_check_interval`), so actions may be dispatched up to N seconds after their scheduled time, where N is the check interval.
+- **Single processor**: The background processor runs as a single instance. High-availability deployments should use leader election or a distributed lock to prevent duplicate dispatches.

--- a/examples/approval.toml
+++ b/examples/approval.toml
@@ -1,0 +1,27 @@
+# Acteon config for approval_simulation.
+#
+# Start the server:
+#   cargo run -p acteon-server -- -c examples/approval.toml
+#
+# Then run the simulation:
+#   cargo run -p acteon-simulation --example approval_simulation
+
+[[providers]]
+name = "payments"
+type = "log"
+
+[[providers]]
+name = "slack"
+type = "log"
+
+[server]
+# Hex-encoded HMAC secret for signing approval URLs.
+approval_secret = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+[rules]
+directory = "examples/rules"
+
+[audit]
+enabled = true
+backend = "memory"
+store_payload = true

--- a/examples/full.toml
+++ b/examples/full.toml
@@ -42,6 +42,24 @@ cleanup_interval_seconds = 3600
 # Whether to store the full action payload in audit records
 store_payload = true
 
+# ──────────────────────────────────────────────────────────────────────────────
+# Providers
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Webhook provider (HTTP POST to a URL)
+# [[providers]]
+# name = "email"
+# type = "webhook"
+# url = "http://localhost:9999/webhook"
+#
+# [providers.headers]
+# Authorization = "Bearer token123"
+
+# Log provider (logs action and returns success, no external deps)
+# [[providers]]
+# name = "slack"
+# type = "log"
+
 [rules]
 # Path to directory containing YAML rule files
 # directory = "./rules"

--- a/examples/rules/approval.yaml
+++ b/examples/rules/approval.yaml
@@ -1,0 +1,14 @@
+rules:
+  - name: approve-large-refunds
+    priority: 1
+    condition:
+      all:
+        - field: action.action_type
+          eq: "process_refund"
+        - field: action.payload.amount
+          gt: 1000
+    action:
+      type: request_approval
+      notify_provider: slack
+      timeout_seconds: 3600
+      message: "Refund over $1000 requires manager approval"

--- a/examples/rules/simulation.yaml
+++ b/examples/rules/simulation.yaml
@@ -1,0 +1,8 @@
+rules:
+  - name: block-spam
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "spam"
+    action:
+      type: suppress

--- a/examples/simulation.toml
+++ b/examples/simulation.toml
@@ -1,0 +1,20 @@
+# Acteon config for http_client_simulation and replay_simulation.
+#
+# Start the server:
+#   cargo run -p acteon-server -- -c examples/simulation.toml
+#
+# Then run the simulations:
+#   cargo run -p acteon-simulation --example http_client_simulation
+#   cargo run -p acteon-simulation --example replay_simulation
+
+[[providers]]
+name = "email"
+type = "log"
+
+[rules]
+directory = "examples/rules"
+
+[audit]
+enabled = true
+backend = "memory"
+store_payload = true


### PR DESCRIPTION
## Summary

- Adds a new `Schedule` rule action type that delays action execution by a configurable number of seconds
- Gateway stores scheduled actions in the state backend; a background processor polls and dispatches them when due
- Full-stack implementation across 22 files: core types, rules IR (YAML + CEL), gateway handler, background processor, state keys, server config, metrics, streaming events, simulation example, and comprehensive tests

### Use Cases
- **Delayed email reminders**: "send welcome email in 24 hours"
- **Off-peak retries**: "retry this action at 3am during low traffic"
- **Escalation workflows**: "escalate if not acknowledged in 30 minutes"
- **Batch processing windows**: schedule actions to execute during batch windows

### Architecture
- `RuleAction::Schedule { delay_seconds }` in rule IR, with YAML syntax `type: schedule`
- `handle_schedule()` in gateway stores action + indexes timeout via `index_timeout()`
- Background processor polls `get_expired_timeouts()` for O(log N + M) efficiency
- Returns `ActionOutcome::Scheduled { action_id, scheduled_for }` immediately
- Broadcasts `StreamEventType::ScheduledActionDue` via SSE when actions fire
- `KeyKind::ScheduledAction` / `KeyKind::PendingScheduled` for state management

### New Files
- `crates/simulation/examples/scheduled_actions_simulation.rs` — multi-scenario demo

## Test plan
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --no-deps -- -D warnings` — no warnings
- [x] `cargo test --workspace --lib --tests` — all tests pass (0 failures)
- [x] YAML parser tests for `type: schedule` rules
- [x] Rule verdict conversion tests
- [x] Gateway `handle_schedule()` unit tests
- [x] Background processor polling tests
- [x] `ActionOutcome::Scheduled` serde roundtrip tests
- [x] `StreamEventType::ScheduledActionDue` tests
- [x] Simulation example compiles and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)