### PR TITLE
Add conditional chain branching for DAG-style workflows

### DIFF
--- a/crates/core/src/chain.rs
+++ b/crates/core/src/chain.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -24,6 +26,120 @@ pub enum StepFailurePolicy {
     Dlq,
 }
 
+/// Comparison operator for branch conditions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BranchOperator {
+    /// Equality check (`==`).
+    Eq,
+    /// Inequality check (`!=`).
+    Neq,
+    /// Check if a string field contains a substring.
+    Contains,
+    /// Check if a field exists and is not `null`.
+    Exists,
+}
+
+/// A condition that determines which step to execute next after the current
+/// step completes.
+///
+/// Conditions are evaluated in order; the first match wins.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BranchCondition {
+    /// The field to evaluate. Supported paths:
+    /// - `"success"` — boolean indicating step success/failure
+    /// - `"body"` — the full response body
+    /// - `"body.field.path"` — a nested field within the response body
+    pub field: String,
+    /// The comparison operator.
+    pub operator: BranchOperator,
+    /// The value to compare against. Ignored for the `exists` operator.
+    #[serde(default)]
+    pub value: Option<serde_json::Value>,
+    /// The name of the target step to jump to when this condition matches.
+    pub target: String,
+}
+
+impl BranchCondition {
+    /// Create a new branch condition.
+    #[must_use]
+    pub fn new(
+        field: impl Into<String>,
+        operator: BranchOperator,
+        value: Option<serde_json::Value>,
+        target: impl Into<String>,
+    ) -> Self {
+        Self {
+            field: field.into(),
+            operator,
+            value,
+            target: target.into(),
+        }
+    }
+
+    /// Evaluate this condition against a step result.
+    ///
+    /// Returns `true` if the condition matches.
+    #[must_use]
+    pub fn evaluate(&self, step_result: &StepResult) -> bool {
+        let field_value = self.resolve_field(step_result);
+        match self.operator {
+            BranchOperator::Eq => self.value.as_ref().is_some_and(|v| field_value == *v),
+            BranchOperator::Neq => self.value.as_ref().is_some_and(|v| field_value != *v),
+            BranchOperator::Contains => {
+                if let (
+                    serde_json::Value::String(haystack),
+                    Some(serde_json::Value::String(needle)),
+                ) = (&field_value, self.value.as_ref())
+                {
+                    haystack.contains(needle.as_str())
+                } else {
+                    false
+                }
+            }
+            BranchOperator::Exists => !field_value.is_null(),
+        }
+    }
+
+    /// Resolve the field path against a step result.
+    fn resolve_field(&self, step_result: &StepResult) -> serde_json::Value {
+        if self.field == "success" {
+            return serde_json::Value::Bool(step_result.success);
+        }
+
+        if self.field == "body" {
+            return step_result
+                .response_body
+                .clone()
+                .unwrap_or(serde_json::Value::Null);
+        }
+
+        if let Some(path) = self.field.strip_prefix("body.") {
+            let body = step_result
+                .response_body
+                .clone()
+                .unwrap_or(serde_json::Value::Null);
+            return resolve_json_path(&body, path);
+        }
+
+        serde_json::Value::Null
+    }
+}
+
+/// Resolve a dotted path against a JSON value.
+fn resolve_json_path(value: &serde_json::Value, path: &str) -> serde_json::Value {
+    let mut current = value.clone();
+    for segment in path.split('.') {
+        match current {
+            serde_json::Value::Object(ref map) => {
+                current = map.get(segment).cloned().unwrap_or(serde_json::Value::Null);
+            }
+            _ => return serde_json::Value::Null,
+        }
+    }
+    current
+}
+
 /// Configuration for a single step in a task chain.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChainStepConfig {
@@ -46,6 +162,19 @@ pub struct ChainStepConfig {
     /// completes.
     #[serde(default)]
     pub delay_seconds: Option<u64>,
+    /// Optional list of branch conditions evaluated after this step completes.
+    ///
+    /// Conditions are evaluated in order; the first matching condition determines
+    /// the next step. If no condition matches, `default_next` is used. If
+    /// `default_next` is also `None`, the chain advances sequentially.
+    #[serde(default)]
+    pub branches: Vec<BranchCondition>,
+    /// The default next step name when no branch condition matches.
+    ///
+    /// If `None` and no branch matches, the chain advances to the next
+    /// sequential step.
+    #[serde(default)]
+    pub default_next: Option<String>,
 }
 
 impl ChainStepConfig {
@@ -64,6 +193,8 @@ impl ChainStepConfig {
             payload_template,
             on_failure: None,
             delay_seconds: None,
+            branches: Vec::new(),
+            default_next: None,
         }
     }
 
@@ -79,6 +210,26 @@ impl ChainStepConfig {
     pub fn with_delay(mut self, seconds: u64) -> Self {
         self.delay_seconds = Some(seconds);
         self
+    }
+
+    /// Add a branch condition to this step.
+    #[must_use]
+    pub fn with_branch(mut self, condition: BranchCondition) -> Self {
+        self.branches.push(condition);
+        self
+    }
+
+    /// Set the default next step when no branch condition matches.
+    #[must_use]
+    pub fn with_default_next(mut self, step_name: impl Into<String>) -> Self {
+        self.default_next = Some(step_name.into());
+        self
+    }
+
+    /// Returns `true` if this step has any branching configuration.
+    #[must_use]
+    pub fn has_branches(&self) -> bool {
+        !self.branches.is_empty() || self.default_next.is_some()
     }
 }
 
@@ -148,6 +299,116 @@ impl ChainConfig {
         self.on_cancel = Some(target);
         self
     }
+
+    /// Build a map from step name to step index for quick lookups.
+    #[must_use]
+    pub fn step_index_map(&self) -> HashMap<String, usize> {
+        self.steps
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (s.name.clone(), i))
+            .collect()
+    }
+
+    /// Returns `true` if any step in this chain uses branching.
+    #[must_use]
+    pub fn has_branches(&self) -> bool {
+        self.steps.iter().any(ChainStepConfig::has_branches)
+    }
+
+    /// Validate the chain configuration, checking for:
+    /// - Duplicate step names
+    /// - Branch targets referencing non-existent steps
+    /// - Cycles in the branch graph (a step must not be reachable from itself)
+    ///
+    /// Returns a list of validation error messages. An empty list means valid.
+    #[must_use]
+    pub fn validate(&self) -> Vec<String> {
+        let mut errors = Vec::new();
+        let step_names: HashSet<&str> = self.steps.iter().map(|s| s.name.as_str()).collect();
+
+        // Check for duplicate step names.
+        if step_names.len() != self.steps.len() {
+            let mut seen = HashSet::new();
+            for step in &self.steps {
+                if !seen.insert(&step.name) {
+                    errors.push(format!("duplicate step name: `{}`", step.name));
+                }
+            }
+        }
+
+        // Check that all branch targets reference existing steps.
+        for step in &self.steps {
+            for branch in &step.branches {
+                if !step_names.contains(branch.target.as_str()) {
+                    errors.push(format!(
+                        "step `{}` branches to non-existent step `{}`",
+                        step.name, branch.target
+                    ));
+                }
+            }
+            if let Some(ref default_next) = step.default_next
+                && !step_names.contains(default_next.as_str())
+            {
+                errors.push(format!(
+                    "step `{}` has default_next targeting non-existent step `{default_next}`",
+                    step.name
+                ));
+            }
+        }
+
+        // Check for cycles using BFS from each step.
+        let index_map = self.step_index_map();
+        for (i, step) in self.steps.iter().enumerate() {
+            if !step.has_branches() {
+                continue;
+            }
+            // Collect all possible next steps from this step (via branches).
+            let mut visited = HashSet::new();
+            let mut queue = VecDeque::new();
+            for branch in &step.branches {
+                if let Some(&target_idx) = index_map.get(&branch.target) {
+                    queue.push_back(target_idx);
+                }
+            }
+            if let Some(ref default_next) = step.default_next
+                && let Some(&target_idx) = index_map.get(default_next)
+            {
+                queue.push_back(target_idx);
+            }
+            while let Some(idx) = queue.pop_front() {
+                if idx == i {
+                    errors.push(format!(
+                        "cycle detected: step `{}` is reachable from itself via branches",
+                        step.name
+                    ));
+                    break;
+                }
+                if !visited.insert(idx) {
+                    continue;
+                }
+                if idx < self.steps.len() {
+                    let target_step = &self.steps[idx];
+                    for branch in &target_step.branches {
+                        if let Some(&next_idx) = index_map.get(&branch.target) {
+                            queue.push_back(next_idx);
+                        }
+                    }
+                    if let Some(ref dn) = target_step.default_next
+                        && let Some(&next_idx) = index_map.get(dn)
+                    {
+                        queue.push_back(next_idx);
+                    }
+                    // Also consider sequential fallthrough for steps without branches.
+                    if !target_step.has_branches() && idx + 1 < self.steps.len() {
+                        queue.push_back(idx + 1);
+                    }
+                }
+            }
+        }
+
+        errors
+    }
 }
 
 /// Status of a chain execution.
@@ -214,6 +475,12 @@ pub struct ChainState {
     /// Who cancelled the chain (if cancelled).
     #[serde(default)]
     pub cancelled_by: Option<String>,
+    /// Ordered list of step names that have been executed (or are being
+    /// executed), representing the actual execution path through the chain.
+    /// For linear chains this matches the step order; for branching chains
+    /// it records the branch path taken.
+    #[serde(default)]
+    pub execution_path: Vec<String>,
 }
 
 #[cfg(test)]
@@ -305,5 +572,422 @@ mod tests {
             let back: StepFailurePolicy = serde_json::from_str(&json).unwrap();
             assert_eq!(&back, policy);
         }
+    }
+
+    #[test]
+    fn branch_condition_evaluate_success_eq() {
+        let cond = BranchCondition::new(
+            "success",
+            BranchOperator::Eq,
+            Some(serde_json::Value::Bool(true)),
+            "next-step",
+        );
+        let result = StepResult {
+            step_name: "check".into(),
+            success: true,
+            response_body: None,
+            error: None,
+            completed_at: Utc::now(),
+        };
+        assert!(cond.evaluate(&result));
+    }
+
+    #[test]
+    fn branch_condition_evaluate_body_field() {
+        let cond = BranchCondition::new(
+            "body.status",
+            BranchOperator::Eq,
+            Some(serde_json::json!("critical")),
+            "escalate",
+        );
+        let result = StepResult {
+            step_name: "check".into(),
+            success: true,
+            response_body: Some(serde_json::json!({"status": "critical", "count": 5})),
+            error: None,
+            completed_at: Utc::now(),
+        };
+        assert!(cond.evaluate(&result));
+    }
+
+    #[test]
+    fn branch_condition_evaluate_neq() {
+        let cond = BranchCondition::new(
+            "body.level",
+            BranchOperator::Neq,
+            Some(serde_json::json!("info")),
+            "alert",
+        );
+        let result = StepResult {
+            step_name: "check".into(),
+            success: true,
+            response_body: Some(serde_json::json!({"level": "error"})),
+            error: None,
+            completed_at: Utc::now(),
+        };
+        assert!(cond.evaluate(&result));
+    }
+
+    #[test]
+    fn branch_condition_evaluate_contains() {
+        let cond = BranchCondition::new(
+            "body.message",
+            BranchOperator::Contains,
+            Some(serde_json::json!("timeout")),
+            "retry",
+        );
+        let result = StepResult {
+            step_name: "call".into(),
+            success: false,
+            response_body: Some(serde_json::json!({"message": "connection timeout after 30s"})),
+            error: None,
+            completed_at: Utc::now(),
+        };
+        assert!(cond.evaluate(&result));
+    }
+
+    #[test]
+    fn branch_condition_evaluate_exists() {
+        let cond = BranchCondition::new("body.data", BranchOperator::Exists, None, "process");
+        let result = StepResult {
+            step_name: "fetch".into(),
+            success: true,
+            response_body: Some(serde_json::json!({"data": [1, 2, 3]})),
+            error: None,
+            completed_at: Utc::now(),
+        };
+        assert!(cond.evaluate(&result));
+
+        let result_no_data = StepResult {
+            step_name: "fetch".into(),
+            success: true,
+            response_body: Some(serde_json::json!({"other": true})),
+            error: None,
+            completed_at: Utc::now(),
+        };
+        assert!(!cond.evaluate(&result_no_data));
+    }
+
+    #[test]
+    fn branch_condition_missing_field_returns_null() {
+        let cond = BranchCondition::new(
+            "body.nonexistent.deep",
+            BranchOperator::Eq,
+            Some(serde_json::json!("x")),
+            "step",
+        );
+        let result = StepResult {
+            step_name: "s".into(),
+            success: true,
+            response_body: Some(serde_json::json!({"other": 1})),
+            error: None,
+            completed_at: Utc::now(),
+        };
+        assert!(!cond.evaluate(&result));
+    }
+
+    #[test]
+    fn chain_step_config_with_branches() {
+        let step = ChainStepConfig::new("check", "api", "get_status", serde_json::json!({}))
+            .with_branch(BranchCondition::new(
+                "body.severity",
+                BranchOperator::Eq,
+                Some(serde_json::json!("high")),
+                "escalate",
+            ))
+            .with_branch(BranchCondition::new(
+                "body.severity",
+                BranchOperator::Eq,
+                Some(serde_json::json!("low")),
+                "log-only",
+            ))
+            .with_default_next("notify");
+
+        assert!(step.has_branches());
+        assert_eq!(step.branches.len(), 2);
+        assert_eq!(step.default_next.as_deref(), Some("notify"));
+    }
+
+    #[test]
+    fn chain_step_config_without_branches_is_not_branching() {
+        let step = ChainStepConfig::new("check", "api", "get_status", serde_json::json!({}));
+        assert!(!step.has_branches());
+    }
+
+    #[test]
+    fn chain_config_validate_valid_linear() {
+        let config = ChainConfig::new("linear")
+            .with_step(ChainStepConfig::new("a", "p", "t", serde_json::json!({})))
+            .with_step(ChainStepConfig::new("b", "p", "t", serde_json::json!({})));
+        assert!(config.validate().is_empty());
+    }
+
+    #[test]
+    fn chain_config_validate_valid_branches() {
+        let config = ChainConfig::new("branching")
+            .with_step(
+                ChainStepConfig::new("check", "api", "status", serde_json::json!({}))
+                    .with_branch(BranchCondition::new(
+                        "body.status",
+                        BranchOperator::Eq,
+                        Some(serde_json::json!("critical")),
+                        "escalate",
+                    ))
+                    .with_default_next("log"),
+            )
+            .with_step(ChainStepConfig::new(
+                "escalate",
+                "pagerduty",
+                "alert",
+                serde_json::json!({}),
+            ))
+            .with_step(ChainStepConfig::new(
+                "log",
+                "logger",
+                "info",
+                serde_json::json!({}),
+            ));
+        assert!(config.validate().is_empty());
+    }
+
+    #[test]
+    fn chain_config_validate_duplicate_names() {
+        let config = ChainConfig::new("dupes")
+            .with_step(ChainStepConfig::new("a", "p", "t", serde_json::json!({})))
+            .with_step(ChainStepConfig::new("a", "p", "t", serde_json::json!({})));
+        let errors = config.validate();
+        assert!(!errors.is_empty());
+        assert!(errors[0].contains("duplicate step name"));
+    }
+
+    #[test]
+    fn chain_config_validate_bad_branch_target() {
+        let config = ChainConfig::new("bad-target")
+            .with_step(
+                ChainStepConfig::new("a", "p", "t", serde_json::json!({})).with_branch(
+                    BranchCondition::new(
+                        "success",
+                        BranchOperator::Eq,
+                        Some(serde_json::json!(true)),
+                        "nonexistent",
+                    ),
+                ),
+            )
+            .with_step(ChainStepConfig::new("b", "p", "t", serde_json::json!({})));
+        let errors = config.validate();
+        assert!(!errors.is_empty());
+        assert!(errors[0].contains("non-existent step"));
+    }
+
+    #[test]
+    fn chain_config_validate_cycle_detection() {
+        // a -> b -> a (cycle)
+        let config = ChainConfig::new("cycle")
+            .with_step(
+                ChainStepConfig::new("a", "p", "t", serde_json::json!({})).with_default_next("b"),
+            )
+            .with_step(
+                ChainStepConfig::new("b", "p", "t", serde_json::json!({})).with_default_next("a"),
+            );
+        let errors = config.validate();
+        assert!(!errors.is_empty());
+        assert!(errors.iter().any(|e| e.contains("cycle detected")));
+    }
+
+    #[test]
+    fn chain_config_step_index_map() {
+        let config = ChainConfig::new("test")
+            .with_step(ChainStepConfig::new(
+                "alpha",
+                "p",
+                "t",
+                serde_json::json!({}),
+            ))
+            .with_step(ChainStepConfig::new(
+                "beta",
+                "p",
+                "t",
+                serde_json::json!({}),
+            ))
+            .with_step(ChainStepConfig::new(
+                "gamma",
+                "p",
+                "t",
+                serde_json::json!({}),
+            ));
+        let map = config.step_index_map();
+        assert_eq!(map.get("alpha"), Some(&0));
+        assert_eq!(map.get("beta"), Some(&1));
+        assert_eq!(map.get("gamma"), Some(&2));
+    }
+
+    #[test]
+    fn branch_condition_serde_roundtrip() {
+        let cond = BranchCondition::new(
+            "body.status",
+            BranchOperator::Eq,
+            Some(serde_json::json!("critical")),
+            "escalate",
+        );
+        let json = serde_json::to_string(&cond).unwrap();
+        let back: BranchCondition = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.field, "body.status");
+        assert_eq!(back.operator, BranchOperator::Eq);
+        assert_eq!(back.target, "escalate");
+    }
+
+    #[test]
+    fn chain_config_with_branches_serde_roundtrip() {
+        let config = ChainConfig::new("branching")
+            .with_step(
+                ChainStepConfig::new("check", "api", "status", serde_json::json!({}))
+                    .with_branch(BranchCondition::new(
+                        "body.level",
+                        BranchOperator::Eq,
+                        Some(serde_json::json!("high")),
+                        "escalate",
+                    ))
+                    .with_default_next("log"),
+            )
+            .with_step(ChainStepConfig::new(
+                "escalate",
+                "p",
+                "t",
+                serde_json::json!({}),
+            ))
+            .with_step(ChainStepConfig::new("log", "p", "t", serde_json::json!({})));
+
+        let json = serde_json::to_string(&config).unwrap();
+        let back: ChainConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.steps[0].branches.len(), 1);
+        assert_eq!(back.steps[0].default_next.as_deref(), Some("log"));
+        assert!(back.has_branches());
+    }
+
+    #[test]
+    fn backward_compatible_deserialization_no_branches() {
+        // Simulate old JSON without branches or default_next fields.
+        let json = r#"{
+            "name": "old-chain",
+            "steps": [{
+                "name": "s1",
+                "provider": "p",
+                "action_type": "t",
+                "payload_template": {}
+            }]
+        }"#;
+        let config: ChainConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.steps[0].branches.len(), 0);
+        assert!(config.steps[0].default_next.is_none());
+        assert!(!config.has_branches());
+    }
+
+    #[test]
+    fn chain_config_validate_valid_with_multiple_branch_points() {
+        // Chain: check -> (branch to escalate or warn) -> notify
+        //        escalate -> notify
+        //        warn -> notify
+        let config = ChainConfig::new("multi-branch-points")
+            .with_step(
+                ChainStepConfig::new("check", "api", "status", serde_json::json!({}))
+                    .with_branch(BranchCondition::new(
+                        "body.severity",
+                        BranchOperator::Eq,
+                        Some(serde_json::json!("high")),
+                        "escalate",
+                    ))
+                    .with_branch(BranchCondition::new(
+                        "body.severity",
+                        BranchOperator::Eq,
+                        Some(serde_json::json!("low")),
+                        "warn",
+                    ))
+                    .with_default_next("notify"),
+            )
+            .with_step(
+                ChainStepConfig::new("escalate", "pagerduty", "alert", serde_json::json!({}))
+                    .with_default_next("notify"),
+            )
+            .with_step(
+                ChainStepConfig::new("warn", "slack", "message", serde_json::json!({}))
+                    .with_default_next("notify"),
+            )
+            .with_step(ChainStepConfig::new(
+                "notify",
+                "email",
+                "send",
+                serde_json::json!({}),
+            ));
+        assert!(
+            config.validate().is_empty(),
+            "valid chain with multiple branch points should have no errors"
+        );
+        assert!(config.has_branches());
+    }
+
+    #[test]
+    fn chain_config_validate_default_next_to_nonexistent_step() {
+        let config = ChainConfig::new("bad-default")
+            .with_step(
+                ChainStepConfig::new("a", "p", "t", serde_json::json!({}))
+                    .with_default_next("ghost"),
+            )
+            .with_step(ChainStepConfig::new("b", "p", "t", serde_json::json!({})));
+        let errors = config.validate();
+        assert!(!errors.is_empty());
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("default_next") && e.contains("ghost")),
+            "should report default_next targeting non-existent step, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn chain_config_validate_complex_cycle_a_b_c_a() {
+        // A -> B -> C -> A (cycle through three steps)
+        let config = ChainConfig::new("complex-cycle")
+            .with_step(
+                ChainStepConfig::new("a", "p", "t", serde_json::json!({})).with_default_next("b"),
+            )
+            .with_step(
+                ChainStepConfig::new("b", "p", "t", serde_json::json!({})).with_default_next("c"),
+            )
+            .with_step(
+                ChainStepConfig::new("c", "p", "t", serde_json::json!({})).with_default_next("a"),
+            );
+        let errors = config.validate();
+        assert!(
+            errors.iter().any(|e| e.contains("cycle detected")),
+            "should detect A->B->C->A cycle, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn backward_compatible_chain_state_deserialization() {
+        // Simulate old ChainState JSON without execution_path.
+        let json = serde_json::json!({
+            "chain_id": "abc",
+            "chain_name": "test",
+            "origin_action": {
+                "id": "id1",
+                "namespace": "ns",
+                "tenant": "t",
+                "provider": "p",
+                "action_type": "at",
+                "payload": {},
+                "created_at": "2026-01-01T00:00:00Z"
+            },
+            "current_step": 0,
+            "total_steps": 1,
+            "status": "running",
+            "step_results": [null],
+            "started_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "namespace": "ns",
+            "tenant": "t"
+        });
+        let state: ChainState = serde_json::from_value(json).unwrap();
+        assert!(state.execution_path.is_empty());
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,8 +14,8 @@ pub mod types;
 pub use action::{Action, ActionMetadata};
 pub use caller::Caller;
 pub use chain::{
-    ChainConfig, ChainFailurePolicy, ChainNotificationTarget, ChainState, ChainStatus,
-    ChainStepConfig, StepFailurePolicy, StepResult,
+    BranchCondition, BranchOperator, ChainConfig, ChainFailurePolicy, ChainNotificationTarget,
+    ChainState, ChainStatus, ChainStepConfig, StepFailurePolicy, StepResult,
 };
 pub use context::ActionContext;
 pub use error::ActeonError;

--- a/crates/server/src/api/chains.rs
+++ b/crates/server/src/api/chains.rs
@@ -117,6 +117,10 @@ pub struct ChainDetailResponse {
     /// Who cancelled the chain (if cancelled).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cancelled_by: Option<String>,
+    /// The ordered list of step names that were executed (the branch path taken).
+    /// Empty for chains that haven't started or for legacy chains without path tracking.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub execution_path: Vec<String>,
 }
 
 fn parse_status_filter(s: &str) -> Option<ChainStatus> {
@@ -261,6 +265,7 @@ pub async fn get_chain(
                 expires_at: chain_state.expires_at,
                 cancel_reason: chain_state.cancel_reason,
                 cancelled_by: chain_state.cancelled_by,
+                execution_path: chain_state.execution_path,
             };
             (StatusCode::OK, Json(detail)).into_response()
         }
@@ -325,6 +330,7 @@ pub async fn cancel_chain(
                 expires_at: chain_state.expires_at,
                 cancel_reason: chain_state.cancel_reason,
                 cancelled_by: chain_state.cancelled_by,
+                execution_path: chain_state.execution_path,
             };
             (StatusCode::OK, Json(detail)).into_response()
         }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -762,6 +762,26 @@ pub struct ChainStepConfigToml {
     pub on_failure: Option<String>,
     /// Optional delay in seconds before executing this step.
     pub delay_seconds: Option<u64>,
+    /// Conditional branch conditions evaluated after this step completes.
+    #[serde(default)]
+    pub branches: Vec<BranchConditionToml>,
+    /// Default next step name when no branch condition matches.
+    #[serde(default)]
+    pub default_next: Option<String>,
+}
+
+/// A branch condition in a chain step, loaded from TOML.
+#[derive(Debug, Deserialize)]
+pub struct BranchConditionToml {
+    /// The field to evaluate (e.g., `"success"`, `"body.status"`).
+    pub field: String,
+    /// Comparison operator: `"eq"`, `"neq"`, `"contains"`, or `"exists"`.
+    pub operator: String,
+    /// Value to compare against (ignored for `"exists"`).
+    #[serde(default)]
+    pub value: Option<serde_json::Value>,
+    /// Name of the target step to jump to when this condition matches.
+    pub target: String,
 }
 
 /// Configuration for `OpenTelemetry` distributed tracing.

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -93,6 +93,10 @@ name = "otel_tracing_simulation"
 # No required-features - uses in-memory backends
 
 [[example]]
+name = "branch_chain_simulation"
+# No required-features - uses in-memory backends
+
+[[example]]
 name = "scheduled_actions_simulation"
 # No required-features - uses in-memory backends
 

--- a/crates/simulation/examples/branch_chain_simulation.rs
+++ b/crates/simulation/examples/branch_chain_simulation.rs
@@ -1,0 +1,938 @@
+//! Simulation of conditional branching in task chains.
+//!
+//! Demonstrates:
+//! 1. Incident severity routing (branch on response body field)
+//! 2. Success/failure branching (branch on step success)
+//! 3. Multi-step branch paths converging to a common finalize step
+//! 4. Default fallthrough when no branch condition matches
+//! 5. Linear chain backward compatibility (`execution_path` populated)
+//!
+//! Run with: `cargo run -p acteon-simulation --example branch_chain_simulation`
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use acteon_core::chain::{BranchCondition, BranchOperator, ChainConfig, ChainStepConfig};
+use acteon_core::{Action, ActionOutcome};
+use acteon_gateway::GatewayBuilder;
+use acteon_rules::Rule;
+use acteon_rules_yaml::YamlFrontend;
+use acteon_simulation::prelude::*;
+use acteon_state_memory::{MemoryDistributedLock, MemoryStateStore};
+
+fn parse_rules(yaml: &str) -> Vec<Rule> {
+    let frontend = YamlFrontend;
+    acteon_rules::RuleFrontend::parse(&frontend, yaml).expect("failed to parse rules")
+}
+
+/// Helper: build a gateway with given providers, chain, and rule YAML.
+#[allow(clippy::unused_async)]
+async fn build_gateway(
+    providers: Vec<Arc<dyn acteon_provider::DynProvider>>,
+    chain_config: ChainConfig,
+    rule_yaml: &str,
+) -> Result<acteon_gateway::Gateway, Box<dyn std::error::Error>> {
+    let state: Arc<dyn acteon_state::StateStore> = Arc::new(MemoryStateStore::new());
+    let lock: Arc<dyn acteon_state::DistributedLock> = Arc::new(MemoryDistributedLock::new());
+    let rules = parse_rules(rule_yaml);
+
+    let mut builder = GatewayBuilder::new()
+        .state(state)
+        .lock(lock)
+        .rules(rules)
+        .chain(chain_config)
+        .completed_chain_ttl(Duration::from_secs(3600));
+
+    for p in providers {
+        builder = builder.provider(p);
+    }
+
+    Ok(builder.build()?)
+}
+
+/// Helper: dispatch an action and extract the `chain_id` from `ChainStarted`.
+async fn start_chain(
+    gateway: &acteon_gateway::Gateway,
+    namespace: &str,
+    tenant: &str,
+    provider: &str,
+    action_type: &str,
+    payload: serde_json::Value,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let action = Action::new(namespace, tenant, provider, action_type, payload);
+    let outcome = gateway.dispatch(action, None).await?;
+    match outcome {
+        ActionOutcome::ChainStarted { chain_id, .. } => Ok(chain_id),
+        other => Err(format!("expected ChainStarted, got {other:?}").into()),
+    }
+}
+
+#[tokio::main]
+#[allow(clippy::too_many_lines, clippy::similar_names)]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("==================================================================");
+    println!("     ACTEON BRANCH CHAIN SIMULATION");
+    println!("==================================================================\n");
+
+    // =========================================================================
+    // DEMO 1: Incident Severity Routing
+    // =========================================================================
+    //
+    // Chain shape:
+    //   check-severity ─┬─ severity=="critical" ──> escalate ──> done
+    //                   ├─ severity=="warning"  ──> notify   ──> done
+    //                   └─ default              ──> log-only ──> done
+    //
+    // Each branch target uses with_default_next("done") to skip to the
+    // terminal step, preventing sequential fallthrough between branches.
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DEMO 1: INCIDENT SEVERITY ROUTING");
+    println!("------------------------------------------------------------------\n");
+
+    let check_provider = Arc::new(
+        RecordingProvider::new("incident-api").with_response_fn(|_| {
+            Ok(acteon_core::ProviderResponse::success(serde_json::json!({
+                "severity": "critical",
+                "source": "monitoring"
+            })))
+        }),
+    );
+    let pagerduty_provider = Arc::new(RecordingProvider::new("pagerduty"));
+    let slack_provider = Arc::new(RecordingProvider::new("slack"));
+    let logger_provider = Arc::new(RecordingProvider::new("logger"));
+    let done_provider = Arc::new(RecordingProvider::new("done-svc"));
+
+    // The "done" step is the terminal convergence point. Each exclusive
+    // branch target explicitly routes here via default_next.
+    let chain_config = ChainConfig::new("incident-routing")
+        .with_step(
+            ChainStepConfig::new(
+                "check-severity",
+                "incident-api",
+                "check_incident",
+                serde_json::json!({"incident_id": "{{origin.payload.incident_id}}"}),
+            )
+            .with_branch(BranchCondition::new(
+                "body.severity",
+                BranchOperator::Eq,
+                Some(serde_json::json!("critical")),
+                "escalate",
+            ))
+            .with_branch(BranchCondition::new(
+                "body.severity",
+                BranchOperator::Eq,
+                Some(serde_json::json!("warning")),
+                "notify",
+            ))
+            .with_default_next("log-only"),
+        )
+        .with_step(
+            ChainStepConfig::new(
+                "escalate",
+                "pagerduty",
+                "create_alert",
+                serde_json::json!({"urgency": "high"}),
+            )
+            .with_default_next("done"),
+        )
+        .with_step(
+            ChainStepConfig::new(
+                "notify",
+                "slack",
+                "send_message",
+                serde_json::json!({"channel": "#incidents"}),
+            )
+            .with_default_next("done"),
+        )
+        .with_step(
+            ChainStepConfig::new(
+                "log-only",
+                "logger",
+                "log",
+                serde_json::json!({"level": "info"}),
+            )
+            .with_default_next("done"),
+        )
+        .with_step(ChainStepConfig::new(
+            "done",
+            "done-svc",
+            "ack",
+            serde_json::json!({}),
+        ))
+        .with_timeout(30);
+
+    let rule_yaml = r#"
+rules:
+  - name: incident-chain
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "incident"
+    action:
+      type: chain
+      chain: incident-routing
+"#;
+
+    let gateway = build_gateway(
+        vec![
+            Arc::clone(&check_provider) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&pagerduty_provider) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&slack_provider) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&logger_provider) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&done_provider) as Arc<dyn acteon_provider::DynProvider>,
+        ],
+        chain_config,
+        rule_yaml,
+    )
+    .await?;
+
+    let chain_id = start_chain(
+        &gateway,
+        "ops",
+        "tenant-1",
+        "incident-api",
+        "incident",
+        serde_json::json!({"incident_id": "INC-001"}),
+    )
+    .await?;
+    println!("  Chain started: {chain_id}");
+
+    // Advance check-severity -> branches to "escalate" (severity == critical)
+    gateway.advance_chain("ops", "tenant-1", &chain_id).await?;
+    println!("  Step 0 (check-severity) advanced -> escalate");
+
+    // Advance escalate -> default_next "done"
+    gateway.advance_chain("ops", "tenant-1", &chain_id).await?;
+    println!("  Step 1 (escalate) advanced -> done");
+
+    // Advance done -> chain completes
+    gateway.advance_chain("ops", "tenant-1", &chain_id).await?;
+    println!("  Step 2 (done) advanced -> complete");
+
+    let chain_state = gateway
+        .get_chain_status("ops", "tenant-1", &chain_id)
+        .await?
+        .expect("chain state should exist");
+
+    println!("\n  Final chain status: {:?}", chain_state.status);
+    println!("  Execution path: {:?}", chain_state.execution_path);
+    assert_eq!(
+        chain_state.status,
+        acteon_core::chain::ChainStatus::Completed
+    );
+    assert_eq!(
+        chain_state.execution_path,
+        vec!["check-severity", "escalate", "done"]
+    );
+
+    println!("\n  Provider call counts:");
+    println!("    incident-api: {}", check_provider.call_count());
+    println!("    pagerduty:    {}", pagerduty_provider.call_count());
+    println!(
+        "    slack:        {} (not reached)",
+        slack_provider.call_count()
+    );
+    println!(
+        "    logger:       {} (not reached)",
+        logger_provider.call_count()
+    );
+    check_provider.assert_called(1);
+    pagerduty_provider.assert_called(1);
+    slack_provider.assert_not_called();
+    logger_provider.assert_not_called();
+
+    gateway.shutdown().await;
+    println!("\n  PASSED\n");
+
+    // =========================================================================
+    // DEMO 2: Success/Failure Branching
+    // =========================================================================
+    //
+    // Chain shape:
+    //   validate ─┬─ success==true  ──> process ──(end)
+    //             └─ success!=true  ──> reject  ──(end)
+    //
+    // "reject" is the last step so it naturally terminates. "process" uses
+    // default_next to skip over "reject" to chain end. We demonstrate this
+    // twice: once where validation succeeds and once where it fails.
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DEMO 2: SUCCESS/FAILURE BRANCHING");
+    println!("------------------------------------------------------------------\n");
+
+    // --- Run A: validation succeeds ---
+    println!("  --- Run A: validation succeeds ---\n");
+
+    let validate_ok = Arc::new(RecordingProvider::new("validator").with_response_fn(|_| {
+        Ok(acteon_core::ProviderResponse::success(
+            serde_json::json!({"valid": true}),
+        ))
+    }));
+    let process_provider = Arc::new(RecordingProvider::new("processor"));
+    let reject_provider = Arc::new(RecordingProvider::new("rejector"));
+    let done2a_provider = Arc::new(RecordingProvider::new("done-svc"));
+
+    let chain_config = ChainConfig::new("validate-chain")
+        .with_step(
+            ChainStepConfig::new(
+                "validate",
+                "validator",
+                "validate",
+                serde_json::json!({"data": "{{origin.payload}}"}),
+            )
+            .with_branch(BranchCondition::new(
+                "success",
+                BranchOperator::Eq,
+                Some(serde_json::Value::Bool(true)),
+                "process",
+            ))
+            .with_branch(BranchCondition::new(
+                "success",
+                BranchOperator::Neq,
+                Some(serde_json::Value::Bool(true)),
+                "reject",
+            )),
+        )
+        .with_step(
+            ChainStepConfig::new(
+                "process",
+                "processor",
+                "process_data",
+                serde_json::json!({}),
+            )
+            .with_default_next("done"),
+        )
+        .with_step(
+            ChainStepConfig::new(
+                "reject",
+                "rejector",
+                "send_rejection",
+                serde_json::json!({}),
+            )
+            .with_default_next("done"),
+        )
+        .with_step(ChainStepConfig::new(
+            "done",
+            "done-svc",
+            "ack",
+            serde_json::json!({}),
+        ))
+        .with_timeout(30);
+
+    let rule_yaml_validate = r#"
+rules:
+  - name: validate-chain
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "validate"
+    action:
+      type: chain
+      chain: validate-chain
+"#;
+
+    let gateway = build_gateway(
+        vec![
+            Arc::clone(&validate_ok) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&process_provider) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&reject_provider) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&done2a_provider) as Arc<dyn acteon_provider::DynProvider>,
+        ],
+        chain_config.clone(),
+        rule_yaml_validate,
+    )
+    .await?;
+
+    let chain_id = start_chain(
+        &gateway,
+        "app",
+        "tenant-1",
+        "validator",
+        "validate",
+        serde_json::json!({"record": "abc"}),
+    )
+    .await?;
+
+    // Advance validate (succeeds) -> branches to "process"
+    gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+    println!("  Step 0 (validate) advanced -> process");
+
+    // Advance process -> default_next "done"
+    gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+    println!("  Step 1 (process) advanced -> done");
+
+    // Advance done -> chain completes
+    gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+    println!("  Step 2 (done) advanced -> complete");
+
+    let chain_state = gateway
+        .get_chain_status("app", "tenant-1", &chain_id)
+        .await?
+        .expect("chain state should exist");
+
+    println!("  Final status: {:?}", chain_state.status);
+    println!("  Execution path: {:?}", chain_state.execution_path);
+    assert_eq!(
+        chain_state.status,
+        acteon_core::chain::ChainStatus::Completed
+    );
+    assert_eq!(
+        chain_state.execution_path,
+        vec!["validate", "process", "done"]
+    );
+    process_provider.assert_called(1);
+    reject_provider.assert_not_called();
+
+    gateway.shutdown().await;
+    println!("  PASSED\n");
+
+    // --- Run B: validation fails ---
+    println!("  --- Run B: validation fails ---\n");
+
+    let validate_fail =
+        Arc::new(RecordingProvider::new("validator").with_failure_mode(FailureMode::Always));
+    let process_provider_b = Arc::new(RecordingProvider::new("processor"));
+    let reject_provider_b = Arc::new(RecordingProvider::new("rejector"));
+    let done2b_provider = Arc::new(RecordingProvider::new("done-svc"));
+
+    let gateway = build_gateway(
+        vec![
+            Arc::clone(&validate_fail) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&process_provider_b) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&reject_provider_b) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&done2b_provider) as Arc<dyn acteon_provider::DynProvider>,
+        ],
+        // Reuse the same chain config but with skip-on-failure for validate.
+        ChainConfig::new("validate-chain")
+            .with_step(
+                ChainStepConfig::new("validate", "validator", "validate", serde_json::json!({}))
+                    .with_on_failure(acteon_core::chain::StepFailurePolicy::Skip)
+                    .with_branch(BranchCondition::new(
+                        "success",
+                        BranchOperator::Eq,
+                        Some(serde_json::Value::Bool(true)),
+                        "process",
+                    ))
+                    .with_branch(BranchCondition::new(
+                        "success",
+                        BranchOperator::Neq,
+                        Some(serde_json::Value::Bool(true)),
+                        "reject",
+                    )),
+            )
+            .with_step(
+                ChainStepConfig::new(
+                    "process",
+                    "processor",
+                    "process_data",
+                    serde_json::json!({}),
+                )
+                .with_default_next("done"),
+            )
+            .with_step(
+                ChainStepConfig::new(
+                    "reject",
+                    "rejector",
+                    "send_rejection",
+                    serde_json::json!({}),
+                )
+                .with_default_next("done"),
+            )
+            .with_step(ChainStepConfig::new(
+                "done",
+                "done-svc",
+                "ack",
+                serde_json::json!({}),
+            ))
+            .with_timeout(30),
+        rule_yaml_validate,
+    )
+    .await?;
+
+    let chain_id = start_chain(
+        &gateway,
+        "app",
+        "tenant-1",
+        "validator",
+        "validate",
+        serde_json::json!({"record": "xyz"}),
+    )
+    .await?;
+
+    // Advance validate -> fails (skip policy) -> branches to "reject"
+    gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+    println!("  Step 0 (validate) failed -> skip -> reject");
+
+    // Advance reject -> default_next "done"
+    gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+    println!("  Step 1 (reject) advanced -> done");
+
+    // Advance done -> chain completes
+    gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+    println!("  Step 2 (done) advanced -> complete");
+
+    let chain_state = gateway
+        .get_chain_status("app", "tenant-1", &chain_id)
+        .await?
+        .expect("chain state should exist");
+
+    println!("  Final status: {:?}", chain_state.status);
+    println!("  Execution path: {:?}", chain_state.execution_path);
+    assert_eq!(
+        chain_state.status,
+        acteon_core::chain::ChainStatus::Completed
+    );
+    assert_eq!(
+        chain_state.execution_path,
+        vec!["validate", "reject", "done"]
+    );
+    process_provider_b.assert_not_called();
+    reject_provider_b.assert_called(1);
+
+    gateway.shutdown().await;
+    println!("  PASSED\n");
+
+    // =========================================================================
+    // DEMO 3: Multi-Step Branch Paths Converging
+    // =========================================================================
+    //
+    // Chain shape:
+    //   classify ─┬─ type=="A" ──> handle-a ──┐
+    //             └─ type=="B" ──> handle-b ──┤
+    //                                         └──> finalize ──(end)
+    //
+    // Both handle-a and handle-b use default_next to converge on "finalize".
+    // We run this twice with different classification results to verify
+    // that execution_path differs.
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DEMO 3: MULTI-STEP BRANCH PATHS CONVERGING");
+    println!("------------------------------------------------------------------\n");
+
+    let classify_provider = Arc::new(RecordingProvider::new("classifier").with_response_fn(
+        |_action| {
+            Ok(acteon_core::ProviderResponse::success(serde_json::json!({
+                "type": "A"
+            })))
+        },
+    ));
+    let handle_a_provider = Arc::new(RecordingProvider::new("handler-a"));
+    let handle_b_provider = Arc::new(RecordingProvider::new("handler-b"));
+    let finalize_provider = Arc::new(RecordingProvider::new("finalizer"));
+
+    let chain_config = ChainConfig::new("classify-chain")
+        .with_step(
+            ChainStepConfig::new("classify", "classifier", "classify", serde_json::json!({}))
+                .with_branch(BranchCondition::new(
+                    "body.type",
+                    BranchOperator::Eq,
+                    Some(serde_json::json!("A")),
+                    "handle-a",
+                ))
+                .with_branch(BranchCondition::new(
+                    "body.type",
+                    BranchOperator::Eq,
+                    Some(serde_json::json!("B")),
+                    "handle-b",
+                )),
+        )
+        .with_step(
+            ChainStepConfig::new("handle-a", "handler-a", "process_a", serde_json::json!({}))
+                .with_default_next("finalize"),
+        )
+        .with_step(
+            ChainStepConfig::new("handle-b", "handler-b", "process_b", serde_json::json!({}))
+                .with_default_next("finalize"),
+        )
+        .with_step(ChainStepConfig::new(
+            "finalize",
+            "finalizer",
+            "finalize",
+            serde_json::json!({}),
+        ))
+        .with_timeout(30);
+
+    let rule_yaml_classify = r#"
+rules:
+  - name: classify-chain
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "classify"
+    action:
+      type: chain
+      chain: classify-chain
+"#;
+
+    // --- Run with type A ---
+    println!("  --- Run with type A ---\n");
+
+    let gateway = build_gateway(
+        vec![
+            Arc::clone(&classify_provider) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&handle_a_provider) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&handle_b_provider) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&finalize_provider) as Arc<dyn acteon_provider::DynProvider>,
+        ],
+        chain_config.clone(),
+        rule_yaml_classify,
+    )
+    .await?;
+
+    let chain_id = start_chain(
+        &gateway,
+        "app",
+        "tenant-1",
+        "classifier",
+        "classify",
+        serde_json::json!({}),
+    )
+    .await?;
+
+    // classify -> handle-a -> finalize -> complete
+    gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+    println!("  Step 0 (classify) -> handle-a");
+
+    gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+    println!("  Step 1 (handle-a) -> finalize");
+
+    gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+    println!("  Step 2 (finalize) -> complete");
+
+    let chain_state = gateway
+        .get_chain_status("app", "tenant-1", &chain_id)
+        .await?
+        .expect("chain state should exist");
+
+    println!("  Final status: {:?}", chain_state.status);
+    println!("  Execution path: {:?}", chain_state.execution_path);
+    assert_eq!(
+        chain_state.status,
+        acteon_core::chain::ChainStatus::Completed
+    );
+    assert_eq!(
+        chain_state.execution_path,
+        vec!["classify", "handle-a", "finalize"]
+    );
+    handle_a_provider.assert_called(1);
+    handle_b_provider.assert_not_called();
+    finalize_provider.assert_called(1);
+
+    gateway.shutdown().await;
+    println!("  PASSED\n");
+
+    // --- Run with type B ---
+    println!("  --- Run with type B ---\n");
+
+    let classify_b_provider =
+        Arc::new(RecordingProvider::new("classifier").with_response_fn(|_| {
+            Ok(acteon_core::ProviderResponse::success(serde_json::json!({
+                "type": "B"
+            })))
+        }));
+    let handle_a2 = Arc::new(RecordingProvider::new("handler-a"));
+    let handle_b2 = Arc::new(RecordingProvider::new("handler-b"));
+    let finalize2 = Arc::new(RecordingProvider::new("finalizer"));
+
+    let gateway = build_gateway(
+        vec![
+            Arc::clone(&classify_b_provider) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&handle_a2) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&handle_b2) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&finalize2) as Arc<dyn acteon_provider::DynProvider>,
+        ],
+        chain_config,
+        rule_yaml_classify,
+    )
+    .await?;
+
+    let chain_id = start_chain(
+        &gateway,
+        "app",
+        "tenant-1",
+        "classifier",
+        "classify",
+        serde_json::json!({}),
+    )
+    .await?;
+
+    // classify -> handle-b -> finalize -> complete
+    gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+    println!("  Step 0 (classify) -> handle-b");
+
+    gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+    println!("  Step 1 (handle-b) -> finalize");
+
+    gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+    println!("  Step 2 (finalize) -> complete");
+
+    let chain_state = gateway
+        .get_chain_status("app", "tenant-1", &chain_id)
+        .await?
+        .expect("chain state should exist");
+
+    println!("  Final status: {:?}", chain_state.status);
+    println!("  Execution path: {:?}", chain_state.execution_path);
+    assert_eq!(
+        chain_state.status,
+        acteon_core::chain::ChainStatus::Completed
+    );
+    assert_eq!(
+        chain_state.execution_path,
+        vec!["classify", "handle-b", "finalize"]
+    );
+    handle_a2.assert_not_called();
+    handle_b2.assert_called(1);
+    finalize2.assert_called(1);
+
+    gateway.shutdown().await;
+    println!("  PASSED\n");
+
+    // =========================================================================
+    // DEMO 4: Default Fallthrough
+    // =========================================================================
+    //
+    // Chain shape:
+    //   check ─┬─ priority=="high"   ──> handle-high ──> done
+    //          ├─ priority=="medium" ──> handle-high ──> done
+    //          └─ default            ──> fallback    ──> done
+    //
+    // The response has priority "low", so no branch matches and the
+    // default_next step "fallback" is used instead.
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DEMO 4: DEFAULT FALLTHROUGH");
+    println!("------------------------------------------------------------------\n");
+
+    let check_provider_d4 = Arc::new(RecordingProvider::new("checker").with_response_fn(|_| {
+        Ok(acteon_core::ProviderResponse::success(serde_json::json!({
+            "priority": "low"
+        })))
+    }));
+    let high_handler = Arc::new(RecordingProvider::new("high-handler"));
+    let fallback_handler = Arc::new(RecordingProvider::new("fallback-svc"));
+    let done4_provider = Arc::new(RecordingProvider::new("done-svc"));
+
+    let chain_config = ChainConfig::new("fallthrough-chain")
+        .with_step(
+            ChainStepConfig::new("check", "checker", "check", serde_json::json!({}))
+                .with_branch(BranchCondition::new(
+                    "body.priority",
+                    BranchOperator::Eq,
+                    Some(serde_json::json!("high")),
+                    "handle-high",
+                ))
+                .with_branch(BranchCondition::new(
+                    "body.priority",
+                    BranchOperator::Eq,
+                    Some(serde_json::json!("medium")),
+                    "handle-high",
+                ))
+                // Neither "high" nor "medium" match "low" -> default_next
+                .with_default_next("fallback"),
+        )
+        .with_step(
+            ChainStepConfig::new(
+                "handle-high",
+                "high-handler",
+                "handle",
+                serde_json::json!({}),
+            )
+            .with_default_next("done"),
+        )
+        .with_step(
+            ChainStepConfig::new(
+                "fallback",
+                "fallback-svc",
+                "fallback_action",
+                serde_json::json!({}),
+            )
+            .with_default_next("done"),
+        )
+        .with_step(ChainStepConfig::new(
+            "done",
+            "done-svc",
+            "ack",
+            serde_json::json!({}),
+        ))
+        .with_timeout(30);
+
+    let rule_yaml_fallthrough = r#"
+rules:
+  - name: fallthrough-chain
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "fallthrough"
+    action:
+      type: chain
+      chain: fallthrough-chain
+"#;
+
+    let gateway = build_gateway(
+        vec![
+            Arc::clone(&check_provider_d4) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&high_handler) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&fallback_handler) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&done4_provider) as Arc<dyn acteon_provider::DynProvider>,
+        ],
+        chain_config,
+        rule_yaml_fallthrough,
+    )
+    .await?;
+
+    let chain_id = start_chain(
+        &gateway,
+        "app",
+        "tenant-1",
+        "checker",
+        "fallthrough",
+        serde_json::json!({}),
+    )
+    .await?;
+    println!("  Chain started: {chain_id}");
+
+    // check -> no branch matches -> default_next "fallback"
+    gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+    println!("  Step 0 (check) -> no branch match -> fallback");
+
+    // fallback -> default_next "done"
+    gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+    println!("  Step 1 (fallback) -> done");
+
+    // done -> complete
+    gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+    println!("  Step 2 (done) -> complete");
+
+    let chain_state = gateway
+        .get_chain_status("app", "tenant-1", &chain_id)
+        .await?
+        .expect("chain state should exist");
+
+    println!("\n  Final status: {:?}", chain_state.status);
+    println!("  Execution path: {:?}", chain_state.execution_path);
+    assert_eq!(
+        chain_state.status,
+        acteon_core::chain::ChainStatus::Completed
+    );
+    assert_eq!(
+        chain_state.execution_path,
+        vec!["check", "fallback", "done"]
+    );
+    high_handler.assert_not_called();
+    fallback_handler.assert_called(1);
+
+    gateway.shutdown().await;
+    println!("\n  PASSED\n");
+
+    // =========================================================================
+    // DEMO 5: Linear Chain Backward Compatibility
+    // =========================================================================
+    //
+    // A standard linear chain (no branches) still works exactly as before
+    // and execution_path is populated correctly with the sequential step
+    // order.
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DEMO 5: LINEAR CHAIN BACKWARD COMPATIBILITY");
+    println!("------------------------------------------------------------------\n");
+
+    let step_a_provider = Arc::new(RecordingProvider::new("svc-a"));
+    let step_b_provider = Arc::new(RecordingProvider::new("svc-b"));
+    let step_c_provider = Arc::new(RecordingProvider::new("svc-c"));
+
+    let chain_config = ChainConfig::new("linear-chain")
+        .with_step(ChainStepConfig::new(
+            "first",
+            "svc-a",
+            "do_a",
+            serde_json::json!({}),
+        ))
+        .with_step(ChainStepConfig::new(
+            "second",
+            "svc-b",
+            "do_b",
+            serde_json::json!({}),
+        ))
+        .with_step(ChainStepConfig::new(
+            "third",
+            "svc-c",
+            "do_c",
+            serde_json::json!({}),
+        ))
+        .with_timeout(30);
+
+    let rule_yaml_linear = r#"
+rules:
+  - name: linear-chain
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "linear"
+    action:
+      type: chain
+      chain: linear-chain
+"#;
+
+    let gateway = build_gateway(
+        vec![
+            Arc::clone(&step_a_provider) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&step_b_provider) as Arc<dyn acteon_provider::DynProvider>,
+            Arc::clone(&step_c_provider) as Arc<dyn acteon_provider::DynProvider>,
+        ],
+        chain_config,
+        rule_yaml_linear,
+    )
+    .await?;
+
+    let chain_id = start_chain(
+        &gateway,
+        "app",
+        "tenant-1",
+        "svc-a",
+        "linear",
+        serde_json::json!({}),
+    )
+    .await?;
+    println!("  Chain started: {chain_id}");
+
+    for i in 0..3 {
+        gateway.advance_chain("app", "tenant-1", &chain_id).await?;
+        println!("  Step {i} advanced");
+    }
+
+    let chain_state = gateway
+        .get_chain_status("app", "tenant-1", &chain_id)
+        .await?
+        .expect("chain state should exist");
+
+    println!("\n  Final status: {:?}", chain_state.status);
+    println!("  Execution path: {:?}", chain_state.execution_path);
+    assert_eq!(
+        chain_state.status,
+        acteon_core::chain::ChainStatus::Completed
+    );
+    assert_eq!(chain_state.execution_path, vec!["first", "second", "third"]);
+    step_a_provider.assert_called(1);
+    step_b_provider.assert_called(1);
+    step_c_provider.assert_called(1);
+
+    // Verify step_results are populated for all steps.
+    for (i, name) in ["first", "second", "third"].iter().enumerate() {
+        let result = chain_state.step_results[i]
+            .as_ref()
+            .unwrap_or_else(|| panic!("step_results[{i}] should be Some"));
+        assert!(result.success, "step '{name}' should have succeeded");
+        assert_eq!(result.step_name, *name);
+    }
+
+    gateway.shutdown().await;
+    println!("\n  PASSED\n");
+
+    println!("==================================================================");
+    println!("     ALL BRANCH CHAIN SIMULATIONS PASSED");
+    println!("==================================================================");
+
+    Ok(())
+}

--- a/docs/brainstorm-new-features.md
+++ b/docs/brainstorm-new-features.md
@@ -124,11 +124,23 @@ are exhausted.
 
 ## 5. Enhanced Workflow Capabilities
 
-### Conditional Chain Branching
+### Conditional Chain Branching — IMPLEMENTED
 Current chains are linear (step 1 -> step 2 -> step 3). Add conditional
 branches: "if step 2 returns status X, go to step 3a; otherwise step 3b."
 This turns chains into lightweight DAG workflows without requiring a full
 workflow engine.
+
+**Implemented**: Each chain step can define `branches` — an ordered list of
+`BranchCondition` with `field`, `operator` (eq/neq/contains/exists), `value`,
+and `target` (step name). Conditions are evaluated in order after step
+completion; first match wins. A `default_next` fallback is used when no
+condition matches, with sequential advancement as the final fallback.
+`ChainState.execution_path` tracks the actual branch path taken. Cycle
+detection validates configs at dispatch time. Supports branching on
+`success`, `body.*`, and nested JSON paths. Fully backward-compatible — linear
+chains work identically. Server config (TOML) and API responses include
+branching fields. See `crates/simulation/examples/branch_chain_simulation.rs`
+for demos.
 
 ### Parallel Chain Steps
 Execute multiple steps concurrently within a chain, then join on all/any
@@ -332,4 +344,4 @@ Ranked by impact-to-effort ratio:
 | 7 | Cron-Based Rule Activation | Low | Medium | **DONE** |
 | 8 | Action Replay | Medium | Medium | **DONE** |
 | 9 | WebSocket/SSE Stream | Medium | Medium | **DONE** |
-| 10 | Conditional Chain Branching | Medium | Medium | Pending |
+| 10 | Conditional Chain Branching | Medium | Medium | **DONE** |


### PR DESCRIPTION
## Summary

- **Conditional branching**: Chain steps can now define ordered branch conditions (`field`/`operator`/`value`/`target`) evaluated after step completion. First match wins, with `default_next` fallback and sequential advancement as final fallback.
- **Core types**: `BranchCondition` and `BranchOperator` (Eq/Neq/Contains/Exists) with `evaluate()` against `StepResult`. `ChainConfig.validate()` performs cycle detection via BFS and checks for duplicate/invalid step references. `ChainState.execution_path` tracks the actual branch path taken.
- **Gateway**: `resolve_next_step()` evaluates branches using pre-cached step index maps (built once at gateway construction). Step-name-based dedup keys handle non-sequential execution. Branching-aware `{{prev.*}}` template resolution uses `execution_path`. Debug logging on branch fallthrough aids debugging.
- **Server**: `BranchConditionToml` for TOML config, `execution_path` field in `ChainDetailResponse` API.
- **Simulation**: 5 demo scenarios covering severity routing, success/failure branching, convergent paths, default fallthrough, and linear backward compatibility.

Fully backward-compatible — existing linear chains work identically with no config changes.

## Test plan

- [x] All 9 `resolve_next_step` unit tests pass (linear, branch match, multi-branch first-match-wins, default_next, fallthrough, final step, branch-back, success/failure routing, body field conditions)
- [x] 20+ core unit tests for `BranchCondition.evaluate()`, serialization roundtrip, `ChainConfig.validate()` cycle detection, backward compat deserialization
- [x] 4 branching-aware `{{prev.*}}` template resolution tests
- [x] `cargo clippy --workspace --no-deps -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] Run `cargo run -p acteon-simulation --example branch_chain_simulation` to verify demo scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)