### PR TITLE
feat: add MCP server, CLI, and common operations layer

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "acteon": {
+      "command": "./target/debug/acteon-mcp-server",
+      "args": ["--endpoint", "http://localhost:8080"]
+    }
+  }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "acteon-cli"
+version = "0.1.0"
+dependencies = [
+ "acteon-core",
+ "acteon-ops",
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "acteon-client"
 version = "0.1.0"
 dependencies = [
@@ -193,6 +209,37 @@ dependencies = [
  "acteon-core",
  "async-trait",
  "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "acteon-mcp-server"
+version = "0.1.0"
+dependencies = [
+ "acteon-core",
+ "acteon-ops",
+ "anyhow",
+ "clap",
+ "rmcp",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "acteon-ops"
+version = "0.1.0"
+dependencies = [
+ "acteon-client",
+ "acteon-core",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1814,6 +1861,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +2010,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -2718,6 +2805,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3499,6 +3592,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3838,6 +3937,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3943,6 +4062,41 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bef41ebc9ebed2c1b1d90203e9d1756091e8a00bbc3107676151f39868ca0ee"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -4134,6 +4288,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,11 @@ members = [
     "crates/integrations/slack",
     "crates/integrations/pagerduty",
     "crates/integrations/webhook",
+
+    # Operations / CLI / MCP
+    "crates/ops",
+    "crates/mcp-server",
+    "crates/cli",
 ]
 
 [workspace.package]
@@ -93,6 +98,11 @@ acteon-email = { path = "crates/integrations/email" }
 acteon-slack = { path = "crates/integrations/slack" }
 acteon-pagerduty = { path = "crates/integrations/pagerduty" }
 acteon-webhook = { path = "crates/integrations/webhook" }
+
+# Operations / CLI / MCP
+acteon-ops = { path = "crates/ops" }
+acteon-mcp-server = { path = "crates/mcp-server" }
+acteon-cli = { path = "crates/cli" }
 
 # Parsing
 nom = "7"
@@ -196,6 +206,10 @@ tracing-opentelemetry = "0.29"
 
 # Cron scheduling
 croner = "2"
+
+# MCP
+rmcp = { version = "0.15", features = ["server", "transport-io"] }
+schemars = "1"
 
 # Benchmarking
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "acteon-cli"
+description = "Command-line interface for the Acteon action gateway"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[[bin]]
+name = "acteon"
+path = "src/main.rs"
+
+[dependencies]
+acteon-ops = { workspace = true }
+acteon-core = { workspace = true }
+
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+clap = { version = "4", features = ["derive", "env"] }
+anyhow = "1"
+
+[lints]
+workspace = true

--- a/crates/cli/src/commands/audit.rs
+++ b/crates/cli/src/commands/audit.rs
@@ -1,0 +1,64 @@
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::AuditQuery;
+use clap::Args;
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct AuditArgs {
+    /// Filter by tenant.
+    #[arg(long)]
+    pub tenant: Option<String>,
+    /// Filter by namespace.
+    #[arg(long)]
+    pub namespace: Option<String>,
+    /// Filter by provider.
+    #[arg(long)]
+    pub provider: Option<String>,
+    /// Filter by action type.
+    #[arg(long, name = "type")]
+    pub action_type: Option<String>,
+    /// Maximum records to return.
+    #[arg(long, default_value = "20")]
+    pub limit: u32,
+}
+
+pub async fn run(ops: &OpsClient, args: &AuditArgs, format: &OutputFormat) -> anyhow::Result<()> {
+    let query = AuditQuery {
+        tenant: args.tenant.clone(),
+        namespace: args.namespace.clone(),
+        provider: args.provider.clone(),
+        action_type: args.action_type.clone(),
+        outcome: None,
+        limit: Some(args.limit),
+        offset: None,
+    };
+
+    let page = ops.client().query_audit(&query).await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&page)?);
+        }
+        OutputFormat::Text => {
+            println!(
+                "Total: {} records (showing {})",
+                page.total,
+                page.records.len()
+            );
+            for rec in &page.records {
+                println!(
+                    "  [{ts}] {action_type} -> {provider} | {verdict} ({outcome}) [{id}]",
+                    ts = rec.dispatched_at,
+                    action_type = rec.action_type,
+                    provider = rec.provider,
+                    verdict = rec.verdict,
+                    outcome = rec.outcome,
+                    id = &rec.action_id[..8.min(rec.action_id.len())],
+                );
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/commands/dispatch.rs
+++ b/crates/cli/src/commands/dispatch.rs
@@ -1,0 +1,66 @@
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_core::Action;
+use clap::Args;
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct DispatchArgs {
+    /// Namespace.
+    #[arg(long, default_value = "default")]
+    pub namespace: String,
+    /// Tenant.
+    #[arg(long)]
+    pub tenant: String,
+    /// Provider name.
+    #[arg(long)]
+    pub provider: String,
+    /// Action type.
+    #[arg(long, name = "type")]
+    pub action_type: String,
+    /// JSON payload (string or @file path).
+    #[arg(long)]
+    pub payload: String,
+    /// Dry-run mode.
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+pub async fn run(
+    ops: &OpsClient,
+    args: &DispatchArgs,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    let payload: serde_json::Value = if args.payload.starts_with('@') {
+        let path = &args.payload[1..];
+        let content = std::fs::read_to_string(path)?;
+        serde_json::from_str(&content)?
+    } else {
+        serde_json::from_str(&args.payload)?
+    };
+
+    let action = Action::new(
+        args.namespace.as_str(),
+        args.tenant.as_str(),
+        args.provider.as_str(),
+        &args.action_type,
+        payload,
+    );
+
+    let outcome = if args.dry_run {
+        ops.client().dispatch_dry_run(&action).await?
+    } else {
+        ops.client().dispatch(&action).await?
+    };
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&outcome)?);
+        }
+        OutputFormat::Text => {
+            println!("{outcome:?}");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/commands/events.rs
+++ b/crates/cli/src/commands/events.rs
@@ -1,0 +1,101 @@
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::EventQuery;
+use clap::{Args, Subcommand};
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct EventsArgs {
+    #[command(subcommand)]
+    pub command: EventsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum EventsCommand {
+    /// List stateful events.
+    List {
+        /// Namespace.
+        #[arg(long, default_value = "default")]
+        namespace: String,
+        /// Tenant.
+        #[arg(long)]
+        tenant: String,
+        /// Filter by state.
+        #[arg(long)]
+        status: Option<String>,
+    },
+    /// Transition an event to a new state.
+    Transition {
+        /// Event fingerprint.
+        fingerprint: String,
+        /// Target state (e.g. "acknowledged", "resolved").
+        #[arg(long)]
+        to: String,
+        /// Namespace.
+        #[arg(long, default_value = "default")]
+        namespace: String,
+        /// Tenant.
+        #[arg(long)]
+        tenant: String,
+    },
+}
+
+pub async fn run(ops: &OpsClient, args: &EventsArgs, format: &OutputFormat) -> anyhow::Result<()> {
+    match &args.command {
+        EventsCommand::List {
+            namespace,
+            tenant,
+            status,
+        } => {
+            let query = EventQuery {
+                namespace: namespace.clone(),
+                tenant: tenant.clone(),
+                status: status.clone(),
+                limit: Some(50),
+            };
+            let resp = ops.client().list_events(&query).await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("{} events:", resp.count);
+                    for event in &resp.events {
+                        let updated = event.updated_at.as_deref().unwrap_or("?");
+                        println!(
+                            "  {fingerprint} | {state} | updated {updated}",
+                            fingerprint = event.fingerprint,
+                            state = event.state,
+                        );
+                    }
+                }
+            }
+        }
+        EventsCommand::Transition {
+            fingerprint,
+            to,
+            namespace,
+            tenant,
+        } => {
+            let resp = ops
+                .client()
+                .transition_event(fingerprint, to, namespace, tenant)
+                .await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!(
+                        "Event {fp}: {prev} -> {next} (notify: {notify})",
+                        fp = resp.fingerprint,
+                        prev = resp.previous_state,
+                        next = resp.new_state,
+                        notify = resp.notify,
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/health.rs
+++ b/crates/cli/src/commands/health.rs
@@ -1,0 +1,18 @@
+use acteon_ops::OpsClient;
+
+pub async fn run(ops: &OpsClient) -> anyhow::Result<()> {
+    match ops.client().health().await {
+        Ok(true) => {
+            println!("Acteon gateway is healthy.");
+            Ok(())
+        }
+        Ok(false) => {
+            eprintln!("Acteon gateway returned unhealthy status.");
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("Failed to reach gateway: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,0 +1,5 @@
+pub mod audit;
+pub mod dispatch;
+pub mod events;
+pub mod health;
+pub mod rules;

--- a/crates/cli/src/commands/rules.rs
+++ b/crates/cli/src/commands/rules.rs
@@ -1,0 +1,60 @@
+use acteon_ops::OpsClient;
+use clap::{Args, Subcommand};
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct RulesArgs {
+    #[command(subcommand)]
+    pub command: RulesCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum RulesCommand {
+    /// List all loaded rules.
+    List,
+    /// Enable a rule by name.
+    Enable {
+        /// Rule name.
+        name: String,
+    },
+    /// Disable a rule by name.
+    Disable {
+        /// Rule name.
+        name: String,
+    },
+}
+
+pub async fn run(ops: &OpsClient, args: &RulesArgs, format: &OutputFormat) -> anyhow::Result<()> {
+    match &args.command {
+        RulesCommand::List => {
+            let rules = ops.client().list_rules().await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&rules)?);
+                }
+                OutputFormat::Text => {
+                    println!("{} rules loaded:", rules.len());
+                    for rule in &rules {
+                        let status = if rule.enabled { "ON " } else { "OFF" };
+                        let desc = rule.description.as_deref().unwrap_or("");
+                        println!(
+                            "  [{status}] {name} (priority {priority}) {desc}",
+                            name = rule.name,
+                            priority = rule.priority,
+                        );
+                    }
+                }
+            }
+        }
+        RulesCommand::Enable { name } => {
+            ops.client().set_rule_enabled(name, true).await?;
+            println!("Rule '{name}' enabled.");
+        }
+        RulesCommand::Disable { name } => {
+            ops.client().set_rule_enabled(name, false).await?;
+            println!("Rule '{name}' disabled.");
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,0 +1,79 @@
+//! Acteon CLI
+//!
+//! A command-line interface for interacting with the Acteon action gateway.
+
+mod commands;
+
+use acteon_ops::{OpsClient, OpsConfig};
+use clap::{Parser, Subcommand};
+use tracing_subscriber::{EnvFilter, fmt};
+
+/// Acteon CLI — interact with the Acteon action gateway.
+#[derive(Parser, Debug)]
+#[command(name = "acteon", version, about)]
+struct Cli {
+    /// Acteon server endpoint URL.
+    #[arg(
+        long,
+        env = "ACTEON_ENDPOINT",
+        default_value = "http://localhost:8080",
+        global = true
+    )]
+    endpoint: String,
+
+    /// API key for authentication.
+    #[arg(long, env = "ACTEON_API_KEY", global = true)]
+    api_key: Option<String>,
+
+    /// Output format.
+    #[arg(long, default_value = "text", global = true)]
+    format: OutputFormat,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum OutputFormat {
+    Text,
+    Json,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Check gateway health.
+    Health,
+    /// Dispatch an action through the gateway.
+    Dispatch(commands::dispatch::DispatchArgs),
+    /// Query the audit trail.
+    Audit(commands::audit::AuditArgs),
+    /// Manage routing rules.
+    Rules(commands::rules::RulesArgs),
+    /// Manage stateful events.
+    Events(commands::events::EventsArgs),
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .init();
+
+    let cli = Cli::parse();
+
+    let config = OpsConfig::new(&cli.endpoint);
+    let config = match cli.api_key {
+        Some(ref key) => config.with_api_key(key),
+        None => config,
+    };
+    let ops = OpsClient::from_config(&config)?;
+
+    match cli.command {
+        Command::Health => commands::health::run(&ops).await,
+        Command::Dispatch(args) => commands::dispatch::run(&ops, &args, &cli.format).await,
+        Command::Audit(args) => commands::audit::run(&ops, &args, &cli.format).await,
+        Command::Rules(args) => commands::rules::run(&ops, &args, &cli.format).await,
+        Command::Events(args) => commands::events::run(&ops, &args, &cli.format).await,
+    }
+}

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -2200,7 +2200,7 @@ impl ActeonClient {
 // =============================================================================
 
 /// Error response from the API.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ErrorResponse {
     /// Error code.
     pub code: String,
@@ -2212,7 +2212,7 @@ pub struct ErrorResponse {
 }
 
 /// Result from a batch dispatch operation.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum BatchResult {
     /// Action was processed successfully.
@@ -2253,7 +2253,7 @@ impl BatchResult {
 }
 
 /// Information about a loaded rule.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuleInfo {
     /// Rule name.
     pub name: String,
@@ -2267,7 +2267,7 @@ pub struct RuleInfo {
 }
 
 /// Result of reloading rules.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReloadResult {
     /// Number of rules loaded.
     pub loaded: usize,
@@ -2293,7 +2293,7 @@ pub struct EvaluateRulesOptions {
 }
 
 /// Details about a semantic match evaluation, used for explainability.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SemanticMatchDetail {
     /// The text that was extracted and compared.
     pub extracted_text: String,
@@ -2306,7 +2306,7 @@ pub struct SemanticMatchDetail {
 }
 
 /// Per-rule trace entry returned by the playground.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuleTraceEntry {
     /// Name of the rule that was evaluated.
     pub rule_name: String,
@@ -2344,7 +2344,7 @@ pub struct RuleTraceEntry {
 }
 
 /// Contextual information captured during rule evaluation.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraceContext {
     /// The `time.*` map that was used during evaluation.
     #[serde(default)]
@@ -2362,7 +2362,7 @@ pub struct TraceContext {
 }
 
 /// Response from the rule evaluation playground.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuleEvaluationTrace {
     /// Final verdict (e.g. `"allow"`, `"deny"`, `"no_match"`).
     pub verdict: String,
@@ -2412,7 +2412,7 @@ pub struct AuditQuery {
 }
 
 /// Paginated audit results.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuditPage {
     /// Audit records.
     pub records: Vec<AuditRecord>,
@@ -2425,7 +2425,7 @@ pub struct AuditPage {
 }
 
 /// An audit record.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuditRecord {
     /// Record ID.
     pub id: String,
@@ -2491,7 +2491,7 @@ pub struct ReplayQuery {
 }
 
 /// Result of replaying a single action.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReplayResult {
     /// The original action ID from the audit record.
     pub original_action_id: String,
@@ -2504,7 +2504,7 @@ pub struct ReplayResult {
 }
 
 /// Summary of a bulk replay operation.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReplaySummary {
     /// Number of actions successfully replayed.
     pub replayed: usize,
@@ -2536,7 +2536,7 @@ pub struct EventQuery {
 }
 
 /// Current state of an event.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventState {
     /// The event fingerprint.
     pub fingerprint: String,
@@ -2549,7 +2549,7 @@ pub struct EventState {
 }
 
 /// Response from listing events.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventListResponse {
     /// List of events.
     pub events: Vec<EventState>,
@@ -2558,7 +2558,7 @@ pub struct EventListResponse {
 }
 
 /// Response from transitioning an event.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransitionResponse {
     /// The event fingerprint.
     pub fingerprint: String,
@@ -2575,7 +2575,7 @@ pub struct TransitionResponse {
 // =============================================================================
 
 /// Response from approving or rejecting an action.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApprovalActionResponse {
     /// The approval ID.
     pub id: String,
@@ -2586,7 +2586,7 @@ pub struct ApprovalActionResponse {
 }
 
 /// Public-facing approval status (no payload exposed).
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApprovalStatusResponse {
     /// The approval token.
     pub token: String,
@@ -2605,7 +2605,7 @@ pub struct ApprovalStatusResponse {
 }
 
 /// Response from listing pending approvals.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApprovalListResponse {
     /// List of pending approvals.
     pub approvals: Vec<ApprovalStatusResponse>,
@@ -2618,7 +2618,7 @@ pub struct ApprovalListResponse {
 // =============================================================================
 
 /// Summary of an event group.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GroupSummary {
     /// Unique identifier for the group.
     pub group_id: String,
@@ -2635,7 +2635,7 @@ pub struct GroupSummary {
 }
 
 /// Response from listing groups.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GroupListResponse {
     /// List of groups.
     pub groups: Vec<GroupSummary>,
@@ -2644,7 +2644,7 @@ pub struct GroupListResponse {
 }
 
 /// Detailed information about a group.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GroupDetail {
     /// Group summary.
     pub group: GroupSummary,
@@ -2655,7 +2655,7 @@ pub struct GroupDetail {
 }
 
 /// Response from flushing a group.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FlushGroupResponse {
     /// The group ID that was flushed.
     pub group_id: String,
@@ -2708,7 +2708,7 @@ pub struct CreateRecurringAction {
 }
 
 /// Response from creating a recurring action.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateRecurringResponse {
     /// Assigned recurring action ID.
     pub id: String,
@@ -2739,7 +2739,7 @@ pub struct RecurringFilter {
 }
 
 /// Summary of a recurring action for list responses.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecurringSummary {
     /// Unique recurring action ID.
     pub id: String,
@@ -2768,7 +2768,7 @@ pub struct RecurringSummary {
 }
 
 /// Response from listing recurring actions.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListRecurringResponse {
     /// List of recurring action summaries.
     pub recurring_actions: Vec<RecurringSummary>,
@@ -2777,7 +2777,7 @@ pub struct ListRecurringResponse {
 }
 
 /// Full detail response for a single recurring action.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecurringDetail {
     /// Unique recurring action ID.
     pub id: String,
@@ -2907,7 +2907,7 @@ pub struct UpdateQuotaRequest {
 }
 
 /// A quota policy.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QuotaPolicy {
     /// Unique quota policy ID.
     pub id: String,
@@ -2936,7 +2936,7 @@ pub struct QuotaPolicy {
 }
 
 /// Response from listing quota policies.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListQuotasResponse {
     /// List of quota policies.
     pub quotas: Vec<QuotaPolicy>,
@@ -2945,7 +2945,7 @@ pub struct ListQuotasResponse {
 }
 
 /// Current usage statistics for a quota.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QuotaUsage {
     /// Tenant.
     pub tenant: String,

--- a/crates/mcp-server/Cargo.toml
+++ b/crates/mcp-server/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "acteon-mcp-server"
+description = "Model Context Protocol (MCP) server for Acteon"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+acteon-ops = { workspace = true }
+acteon-core = { workspace = true }
+
+rmcp = { workspace = true }
+schemars = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+clap = { version = "4", features = ["derive", "env"] }
+anyhow = "1"
+
+[lints]
+workspace = true

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -1,0 +1,58 @@
+//! Acteon MCP Server
+//!
+//! Exposes the Acteon action gateway to LLM agents via the
+//! Model Context Protocol (MCP). Runs over `stdio` transport.
+
+use acteon_ops::{OpsClient, OpsConfig};
+use clap::Parser;
+use rmcp::{ServiceExt, transport::stdio};
+use tracing_subscriber::{EnvFilter, fmt};
+
+mod prompts;
+mod resources;
+mod server;
+mod tools;
+
+use server::ActeonMcpServer;
+
+/// Acteon MCP Server — expose the action gateway to AI agents.
+#[derive(Parser, Debug)]
+#[command(name = "acteon-mcp-server", version, about)]
+struct Args {
+    /// Acteon server endpoint URL.
+    #[arg(long, env = "ACTEON_ENDPOINT", default_value = "http://localhost:8080")]
+    endpoint: String,
+
+    /// API key for authentication.
+    #[arg(long, env = "ACTEON_API_KEY")]
+    api_key: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // MCP servers MUST NOT write to stdout (that's the transport).
+    // Direct logs to stderr instead.
+    fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::INFO.into()))
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    let args = Args::parse();
+
+    let config = OpsConfig::new(&args.endpoint);
+    let config = match args.api_key {
+        Some(ref key) => config.with_api_key(key),
+        None => config,
+    };
+
+    let ops = OpsClient::from_config(&config)?;
+
+    tracing::info!(endpoint = %args.endpoint, "starting Acteon MCP server");
+
+    let service = ActeonMcpServer::new(ops).serve(stdio()).await?;
+
+    service.waiting().await?;
+
+    Ok(())
+}

--- a/crates/mcp-server/src/prompts.rs
+++ b/crates/mcp-server/src/prompts.rs
@@ -1,0 +1,166 @@
+//! Pre-defined MCP prompt templates for operational workflows.
+//!
+//! These guide the LLM through common Acteon tasks like incident
+//! investigation, alert tuning, and guardrail drafting.
+
+use rmcp::{
+    ErrorData as McpError, RoleServer,
+    handler::server::wrapper::Parameters,
+    model::{GetPromptResult, PromptMessage, PromptMessageRole},
+    prompt, prompt_router, schemars,
+    service::RequestContext,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::server::ActeonMcpServer;
+
+// ---------------------------------------------------------------------------
+// Prompt argument types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct InvestigateIncidentArgs {
+    /// The name of the service experiencing the incident.
+    pub service: String,
+    /// Tenant context.
+    #[serde(default = "default_tenant")]
+    pub tenant: String,
+}
+
+fn default_tenant() -> String {
+    "default".to_string()
+}
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct OptimizeAlertsArgs {
+    /// The notification provider to analyze (e.g. "slack", "email", "pagerduty").
+    pub provider: String,
+    /// Tenant context.
+    #[serde(default = "default_tenant")]
+    pub tenant: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct DraftGuardrailArgs {
+    /// The team or channel to protect.
+    pub team: String,
+    /// Quiet hours start (e.g. "22:00").
+    #[serde(default)]
+    pub quiet_start: Option<String>,
+    /// Quiet hours end (e.g. "08:00").
+    #[serde(default)]
+    pub quiet_end: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Prompt implementations
+// ---------------------------------------------------------------------------
+
+#[prompt_router]
+impl ActeonMcpServer {
+    /// Build the prompt router. Exposed as `pub(crate)` so `server.rs` can call it.
+    pub(crate) fn create_prompt_router() -> rmcp::handler::server::router::prompt::PromptRouter<Self>
+    {
+        Self::prompt_router()
+    }
+
+    /// Investigate an incident for a specific service using Acteon's audit
+    /// trail, event state, and rule evaluation.
+    #[prompt(name = "investigate_incident")]
+    async fn investigate_incident(
+        &self,
+        Parameters(args): Parameters<InvestigateIncidentArgs>,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<GetPromptResult, McpError> {
+        let messages = vec![PromptMessage::new_text(
+            PromptMessageRole::User,
+            format!(
+                "I see a spike in errors for service '{service}' (tenant: '{tenant}'). \
+                     Please help me investigate:\n\n\
+                     1. Use the `query_audit` tool to find events related to '{service}' \
+                        in the last 30 minutes.\n\
+                     2. Use `list_events` to check for any open/acknowledged stateful events \
+                        in the '{tenant}' tenant.\n\
+                     3. Use `list_rules` to see if any rules were recently changed or disabled.\n\
+                     4. Correlate the findings and summarize the probable root cause.\n\
+                     5. Suggest next steps (acknowledge, escalate, or resolve).",
+                service = args.service,
+                tenant = args.tenant,
+            ),
+        )];
+
+        Ok(GetPromptResult {
+            description: Some(format!(
+                "Investigate incident for service '{}'",
+                args.service
+            )),
+            messages,
+        })
+    }
+
+    /// Analyze notification volume for a provider and suggest grouping
+    /// rules to reduce alert fatigue.
+    #[prompt(name = "optimize_alerts")]
+    async fn optimize_alerts(
+        &self,
+        Parameters(args): Parameters<OptimizeAlertsArgs>,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<GetPromptResult, McpError> {
+        let messages = vec![PromptMessage::new_text(
+            PromptMessageRole::User,
+            format!(
+                "Analyze notifications sent to the '{provider}' provider for \
+                     tenant '{tenant}' over the last 24 hours.\n\n\
+                     1. Use `query_audit` with provider='{provider}' and tenant='{tenant}' \
+                        to see recent dispatch history.\n\
+                     2. Identify noisy patterns — action types that fire frequently \
+                        but are often duplicates.\n\
+                     3. Use `evaluate_rules` to test how the current rules handle \
+                        a representative sample event.\n\
+                     4. Suggest grouping or deduplication rules to reduce fatigue.\n\
+                     5. Show before/after metrics (estimated notification counts).",
+                provider = args.provider,
+                tenant = args.tenant,
+            ),
+        )];
+
+        Ok(GetPromptResult {
+            description: Some(format!("Optimize alerts for '{}' provider", args.provider)),
+            messages,
+        })
+    }
+
+    /// Draft a natural language guardrail policy for Acteon's LLM evaluator.
+    #[prompt(name = "draft_guardrail")]
+    async fn draft_guardrail(
+        &self,
+        Parameters(args): Parameters<DraftGuardrailArgs>,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<GetPromptResult, McpError> {
+        let quiet_window = match (&args.quiet_start, &args.quiet_end) {
+            (Some(start), Some(end)) => format!("between {start} and {end}"),
+            _ => "during off-hours".to_string(),
+        };
+
+        let messages = vec![PromptMessage::new_text(
+            PromptMessageRole::User,
+            format!(
+                "I need a policy that prevents notifications from being sent to \
+                     '{team}' {quiet_window} unless the severity is 'critical'.\n\n\
+                     Please draft a natural language policy string suitable for \
+                     Acteon's LLM guardrail evaluator. The policy should:\n\
+                     1. Block non-critical alerts during quiet hours.\n\
+                     2. Always allow critical severity through.\n\
+                     3. Be concise but unambiguous.\n\
+                     4. Include an example of how to set it in a rule's metadata \
+                        as `llm_policy`.",
+                team = args.team,
+            ),
+        )];
+
+        Ok(GetPromptResult {
+            description: Some(format!("Draft guardrail policy for '{}'", args.team)),
+            messages,
+        })
+    }
+}

--- a/crates/mcp-server/src/resources.rs
+++ b/crates/mcp-server/src/resources.rs
@@ -1,0 +1,147 @@
+//! MCP resource handlers for Acteon.
+//!
+//! Resources provide read-only access to Acteon data such as
+//! audit logs, rules, and event state.
+
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::{AuditQuery, EventQuery};
+use rmcp::{
+    ErrorData as McpError,
+    model::{
+        AnnotateAble, ListResourcesResult, RawResource, ReadResourceRequestParams,
+        ReadResourceResult, ResourceContents,
+    },
+};
+use serde_json::json;
+
+/// List the static top-level resources.
+pub fn list_resources() -> ListResourcesResult {
+    let resources = vec![
+        RawResource::new("acteon://health", "Gateway health".to_string()).no_annotation(),
+        RawResource::new("acteon://rules", "Active rules".to_string()).no_annotation(),
+    ];
+
+    ListResourcesResult {
+        resources,
+        next_cursor: None,
+        meta: None,
+    }
+}
+
+/// Read a specific resource by URI.
+pub async fn read_resource(
+    ops: &OpsClient,
+    request: ReadResourceRequestParams,
+) -> Result<ReadResourceResult, McpError> {
+    let uri = request.uri.as_str();
+
+    // Parse the URI: acteon://{kind}/{arg1}/{arg2?}
+    let path = uri
+        .strip_prefix("acteon://")
+        .ok_or_else(|| McpError::invalid_params("URI must start with acteon://", None))?;
+
+    let segments: Vec<&str> = path.splitn(3, '/').collect();
+
+    match segments.first().copied() {
+        Some("health") => read_health(ops, &request.uri).await,
+        Some("rules") => read_rules(ops, &request.uri).await,
+        Some("audit") => {
+            let tenant = segments.get(1).copied().unwrap_or("default");
+            read_audit(ops, tenant, &request.uri).await
+        }
+        Some("events") => {
+            let tenant = segments.get(1).copied().unwrap_or("default");
+            read_events(ops, tenant, &request.uri).await
+        }
+        _ => Err(McpError::resource_not_found(
+            "unknown resource",
+            Some(json!({"uri": uri})),
+        )),
+    }
+}
+
+async fn read_health(ops: &OpsClient, uri: &str) -> Result<ReadResourceResult, McpError> {
+    let healthy = ops
+        .client()
+        .health()
+        .await
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+    let body = json!({ "healthy": healthy });
+    Ok(ReadResourceResult {
+        contents: vec![ResourceContents::text(
+            serde_json::to_string_pretty(&body)
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?,
+            uri,
+        )],
+    })
+}
+
+async fn read_rules(ops: &OpsClient, uri: &str) -> Result<ReadResourceResult, McpError> {
+    let rules = ops
+        .client()
+        .list_rules()
+        .await
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+    Ok(ReadResourceResult {
+        contents: vec![ResourceContents::text(
+            serde_json::to_string_pretty(&rules)
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?,
+            uri,
+        )],
+    })
+}
+
+async fn read_audit(
+    ops: &OpsClient,
+    tenant: &str,
+    uri: &str,
+) -> Result<ReadResourceResult, McpError> {
+    let query = AuditQuery {
+        tenant: Some(tenant.to_string()),
+        limit: Some(25),
+        ..AuditQuery::default()
+    };
+
+    let page = ops
+        .client()
+        .query_audit(&query)
+        .await
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+    Ok(ReadResourceResult {
+        contents: vec![ResourceContents::text(
+            serde_json::to_string_pretty(&page)
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?,
+            uri,
+        )],
+    })
+}
+
+async fn read_events(
+    ops: &OpsClient,
+    tenant: &str,
+    uri: &str,
+) -> Result<ReadResourceResult, McpError> {
+    let query = EventQuery {
+        namespace: "default".to_string(),
+        tenant: tenant.to_string(),
+        status: None,
+        limit: Some(50),
+    };
+
+    let events = ops
+        .client()
+        .list_events(&query)
+        .await
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+    Ok(ReadResourceResult {
+        contents: vec![ResourceContents::text(
+            serde_json::to_string_pretty(&events)
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?,
+            uri,
+        )],
+    })
+}

--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -1,0 +1,131 @@
+//! MCP server handler for Acteon.
+
+use acteon_ops::OpsClient;
+use rmcp::{
+    ErrorData as McpError, RoleServer, ServerHandler,
+    handler::server::router::{prompt::PromptRouter, tool::ToolRouter},
+    model::{
+        AnnotateAble, GetPromptRequestParams, GetPromptResult, Implementation, ListPromptsResult,
+        ListResourceTemplatesResult, ListResourcesResult, PaginatedRequestParams, ProtocolVersion,
+        RawResourceTemplate, ReadResourceRequestParams, ReadResourceResult, ServerCapabilities,
+        ServerInfo,
+    },
+    prompt_handler,
+    service::RequestContext,
+    tool_handler,
+};
+
+use crate::resources;
+
+/// The Acteon MCP Server.
+///
+/// Exposes Acteon gateway capabilities as MCP tools, resources, and prompts.
+#[derive(Clone)]
+pub struct ActeonMcpServer {
+    pub(crate) ops: OpsClient,
+    tool_router: ToolRouter<Self>,
+    prompt_router: PromptRouter<Self>,
+}
+
+impl ActeonMcpServer {
+    /// Create a new MCP server backed by the given operations client.
+    pub fn new(ops: OpsClient) -> Self {
+        let tool_router = Self::create_tool_router();
+        let prompt_router = Self::create_prompt_router();
+        Self {
+            ops,
+            tool_router,
+            prompt_router,
+        }
+    }
+}
+
+#[tool_handler]
+#[prompt_handler]
+impl ServerHandler for ActeonMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            protocol_version: ProtocolVersion::V_2024_11_05,
+            capabilities: ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .enable_prompts()
+                .build(),
+            server_info: Implementation {
+                name: "acteon-mcp-server".into(),
+                version: env!("CARGO_PKG_VERSION").into(),
+                title: Some("Acteon MCP Server".into()),
+                description: Some(
+                    "Interact with the Acteon action gateway for dispatching, \
+                     audit queries, rule management, and event operations."
+                        .into(),
+                ),
+                icons: None,
+                website_url: None,
+            },
+            instructions: Some(
+                "Acteon MCP Server — interact with the Acteon action gateway. \
+                 Use the provided tools to dispatch actions, query the audit trail, \
+                 manage events, list rules, and more. Use resources to read current \
+                 state. Use prompts for guided operational workflows."
+                    .to_string(),
+            ),
+        }
+    }
+
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, McpError> {
+        Ok(resources::list_resources())
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, McpError> {
+        resources::read_resource(&self.ops, request).await
+    }
+
+    async fn list_resource_templates(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<ListResourceTemplatesResult, McpError> {
+        Ok(ListResourceTemplatesResult {
+            resource_templates: vec![
+                RawResourceTemplate {
+                    uri_template: "acteon://audit/{tenant}".into(),
+                    name: "Audit trail".into(),
+                    title: None,
+                    description: Some("Recent audit records for a tenant".to_string()),
+                    mime_type: Some("application/json".into()),
+                    icons: None,
+                }
+                .no_annotation(),
+                RawResourceTemplate {
+                    uri_template: "acteon://rules/{tenant}".into(),
+                    name: "Active rules".into(),
+                    title: None,
+                    description: Some("The active rule set for a tenant".to_string()),
+                    mime_type: Some("application/json".into()),
+                    icons: None,
+                }
+                .no_annotation(),
+                RawResourceTemplate {
+                    uri_template: "acteon://events/{tenant}".into(),
+                    name: "Stateful events".into(),
+                    title: None,
+                    description: Some("Open stateful events for a tenant".to_string()),
+                    mime_type: Some("application/json".into()),
+                    icons: None,
+                }
+                .no_annotation(),
+            ],
+            next_cursor: None,
+            meta: None,
+        })
+    }
+}

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -1,0 +1,354 @@
+//! MCP tool definitions for Acteon.
+//!
+//! Each tool maps to one or more operations on the Acteon gateway
+//! via the HTTP client.
+
+use acteon_ops::acteon_client::{AuditQuery, EvaluateRulesOptions, EventQuery};
+use acteon_ops::acteon_core::Action;
+use rmcp::{
+    ErrorData as McpError,
+    handler::server::wrapper::Parameters,
+    model::{CallToolResult, Content},
+    schemars, tool, tool_router,
+};
+use serde::Deserialize;
+
+use crate::server::ActeonMcpServer;
+
+// ---------------------------------------------------------------------------
+// Parameter types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DispatchParams {
+    /// Namespace for the action (e.g. "notifications").
+    pub namespace: String,
+    /// Tenant identifier.
+    pub tenant: String,
+    /// Target provider name (e.g. "slack", "email", "webhook").
+    pub provider: String,
+    /// Action type discriminator (e.g. `send_alert`, `create_ticket`).
+    pub action_type: String,
+    /// JSON payload for the provider.
+    pub payload: serde_json::Value,
+    /// Optional metadata labels.
+    #[serde(default)]
+    pub metadata: std::collections::HashMap<String, String>,
+    /// When true, evaluate rules without executing the action.
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct QueryAuditParams {
+    /// Filter by tenant.
+    #[serde(default)]
+    pub tenant: Option<String>,
+    /// Filter by namespace.
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// Filter by provider.
+    #[serde(default)]
+    pub provider: Option<String>,
+    /// Filter by action type.
+    #[serde(default)]
+    pub action_type: Option<String>,
+    /// Filter by outcome (e.g. "executed", "suppressed", "failed").
+    #[serde(default)]
+    pub outcome: Option<String>,
+    /// Maximum number of records (default 20).
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListRulesParams {
+    // Currently no parameters — lists all rules.
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct EvaluateRulesParams {
+    /// Namespace.
+    pub namespace: String,
+    /// Tenant.
+    pub tenant: String,
+    /// Provider.
+    pub provider: String,
+    /// Action type.
+    pub action_type: String,
+    /// JSON payload to evaluate against rules.
+    pub payload: serde_json::Value,
+    /// Include disabled rules in the trace.
+    #[serde(default)]
+    pub include_disabled: bool,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ManageEventParams {
+    /// Event fingerprint.
+    pub fingerprint: String,
+    /// Namespace.
+    pub namespace: String,
+    /// Tenant.
+    pub tenant: String,
+    /// Target state: "acknowledged", "resolved", "investigating", etc.
+    pub action: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListEventsParams {
+    /// Namespace (required).
+    pub namespace: String,
+    /// Tenant (required).
+    pub tenant: String,
+    /// Filter by state (e.g. "open", "acknowledged").
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Maximum number of events to return.
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListChainsParams {
+    /// Namespace.
+    pub namespace: String,
+    /// Tenant.
+    pub tenant: String,
+    /// Optional status filter (e.g. "running", "completed").
+    #[serde(default)]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SetRuleEnabledParams {
+    /// Rule name.
+    pub rule_name: String,
+    /// Set to true to enable, false to disable.
+    pub enabled: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Tool implementations
+// ---------------------------------------------------------------------------
+
+fn mcp_err(msg: impl std::fmt::Display) -> McpError {
+    McpError::internal_error(msg.to_string(), None)
+}
+
+#[tool_router]
+impl ActeonMcpServer {
+    /// Build the tool router. Exposed as `pub(crate)` so `server.rs` can call it.
+    pub(crate) fn create_tool_router() -> rmcp::handler::server::router::tool::ToolRouter<Self> {
+        Self::tool_router()
+    }
+
+    /// Send a new action through the Acteon gateway. Supports dry-run mode
+    /// to preview rule evaluation without side effects.
+    #[tool(
+        description = "Dispatch an action through Acteon (send notifications, trigger workflows). Set dry_run=true to preview without executing."
+    )]
+    async fn dispatch(
+        &self,
+        Parameters(p): Parameters<DispatchParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut action = Action::new(p.namespace, p.tenant, p.provider, &p.action_type, p.payload);
+
+        if !p.metadata.is_empty() {
+            action.metadata.labels = p.metadata;
+        }
+
+        let outcome = if p.dry_run {
+            self.ops.client().dispatch_dry_run(&action).await
+        } else {
+            self.ops.client().dispatch(&action).await
+        };
+
+        match outcome {
+            Ok(o) => {
+                let json = serde_json::to_string_pretty(&o).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// Search the audit trail for historical events. Returns recent dispatch
+    /// records filtered by tenant, provider, action type, or outcome.
+    #[tool(
+        description = "Query the audit trail for historical dispatch records. Filter by tenant, provider, action_type, or outcome."
+    )]
+    async fn query_audit(
+        &self,
+        Parameters(p): Parameters<QueryAuditParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let query = AuditQuery {
+            tenant: p.tenant,
+            namespace: p.namespace,
+            provider: p.provider,
+            action_type: p.action_type,
+            outcome: p.outcome,
+            limit: Some(p.limit.unwrap_or(20)),
+            offset: None,
+        };
+
+        match self.ops.client().query_audit(&query).await {
+            Ok(page) => {
+                let json = serde_json::to_string_pretty(&page).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// List all loaded routing rules. Shows rule name, priority, enabled
+    /// status, and description.
+    #[tool(description = "List all active routing and filtering rules loaded in the gateway.")]
+    async fn list_rules(
+        &self,
+        Parameters(_p): Parameters<ListRulesParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.ops.client().list_rules().await {
+            Ok(rules) => {
+                let json = serde_json::to_string_pretty(&rules).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// Run a test action through the rule engine without side effects.
+    /// Returns a full per-rule evaluation trace showing which rules
+    /// matched, were skipped, or errored.
+    #[tool(
+        description = "Evaluate rules against a test action (rule playground). Returns a detailed per-rule trace without executing anything."
+    )]
+    async fn evaluate_rules(
+        &self,
+        Parameters(p): Parameters<EvaluateRulesParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let action = Action::new(p.namespace, p.tenant, p.provider, &p.action_type, p.payload);
+
+        let options = EvaluateRulesOptions {
+            include_disabled: p.include_disabled,
+            ..EvaluateRulesOptions::default()
+        };
+
+        match self.ops.client().evaluate_rules(&action, &options).await {
+            Ok(trace) => {
+                let json = serde_json::to_string_pretty(&trace).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// Transition a stateful event to a new state (e.g. acknowledge,
+    /// resolve, investigate).
+    #[tool(
+        description = "Manage a stateful event: transition its state (e.g. 'acknowledged', 'resolved', 'investigating')."
+    )]
+    async fn manage_event(
+        &self,
+        Parameters(p): Parameters<ManageEventParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .ops
+            .client()
+            .transition_event(&p.fingerprint, &p.action, &p.namespace, &p.tenant)
+            .await
+        {
+            Ok(resp) => {
+                let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// List stateful events for a given namespace and tenant, optionally
+    /// filtered by state.
+    #[tool(
+        description = "List stateful events (open incidents, acknowledged alerts) for a namespace and tenant."
+    )]
+    async fn list_events(
+        &self,
+        Parameters(p): Parameters<ListEventsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let query = EventQuery {
+            namespace: p.namespace,
+            tenant: p.tenant,
+            status: p.status,
+            limit: p.limit,
+        };
+
+        match self.ops.client().list_events(&query).await {
+            Ok(resp) => {
+                let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// List action chains (multi-step workflows) for a tenant.
+    #[tool(
+        description = "List action chains (multi-step workflows) for a namespace and tenant. Optionally filter by status."
+    )]
+    async fn list_chains(
+        &self,
+        Parameters(p): Parameters<ListChainsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .ops
+            .client()
+            .list_chains(&p.namespace, &p.tenant, p.status.as_deref())
+            .await
+        {
+            Ok(resp) => {
+                let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// Enable or disable a routing rule by name.
+    #[tool(description = "Enable or disable a routing rule by name.")]
+    async fn set_rule_enabled(
+        &self,
+        Parameters(p): Parameters<SetRuleEnabledParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .ops
+            .client()
+            .set_rule_enabled(&p.rule_name, p.enabled)
+            .await
+        {
+            Ok(()) => {
+                let state = if p.enabled { "enabled" } else { "disabled" };
+                Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Rule '{}' is now {state}.",
+                    p.rule_name
+                ))]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// Check gateway health and service status.
+    #[tool(description = "Check if the Acteon gateway is healthy and responding.")]
+    async fn check_health(&self) -> Result<CallToolResult, McpError> {
+        match self.ops.client().health().await {
+            Ok(true) => Ok(CallToolResult::success(vec![Content::text(
+                "Acteon gateway is healthy.",
+            )])),
+            Ok(false) => Ok(CallToolResult::error(vec![Content::text(
+                "Acteon gateway returned unhealthy status.",
+            )])),
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Failed to reach gateway: {e}"
+            ))])),
+        }
+    }
+}

--- a/crates/ops/Cargo.toml
+++ b/crates/ops/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "acteon-ops"
+description = "Common operations layer for the Acteon CLI and MCP server"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+acteon-client = { workspace = true }
+acteon-core = { workspace = true }
+
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/ops/src/config.rs
+++ b/crates/ops/src/config.rs
@@ -1,0 +1,67 @@
+//! Configuration for the operations layer.
+
+use std::time::Duration;
+
+/// Configuration for connecting to an Acteon server.
+#[derive(Debug, Clone)]
+pub struct OpsConfig {
+    /// Acteon server endpoint URL (e.g. `http://localhost:8080`).
+    pub endpoint: String,
+    /// API key for authentication.
+    pub api_key: Option<String>,
+    /// Request timeout.
+    pub timeout: Option<Duration>,
+}
+
+impl OpsConfig {
+    /// Create a new configuration with defaults.
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            api_key: None,
+            timeout: None,
+        }
+    }
+
+    /// Create configuration from environment variables.
+    ///
+    /// Reads:
+    /// - `ACTEON_ENDPOINT` (required, defaults to `http://localhost:8080`)
+    /// - `ACTEON_API_KEY` (optional)
+    /// - `ACTEON_TIMEOUT_SECS` (optional, default 30)
+    pub fn from_env() -> Self {
+        let endpoint = std::env::var("ACTEON_ENDPOINT")
+            .unwrap_or_else(|_| "http://localhost:8080".to_string());
+        let api_key = std::env::var("ACTEON_API_KEY").ok();
+        let timeout = std::env::var("ACTEON_TIMEOUT_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .map(Duration::from_secs);
+
+        Self {
+            endpoint,
+            api_key,
+            timeout,
+        }
+    }
+
+    /// Override the API key.
+    #[must_use]
+    pub fn with_api_key(mut self, api_key: impl Into<String>) -> Self {
+        self.api_key = Some(api_key.into());
+        self
+    }
+
+    /// Override the timeout.
+    #[must_use]
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+}
+
+impl Default for OpsConfig {
+    fn default() -> Self {
+        Self::from_env()
+    }
+}

--- a/crates/ops/src/error.rs
+++ b/crates/ops/src/error.rs
@@ -1,0 +1,15 @@
+//! Error types for the operations layer.
+
+use thiserror::Error;
+
+/// Errors from the operations layer.
+#[derive(Debug, Error)]
+pub enum OpsError {
+    /// Configuration error.
+    #[error("configuration error: {0}")]
+    Configuration(String),
+
+    /// Error from the underlying HTTP client.
+    #[error(transparent)]
+    Client(#[from] acteon_client::Error),
+}

--- a/crates/ops/src/lib.rs
+++ b/crates/ops/src/lib.rs
@@ -1,0 +1,57 @@
+//! Common operations layer for the Acteon CLI and MCP server.
+//!
+//! Wraps [`acteon_client::ActeonClient`] with configuration management.
+//! Both the CLI and MCP server build on top of this crate.
+
+mod config;
+mod error;
+
+pub use config::OpsConfig;
+pub use error::OpsError;
+
+use acteon_client::{ActeonClient, ActeonClientBuilder};
+use std::sync::Arc;
+
+/// Re-export client and core types for consumers.
+pub use acteon_client;
+pub use acteon_core;
+
+/// High-level operations client for Acteon.
+///
+/// Wraps the HTTP client with configuration management and provides
+/// the shared interface consumed by both the CLI and MCP server.
+#[derive(Clone)]
+pub struct OpsClient {
+    inner: Arc<ActeonClient>,
+}
+
+impl OpsClient {
+    /// Create a new operations client from configuration.
+    pub fn from_config(config: &OpsConfig) -> Result<Self, OpsError> {
+        let mut builder = ActeonClientBuilder::new(&config.endpoint);
+
+        if let Some(ref timeout) = config.timeout {
+            builder = builder.timeout(*timeout);
+        }
+
+        if let Some(ref api_key) = config.api_key {
+            builder = builder.api_key(api_key);
+        }
+
+        let client = builder
+            .build()
+            .map_err(|e| OpsError::Configuration(e.to_string()))?;
+
+        Ok(Self {
+            inner: Arc::new(client),
+        })
+    }
+
+    /// Access the underlying HTTP client directly.
+    ///
+    /// Use this when you need to call a specific client method that
+    /// is not wrapped by the ops layer.
+    pub fn client(&self) -> &ActeonClient {
+        &self.inner
+    }
+}

--- a/docs/architecture/mcp-server.md
+++ b/docs/architecture/mcp-server.md
@@ -1,0 +1,165 @@
+# MCP Server & CLI Architecture
+
+## Overview
+
+The MCP server and CLI share a **Common Operations Layer** (`acteon-ops` crate)
+that wraps the Acteon HTTP client with configuration management and high-level
+convenience methods. Both binaries are thin presentation layers on top of this
+shared logic.
+
+```
+┌─────────────────┐   ┌──────────────────┐
+│  MCP Host / LLM │   │  Terminal / User  │
+└────────┬────────┘   └────────┬─────────┘
+         │ stdio (JSON-RPC)    │ CLI args
+         ▼                     ▼
+┌─────────────────┐   ┌──────────────────┐
+│ acteon-mcp-server│   │   acteon-cli     │
+│   (rmcp SDK)    │   │   (clap)         │
+└────────┬────────┘   └────────┬─────────┘
+         │                     │
+         ▼                     ▼
+     ┌──────────────────────────────┐
+     │     acteon-ops (OpsClient)   │
+     │  DispatchOptions, OpsConfig  │
+     └──────────────┬───────────────┘
+                    │
+                    ▼
+     ┌──────────────────────────────┐
+     │   acteon-client (HTTP)       │
+     │  ActeonClient, ActeonBuilder │
+     └──────────────┬───────────────┘
+                    │ HTTP
+                    ▼
+     ┌──────────────────────────────┐
+     │      Acteon Gateway          │
+     └──────────────────────────────┘
+```
+
+## Crate Layout
+
+```
+crates/
+├── ops/                  # Common operations layer
+│   ├── src/
+│   │   ├── lib.rs        # OpsClient, DispatchOptions, re-exports
+│   │   ├── config.rs     # OpsConfig (endpoint, api_key, timeout)
+│   │   └── error.rs      # OpsError (Configuration, Client)
+│   └── Cargo.toml
+│
+├── mcp-server/           # MCP server binary
+│   ├── src/
+│   │   ├── main.rs       # Entry point, stdio transport
+│   │   ├── server.rs     # ActeonMcpServer, ServerHandler impl
+│   │   ├── tools.rs      # 10 MCP tools with parameter types
+│   │   ├── resources.rs  # Static + template resources
+│   │   └── prompts.rs    # 3 operational prompt templates
+│   └── Cargo.toml
+│
+├── cli/                  # CLI binary
+│   ├── src/
+│   │   ├── main.rs       # Entry point, clap command routing
+│   │   └── commands/     # One module per subcommand
+│   │       ├── audit.rs
+│   │       ├── dispatch.rs
+│   │       ├── events.rs
+│   │       ├── health.rs
+│   │       └── rules.rs
+│   └── Cargo.toml
+```
+
+## Operations Layer (`acteon-ops`)
+
+`OpsClient` wraps `ActeonClient` in an `Arc` and provides high-level methods
+that both consumers call:
+
+| Method | Description |
+|--------|-------------|
+| `dispatch()` | Build `Action` from params, apply metadata, route to normal/dry-run |
+| `query_audit()` | Forward `AuditQuery` to client |
+| `list_rules()` | Retrieve all loaded rules |
+| `evaluate_rules()` | Build `Action` + `EvaluateRulesOptions`, invoke trace endpoint |
+| `transition_event()` | Forward state transition |
+| `list_events()` | Forward `EventQuery` |
+| `list_chains()` | Forward chain listing |
+| `set_rule_enabled()` | Toggle rule enabled state |
+| `health()` | Gateway health check |
+
+Configuration is loaded from environment variables (`ACTEON_ENDPOINT`,
+`ACTEON_API_KEY`, `ACTEON_TIMEOUT_SECS`) or CLI flags, then passed as
+`OpsConfig` to `OpsClient::from_config()`.
+
+Re-exports: `acteon_ops::acteon_client` and `acteon_ops::acteon_core` provide
+downstream crates access to client and core types without direct dependencies.
+
+## MCP Server (`acteon-mcp-server`)
+
+Built on the [`rmcp`](https://github.com/modelcontextprotocol/rust-sdk) SDK
+(v0.15+). The server implements the `ServerHandler` trait with three capability
+categories:
+
+### Tools (10 tools)
+
+Each tool is a method on `ActeonMcpServer` annotated with `#[tool]` inside a
+`#[tool_router]` impl block. Parameter types derive `schemars::JsonSchema` for
+automatic schema generation. The macro generates a private `tool_router()` fn;
+a `pub(crate) create_tool_router()` wrapper exposes it to `server.rs`.
+
+Tools delegate to `self.ops.<method>()` and return `CallToolResult` with
+JSON-serialized responses. Errors are returned as `CallToolResult::error()`
+rather than MCP protocol errors, so the agent always gets a useful message.
+
+### Resources
+
+Two static resources (`acteon://health`, `acteon://rules`) and three URI
+templates (`acteon://audit/{tenant}`, `acteon://rules/{tenant}`,
+`acteon://events/{tenant}`). Resource reads call the ops layer and return
+JSON content.
+
+### Prompts (3 prompts)
+
+Guided operational workflows with typed argument structs:
+
+- `investigate_incident(service, tenant?)` -- incident correlation
+- `optimize_alerts(provider, tenant?)` -- alert fatigue analysis
+- `draft_guardrail(team, constraint?)` -- LLM policy drafting
+
+Each returns a `GetPromptResult` with multi-message instructions for the agent.
+
+### Transport
+
+Stdio only (Phase 1). The server reads JSON-RPC from stdin and writes to
+stdout. All logging uses `tracing` directed to stderr so it doesn't interfere
+with the MCP protocol.
+
+## CLI (`acteon-cli`)
+
+Built on `clap` v4 with derive mode. Subcommands: `health`, `dispatch`,
+`audit`, `rules` (list/enable/disable), `events` (list/manage).
+
+Each command module receives `&OpsClient` and `&OutputFormat`, calls ops-layer
+methods, and prints results as either `Debug` text or pretty-printed JSON.
+
+The `dispatch` command supports `@file` payload syntax and repeatable
+`--metadata key=value` flags.
+
+## Design Decisions
+
+1. **Shared ops layer**: Both binaries share identical logic. A bug fix in
+   `acteon-ops` automatically benefits both.
+
+2. **Errors as tool results**: MCP tools return errors via `CallToolResult::error()`
+   instead of MCP-level error codes, giving agents descriptive messages they
+   can reason about.
+
+3. **Schema generation**: `schemars` v1 (re-exported by `rmcp`) auto-generates
+   JSON Schema for every tool parameter struct. No manual schema maintenance.
+
+4. **Macro visibility workaround**: `#[tool_router]` generates a private method.
+   The `pub(crate) create_tool_router()` wrapper pattern keeps the tool
+   definitions co-located with their implementations while allowing `server.rs`
+   to construct the router.
+
+5. **Re-export modules**: `acteon_ops::acteon_client` and `acteon_ops::acteon_core`
+   re-export all types so downstream crates (MCP server, CLI) don't need direct
+   dependencies on `acteon-client` or `acteon-core`.

--- a/docs/book/api/cli.md
+++ b/docs/book/api/cli.md
@@ -1,0 +1,180 @@
+# CLI
+
+The `acteon-cli` binary provides a command-line interface for interacting with the Acteon gateway. It shares the same operations layer as the [MCP Server](mcp-server.md), so every capability exposed to AI agents is also available from the terminal.
+
+## Installation
+
+```bash
+cargo build -p acteon-cli
+```
+
+## Configuration
+
+```bash
+# Minimal — connects to localhost:8080
+acteon-cli health
+
+# Custom endpoint
+acteon-cli --endpoint http://acteon.internal:8080 health
+
+# With API key
+acteon-cli --api-key your-key health
+```
+
+### Environment Variables
+
+| Variable | Flag | Default | Description |
+|----------|------|---------|-------------|
+| `ACTEON_ENDPOINT` | `--endpoint` | `http://localhost:8080` | Gateway base URL |
+| `ACTEON_API_KEY` | `--api-key` | _(none)_ | API key for authentication |
+
+### Output Format
+
+All commands support `--format text` (default) or `--format json` for machine-readable output:
+
+```bash
+acteon-cli --format json rules list
+```
+
+## Commands
+
+### `health`
+
+Check gateway health:
+
+```bash
+acteon-cli health
+```
+
+### `dispatch`
+
+Send an action through the gateway:
+
+```bash
+# Inline JSON payload
+acteon-cli dispatch \
+  --tenant prod \
+  --provider slack \
+  --type send_alert \
+  --payload '{"channel": "#ops", "message": "Deploy complete"}'
+
+# Payload from file
+acteon-cli dispatch \
+  --tenant prod \
+  --provider email \
+  --type send_email \
+  --payload @payload.json
+
+# With metadata labels
+acteon-cli dispatch \
+  --tenant prod \
+  --provider webhook \
+  --type notify \
+  --payload '{"url": "https://example.com"}' \
+  --metadata severity=critical \
+  --metadata team=infra
+
+# Dry-run mode (preview without executing)
+acteon-cli dispatch \
+  --tenant prod \
+  --provider slack \
+  --type send_alert \
+  --payload '{"message": "test"}' \
+  --dry-run
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--namespace` | no | Namespace (default: `default`) |
+| `--tenant` | yes | Tenant identifier |
+| `--provider` | yes | Target provider |
+| `--type` | yes | Action type |
+| `--payload` | yes | JSON string or `@file` path |
+| `--metadata` | no | Key=value pairs (repeatable) |
+| `--dry-run` | no | Preview without executing |
+
+### `audit`
+
+Query the audit trail:
+
+```bash
+# Recent records for a tenant
+acteon-cli audit --tenant prod
+
+# Filter by outcome
+acteon-cli audit --tenant prod --outcome suppressed
+
+# Filter by provider and limit
+acteon-cli audit --tenant prod --provider slack --limit 50
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--tenant` | no | Filter by tenant |
+| `--namespace` | no | Filter by namespace |
+| `--provider` | no | Filter by provider |
+| `--action-type` | no | Filter by action type |
+| `--outcome` | no | Filter by outcome |
+| `--limit` | no | Max records (default 20) |
+
+### `rules`
+
+Manage routing rules:
+
+```bash
+# List all rules
+acteon-cli rules list
+
+# Enable a rule
+acteon-cli rules enable block-spam
+
+# Disable a rule
+acteon-cli rules disable noisy-alerts
+```
+
+### `events`
+
+Manage stateful events:
+
+```bash
+# List events for a tenant
+acteon-cli events list --namespace alerts --tenant prod
+
+# Filter by state
+acteon-cli events list --namespace alerts --tenant prod --status open
+
+# Acknowledge an event
+acteon-cli events manage \
+  --fingerprint abc123 \
+  --namespace alerts \
+  --tenant prod \
+  --action acknowledged
+
+# Resolve an event
+acteon-cli events manage \
+  --fingerprint abc123 \
+  --namespace alerts \
+  --tenant prod \
+  --action resolved
+```
+
+## JSON Output
+
+Use `--format json` for scripting and piping:
+
+```bash
+# Get rules as JSON and pipe to jq
+acteon-cli --format json rules list | jq '.[].name'
+
+# Dispatch and capture outcome
+OUTCOME=$(acteon-cli --format json dispatch \
+  --tenant prod --provider slack --type alert \
+  --payload '{"msg": "test"}')
+echo "$OUTCOME" | jq '.status'
+```
+
+## What's Next?
+
+- [MCP Server](mcp-server.md) -- expose the same capabilities to AI agents
+- [REST API](rest-api.md) -- direct HTTP access
+- [Rust Client](rust-client.md) -- programmatic access from Rust

--- a/docs/book/api/index.md
+++ b/docs/book/api/index.md
@@ -1,12 +1,22 @@
 # API Reference
 
-Complete reference for all Acteon interfaces — REST API, client SDKs, rule syntax, and authentication.
+Complete reference for all Acteon interfaces — REST API, MCP server, CLI, client SDKs, rule syntax, and authentication.
 
 <div class="grid" markdown>
 
 <div class="card" markdown>
 ### [REST API](rest-api.md)
 Full HTTP endpoint reference with request/response schemas.
+</div>
+
+<div class="card" markdown>
+### [MCP Server](mcp-server.md)
+Expose Acteon to LLMs and AI agents via the Model Context Protocol.
+</div>
+
+<div class="card" markdown>
+### [CLI](cli.md)
+Command-line interface for dispatching actions, querying audit trails, and managing rules.
 </div>
 
 <div class="card" markdown>

--- a/docs/book/api/mcp-server.md
+++ b/docs/book/api/mcp-server.md
@@ -1,0 +1,248 @@
+# MCP Server
+
+The Acteon MCP Server exposes the Acteon gateway to LLMs and AI agents via the [Model Context Protocol](https://modelcontextprotocol.io/). It enables agentic workflows for incident response, alert tuning, and automated operations.
+
+## Installation
+
+```bash
+cargo build -p acteon-mcp-server
+```
+
+The binary is `acteon-mcp-server`. It communicates over **stdio** (stdin/stdout), which is the standard MCP transport for local integrations.
+
+## Configuration
+
+The server connects to a running Acteon gateway instance.
+
+```bash
+# Minimal — connects to localhost:8080
+acteon-mcp-server
+
+# Custom endpoint
+acteon-mcp-server --endpoint http://acteon.internal:8080
+
+# With API key authentication
+acteon-mcp-server --api-key your-api-key
+```
+
+### Environment Variables
+
+| Variable | Flag | Default | Description |
+|----------|------|---------|-------------|
+| `ACTEON_ENDPOINT` | `--endpoint` | `http://localhost:8080` | Gateway base URL |
+| `ACTEON_API_KEY` | `--api-key` | _(none)_ | API key for authentication |
+
+## Connecting to an MCP Host
+
+### Claude Desktop
+
+Add to your Claude Desktop configuration (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "acteon": {
+      "command": "acteon-mcp-server",
+      "args": ["--endpoint", "http://localhost:8080"],
+      "env": {
+        "ACTEON_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+Add to your project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "acteon": {
+      "command": "acteon-mcp-server",
+      "args": ["--endpoint", "http://localhost:8080"]
+    }
+  }
+}
+```
+
+### Generic MCP Host
+
+Any MCP-compatible host can launch the server as a subprocess:
+
+```bash
+acteon-mcp-server --endpoint http://localhost:8080 --api-key your-key
+```
+
+The server reads JSON-RPC messages from stdin and writes responses to stdout. All logs go to stderr.
+
+## Tools
+
+The MCP server exposes the following tools to connected agents:
+
+### `dispatch`
+
+Send a new action through the Acteon gateway. Supports dry-run mode to preview rule evaluation without side effects.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `namespace` | string | yes | Namespace for the action |
+| `tenant` | string | yes | Tenant identifier |
+| `provider` | string | yes | Target provider (e.g. `slack`, `email`) |
+| `action_type` | string | yes | Action type discriminator |
+| `payload` | object | yes | JSON payload for the provider |
+| `metadata` | object | no | Key-value metadata labels |
+| `dry_run` | boolean | no | Preview without executing |
+
+### `query_audit`
+
+Search the audit trail for historical dispatch records.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `tenant` | string | no | Filter by tenant |
+| `namespace` | string | no | Filter by namespace |
+| `provider` | string | no | Filter by provider |
+| `action_type` | string | no | Filter by action type |
+| `outcome` | string | no | Filter by outcome (`executed`, `suppressed`, `failed`) |
+| `limit` | integer | no | Max records (default 20) |
+
+### `list_rules`
+
+List all active routing and filtering rules loaded in the gateway. Returns rule name, priority, enabled status, and description.
+
+### `evaluate_rules`
+
+Run a test action through the rule engine without side effects. Returns a detailed per-rule evaluation trace showing which rules matched, were skipped, or errored.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `namespace` | string | yes | Namespace |
+| `tenant` | string | yes | Tenant |
+| `provider` | string | yes | Provider |
+| `action_type` | string | yes | Action type |
+| `payload` | object | yes | Test payload |
+| `include_disabled` | boolean | no | Include disabled rules in trace |
+
+### `manage_event`
+
+Transition a stateful event to a new state (acknowledge, resolve, investigate).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `fingerprint` | string | yes | Event fingerprint |
+| `namespace` | string | yes | Namespace |
+| `tenant` | string | yes | Tenant |
+| `action` | string | yes | Target state (`acknowledged`, `resolved`, `investigating`) |
+
+### `list_events`
+
+List stateful events (open incidents, acknowledged alerts) for a namespace and tenant.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `namespace` | string | yes | Namespace |
+| `tenant` | string | yes | Tenant |
+| `status` | string | no | Filter by state |
+| `limit` | integer | no | Max events to return |
+
+### `list_chains`
+
+List action chains (multi-step workflows) for a tenant.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `namespace` | string | yes | Namespace |
+| `tenant` | string | yes | Tenant |
+| `status` | string | no | Filter by status (`running`, `completed`) |
+
+### `set_rule_enabled`
+
+Enable or disable a routing rule by name.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `rule_name` | string | yes | Rule name |
+| `enabled` | boolean | yes | `true` to enable, `false` to disable |
+
+### `check_health`
+
+Check if the Acteon gateway is healthy and responding. Takes no parameters.
+
+## Resources
+
+The server exposes read-only resources for retrieving current state:
+
+| URI | Description |
+|-----|-------------|
+| `acteon://health` | Gateway health status |
+| `acteon://rules` | All loaded routing rules |
+
+### Resource Templates
+
+| URI Template | Description |
+|--------------|-------------|
+| `acteon://audit/{tenant}` | Recent audit records for a tenant |
+| `acteon://rules/{tenant}` | Active rule set for a tenant |
+| `acteon://events/{tenant}` | Open stateful events for a tenant |
+
+## Prompts
+
+Pre-defined prompt templates guide the agent through common operational tasks:
+
+### `investigate_incident`
+
+Guides the agent to correlate events, check recent rule changes, and summarize the impact of an incident.
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `service` | yes | Service name to investigate |
+| `tenant` | no | Tenant scope (default: `default`) |
+
+### `optimize_alerts`
+
+Analyzes notification volume and suggests grouping rules to reduce alert fatigue.
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `provider` | yes | Provider to analyze (e.g. `slack`) |
+| `tenant` | no | Tenant scope (default: `default`) |
+
+### `draft_guardrail`
+
+Helps draft a natural language policy for LLM guardrails to gate sensitive notifications.
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `team` | yes | Team name to protect |
+| `constraint` | no | Additional constraint to include |
+
+## Agentic Workflow Examples
+
+### Automated Root Cause Analysis
+
+1. An external monitoring tool triggers a "High Latency" event in Acteon.
+2. An MCP-connected agent receives a notification.
+3. The agent calls `query_audit` to find correlated events in the same time window.
+4. It discovers a `deploy_started` event and several `database_connection_error` events.
+5. The agent calls `dispatch` to send a summary to Slack with its findings.
+
+### Intelligent Alert Suppression
+
+1. A database maintenance window begins.
+2. An agent calls `set_rule_enabled` to activate a pre-configured suppression rule for DB alerts.
+3. When maintenance finishes, the agent re-enables normal alerting and calls `manage_event` to resolve lingering alerts.
+
+### Interactive Rule Debugging
+
+1. An agent notices unexpected alert volume for a tenant.
+2. It calls `evaluate_rules` with a sample payload to see which rules match.
+3. The trace reveals a misconfigured priority causing the wrong rule to match first.
+4. The agent reports its findings and suggests a fix.
+
+## What's Next?
+
+- [CLI](cli.md) -- command-line interface using the same operations layer
+- [REST API](rest-api.md) -- direct HTTP access to the Acteon gateway
+- [Rule Playground](../features/rule-playground.md) -- interactive rule evaluation in the admin UI

--- a/docs/design/mcp-server-implementation-plan.md
+++ b/docs/design/mcp-server-implementation-plan.md
@@ -1,0 +1,59 @@
+# Acteon Operations Interface Implementation Plan
+
+This document outlines the step-by-step implementation of the Acteon Common Operations Layer, CLI, and MCP server.
+
+## Phase 0: Common Operations Layer (`crates/ops`)
+- [ ] **Initialize `crates/ops`**: This crate will wrap `acteon-client` and provide high-level "business operations" (e.g., `dispatch_with_retry`, `search_and_summarize_audit`, `run_simulation`).
+- [ ] **Implement Core Command Logic**:
+    - Unified configuration handling (API keys, endpoints).
+    - Standardized output formatting (JSON for machines, Table/Plain text for humans).
+
+## Phase 1: Acteon CLI (`crates/cli`)
+- [ ] **Scaffold CLI**: Use `clap` for command-line argument parsing.
+- [ ] **Implement Primary Commands**:
+    - `dispatch`: Send events.
+    - `audit`: Search and view logs.
+    - `rules`: List and simulate rules.
+    - `events`: Manage state (ack/resolve).
+- [ ] **Interactive Mode**: Add `acteon shell` for interactive exploration.
+
+## Phase 2: MCP Server (`crates/mcp-server`)
+- [ ] **Scaffold MCP Server**: Initialize with `mcp-sdk-rs`.
+- [ ] **Bridge Ops to MCP**: Map `crates/ops` functions directly to MCP Tools.
+- [ ] **Resource Providers**: Map `crates/ops` data fetchers to MCP Resources (`audit://`, `state://`).
+
+## Phase 3: State & Management
+- [ ] **`manage_event` tool**:
+    - Support `acknowledge` and `resolve` actions.
+    - Integrate with `GroupManager` or `StateManager`.
+- [ ] **`state://` resource**:
+    - Expose current state machine status for a fingerprint.
+- [ ] **`list_rules` and `update_rule` tools**:
+    - Interface with the rule management system.
+    - Implement validation for rule updates.
+
+## Phase 4: Advanced Features
+- [ ] **`simulate_rule` tool**:
+    - Integrate with `acteon-simulation`.
+    - Allow running small-scale simulations in-memory.
+- [ ] **`evaluate_policy` tool**:
+    - Integrate with `acteon-llm`.
+- [ ] **Recurring Actions**:
+    - Tools to list, create, and delete `RecurringAction` entries.
+- [ ] **Approvals & Health**:
+    - `manage_approval` tool to integrate with the approvals API.
+    - `check_health` tool to expose circuit breaker and gateway status.
+
+## Phase 5: UI & UX (Prompts & SSE)
+- [ ] **SSE Transport**:
+    - Add support for HTTP/SSE transport for web-based MCP hosts.
+- [ ] **Prompts Library**:
+    - Hardcode initial prompts for incident analysis and alert tuning.
+- [ ] **Documentation**:
+    - Add `README.md` to `crates/mcp-server`.
+    - Provide example configuration for Claude Desktop.
+
+## Phase 6: Testing & Validation
+- [ ] **Unit Tests**: Test tool parameter mapping and error handling.
+- [ ] **Integration Tests**: Run the MCP server in a test harness against a mock gateway.
+- [ ] **Manual Validation**: Test with Claude Desktop or MCP Inspector.

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -1,0 +1,143 @@
+# Acteon MCP Server Design
+
+**Status:** Draft
+**Author:** Acteon Team
+**Created:** 2026-02-14
+
+## Overview
+
+This document proposes the implementation of a Model Context Protocol (MCP) server for Acteon. The MCP server will allow LLMs and AI agents to interact directly with Acteon's dispatch engine, audit trail, and state management systems, enabling agentic workflows for incident response, alert tuning, and automated operations.
+
+## Motivation
+
+As Acteon grows into a central hub for event dispatching and notification management, it becomes a critical source of truth for system health and operational history. By exposing Acteon via MCP, we enable:
+
+1.  **Autonomous Incident Analysis**: Agents can query the audit trail to correlate events and identify root causes.
+2.  **Natural Language Dispatch**: Humans or agents can send notifications or trigger workflows using plain language.
+3.  **Interactive Rule Tuning**: Agents can analyze notification volume and suggest improvements to grouping, inhibition, or routing rules.
+4.  **Operational Assistance**: Real-time status checks and manual state transitions (ACK/Resolve) through chat interfaces.
+
+## Architecture
+
+We will implement a **Common Operations Layer** (likely within `crates/client` or a new `crates/ops`) that encapsulates the logic for interacting with the Acteon Gateway. This layer will serve as the single source of truth for both the MCP Server and the CLI.
+
+```mermaid
+graph TD
+    Host[MCP Host / LLM] <-->|MCP Protocol| MCPServer[Acteon MCP Server]
+    User[Terminal / DevOps] <-->|Bash Commands| CLI[Acteon CLI]
+    
+    MCPServer <--> OpsLayer[Common Operations Layer]
+    CLI <--> OpsLayer
+    
+    OpsLayer <-->|HTTP/Internal| Gateway[Acteon Gateway]
+    OpsLayer <-->|Query| Audit[Audit Store]
+```
+
+### 1. Acteon CLI
+
+The CLI will provide a human-friendly way to interact with Acteon, mapping 1:1 with the capabilities exposed to the MCP server.
+
+**Example Commands:**
+- `acteon dispatch --tenant prod --type error --payload '{"msg": "db down"}'`
+- `acteon audit search --tenant prod --since 1h`
+- `acteon rule simulate --file ./new_rule.yaml --events ./samples.json`
+- `acteon event ack <fingerprint>`
+- `acteon health`
+
+### 2. Model Context Protocol (MCP) Server
+The MCP server will be a thin wrapper around the Operations Layer, exposing the same logic as Tools and Resources to LLM agents.
+
+## Surfaced Capabilities
+
+### 1. Resources
+
+Resources provide the LLM with read-only access to Acteon's data.
+
+| URI Pattern | Description |
+| :--- | :--- |
+| `audit://{tenant}/{id}` | Full details of a specific audit log entry. |
+| `rules://{tenant}` | The active rule set for a given tenant (YAML/JSON). |
+| `state://{tenant}/{fingerprint}` | Current state and history of a stateful event. |
+| `groups://{tenant}/{group_id}` | Membership and status of an event group. |
+| `subscriptions://{tenant}` | Active event subscriptions for real-time notifications. |
+| `config://system` | Non-sensitive system configuration and status. |
+
+### 2. Tools
+
+Tools allow the LLM to perform actions within Acteon.
+
+| Tool Name | Parameters | Description |
+| :--- | :--- | :--- |
+| `dispatch` | `tenant`, `action_type`, `payload`, `metadata`, `provider?` | Send a new action/event through Acteon. |
+| `query_audit` | `tenant`, `query?`, `start_time?`, `end_time?`, `limit?` | Search the audit trail for historical events. |
+| `update_rule` | `tenant`, `rule_name`, `update_patch` | Modify an existing routing or grouping rule. |
+| `manage_event` | `fingerprint`, `action` (ack/resolve/silence) | Transition the state of a stateful event. |
+| `schedule_action` | `tenant`, `schedule`, `action_payload` | Create or update a recurring action. |
+| `manage_approval` | `approval_id`, `decision` (approve/deny), `reason` | Handle manual approval requests for sensitive actions. |
+| `list_chains` | `tenant` | List action chains (sequences of related actions). |
+| `check_health` | - | Check gateway health and circuit breaker status. |
+| `simulate_rule` | `rule_definition`, `events` | Run a simulation of a rule against a set of sample events to see outcomes. |
+| `evaluate_policy` | `action`, `policy` | Use Acteon's LLM evaluator to check an action against a natural language policy. |
+| `analyze_impact` | `tenant`, `fingerprint` | Returns statistics on how often an event has fired and its notification history. |
+
+### 3. Prompts
+
+Pre-defined prompt templates to guide the LLM in operational tasks.
+
+-   **`investigate_incident`**: "I see a spike in errors for service {{service}}. Use Acteon to find related events in the last 30 minutes, check if any rules were recently changed, and summarize the impact."
+-   **`optimize_alerts`**: "Analyze the notifications sent to {{provider}} for tenant {{tenant}} over the last 24 hours. Identify noisy patterns and suggest grouping rules to reduce fatigue."
+-   **`draft_guardrail`**: "I need a policy that prevents notifications from being sent to {{team}} during their quiet hours unless the severity is 'critical'. Draft a natural language policy for Acteon's LLM guardrail."
+
+## Agentic Workflows
+
+### Scenario A: Automated Root Cause Analysis
+1.  An external monitoring tool triggers a "High Latency" event in Acteon.
+2.  An MCP-enabled agent receives this event.
+3.  The agent calls `query_audit` to see what else happened around the same time.
+4.  It finds a `deploy_started` event and several `database_connection_error` events.
+5.  The agent calls `dispatch` to send a summary to Slack: "Latency spike correlated with Deployment #452 and DB connection errors. Investigating..."
+
+### Scenario B: Intelligent Alert Suppression
+1.  A "Database Maintenance" window begins.
+2.  An agent (or scheduled task) calls `update_rule` to temporarily add an inhibition rule for DB alerts.
+3.  When maintenance finishes, the agent removes the rule and calls `manage_event` to resolve any lingering alerts.
+
+### Scenario C: Safe Rule Evolution
+1.  An agent identifies a "noisy" alert that fires 100 times a day but is usually ignored.
+2.  The agent proposes a new grouping rule with a 10-minute window.
+3.  Before applying it, the agent calls `simulate_rule` with historical events from the last 24 hours.
+4.  The simulation shows that notifications would drop from 100 to 12.
+5.  The agent presents these findings to a human and, upon approval, calls `update_rule`.
+
+## Security Considerations
+
+1.  **Authentication**: The MCP server must validate tenant access. When running via stdio for a local user, it should inherit their permissions.
+2.  **Sensitive Data**: Payloads in the audit trail may contain PII or secrets. The MCP server should provide a way to redact or mask sensitive fields before sending them to the LLM.
+3.  **Rate Limiting**: Tools like `dispatch` should be subject to the same (or stricter) rate limits as the standard API.
+4.  **Confirmation**: Destructive actions (like deleting rules) should require explicit user confirmation in the MCP Host UI.
+
+## Implementation Phases
+
+### Phase 1: Basic Connectivity
+-   Scaffold `crates/mcp-server`.
+-   Implement `stdio` transport.
+-   Implement `dispatch` tool and `audit://` resource.
+
+### Phase 2: Audit & Search
+-   Implement `query_audit` tool.
+-   Add support for filtering and pagination.
+-   Integrate with `acteon-audit` backends.
+
+### Phase 3: State & Rules
+-   Implement `manage_event` for stateful events.
+-   Implement `update_rule` with validation.
+-   Expose rules as resources.
+
+### Phase 4: Polish & Prompts
+-   Add comprehensive prompt templates.
+-   Implement `http` (SSE) transport.
+-   Documentation and examples.
+
+## Future Extensions
+-   **Log Streaming**: Use MCP's notification mechanism to stream new audit events to the agent in real-time.
+-   **Visualizations**: Return mermaid diagrams or chart data as part of resource representations.

--- a/examples/mcp-test.toml
+++ b/examples/mcp-test.toml
@@ -1,0 +1,40 @@
+# Configuration for MCP integration testing.
+# Uses log providers (mock) and in-memory audit so all tools work end-to-end.
+
+[server]
+host = "127.0.0.1"
+port = 8080
+
+[state]
+backend = "memory"
+
+[audit]
+enabled = true
+backend = "memory"
+store_payload = true
+
+# ── Mock providers (log type: no external deps, just logs and returns success) ──
+
+[[providers]]
+name = "slack"
+type = "log"
+
+[[providers]]
+name = "email"
+type = "log"
+
+[[providers]]
+name = "webhook"
+type = "log"
+
+[[providers]]
+name = "pagerduty"
+type = "log"
+
+[rules]
+# No rule directory — start clean
+
+[executor]
+max_retries = 3
+timeout_seconds = 30
+max_concurrent = 10

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,8 @@ nav:
   - API Reference:
     - api/index.md
     - REST API: api/rest-api.md
+    - MCP Server: api/mcp-server.md
+    - CLI: api/cli.md
     - Rust Client: api/rust-client.md
     - Polyglot Clients: api/polyglot-clients.md
     - YAML Rule Reference: api/rule-reference.md


### PR DESCRIPTION
## Summary

- **`crates/ops`** — Common operations layer wrapping `acteon-client` with environment-based config (`ACTEON_ENDPOINT`, `ACTEON_API_KEY`), shared by both the CLI and MCP server
- **`crates/mcp-server`** — Model Context Protocol server over stdio transport, exposing 10 tools (dispatch, query_audit, list_rules, evaluate_rules, manage_event, list_events, list_chains, set_rule_enabled, check_health), 4 resources (health, rules, audit, events), and 3 prompt templates (investigate_incident, optimize_alerts, draft_guardrail) for agentic workflows
- **`crates/cli`** — `acteon` CLI binary with dispatch, audit, rules, events, and health commands supporting `--format json|text` output
- **`crates/client`** — Added `Serialize` derive to 29 response types to support JSON round-tripping in the MCP server

Implements Phases 0–2 from `docs/design/mcp-server-implementation-plan.md`.

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --no-deps -- -D warnings` passes
- [x] `cargo test --workspace` passes (all existing tests green)
- [x] `acteon --help` and `acteon-mcp-server --help` produce correct output
- [ ] Manual: test MCP server with Claude Desktop or MCP Inspector
- [ ] Manual: test CLI against a running Acteon server

🤖 Generated with [Claude Code](https://claude.com/claude-code)