### PR TITLE
fix: resolve compilation errors from MCP server integration

### DIFF
--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -67,7 +67,9 @@ pub use stream::{EventStream, StreamFilter, StreamItem};
 use std::fmt::Write;
 use std::time::Duration;
 
-use acteon_core::{Action, ActionOutcome};
+use acteon_core::{
+    Action, ActionOutcome, CircuitBreakerActionResponse, ListCircuitBreakersResponse,
+};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
@@ -2190,6 +2192,107 @@ impl ActeonClient {
             Err(Error::Http {
                 status: response.status().as_u16(),
                 message: format!("Failed to drain DLQ: {}", response.status()),
+            })
+        }
+    }
+
+    // =========================================================================
+    // Circuit Breakers
+    // =========================================================================
+
+    /// List all circuit breakers and their current status.
+    ///
+    /// Requires admin permissions.
+    pub async fn list_circuit_breakers(&self) -> Result<ListCircuitBreakersResponse, Error> {
+        let url = format!("{}/admin/circuit-breakers", self.base_url);
+
+        let response = self
+            .add_auth(self.client.get(&url))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+
+        if response.status().is_success() {
+            let result = response
+                .json::<ListCircuitBreakersResponse>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))?;
+            Ok(result)
+        } else {
+            Err(Error::Http {
+                status: response.status().as_u16(),
+                message: format!("Failed to list circuit breakers: {}", response.status()),
+            })
+        }
+    }
+
+    /// Trip (force open) a circuit breaker for a specific provider.
+    ///
+    /// Requires admin permissions.
+    pub async fn trip_circuit_breaker(
+        &self,
+        provider: &str,
+    ) -> Result<CircuitBreakerActionResponse, Error> {
+        let url = format!("{}/admin/circuit-breakers/{}/trip", self.base_url, provider);
+
+        let response = self
+            .add_auth(self.client.post(&url))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+
+        if response.status().is_success() {
+            let result = response
+                .json::<CircuitBreakerActionResponse>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))?;
+            Ok(result)
+        } else {
+            let error = response
+                .json::<ErrorResponse>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))?;
+            Err(Error::Api {
+                code: error.code,
+                message: error.message,
+                retryable: error.retryable,
+            })
+        }
+    }
+
+    /// Reset (force close) a circuit breaker for a specific provider.
+    ///
+    /// Requires admin permissions.
+    pub async fn reset_circuit_breaker(
+        &self,
+        provider: &str,
+    ) -> Result<CircuitBreakerActionResponse, Error> {
+        let url = format!(
+            "{}/admin/circuit-breakers/{}/reset",
+            self.base_url, provider
+        );
+
+        let response = self
+            .add_auth(self.client.post(&url))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+
+        if response.status().is_success() {
+            let result = response
+                .json::<CircuitBreakerActionResponse>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))?;
+            Ok(result)
+        } else {
+            let error = response
+                .json::<ErrorResponse>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))?;
+            Err(Error::Api {
+                code: error.code,
+                message: error.message,
+                retryable: error.retryable,
             })
         }
     }

--- a/crates/core/src/circuit_breaker.rs
+++ b/crates/core/src/circuit_breaker.rs
@@ -1,0 +1,52 @@
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "utoipa")]
+use utoipa::ToSchema;
+
+/// Summary of a single circuit breaker's current state and configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(ToSchema))]
+pub struct CircuitBreakerStatus {
+    /// Provider name.
+    #[cfg_attr(feature = "utoipa", schema(example = "email"))]
+    pub provider: String,
+    /// Current circuit state ("closed", "open", "`half_open`").
+    #[cfg_attr(feature = "utoipa", schema(example = "closed"))]
+    pub state: String,
+    /// Number of consecutive failures before opening the circuit.
+    #[cfg_attr(feature = "utoipa", schema(example = 5))]
+    pub failure_threshold: u32,
+    /// Number of consecutive successes in half-open state to close the circuit.
+    #[cfg_attr(feature = "utoipa", schema(example = 2))]
+    pub success_threshold: u32,
+    /// Recovery timeout in seconds.
+    #[cfg_attr(feature = "utoipa", schema(example = 60))]
+    pub recovery_timeout_seconds: u64,
+    /// Optional fallback provider.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "utoipa", schema(example = "sms"))]
+    pub fallback_provider: Option<String>,
+}
+
+/// Response for listing all circuit breakers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(ToSchema))]
+pub struct ListCircuitBreakersResponse {
+    /// List of circuit breaker statuses.
+    pub circuit_breakers: Vec<CircuitBreakerStatus>,
+}
+
+/// Response after tripping or resetting a circuit breaker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(ToSchema))]
+pub struct CircuitBreakerActionResponse {
+    /// Provider name.
+    #[cfg_attr(feature = "utoipa", schema(example = "email"))]
+    pub provider: String,
+    /// New circuit state after the action.
+    #[cfg_attr(feature = "utoipa", schema(example = "open"))]
+    pub state: String,
+    /// Human-readable status message.
+    #[cfg_attr(feature = "utoipa", schema(example = "circuit breaker tripped"))]
+    pub message: String,
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod action;
 pub mod caller;
 pub mod chain;
+pub mod circuit_breaker;
 pub mod context;
 pub mod error;
 pub mod fingerprint;
@@ -18,6 +19,9 @@ pub use caller::Caller;
 pub use chain::{
     BranchCondition, BranchOperator, ChainConfig, ChainFailurePolicy, ChainNotificationTarget,
     ChainState, ChainStatus, ChainStepConfig, StepFailurePolicy, StepResult,
+};
+pub use circuit_breaker::{
+    CircuitBreakerActionResponse, CircuitBreakerStatus, ListCircuitBreakersResponse,
 };
 pub use context::ActionContext;
 pub use error::ActeonError;

--- a/crates/ops/src/lib.rs
+++ b/crates/ops/src/lib.rs
@@ -14,7 +14,9 @@ use acteon_client::{
     EventListResponse, EventQuery, ListChainsResponse, RuleEvaluationTrace, RuleInfo,
     TransitionResponse,
 };
-use acteon_core::{Action, ActionOutcome};
+use acteon_core::{
+    Action, ActionOutcome, CircuitBreakerActionResponse, ListCircuitBreakersResponse,
+};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -166,5 +168,26 @@ impl OpsClient {
     /// Check health.
     pub async fn health(&self) -> Result<bool, OpsError> {
         Ok(self.inner.health().await?)
+    }
+
+    /// List all circuit breakers.
+    pub async fn list_circuit_breakers(&self) -> Result<ListCircuitBreakersResponse, OpsError> {
+        Ok(self.inner.list_circuit_breakers().await?)
+    }
+
+    /// Trip a circuit breaker.
+    pub async fn trip_circuit_breaker(
+        &self,
+        provider: String,
+    ) -> Result<CircuitBreakerActionResponse, OpsError> {
+        Ok(self.inner.trip_circuit_breaker(&provider).await?)
+    }
+
+    /// Reset a circuit breaker.
+    pub async fn reset_circuit_breaker(
+        &self,
+        provider: String,
+    ) -> Result<CircuitBreakerActionResponse, OpsError> {
+        Ok(self.inner.reset_circuit_breaker(&provider).await?)
     }
 }

--- a/crates/server/src/api/circuit_breakers.rs
+++ b/crates/server/src/api/circuit_breakers.rs
@@ -2,60 +2,17 @@ use axum::Json;
 use axum::extract::{self, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use serde::{Deserialize, Serialize};
 use tracing::info;
-use utoipa::ToSchema;
 
 use crate::auth::identity::CallerIdentity;
 use crate::auth::role::Permission;
 
+use acteon_core::{
+    CircuitBreakerActionResponse, CircuitBreakerStatus, ListCircuitBreakersResponse,
+};
+
 use super::AppState;
 use super::schemas::ErrorResponse;
-
-/// Summary of a single circuit breaker's current state and configuration.
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct CircuitBreakerStatus {
-    /// Provider name.
-    #[schema(example = "email")]
-    pub provider: String,
-    /// Current circuit state.
-    #[schema(example = "closed")]
-    pub state: String,
-    /// Number of consecutive failures before opening the circuit.
-    #[schema(example = 5)]
-    pub failure_threshold: u32,
-    /// Number of consecutive successes in half-open state to close the circuit.
-    #[schema(example = 2)]
-    pub success_threshold: u32,
-    /// Recovery timeout in seconds.
-    #[schema(example = 60)]
-    pub recovery_timeout_seconds: u64,
-    /// Optional fallback provider.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "sms")]
-    pub fallback_provider: Option<String>,
-}
-
-/// Response for listing all circuit breakers.
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct ListCircuitBreakersResponse {
-    /// List of circuit breaker statuses.
-    pub circuit_breakers: Vec<CircuitBreakerStatus>,
-}
-
-/// Response after tripping or resetting a circuit breaker.
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct CircuitBreakerActionResponse {
-    /// Provider name.
-    #[schema(example = "email")]
-    pub provider: String,
-    /// New circuit state after the action.
-    #[schema(example = "open")]
-    pub state: String,
-    /// Human-readable status message.
-    #[schema(example = "circuit breaker tripped")]
-    pub message: String,
-}
 
 /// `GET /admin/circuit-breakers` -- list all circuit breakers with current state.
 #[utoipa::path(

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -12,9 +12,6 @@ use super::approvals::{
 use super::chains::{
     ChainCancelRequest, ChainDetailResponse, ChainStepStatus, ChainSummary, ListChainsResponse,
 };
-use super::circuit_breakers::{
-    CircuitBreakerActionResponse, CircuitBreakerStatus, ListCircuitBreakersResponse,
-};
 use super::dlq::{DlqDrainResponse, DlqEntry, DlqStatsResponse};
 use super::embeddings::{SimilarityRequest, SimilarityResponse};
 use super::events::{
@@ -33,6 +30,9 @@ use super::rules::{EvaluateRulesRequest, EvaluateRulesResponse, RuleTraceEntryRe
 use super::schemas::{
     EmbeddingMetricsResponse, ErrorResponse, HealthResponse, MetricsResponse, ReloadRequest,
     ReloadResponse, RuleSummary, SetEnabledRequest, SetEnabledResponse,
+};
+use acteon_core::{
+    CircuitBreakerActionResponse, CircuitBreakerStatus, ListCircuitBreakersResponse,
 };
 
 #[derive(utoipa::OpenApi)]


### PR DESCRIPTION
## Summary
- **Client:** Moved circuit breaker methods (`list_circuit_breakers`, `trip_circuit_breaker`, `reset_circuit_breaker`) back inside `impl ActeonClient` — they were accidentally placed outside the block, causing `&self` parameter errors
- **Server OpenAPI:** Fixed private re-export of `CircuitBreakerActionResponse`, `CircuitBreakerStatus`, `ListCircuitBreakersResponse` — now imports directly from `acteon_core`
- **Core docs:** Added backticks around `half_open` in `circuit_breaker.rs` doc comment to satisfy clippy `doc_markdown` lint

Also includes the other agent's new functionality: circuit breaker types extracted to `acteon-core`, new MCP tools for recurring actions, groups, quotas, and circuit breaker management.

## Test plan
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --no-deps -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all tests pass
- [x] `npm run lint && npm run build` — frontend clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)