### PR TITLE
feat: add native providers for Twilio, Teams, and Discord

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "acteon-discord"
+version = "0.1.0"
+dependencies = [
+ "acteon-core",
+ "acteon-provider",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "acteon-email"
 version = "0.1.0"
 dependencies = [
@@ -346,6 +360,7 @@ dependencies = [
  "acteon-audit-postgres",
  "acteon-core",
  "acteon-crypto",
+ "acteon-discord",
  "acteon-embedding",
  "acteon-executor",
  "acteon-gateway",
@@ -359,6 +374,8 @@ dependencies = [
  "acteon-state-memory",
  "acteon-state-postgres",
  "acteon-state-redis",
+ "acteon-teams",
+ "acteon-twilio",
  "argon2",
  "async-trait",
  "axum 0.8.8",
@@ -533,6 +550,35 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "acteon-teams"
+version = "0.1.0"
+dependencies = [
+ "acteon-core",
+ "acteon-provider",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "acteon-twilio"
+version = "0.1.0"
+dependencies = [
+ "acteon-core",
+ "acteon-provider",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ members = [
     "crates/integrations/slack",
     "crates/integrations/pagerduty",
     "crates/integrations/webhook",
+    "crates/integrations/twilio",
+    "crates/integrations/teams",
+    "crates/integrations/discord",
 
     # Operations / CLI / MCP
     "crates/ops",
@@ -98,6 +101,9 @@ acteon-email = { path = "crates/integrations/email" }
 acteon-slack = { path = "crates/integrations/slack" }
 acteon-pagerduty = { path = "crates/integrations/pagerduty" }
 acteon-webhook = { path = "crates/integrations/webhook" }
+acteon-twilio = { path = "crates/integrations/twilio" }
+acteon-teams = { path = "crates/integrations/teams" }
+acteon-discord = { path = "crates/integrations/discord" }
 
 # Operations / CLI / MCP
 acteon-ops = { path = "crates/ops" }
@@ -159,6 +165,9 @@ lettre = { version = "0.11", features = ["tokio1-native-tls", "smtp-transport"] 
 
 # HTTP client
 reqwest = { version = "0.12", features = ["json"] }
+
+# URL-encoded forms
+serde_urlencoded = "0.7"
 
 # Regex
 regex = "1"

--- a/clients/go/acteon/models.go
+++ b/clients/go/acteon/models.go
@@ -970,3 +970,85 @@ type ProviderHealthStatus struct {
 type ListProviderHealthResponse struct {
 	Providers []ProviderHealthStatus `json:"providers"`
 }
+
+// =============================================================================
+// Provider Payload Helpers
+// =============================================================================
+
+// NewTwilioSmsPayload creates a payload for the Twilio SMS provider.
+func NewTwilioSmsPayload(to, body string) map[string]any {
+	return map[string]any{
+		"to":   to,
+		"body": body,
+	}
+}
+
+// NewTwilioSmsPayloadWithOptions creates a Twilio SMS payload with optional fields.
+func NewTwilioSmsPayloadWithOptions(to, body string, from string, mediaURL string) map[string]any {
+	p := NewTwilioSmsPayload(to, body)
+	if from != "" {
+		p["from"] = from
+	}
+	if mediaURL != "" {
+		p["media_url"] = mediaURL
+	}
+	return p
+}
+
+// NewTeamsMessagePayload creates a payload for the Microsoft Teams provider.
+func NewTeamsMessagePayload(text string) map[string]any {
+	return map[string]any{
+		"text": text,
+	}
+}
+
+// NewTeamsMessagePayloadWithOptions creates a Teams message payload with optional fields.
+func NewTeamsMessagePayloadWithOptions(text, title, themeColor string) map[string]any {
+	p := NewTeamsMessagePayload(text)
+	if title != "" {
+		p["title"] = title
+	}
+	if themeColor != "" {
+		p["theme_color"] = themeColor
+	}
+	return p
+}
+
+// NewTeamsAdaptiveCardPayload creates a payload for Teams with an Adaptive Card.
+func NewTeamsAdaptiveCardPayload(card map[string]any) map[string]any {
+	return map[string]any{
+		"adaptive_card": card,
+	}
+}
+
+// NewDiscordMessagePayload creates a payload for the Discord webhook provider.
+func NewDiscordMessagePayload(content string) map[string]any {
+	return map[string]any{
+		"content": content,
+	}
+}
+
+// NewDiscordEmbedPayload creates a Discord payload with an embed.
+func NewDiscordEmbedPayload(embeds []map[string]any) map[string]any {
+	return map[string]any{
+		"embeds": embeds,
+	}
+}
+
+// NewDiscordMessagePayloadWithOptions creates a Discord payload with all options.
+func NewDiscordMessagePayloadWithOptions(content, username, avatarURL string, embeds []map[string]any) map[string]any {
+	p := map[string]any{}
+	if content != "" {
+		p["content"] = content
+	}
+	if username != "" {
+		p["username"] = username
+	}
+	if avatarURL != "" {
+		p["avatar_url"] = avatarURL
+	}
+	if len(embeds) > 0 {
+		p["embeds"] = embeds
+	}
+	return p
+}

--- a/clients/java/src/main/java/com/acteon/client/models/DiscordMessagePayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/DiscordMessagePayload.java
@@ -1,0 +1,53 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Payload builder for the Discord webhook provider.
+ */
+public class DiscordMessagePayload {
+    private String content;
+    private List<Map<String, Object>> embeds;
+    private String username;
+    private String avatarUrl;
+    private Boolean tts;
+
+    public static DiscordMessagePayload withContent(String content) {
+        DiscordMessagePayload p = new DiscordMessagePayload();
+        p.content = content;
+        return p;
+    }
+
+    public static DiscordMessagePayload withEmbeds(List<Map<String, Object>> embeds) {
+        DiscordMessagePayload p = new DiscordMessagePayload();
+        p.embeds = embeds;
+        return p;
+    }
+
+    public DiscordMessagePayload withUsername(String username) {
+        this.username = username;
+        return this;
+    }
+
+    public DiscordMessagePayload withAvatarUrl(String avatarUrl) {
+        this.avatarUrl = avatarUrl;
+        return this;
+    }
+
+    public DiscordMessagePayload withTts(boolean tts) {
+        this.tts = tts;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        if (content != null) payload.put("content", content);
+        if (embeds != null) payload.put("embeds", embeds);
+        if (username != null) payload.put("username", username);
+        if (avatarUrl != null) payload.put("avatar_url", avatarUrl);
+        if (tts != null) payload.put("tts", tts);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/TeamsMessagePayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/TeamsMessagePayload.java
@@ -1,0 +1,52 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the Microsoft Teams provider.
+ */
+public class TeamsMessagePayload {
+    private String text;
+    private String title;
+    private String themeColor;
+    private String summary;
+    private Map<String, Object> adaptiveCard;
+
+    public static TeamsMessagePayload withText(String text) {
+        TeamsMessagePayload p = new TeamsMessagePayload();
+        p.text = text;
+        return p;
+    }
+
+    public static TeamsMessagePayload withAdaptiveCard(Map<String, Object> card) {
+        TeamsMessagePayload p = new TeamsMessagePayload();
+        p.adaptiveCard = card;
+        return p;
+    }
+
+    public TeamsMessagePayload withTitle(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public TeamsMessagePayload withThemeColor(String themeColor) {
+        this.themeColor = themeColor;
+        return this;
+    }
+
+    public TeamsMessagePayload withSummary(String summary) {
+        this.summary = summary;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        if (text != null) payload.put("text", text);
+        if (title != null) payload.put("title", title);
+        if (themeColor != null) payload.put("theme_color", themeColor);
+        if (summary != null) payload.put("summary", summary);
+        if (adaptiveCard != null) payload.put("adaptive_card", adaptiveCard);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/TwilioSmsPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/TwilioSmsPayload.java
@@ -1,0 +1,38 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the Twilio SMS provider.
+ */
+public class TwilioSmsPayload {
+    private final String to;
+    private final String body;
+    private String from;
+    private String mediaUrl;
+
+    public TwilioSmsPayload(String to, String body) {
+        this.to = to;
+        this.body = body;
+    }
+
+    public TwilioSmsPayload withFrom(String from) {
+        this.from = from;
+        return this;
+    }
+
+    public TwilioSmsPayload withMediaUrl(String mediaUrl) {
+        this.mediaUrl = mediaUrl;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("to", to);
+        payload.put("body", body);
+        if (from != null) payload.put("from", from);
+        if (mediaUrl != null) payload.put("media_url", mediaUrl);
+        return payload;
+    }
+}

--- a/clients/nodejs/src/models.ts
+++ b/clients/nodejs/src/models.ts
@@ -1570,3 +1570,93 @@ export function parseListProviderHealthResponse(data: Record<string, unknown>): 
     providers: items.map(parseProviderHealthStatus),
   };
 }
+
+// =============================================================================
+// Provider Payload Helpers
+// =============================================================================
+
+/** Payload for the Twilio SMS provider. */
+export interface TwilioSmsPayload {
+  to: string;
+  body: string;
+  from?: string;
+  media_url?: string;
+}
+
+/** Create a payload for the Twilio SMS provider. */
+export function createTwilioSmsPayload(
+  to: string,
+  body: string,
+  options?: { from?: string; mediaUrl?: string }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { to, body };
+  if (options?.from) payload.from = options.from;
+  if (options?.mediaUrl) payload.media_url = options.mediaUrl;
+  return payload;
+}
+
+/** Payload for the Microsoft Teams provider. */
+export interface TeamsMessagePayload {
+  text?: string;
+  title?: string;
+  theme_color?: string;
+  summary?: string;
+  adaptive_card?: Record<string, unknown>;
+}
+
+/** Create a payload for the Teams provider (MessageCard). */
+export function createTeamsMessagePayload(
+  text: string,
+  options?: { title?: string; themeColor?: string; summary?: string }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { text };
+  if (options?.title) payload.title = options.title;
+  if (options?.themeColor) payload.theme_color = options.themeColor;
+  if (options?.summary) payload.summary = options.summary;
+  return payload;
+}
+
+/** Create a payload for the Teams provider (Adaptive Card). */
+export function createTeamsAdaptiveCardPayload(
+  card: Record<string, unknown>
+): Record<string, unknown> {
+  return { adaptive_card: card };
+}
+
+/** Payload for the Discord webhook provider. */
+export interface DiscordMessagePayload {
+  content?: string;
+  embeds?: DiscordEmbed[];
+  username?: string;
+  avatar_url?: string;
+  tts?: boolean;
+}
+
+/** A Discord embed object. */
+export interface DiscordEmbed {
+  title?: string;
+  description?: string;
+  color?: number;
+  fields?: Array<{ name: string; value: string; inline?: boolean }>;
+  footer?: { text: string };
+  timestamp?: string;
+}
+
+/** Create a payload for the Discord webhook provider. */
+export function createDiscordMessagePayload(
+  options: {
+    content?: string;
+    embeds?: DiscordEmbed[];
+    username?: string;
+    avatarUrl?: string;
+    tts?: boolean;
+  }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  if (options.content !== undefined) payload.content = options.content;
+  if (options.embeds !== undefined) payload.embeds = options.embeds;
+  if (options.username !== undefined) payload.username = options.username;
+  if (options.avatarUrl !== undefined) payload.avatar_url = options.avatarUrl;
+  if (options.tts !== undefined) payload.tts = options.tts;
+  return payload;
+}

--- a/clients/python/acteon_client/models.py
+++ b/clients/python/acteon_client/models.py
@@ -1708,3 +1708,110 @@ class ListProviderHealthResponse:
         return cls(
             providers=[ProviderHealthStatus.from_dict(p) for p in data["providers"]],
         )
+
+
+# =============================================================================
+# Provider Payload Helpers
+# =============================================================================
+
+
+def twilio_sms_payload(
+    to: str,
+    body: str,
+    *,
+    from_number: Optional[str] = None,
+    media_url: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a payload for the Twilio SMS provider.
+
+    Args:
+        to: Destination phone number (E.164 format).
+        body: Message body text.
+        from_number: Override the default sender phone number.
+        media_url: URL of media to attach (MMS).
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the Twilio provider.
+    """
+    payload: dict[str, Any] = {"to": to, "body": body}
+    if from_number is not None:
+        payload["from"] = from_number
+    if media_url is not None:
+        payload["media_url"] = media_url
+    return payload
+
+
+def teams_message_payload(
+    text: str,
+    *,
+    title: Optional[str] = None,
+    theme_color: Optional[str] = None,
+    summary: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a payload for the Microsoft Teams provider (MessageCard).
+
+    Args:
+        text: Message body text (supports basic markdown).
+        title: Card title.
+        theme_color: Hex color string (e.g., "FF0000").
+        summary: Summary text for notifications.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the Teams provider.
+    """
+    payload: dict[str, Any] = {"text": text}
+    if title is not None:
+        payload["title"] = title
+    if theme_color is not None:
+        payload["theme_color"] = theme_color
+    if summary is not None:
+        payload["summary"] = summary
+    return payload
+
+
+def teams_adaptive_card_payload(card: dict[str, Any]) -> dict[str, Any]:
+    """Build a payload for the Microsoft Teams provider (Adaptive Card).
+
+    Args:
+        card: The Adaptive Card JSON object.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the Teams provider.
+    """
+    return {"adaptive_card": card}
+
+
+def discord_message_payload(
+    *,
+    content: Optional[str] = None,
+    embeds: Optional[List[dict[str, Any]]] = None,
+    username: Optional[str] = None,
+    avatar_url: Optional[str] = None,
+    tts: Optional[bool] = None,
+) -> dict[str, Any]:
+    """Build a payload for the Discord webhook provider.
+
+    At least one of ``content`` or ``embeds`` must be provided.
+
+    Args:
+        content: Plain-text message content.
+        embeds: List of Discord embed objects.
+        username: Override the webhook's default username.
+        avatar_url: Override the webhook's default avatar.
+        tts: Whether the message should be read aloud.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the Discord provider.
+    """
+    payload: dict[str, Any] = {}
+    if content is not None:
+        payload["content"] = content
+    if embeds is not None:
+        payload["embeds"] = embeds
+    if username is not None:
+        payload["username"] = username
+    if avatar_url is not None:
+        payload["avatar_url"] = avatar_url
+    if tts is not None:
+        payload["tts"] = tts
+    return payload

--- a/crates/integrations/discord/Cargo.toml
+++ b/crates/integrations/discord/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "acteon-discord"
+description = "Discord provider for Acteon — posts messages via Discord webhooks"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+
+[dependencies]
+acteon-core = { workspace = true }
+acteon-provider = { workspace = true, features = ["trace-context"] }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/integrations/discord/src/config.rs
+++ b/crates/integrations/discord/src/config.rs
@@ -1,0 +1,102 @@
+/// Configuration for the Discord provider.
+#[derive(Clone)]
+pub struct DiscordConfig {
+    /// Discord webhook URL.
+    pub webhook_url: String,
+
+    /// Whether to append `?wait=true` to the webhook URL, causing Discord to
+    /// return the created message object instead of 204 No Content.
+    pub wait: bool,
+
+    /// Default username to display in Discord messages.
+    pub default_username: Option<String>,
+
+    /// Default avatar URL to display in Discord messages.
+    pub default_avatar_url: Option<String>,
+}
+
+impl std::fmt::Debug for DiscordConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiscordConfig")
+            .field("webhook_url", &"[REDACTED]")
+            .field("wait", &self.wait)
+            .field("default_username", &self.default_username)
+            .field("default_avatar_url", &self.default_avatar_url)
+            .finish()
+    }
+}
+
+impl DiscordConfig {
+    /// Create a new configuration with the given webhook URL.
+    pub fn new(webhook_url: impl Into<String>) -> Self {
+        Self {
+            webhook_url: webhook_url.into(),
+            wait: false,
+            default_username: None,
+            default_avatar_url: None,
+        }
+    }
+
+    /// Enable `?wait=true` on webhook requests.
+    #[must_use]
+    pub fn with_wait(mut self, wait: bool) -> Self {
+        self.wait = wait;
+        self
+    }
+
+    /// Set the default username for messages.
+    #[must_use]
+    pub fn with_default_username(mut self, username: impl Into<String>) -> Self {
+        self.default_username = Some(username.into());
+        self
+    }
+
+    /// Set the default avatar URL for messages.
+    #[must_use]
+    pub fn with_default_avatar_url(mut self, url: impl Into<String>) -> Self {
+        self.default_avatar_url = Some(url.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config() {
+        let config = DiscordConfig::new("https://discord.com/api/webhooks/123/abc");
+        assert_eq!(
+            config.webhook_url,
+            "https://discord.com/api/webhooks/123/abc"
+        );
+        assert!(!config.wait);
+        assert!(config.default_username.is_none());
+        assert!(config.default_avatar_url.is_none());
+    }
+
+    #[test]
+    fn with_all_options() {
+        let config = DiscordConfig::new("https://discord.com/api/webhooks/123/abc")
+            .with_wait(true)
+            .with_default_username("Acteon Bot")
+            .with_default_avatar_url("https://example.com/avatar.png");
+        assert!(config.wait);
+        assert_eq!(config.default_username.as_deref(), Some("Acteon Bot"));
+        assert_eq!(
+            config.default_avatar_url.as_deref(),
+            Some("https://example.com/avatar.png")
+        );
+    }
+
+    #[test]
+    fn debug_redacts_webhook_url() {
+        let config = DiscordConfig::new("https://discord.com/api/webhooks/123/test-placeholder");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("[REDACTED]"), "webhook_url must be redacted");
+        assert!(
+            !debug.contains("test-placeholder"),
+            "webhook_url must not appear in debug output"
+        );
+    }
+}

--- a/crates/integrations/discord/src/error.rs
+++ b/crates/integrations/discord/src/error.rs
@@ -1,0 +1,69 @@
+use acteon_provider::ProviderError;
+use thiserror::Error;
+
+/// Errors specific to the Discord provider.
+///
+/// These are internal errors that get converted into [`ProviderError`] at the
+/// public API boundary.
+#[derive(Debug, Error)]
+pub enum DiscordError {
+    /// An HTTP-level transport error occurred.
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// The Discord API returned an error response.
+    #[error("Discord API error: {0}")]
+    Api(String),
+
+    /// The action payload is missing required fields or has invalid structure.
+    #[error("invalid payload: {0}")]
+    InvalidPayload(String),
+
+    /// The provider received an HTTP 429 (Too Many Requests) response.
+    #[error("rate limited by Discord")]
+    RateLimited,
+}
+
+impl From<DiscordError> for ProviderError {
+    fn from(err: DiscordError) -> Self {
+        match err {
+            DiscordError::Http(e) => ProviderError::Connection(e.to_string()),
+            DiscordError::Api(msg) => ProviderError::ExecutionFailed(msg),
+            DiscordError::InvalidPayload(msg) => ProviderError::Serialization(msg),
+            DiscordError::RateLimited => ProviderError::RateLimited,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limited_maps_to_retryable() {
+        let provider_err: ProviderError = DiscordError::RateLimited.into();
+        assert!(provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::RateLimited));
+    }
+
+    #[test]
+    fn api_error_maps_to_non_retryable() {
+        let provider_err: ProviderError = DiscordError::Api("invalid webhook".into()).into();
+        assert!(!provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn invalid_payload_maps_to_serialization() {
+        let provider_err: ProviderError =
+            DiscordError::InvalidPayload("missing content".into()).into();
+        assert!(!provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::Serialization(_)));
+    }
+
+    #[test]
+    fn error_display() {
+        let err = DiscordError::Api("bad request".into());
+        assert_eq!(err.to_string(), "Discord API error: bad request");
+    }
+}

--- a/crates/integrations/discord/src/lib.rs
+++ b/crates/integrations/discord/src/lib.rs
@@ -1,0 +1,25 @@
+//! Discord provider for the Acteon notification gateway.
+//!
+//! This crate implements the [`Provider`](acteon_provider::Provider) trait,
+//! enabling Acteon to deliver messages through
+//! [Discord webhooks](https://discord.com/developers/docs/resources/webhook).
+//!
+//! # Quick start
+//!
+//! ```rust,no_run
+//! use acteon_discord::{DiscordConfig, DiscordProvider};
+//!
+//! let config = DiscordConfig::new("https://discord.com/api/webhooks/123/abc")
+//!     .with_default_username("Acteon Bot");
+//! let provider = DiscordProvider::new(config);
+//! ```
+
+pub mod config;
+pub mod error;
+pub mod provider;
+pub mod types;
+
+pub use config::DiscordConfig;
+pub use error::DiscordError;
+pub use provider::DiscordProvider;
+pub use types::{DiscordEmbed, DiscordWebhookRequest};

--- a/crates/integrations/discord/src/provider.rs
+++ b/crates/integrations/discord/src/provider.rs
@@ -1,0 +1,450 @@
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::{Provider, ProviderError};
+use reqwest::Client;
+use serde::Deserialize;
+use tracing::{debug, instrument, warn};
+
+use crate::config::DiscordConfig;
+use crate::error::DiscordError;
+use crate::types::{DiscordEmbed, DiscordWebhookRequest, DiscordWebhookResponse};
+
+/// Discord provider that sends messages via Discord webhooks.
+///
+/// Implements the [`Provider`] trait so it can be registered in the provider
+/// registry and used by the action executor.
+pub struct DiscordProvider {
+    config: DiscordConfig,
+    client: Client,
+}
+
+/// Fields extracted from an action payload for a Discord message.
+#[derive(Debug, Deserialize)]
+struct MessagePayload {
+    content: Option<String>,
+    username: Option<String>,
+    avatar_url: Option<String>,
+    tts: Option<bool>,
+    embeds: Option<Vec<DiscordEmbed>>,
+}
+
+impl DiscordProvider {
+    /// Create a new Discord provider with the given configuration.
+    pub fn new(config: DiscordConfig) -> Self {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("failed to build HTTP client");
+        Self { config, client }
+    }
+
+    /// Create a new Discord provider with a custom HTTP client.
+    pub fn with_client(config: DiscordConfig, client: Client) -> Self {
+        Self { config, client }
+    }
+
+    /// Build the effective webhook URL, appending `?wait=true` if configured.
+    fn effective_url(&self) -> String {
+        if self.config.wait {
+            if self.config.webhook_url.contains('?') {
+                format!("{}&wait=true", self.config.webhook_url)
+            } else {
+                format!("{}?wait=true", self.config.webhook_url)
+            }
+        } else {
+            self.config.webhook_url.clone()
+        }
+    }
+}
+
+impl Provider for DiscordProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "discord"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "discord"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        let payload: MessagePayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| DiscordError::InvalidPayload(format!("failed to parse payload: {e}")))?;
+
+        let has_content = payload.content.is_some();
+        let has_embeds = payload.embeds.as_ref().is_some_and(|e| !e.is_empty());
+
+        if !has_content && !has_embeds {
+            return Err(DiscordError::InvalidPayload(
+                "payload must contain at least one of 'content' or 'embeds'".into(),
+            )
+            .into());
+        }
+
+        let request = DiscordWebhookRequest {
+            content: payload.content,
+            username: payload
+                .username
+                .or_else(|| self.config.default_username.clone()),
+            avatar_url: payload
+                .avatar_url
+                .or_else(|| self.config.default_avatar_url.clone()),
+            tts: payload.tts,
+            embeds: payload.embeds,
+        };
+
+        let url = self.effective_url();
+
+        debug!("posting message to Discord webhook");
+
+        let response = acteon_provider::inject_trace_context(self.client.post(&url).json(&request))
+            .send()
+            .await
+            .map_err(DiscordError::Http)?;
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            warn!("Discord API rate limit hit");
+            return Err(DiscordError::RateLimited.into());
+        }
+
+        if !status.is_success() {
+            let response_body = response.text().await.unwrap_or_default();
+            return Err(DiscordError::Api(format!("HTTP {status}: {response_body}")).into());
+        }
+
+        // Discord returns 204 No Content normally, or 200 with JSON if ?wait=true.
+        let response_body = if status == reqwest::StatusCode::NO_CONTENT {
+            serde_json::json!({ "ok": true })
+        } else {
+            match response.json::<DiscordWebhookResponse>().await {
+                Ok(resp) => serde_json::json!({
+                    "ok": true,
+                    "id": resp.id,
+                    "channel_id": resp.channel_id,
+                }),
+                Err(_) => serde_json::json!({ "ok": true }),
+            }
+        };
+
+        Ok(ProviderResponse::success(response_body))
+    }
+
+    #[instrument(skip(self), fields(provider = "discord"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        debug!("performing Discord health check via webhook GET");
+
+        // GET on a Discord webhook URL returns the webhook object.
+        let response = self
+            .client
+            .get(&self.config.webhook_url)
+            .send()
+            .await
+            .map_err(|e| ProviderError::Connection(e.to_string()))?;
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(ProviderError::RateLimited);
+        }
+
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(ProviderError::Connection(format!("HTTP {status}: {body}")));
+        }
+
+        debug!("Discord health check passed");
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use acteon_core::Action;
+    use acteon_provider::{Provider, ProviderError};
+
+    use super::*;
+    use crate::config::DiscordConfig;
+
+    struct MockDiscordServer {
+        listener: tokio::net::TcpListener,
+        base_url: String,
+    }
+
+    impl MockDiscordServer {
+        async fn start() -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("failed to bind mock server");
+            let port = listener.local_addr().unwrap().port();
+            let base_url = format!("http://127.0.0.1:{port}");
+            Self { listener, base_url }
+        }
+
+        async fn respond_once(self, status_code: u16, body: &str) {
+            let body = body.to_owned();
+            let (mut stream, _) = self.listener.accept().await.unwrap();
+
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+            let mut buf = vec![0u8; 8192];
+            let _ = stream.read(&mut buf).await.unwrap();
+
+            let content_type = if body.is_empty() {
+                "text/plain"
+            } else {
+                "application/json"
+            };
+
+            let response = format!(
+                "HTTP/1.1 {status_code} OK\r\n\
+                 Content-Type: {content_type}\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 {body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+        }
+
+        async fn respond_no_content(self) {
+            self.respond_once(204, "").await;
+        }
+
+        async fn respond_rate_limited(self) {
+            self.respond_once(429, r#"{"message":"rate limited"}"#)
+                .await;
+        }
+    }
+
+    fn make_action(payload: serde_json::Value) -> Action {
+        Action::new(
+            "notifications",
+            "tenant-1",
+            "discord",
+            "send_message",
+            payload,
+        )
+    }
+
+    #[test]
+    fn provider_name() {
+        let config = DiscordConfig::new("https://discord.com/api/webhooks/123/abc");
+        let provider = DiscordProvider::new(config);
+        assert_eq!(provider.name(), "discord");
+    }
+
+    #[tokio::test]
+    async fn execute_success_no_content_response() {
+        let server = MockDiscordServer::start().await;
+        let config = DiscordConfig::new(&server.base_url);
+        let provider = DiscordProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "content": "Hello from Acteon!"
+        }));
+
+        let server_handle = tokio::spawn(async move {
+            server.respond_no_content().await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        let response = result.expect("execute should succeed");
+        assert_eq!(response.status, acteon_core::ResponseStatus::Success);
+        assert_eq!(response.body["ok"], true);
+    }
+
+    #[tokio::test]
+    async fn execute_success_with_wait() {
+        let server = MockDiscordServer::start().await;
+        let config = DiscordConfig::new(&server.base_url).with_wait(true);
+        let provider = DiscordProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "content": "Hello!"
+        }));
+
+        let response_body = r#"{"id":"12345","channel_id":"67890"}"#;
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(200, response_body).await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        let response = result.expect("execute should succeed");
+        assert_eq!(response.body["ok"], true);
+        assert_eq!(response.body["id"], "12345");
+    }
+
+    #[tokio::test]
+    async fn execute_with_embeds() {
+        let server = MockDiscordServer::start().await;
+        let config = DiscordConfig::new(&server.base_url);
+        let provider = DiscordProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "embeds": [{
+                "title": "Alert",
+                "description": "Something happened",
+                "color": 16711680
+            }]
+        }));
+
+        let server_handle = tokio::spawn(async move {
+            server.respond_no_content().await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn execute_with_defaults_applied() {
+        let server = MockDiscordServer::start().await;
+        let config = DiscordConfig::new(&server.base_url)
+            .with_default_username("Acteon Bot")
+            .with_default_avatar_url("https://example.com/avatar.png");
+        let provider = DiscordProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "content": "Hello!"
+        }));
+
+        let server_handle = tokio::spawn(async move {
+            server.respond_no_content().await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn execute_missing_content_and_embeds() {
+        let config = DiscordConfig::new("http://localhost:1");
+        let provider = DiscordProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "username": "Bot"
+        }));
+
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_empty_embeds_fails() {
+        let config = DiscordConfig::new("http://localhost:1");
+        let provider = DiscordProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "embeds": []
+        }));
+
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+    }
+
+    #[tokio::test]
+    async fn execute_rate_limited() {
+        let server = MockDiscordServer::start().await;
+        let config = DiscordConfig::new(&server.base_url);
+        let provider = DiscordProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "content": "Hello!"
+        }));
+
+        let server_handle = tokio::spawn(async move {
+            server.respond_rate_limited().await;
+        });
+
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+
+        assert!(matches!(err, ProviderError::RateLimited));
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_api_error() {
+        let server = MockDiscordServer::start().await;
+        let config = DiscordConfig::new(&server.base_url);
+        let provider = DiscordProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "content": "Hello!"
+        }));
+
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(400, r#"{"message":"Invalid Webhook Token"}"#)
+                .await;
+        });
+
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+
+        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn health_check_success() {
+        let server = MockDiscordServer::start().await;
+        let config = DiscordConfig::new(&server.base_url);
+        let provider = DiscordProvider::new(config);
+
+        let response_body = r#"{"type":1,"id":"12345","name":"Acteon","channel_id":"67890"}"#;
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(200, response_body).await;
+        });
+
+        let result = provider.health_check().await;
+        server_handle.await.unwrap();
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn health_check_rate_limited() {
+        let server = MockDiscordServer::start().await;
+        let config = DiscordConfig::new(&server.base_url);
+        let provider = DiscordProvider::new(config);
+
+        let server_handle = tokio::spawn(async move {
+            server.respond_rate_limited().await;
+        });
+
+        let err = provider.health_check().await.unwrap_err();
+        server_handle.await.unwrap();
+
+        assert!(matches!(err, ProviderError::RateLimited));
+    }
+
+    #[test]
+    fn effective_url_without_wait() {
+        let config = DiscordConfig::new("https://discord.com/api/webhooks/123/abc");
+        let provider = DiscordProvider::new(config);
+        assert_eq!(
+            provider.effective_url(),
+            "https://discord.com/api/webhooks/123/abc"
+        );
+    }
+
+    #[test]
+    fn effective_url_with_wait() {
+        let config = DiscordConfig::new("https://discord.com/api/webhooks/123/abc").with_wait(true);
+        let provider = DiscordProvider::new(config);
+        assert_eq!(
+            provider.effective_url(),
+            "https://discord.com/api/webhooks/123/abc?wait=true"
+        );
+    }
+}

--- a/crates/integrations/discord/src/types.rs
+++ b/crates/integrations/discord/src/types.rs
@@ -1,0 +1,150 @@
+use serde::{Deserialize, Serialize};
+
+/// Request body for a Discord webhook execution.
+#[derive(Debug, Clone, Serialize)]
+pub struct DiscordWebhookRequest {
+    /// Message text content. At least one of `content` or `embeds` is required.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+
+    /// Override the webhook's default username.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+
+    /// Override the webhook's default avatar URL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avatar_url: Option<String>,
+
+    /// Whether the message should be read aloud via TTS.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tts: Option<bool>,
+
+    /// Rich embed objects. Up to 10 embeds per message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub embeds: Option<Vec<DiscordEmbed>>,
+}
+
+/// A Discord embed object for rich message formatting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscordEmbed {
+    /// Embed title.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+
+    /// Embed description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Embed color as a decimal integer (e.g., `16711680` for red).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<u32>,
+
+    /// Embed fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields: Option<Vec<DiscordEmbedField>>,
+
+    /// Footer text.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub footer: Option<DiscordEmbedFooter>,
+
+    /// ISO 8601 timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+}
+
+/// A field within a Discord embed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscordEmbedField {
+    /// Field name.
+    pub name: String,
+    /// Field value.
+    pub value: String,
+    /// Whether this field should be displayed inline.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inline: Option<bool>,
+}
+
+/// Footer for a Discord embed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscordEmbedFooter {
+    /// Footer text.
+    pub text: String,
+}
+
+/// Response from a Discord webhook execution (only returned when `?wait=true`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct DiscordWebhookResponse {
+    /// Message ID.
+    pub id: Option<String>,
+    /// Channel ID.
+    pub channel_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn webhook_request_serializes_content_only() {
+        let req = DiscordWebhookRequest {
+            content: Some("Hello!".into()),
+            username: None,
+            avatar_url: None,
+            tts: None,
+            embeds: None,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["content"], "Hello!");
+        assert!(json.get("username").is_none());
+        assert!(json.get("embeds").is_none());
+    }
+
+    #[test]
+    fn webhook_request_serializes_with_embeds() {
+        let embed = DiscordEmbed {
+            title: Some("Alert".into()),
+            description: Some("Something happened".into()),
+            color: Some(16_711_680),
+            fields: Some(vec![DiscordEmbedField {
+                name: "Status".into(),
+                value: "Critical".into(),
+                inline: Some(true),
+            }]),
+            footer: Some(DiscordEmbedFooter {
+                text: "Acteon".into(),
+            }),
+            timestamp: None,
+        };
+
+        let req = DiscordWebhookRequest {
+            content: None,
+            username: Some("Acteon Bot".into()),
+            avatar_url: None,
+            tts: None,
+            embeds: Some(vec![embed]),
+        };
+
+        let json = serde_json::to_value(&req).unwrap();
+        assert!(json.get("content").is_none());
+        assert_eq!(json["username"], "Acteon Bot");
+        assert_eq!(json["embeds"][0]["title"], "Alert");
+        assert_eq!(json["embeds"][0]["color"], 16_711_680);
+        assert_eq!(json["embeds"][0]["fields"][0]["name"], "Status");
+    }
+
+    #[test]
+    fn webhook_response_deserializes() {
+        let json = r#"{"id":"12345","channel_id":"67890"}"#;
+        let resp: DiscordWebhookResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.id.as_deref(), Some("12345"));
+        assert_eq!(resp.channel_id.as_deref(), Some("67890"));
+    }
+
+    #[test]
+    fn embed_deserializes() {
+        let json = r#"{"title":"Test","description":"Desc","color":255}"#;
+        let embed: DiscordEmbed = serde_json::from_str(json).unwrap();
+        assert_eq!(embed.title.as_deref(), Some("Test"));
+        assert_eq!(embed.color, Some(255));
+    }
+}

--- a/crates/integrations/slack/src/config.rs
+++ b/crates/integrations/slack/src/config.rs
@@ -1,5 +1,5 @@
 /// Configuration for the Slack provider.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SlackConfig {
     /// Bot or user OAuth token used to authenticate API requests.
     pub token: String,
@@ -11,6 +11,16 @@ pub struct SlackConfig {
     /// Base URL for the Slack Web API. Override this for testing against a
     /// mock server.
     pub api_base_url: String,
+}
+
+impl std::fmt::Debug for SlackConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SlackConfig")
+            .field("token", &"[REDACTED]")
+            .field("default_channel", &self.default_channel)
+            .field("api_base_url", &self.api_base_url)
+            .finish()
+    }
 }
 
 impl SlackConfig {
@@ -62,5 +72,16 @@ mod tests {
     fn with_custom_api_base_url() {
         let config = SlackConfig::new("xoxb-token").with_api_base_url("http://localhost:9999/api");
         assert_eq!(config.api_base_url, "http://localhost:9999/api");
+    }
+
+    #[test]
+    fn debug_redacts_token() {
+        let config = SlackConfig::new("xoxb-test-placeholder-value");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("[REDACTED]"), "token must be redacted");
+        assert!(
+            !debug.contains("xoxb-test-placeholder-value"),
+            "token must not appear in debug output"
+        );
     }
 }

--- a/crates/integrations/teams/Cargo.toml
+++ b/crates/integrations/teams/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "acteon-teams"
+description = "Microsoft Teams provider for Acteon — posts messages via incoming webhooks"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+
+[dependencies]
+acteon-core = { workspace = true }
+acteon-provider = { workspace = true, features = ["trace-context"] }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/integrations/teams/src/config.rs
+++ b/crates/integrations/teams/src/config.rs
@@ -1,0 +1,46 @@
+/// Configuration for the Microsoft Teams provider.
+#[derive(Clone)]
+pub struct TeamsConfig {
+    /// Incoming webhook URL. The URL itself serves as the authentication
+    /// credential.
+    pub webhook_url: String,
+}
+
+impl std::fmt::Debug for TeamsConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TeamsConfig")
+            .field("webhook_url", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl TeamsConfig {
+    /// Create a new configuration with the given webhook URL.
+    pub fn new(webhook_url: impl Into<String>) -> Self {
+        Self {
+            webhook_url: webhook_url.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_config() {
+        let config = TeamsConfig::new("https://outlook.office.com/webhook/abc");
+        assert_eq!(config.webhook_url, "https://outlook.office.com/webhook/abc");
+    }
+
+    #[test]
+    fn debug_redacts_webhook_url() {
+        let config = TeamsConfig::new("https://outlook.office.com/webhook/test-placeholder-path");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("[REDACTED]"), "webhook_url must be redacted");
+        assert!(
+            !debug.contains("test-placeholder-path"),
+            "webhook_url must not appear in debug output"
+        );
+    }
+}

--- a/crates/integrations/teams/src/error.rs
+++ b/crates/integrations/teams/src/error.rs
@@ -1,0 +1,69 @@
+use acteon_provider::ProviderError;
+use thiserror::Error;
+
+/// Errors specific to the Microsoft Teams provider.
+///
+/// These are internal errors that get converted into [`ProviderError`] at the
+/// public API boundary.
+#[derive(Debug, Error)]
+pub enum TeamsError {
+    /// An HTTP-level transport error occurred.
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// The Teams webhook returned an error response.
+    #[error("Teams webhook error: {0}")]
+    Api(String),
+
+    /// The action payload is missing required fields or has invalid structure.
+    #[error("invalid payload: {0}")]
+    InvalidPayload(String),
+
+    /// The provider received an HTTP 429 (Too Many Requests) response.
+    #[error("rate limited by Teams")]
+    RateLimited,
+}
+
+impl From<TeamsError> for ProviderError {
+    fn from(err: TeamsError) -> Self {
+        match err {
+            TeamsError::Http(e) => ProviderError::Connection(e.to_string()),
+            TeamsError::Api(msg) => ProviderError::ExecutionFailed(msg),
+            TeamsError::InvalidPayload(msg) => ProviderError::Serialization(msg),
+            TeamsError::RateLimited => ProviderError::RateLimited,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limited_maps_to_retryable() {
+        let provider_err: ProviderError = TeamsError::RateLimited.into();
+        assert!(provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::RateLimited));
+    }
+
+    #[test]
+    fn api_error_maps_to_non_retryable() {
+        let provider_err: ProviderError = TeamsError::Api("webhook returned error".into()).into();
+        assert!(!provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn invalid_payload_maps_to_serialization() {
+        let provider_err: ProviderError =
+            TeamsError::InvalidPayload("missing 'text' field".into()).into();
+        assert!(!provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::Serialization(_)));
+    }
+
+    #[test]
+    fn error_display() {
+        let err = TeamsError::Api("bad request".into());
+        assert_eq!(err.to_string(), "Teams webhook error: bad request");
+    }
+}

--- a/crates/integrations/teams/src/lib.rs
+++ b/crates/integrations/teams/src/lib.rs
@@ -1,0 +1,24 @@
+//! Microsoft Teams provider for the Acteon notification gateway.
+//!
+//! This crate implements the [`Provider`](acteon_provider::Provider) trait,
+//! enabling Acteon to deliver messages through
+//! [Microsoft Teams incoming webhooks](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook).
+//!
+//! # Quick start
+//!
+//! ```rust,no_run
+//! use acteon_teams::{TeamsConfig, TeamsProvider};
+//!
+//! let config = TeamsConfig::new("https://outlook.office.com/webhook/...");
+//! let provider = TeamsProvider::new(config);
+//! ```
+
+pub mod config;
+pub mod error;
+pub mod provider;
+pub mod types;
+
+pub use config::TeamsConfig;
+pub use error::TeamsError;
+pub use provider::TeamsProvider;
+pub use types::TeamsMessageCard;

--- a/crates/integrations/teams/src/provider.rs
+++ b/crates/integrations/teams/src/provider.rs
@@ -1,0 +1,357 @@
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::{Provider, ProviderError};
+use reqwest::Client;
+use serde::Deserialize;
+use tracing::{debug, instrument, warn};
+
+use crate::config::TeamsConfig;
+use crate::error::TeamsError;
+use crate::types::TeamsMessageCard;
+
+/// Microsoft Teams provider that sends messages via incoming webhooks.
+///
+/// Implements the [`Provider`] trait so it can be registered in the provider
+/// registry and used by the action executor.
+pub struct TeamsProvider {
+    config: TeamsConfig,
+    client: Client,
+}
+
+/// Fields extracted from an action payload for a Teams message.
+#[derive(Debug, Deserialize)]
+struct MessagePayload {
+    text: Option<String>,
+    title: Option<String>,
+    summary: Option<String>,
+    theme_color: Option<String>,
+    adaptive_card: Option<serde_json::Value>,
+}
+
+impl TeamsProvider {
+    /// Create a new Teams provider with the given configuration.
+    pub fn new(config: TeamsConfig) -> Self {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("failed to build HTTP client");
+        Self { config, client }
+    }
+
+    /// Create a new Teams provider with a custom HTTP client.
+    pub fn with_client(config: TeamsConfig, client: Client) -> Self {
+        Self { config, client }
+    }
+
+    /// Build a JSON body for the webhook request.
+    fn build_body(payload: &MessagePayload) -> Result<serde_json::Value, TeamsError> {
+        if let Some(ref card) = payload.adaptive_card {
+            // Wrap the adaptive card in the Teams attachment envelope.
+            return Ok(serde_json::json!({
+                "type": "message",
+                "attachments": [{
+                    "contentType": "application/vnd.microsoft.card.adaptive",
+                    "content": card
+                }]
+            }));
+        }
+
+        if let Some(ref text) = payload.text {
+            let mut card = TeamsMessageCard::new(text);
+            if let Some(ref title) = payload.title {
+                card = card.with_title(title);
+            }
+            if let Some(ref summary) = payload.summary {
+                card = card.with_summary(summary);
+            }
+            if let Some(ref color) = payload.theme_color {
+                card = card.with_theme_color(color);
+            }
+            return serde_json::to_value(&card)
+                .map_err(|e| TeamsError::InvalidPayload(format!("failed to serialize card: {e}")));
+        }
+
+        Err(TeamsError::InvalidPayload(
+            "payload must contain at least one of 'text' or 'adaptive_card'".into(),
+        ))
+    }
+}
+
+impl Provider for TeamsProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "teams"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "teams"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        let payload: MessagePayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| TeamsError::InvalidPayload(format!("failed to parse payload: {e}")))?;
+
+        let body = Self::build_body(&payload)?;
+
+        debug!("posting message to Teams webhook");
+
+        let response = acteon_provider::inject_trace_context(
+            self.client.post(&self.config.webhook_url).json(&body),
+        )
+        .send()
+        .await
+        .map_err(TeamsError::Http)?;
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            warn!("Teams webhook rate limit hit");
+            return Err(TeamsError::RateLimited.into());
+        }
+
+        if !status.is_success() {
+            let response_body = response.text().await.unwrap_or_default();
+            return Err(TeamsError::Api(format!("HTTP {status}: {response_body}")).into());
+        }
+
+        // Teams returns literal "1" with HTTP 200 on success (not JSON).
+        let response_text = response.text().await.unwrap_or_default();
+
+        let response_body = serde_json::json!({
+            "ok": true,
+            "response": response_text,
+        });
+
+        Ok(ProviderResponse::success(response_body))
+    }
+
+    #[instrument(skip(self), fields(provider = "teams"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        debug!("performing Teams health check via webhook ping");
+
+        // Teams webhooks don't have a dedicated health endpoint. We send a
+        // minimal JSON payload — any HTTP response from the host means the
+        // webhook URL is reachable.
+        let response = self
+            .client
+            .post(&self.config.webhook_url)
+            .json(&serde_json::json!({ "text": "health check" }))
+            .send()
+            .await
+            .map_err(|e| ProviderError::Connection(e.to_string()))?;
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(ProviderError::RateLimited);
+        }
+
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(ProviderError::Connection(format!("HTTP {status}: {body}")));
+        }
+
+        debug!("Teams health check passed");
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use acteon_core::Action;
+    use acteon_provider::{Provider, ProviderError};
+
+    use super::*;
+    use crate::config::TeamsConfig;
+
+    struct MockTeamsServer {
+        listener: tokio::net::TcpListener,
+        base_url: String,
+    }
+
+    impl MockTeamsServer {
+        async fn start() -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("failed to bind mock server");
+            let port = listener.local_addr().unwrap().port();
+            let base_url = format!("http://127.0.0.1:{port}");
+            Self { listener, base_url }
+        }
+
+        async fn respond_once(self, status_code: u16, body: &str) {
+            let body = body.to_owned();
+            let (mut stream, _) = self.listener.accept().await.unwrap();
+
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+            let mut buf = vec![0u8; 8192];
+            let _ = stream.read(&mut buf).await.unwrap();
+
+            let response = format!(
+                "HTTP/1.1 {status_code} OK\r\n\
+                 Content-Type: text/plain\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 {body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+        }
+
+        async fn respond_rate_limited(self) {
+            self.respond_once(429, "rate limited").await;
+        }
+    }
+
+    fn make_action(payload: serde_json::Value) -> Action {
+        Action::new(
+            "notifications",
+            "tenant-1",
+            "teams",
+            "send_message",
+            payload,
+        )
+    }
+
+    #[test]
+    fn provider_name() {
+        let config = TeamsConfig::new("https://example.com/webhook");
+        let provider = TeamsProvider::new(config);
+        assert_eq!(provider.name(), "teams");
+    }
+
+    #[tokio::test]
+    async fn execute_success_with_text() {
+        let server = MockTeamsServer::start().await;
+        let config = TeamsConfig::new(&server.base_url);
+        let provider = TeamsProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "text": "Hello from Acteon!",
+            "title": "Alert",
+            "theme_color": "FF0000"
+        }));
+
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(200, "1").await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        let response = result.expect("execute should succeed");
+        assert_eq!(response.status, acteon_core::ResponseStatus::Success);
+        assert_eq!(response.body["ok"], true);
+    }
+
+    #[tokio::test]
+    async fn execute_success_with_adaptive_card() {
+        let server = MockTeamsServer::start().await;
+        let config = TeamsConfig::new(&server.base_url);
+        let provider = TeamsProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "adaptive_card": {
+                "type": "AdaptiveCard",
+                "version": "1.4",
+                "body": [{"type": "TextBlock", "text": "Hello!"}]
+            }
+        }));
+
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(200, "1").await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn execute_missing_text_and_card() {
+        let config = TeamsConfig::new("http://localhost:1");
+        let provider = TeamsProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "title": "No content"
+        }));
+
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_rate_limited() {
+        let server = MockTeamsServer::start().await;
+        let config = TeamsConfig::new(&server.base_url);
+        let provider = TeamsProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "text": "Hello!"
+        }));
+
+        let server_handle = tokio::spawn(async move {
+            server.respond_rate_limited().await;
+        });
+
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+
+        assert!(matches!(err, ProviderError::RateLimited));
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_api_error() {
+        let server = MockTeamsServer::start().await;
+        let config = TeamsConfig::new(&server.base_url);
+        let provider = TeamsProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "text": "Hello!"
+        }));
+
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(400, "Bad Request").await;
+        });
+
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+
+        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn health_check_success() {
+        let server = MockTeamsServer::start().await;
+        let config = TeamsConfig::new(&server.base_url);
+        let provider = TeamsProvider::new(config);
+
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(200, "1").await;
+        });
+
+        let result = provider.health_check().await;
+        server_handle.await.unwrap();
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn health_check_rate_limited() {
+        let server = MockTeamsServer::start().await;
+        let config = TeamsConfig::new(&server.base_url);
+        let provider = TeamsProvider::new(config);
+
+        let server_handle = tokio::spawn(async move {
+            server.respond_rate_limited().await;
+        });
+
+        let err = provider.health_check().await.unwrap_err();
+        server_handle.await.unwrap();
+
+        assert!(matches!(err, ProviderError::RateLimited));
+    }
+}

--- a/crates/integrations/teams/src/types.rs
+++ b/crates/integrations/teams/src/types.rs
@@ -1,0 +1,95 @@
+use serde::Serialize;
+
+/// A simple `MessageCard` for Teams incoming webhooks.
+///
+/// This follows the [Office 365 MessageCard](https://learn.microsoft.com/en-us/outlook/actionable-messages/message-card-reference)
+/// format which is the simplest way to send formatted messages.
+#[derive(Debug, Clone, Serialize)]
+pub struct TeamsMessageCard {
+    /// Card type — always `"MessageCard"`.
+    #[serde(rename = "@type")]
+    pub card_type: String,
+
+    /// Card context — always the Office 365 connector schema.
+    #[serde(rename = "@context")]
+    pub context: String,
+
+    /// Card title.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+
+    /// Card body text (supports basic markdown).
+    pub text: String,
+
+    /// Summary text (displayed in notifications).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    /// Theme color as a hex string (e.g., `"FF0000"` for red).
+    #[serde(rename = "themeColor", skip_serializing_if = "Option::is_none")]
+    pub theme_color: Option<String>,
+}
+
+impl TeamsMessageCard {
+    /// Create a new message card with the given body text.
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            card_type: "MessageCard".to_owned(),
+            context: "https://schema.org/extensions".to_owned(),
+            title: None,
+            text: text.into(),
+            summary: None,
+            theme_color: None,
+        }
+    }
+
+    /// Set the card title.
+    #[must_use]
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Set the summary text.
+    #[must_use]
+    pub fn with_summary(mut self, summary: impl Into<String>) -> Self {
+        self.summary = Some(summary.into());
+        self
+    }
+
+    /// Set the theme color.
+    #[must_use]
+    pub fn with_theme_color(mut self, color: impl Into<String>) -> Self {
+        self.theme_color = Some(color.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_card_serializes_correctly() {
+        let card = TeamsMessageCard::new("Hello from Acteon!")
+            .with_title("Alert")
+            .with_theme_color("FF0000");
+
+        let json = serde_json::to_value(&card).unwrap();
+        assert_eq!(json["@type"], "MessageCard");
+        assert_eq!(json["@context"], "https://schema.org/extensions");
+        assert_eq!(json["title"], "Alert");
+        assert_eq!(json["text"], "Hello from Acteon!");
+        assert_eq!(json["themeColor"], "FF0000");
+        assert!(json.get("summary").is_none());
+    }
+
+    #[test]
+    fn message_card_minimal() {
+        let card = TeamsMessageCard::new("Just text");
+        let json = serde_json::to_value(&card).unwrap();
+        assert_eq!(json["text"], "Just text");
+        assert!(json.get("title").is_none());
+        assert!(json.get("themeColor").is_none());
+    }
+}

--- a/crates/integrations/twilio/Cargo.toml
+++ b/crates/integrations/twilio/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "acteon-twilio"
+description = "Twilio SMS provider for Acteon — sends messages via the Twilio REST API"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+
+[dependencies]
+acteon-core = { workspace = true }
+acteon-provider = { workspace = true, features = ["trace-context"] }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+serde_urlencoded = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/integrations/twilio/src/config.rs
+++ b/crates/integrations/twilio/src/config.rs
@@ -1,0 +1,97 @@
+/// Configuration for the Twilio provider.
+#[derive(Clone)]
+pub struct TwilioConfig {
+    /// Twilio Account SID used to authenticate API requests.
+    pub account_sid: String,
+
+    /// Twilio Auth Token used for HTTP Basic authentication.
+    pub auth_token: String,
+
+    /// Default "From" phone number (E.164 format) when none is specified in
+    /// the action payload.
+    pub from_number: Option<String>,
+
+    /// Base URL for the Twilio REST API. Override this for testing against a
+    /// mock server.
+    pub api_base_url: String,
+}
+
+impl std::fmt::Debug for TwilioConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TwilioConfig")
+            .field("account_sid", &self.account_sid)
+            .field("auth_token", &"[REDACTED]")
+            .field("from_number", &self.from_number)
+            .field("api_base_url", &self.api_base_url)
+            .finish()
+    }
+}
+
+impl TwilioConfig {
+    /// Create a new configuration with the given Account SID and Auth Token.
+    ///
+    /// Uses the default Twilio API base URL (`https://api.twilio.com`).
+    pub fn new(account_sid: impl Into<String>, auth_token: impl Into<String>) -> Self {
+        Self {
+            account_sid: account_sid.into(),
+            auth_token: auth_token.into(),
+            from_number: None,
+            api_base_url: "https://api.twilio.com".to_owned(),
+        }
+    }
+
+    /// Set the default "From" phone number.
+    #[must_use]
+    pub fn with_from_number(mut self, number: impl Into<String>) -> Self {
+        self.from_number = Some(number.into());
+        self
+    }
+
+    /// Override the API base URL (useful for testing).
+    #[must_use]
+    pub fn with_api_base_url(mut self, url: impl Into<String>) -> Self {
+        self.api_base_url = url.into();
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_api_base_url() {
+        let config = TwilioConfig::new("AC123", "token");
+        assert_eq!(config.api_base_url, "https://api.twilio.com");
+        assert_eq!(config.account_sid, "AC123");
+        assert_eq!(config.auth_token, "token");
+        assert!(config.from_number.is_none());
+    }
+
+    #[test]
+    fn with_from_number() {
+        let config = TwilioConfig::new("AC123", "token").with_from_number("+15551234567");
+        assert_eq!(config.from_number.as_deref(), Some("+15551234567"));
+    }
+
+    #[test]
+    fn with_custom_api_base_url() {
+        let config = TwilioConfig::new("AC123", "token").with_api_base_url("http://localhost:9999");
+        assert_eq!(config.api_base_url, "http://localhost:9999");
+    }
+
+    #[test]
+    fn debug_redacts_auth_token() {
+        let config = TwilioConfig::new("AC123", "test-placeholder-value");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("[REDACTED]"), "auth_token must be redacted");
+        assert!(
+            !debug.contains("test-placeholder-value"),
+            "auth_token must not appear in debug output"
+        );
+        assert!(
+            debug.contains("AC123"),
+            "account_sid should still be visible"
+        );
+    }
+}

--- a/crates/integrations/twilio/src/error.rs
+++ b/crates/integrations/twilio/src/error.rs
@@ -1,0 +1,69 @@
+use acteon_provider::ProviderError;
+use thiserror::Error;
+
+/// Errors specific to the Twilio provider.
+///
+/// These are internal errors that get converted into [`ProviderError`] at the
+/// public API boundary.
+#[derive(Debug, Error)]
+pub enum TwilioError {
+    /// An HTTP-level transport error occurred.
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// The Twilio API returned an error response.
+    #[error("Twilio API error: {0}")]
+    Api(String),
+
+    /// The action payload is missing required fields or has invalid structure.
+    #[error("invalid payload: {0}")]
+    InvalidPayload(String),
+
+    /// The provider received an HTTP 429 (Too Many Requests) response.
+    #[error("rate limited by Twilio")]
+    RateLimited,
+}
+
+impl From<TwilioError> for ProviderError {
+    fn from(err: TwilioError) -> Self {
+        match err {
+            TwilioError::Http(e) => ProviderError::Connection(e.to_string()),
+            TwilioError::Api(msg) => ProviderError::ExecutionFailed(msg),
+            TwilioError::InvalidPayload(msg) => ProviderError::Serialization(msg),
+            TwilioError::RateLimited => ProviderError::RateLimited,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limited_maps_to_retryable() {
+        let provider_err: ProviderError = TwilioError::RateLimited.into();
+        assert!(provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::RateLimited));
+    }
+
+    #[test]
+    fn api_error_maps_to_non_retryable() {
+        let provider_err: ProviderError = TwilioError::Api("invalid_auth".into()).into();
+        assert!(!provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn invalid_payload_maps_to_serialization() {
+        let provider_err: ProviderError =
+            TwilioError::InvalidPayload("missing 'to' field".into()).into();
+        assert!(!provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::Serialization(_)));
+    }
+
+    #[test]
+    fn error_display() {
+        let err = TwilioError::Api("21211".into());
+        assert_eq!(err.to_string(), "Twilio API error: 21211");
+    }
+}

--- a/crates/integrations/twilio/src/lib.rs
+++ b/crates/integrations/twilio/src/lib.rs
@@ -1,0 +1,25 @@
+//! Twilio SMS provider for the Acteon notification gateway.
+//!
+//! This crate implements the [`Provider`](acteon_provider::Provider) trait,
+//! enabling Acteon to deliver SMS messages through the
+//! [Twilio REST API](https://www.twilio.com/docs/sms/api/message-resource).
+//!
+//! # Quick start
+//!
+//! ```rust,no_run
+//! use acteon_twilio::{TwilioConfig, TwilioProvider};
+//!
+//! let config = TwilioConfig::new("ACXXXXXXXX", "auth_token")
+//!     .with_from_number("+15551234567");
+//! let provider = TwilioProvider::new(config);
+//! ```
+
+pub mod config;
+pub mod error;
+pub mod provider;
+pub mod types;
+
+pub use config::TwilioConfig;
+pub use error::TwilioError;
+pub use provider::TwilioProvider;
+pub use types::{TwilioApiResponse, TwilioSendMessageRequest};

--- a/crates/integrations/twilio/src/provider.rs
+++ b/crates/integrations/twilio/src/provider.rs
@@ -1,0 +1,430 @@
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::{Provider, ProviderError};
+use reqwest::Client;
+use serde::Deserialize;
+use tracing::{debug, instrument, warn};
+
+use crate::config::TwilioConfig;
+use crate::error::TwilioError;
+use crate::types::{TwilioApiResponse, TwilioSendMessageRequest};
+
+/// Twilio provider that sends SMS messages via the Twilio REST API.
+///
+/// Implements the [`Provider`] trait so it can be registered in the provider
+/// registry and used by the action executor.
+pub struct TwilioProvider {
+    config: TwilioConfig,
+    client: Client,
+}
+
+/// Fields extracted from an action payload for sending an SMS.
+#[derive(Debug, Deserialize)]
+struct MessagePayload {
+    to: Option<String>,
+    body: Option<String>,
+    from: Option<String>,
+    media_url: Option<String>,
+}
+
+impl TwilioProvider {
+    /// Create a new Twilio provider with the given configuration.
+    ///
+    /// Uses a default `reqwest::Client` with reasonable timeouts.
+    pub fn new(config: TwilioConfig) -> Self {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("failed to build HTTP client");
+        Self { config, client }
+    }
+
+    /// Create a new Twilio provider with a custom HTTP client.
+    ///
+    /// Useful for testing or for sharing a connection pool across providers.
+    pub fn with_client(config: TwilioConfig, client: Client) -> Self {
+        Self { config, client }
+    }
+
+    /// Resolve the "From" phone number from the action payload, falling back to
+    /// the configured default.
+    fn resolve_from(&self, payload_from: Option<&str>) -> Result<String, TwilioError> {
+        payload_from
+            .map(String::from)
+            .or_else(|| self.config.from_number.clone())
+            .ok_or_else(|| {
+                TwilioError::InvalidPayload(
+                    "no 'from' specified in payload and no default from_number configured".into(),
+                )
+            })
+    }
+
+    /// Build the Messages API URL for this account.
+    fn messages_url(&self) -> String {
+        format!(
+            "{}/2010-04-01/Accounts/{}/Messages.json",
+            self.config.api_base_url, self.config.account_sid
+        )
+    }
+
+    /// Build the Account info URL (used for health checks).
+    fn account_url(&self) -> String {
+        format!(
+            "{}/2010-04-01/Accounts/{}.json",
+            self.config.api_base_url, self.config.account_sid
+        )
+    }
+
+    /// Send an SMS message via the Twilio REST API.
+    async fn send_message(
+        &self,
+        request: &TwilioSendMessageRequest,
+    ) -> Result<TwilioApiResponse, TwilioError> {
+        let url = self.messages_url();
+
+        debug!(to = %request.to, "sending SMS via Twilio");
+
+        let response = acteon_provider::inject_trace_context(
+            self.client
+                .post(&url)
+                .basic_auth(&self.config.account_sid, Some(&self.config.auth_token))
+                .form(request),
+        )
+        .send()
+        .await?;
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            warn!("Twilio API rate limit hit");
+            return Err(TwilioError::RateLimited);
+        }
+
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(TwilioError::Api(format!("HTTP {status}: {body}")));
+        }
+
+        let api_response: TwilioApiResponse = response.json().await?;
+
+        if let Some(code) = api_response.error_code {
+            let msg = api_response
+                .error_message
+                .unwrap_or_else(|| format!("error code {code}"));
+            return Err(TwilioError::Api(msg));
+        }
+
+        Ok(api_response)
+    }
+}
+
+impl Provider for TwilioProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "twilio"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "twilio"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        let payload: MessagePayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| TwilioError::InvalidPayload(format!("failed to parse payload: {e}")))?;
+
+        let to = payload.to.ok_or_else(|| {
+            TwilioError::InvalidPayload("payload must contain a 'to' phone number".into())
+        })?;
+
+        let body = payload.body.ok_or_else(|| {
+            TwilioError::InvalidPayload("payload must contain a 'body' message text".into())
+        })?;
+
+        let from = self.resolve_from(payload.from.as_deref())?;
+
+        let request = TwilioSendMessageRequest {
+            to,
+            from,
+            body,
+            media_url: payload.media_url,
+        };
+
+        let api_response = self.send_message(&request).await?;
+
+        let response_body = serde_json::json!({
+            "sid": api_response.sid,
+            "status": api_response.status,
+        });
+
+        Ok(ProviderResponse::success(response_body))
+    }
+
+    #[instrument(skip(self), fields(provider = "twilio"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        let url = self.account_url();
+
+        debug!("performing Twilio health check via account lookup");
+
+        let response = self
+            .client
+            .get(&url)
+            .basic_auth(&self.config.account_sid, Some(&self.config.auth_token))
+            .send()
+            .await
+            .map_err(|e| ProviderError::Connection(e.to_string()))?;
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(ProviderError::RateLimited);
+        }
+
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(ProviderError::Connection(format!("HTTP {status}: {body}")));
+        }
+
+        debug!("Twilio health check passed");
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use acteon_core::Action;
+    use acteon_provider::{Provider, ProviderError};
+
+    use super::*;
+    use crate::config::TwilioConfig;
+
+    /// A minimal mock HTTP server built on tokio that returns canned responses.
+    struct MockTwilioServer {
+        listener: tokio::net::TcpListener,
+        base_url: String,
+    }
+
+    impl MockTwilioServer {
+        async fn start() -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("failed to bind mock server");
+            let port = listener.local_addr().unwrap().port();
+            let base_url = format!("http://127.0.0.1:{port}");
+            Self { listener, base_url }
+        }
+
+        async fn respond_once(self, status_code: u16, body: &str) {
+            let body = body.to_owned();
+            let (mut stream, _) = self.listener.accept().await.unwrap();
+
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+            let mut buf = vec![0u8; 8192];
+            let _ = stream.read(&mut buf).await.unwrap();
+
+            let response = format!(
+                "HTTP/1.1 {status_code} OK\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 {body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+        }
+
+        async fn respond_rate_limited(self) {
+            let body = r#"{"error_code":429,"error_message":"rate limited"}"#;
+            self.respond_once(429, body).await;
+        }
+    }
+
+    fn make_action(payload: serde_json::Value) -> Action {
+        Action::new("notifications", "tenant-1", "twilio", "send_sms", payload)
+    }
+
+    #[test]
+    fn provider_name() {
+        let config = TwilioConfig::new("AC123", "token");
+        let provider = TwilioProvider::new(config);
+        assert_eq!(provider.name(), "twilio");
+    }
+
+    #[tokio::test]
+    async fn execute_success() {
+        let server = MockTwilioServer::start().await;
+        let config = TwilioConfig::new("AC123", "token")
+            .with_api_base_url(&server.base_url)
+            .with_from_number("+15551234567");
+        let provider = TwilioProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "to": "+15559876543",
+            "body": "Hello from Acteon!"
+        }));
+
+        let response_body =
+            r#"{"sid":"SM123","status":"queued","error_code":null,"error_message":null}"#;
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(200, response_body).await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        let response = result.expect("execute should succeed");
+        assert_eq!(response.status, acteon_core::ResponseStatus::Success);
+        assert_eq!(response.body["sid"], "SM123");
+        assert_eq!(response.body["status"], "queued");
+    }
+
+    #[tokio::test]
+    async fn execute_with_explicit_from() {
+        let server = MockTwilioServer::start().await;
+        let config = TwilioConfig::new("AC123", "token").with_api_base_url(&server.base_url);
+        let provider = TwilioProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "to": "+15559876543",
+            "from": "+15550001111",
+            "body": "Hello!"
+        }));
+
+        let response_body =
+            r#"{"sid":"SM456","status":"queued","error_code":null,"error_message":null}"#;
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(200, response_body).await;
+        });
+
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn execute_missing_to_field() {
+        let config = TwilioConfig::new("AC123", "token").with_api_base_url("http://localhost:1");
+        let provider = TwilioProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "body": "Hello!"
+        }));
+
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_missing_body_field() {
+        let config = TwilioConfig::new("AC123", "token").with_api_base_url("http://localhost:1");
+        let provider = TwilioProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "to": "+15559876543",
+            "from": "+15551234567"
+        }));
+
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_missing_from_and_no_default() {
+        let config = TwilioConfig::new("AC123", "token").with_api_base_url("http://localhost:1");
+        let provider = TwilioProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "to": "+15559876543",
+            "body": "Hello!"
+        }));
+
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_rate_limited_is_retryable() {
+        let server = MockTwilioServer::start().await;
+        let config = TwilioConfig::new("AC123", "token")
+            .with_api_base_url(&server.base_url)
+            .with_from_number("+15551234567");
+        let provider = TwilioProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "to": "+15559876543",
+            "body": "Hello!"
+        }));
+
+        let server_handle = tokio::spawn(async move {
+            server.respond_rate_limited().await;
+        });
+
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+
+        assert!(matches!(err, ProviderError::RateLimited));
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_api_error_not_retryable() {
+        let server = MockTwilioServer::start().await;
+        let config = TwilioConfig::new("AC123", "bad-token")
+            .with_api_base_url(&server.base_url)
+            .with_from_number("+15551234567");
+        let provider = TwilioProvider::new(config);
+
+        let action = make_action(serde_json::json!({
+            "to": "+15559876543",
+            "body": "Hello!"
+        }));
+
+        let response_body = r#"{"sid":null,"status":null,"error_code":20003,"error_message":"Authentication Error"}"#;
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(200, response_body).await;
+        });
+
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+
+        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn health_check_success() {
+        let server = MockTwilioServer::start().await;
+        let config = TwilioConfig::new("AC123", "token").with_api_base_url(&server.base_url);
+        let provider = TwilioProvider::new(config);
+
+        let response_body = r#"{"sid":"AC123","friendly_name":"My Account","status":"active"}"#;
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(200, response_body).await;
+        });
+
+        let result = provider.health_check().await;
+        server_handle.await.unwrap();
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn health_check_rate_limited() {
+        let server = MockTwilioServer::start().await;
+        let config = TwilioConfig::new("AC123", "token").with_api_base_url(&server.base_url);
+        let provider = TwilioProvider::new(config);
+
+        let server_handle = tokio::spawn(async move {
+            server.respond_rate_limited().await;
+        });
+
+        let err = provider.health_check().await.unwrap_err();
+        server_handle.await.unwrap();
+
+        assert!(matches!(err, ProviderError::RateLimited));
+        assert!(err.is_retryable());
+    }
+}

--- a/crates/integrations/twilio/src/types.rs
+++ b/crates/integrations/twilio/src/types.rs
@@ -1,0 +1,91 @@
+use serde::{Deserialize, Serialize};
+
+/// Form-encoded request body for the Twilio Messages API.
+///
+/// Twilio expects `application/x-www-form-urlencoded` rather than JSON.
+#[derive(Debug, Clone, Serialize)]
+pub struct TwilioSendMessageRequest {
+    /// Destination phone number in E.164 format.
+    #[serde(rename = "To")]
+    pub to: String,
+
+    /// Sender phone number or messaging service SID.
+    #[serde(rename = "From")]
+    pub from: String,
+
+    /// Message body text.
+    #[serde(rename = "Body")]
+    pub body: String,
+
+    /// Optional media URL for MMS.
+    #[serde(rename = "MediaUrl", skip_serializing_if = "Option::is_none")]
+    pub media_url: Option<String>,
+}
+
+/// Response from the Twilio Messages API.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TwilioApiResponse {
+    /// Message SID (unique identifier).
+    pub sid: Option<String>,
+
+    /// Message status (e.g., `"queued"`, `"sent"`, `"delivered"`).
+    pub status: Option<String>,
+
+    /// Twilio error code (present on failure).
+    pub error_code: Option<i32>,
+
+    /// Twilio error message (present on failure).
+    pub error_message: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn send_message_request_serializes_form_encoded() {
+        let req = TwilioSendMessageRequest {
+            to: "+15559876543".into(),
+            from: "+15551234567".into(),
+            body: "Hello from Acteon!".into(),
+            media_url: None,
+        };
+        let encoded = serde_urlencoded::to_string(&req).unwrap();
+        assert!(encoded.contains("To=%2B15559876543"));
+        assert!(encoded.contains("From=%2B15551234567"));
+        assert!(encoded.contains("Body=Hello+from+Acteon%21"));
+        assert!(!encoded.contains("MediaUrl"));
+    }
+
+    #[test]
+    fn send_message_request_includes_media_url() {
+        let req = TwilioSendMessageRequest {
+            to: "+15559876543".into(),
+            from: "+15551234567".into(),
+            body: "Check this out".into(),
+            media_url: Some("https://example.com/image.jpg".into()),
+        };
+        let encoded = serde_urlencoded::to_string(&req).unwrap();
+        assert!(encoded.contains("MediaUrl="));
+    }
+
+    #[test]
+    fn api_response_deserializes_success() {
+        let json = r#"{"sid":"SM123","status":"queued","error_code":null,"error_message":null}"#;
+        let resp: TwilioApiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.sid.as_deref(), Some("SM123"));
+        assert_eq!(resp.status.as_deref(), Some("queued"));
+        assert!(resp.error_code.is_none());
+    }
+
+    #[test]
+    fn api_response_deserializes_error() {
+        let json = r#"{"sid":null,"status":null,"error_code":21211,"error_message":"Invalid 'To' Phone Number"}"#;
+        let resp: TwilioApiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.error_code, Some(21211));
+        assert_eq!(
+            resp.error_message.as_deref(),
+            Some("Invalid 'To' Phone Number")
+        );
+    }
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -39,6 +39,9 @@ acteon-state-clickhouse = { workspace = true, optional = true }
 acteon-rules = { workspace = true }
 acteon-rules-yaml = { workspace = true }
 acteon-provider = { workspace = true, features = ["webhook"] }
+acteon-twilio = { workspace = true }
+acteon-teams = { workspace = true }
+acteon-discord = { workspace = true }
 acteon-executor = { workspace = true }
 acteon-gateway = { workspace = true }
 acteon-llm = { workspace = true }

--- a/crates/simulation/examples/native_providers_simulation.rs
+++ b/crates/simulation/examples/native_providers_simulation.rs
@@ -1,0 +1,161 @@
+//! Simulation of the three native providers: Twilio, Teams, and Discord.
+//!
+//! Demonstrates dispatching actions with the correct payload shapes for each
+//! provider and validates that all dispatches succeed.
+//!
+//! Run with: cargo run -p acteon-simulation --example native_providers_simulation
+
+use acteon_core::{Action, ActionOutcome};
+use acteon_simulation::prelude::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("══════════════════════════════════════════════════════════════");
+    println!("       NATIVE PROVIDERS SIMULATION");
+    println!("══════════════════════════════════════════════════════════════\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("twilio")
+            .add_recording_provider("teams")
+            .add_recording_provider("discord")
+            .build(),
+    )
+    .await?;
+
+    println!("Started simulation cluster with 1 node");
+    println!("Registered providers: twilio, teams, discord\n");
+
+    let mut results: Vec<(&str, ActionOutcome)> = Vec::new();
+
+    // =========================================================================
+    // Twilio SMS
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  TWILIO SMS");
+    println!("------------------------------------------------------------------\n");
+
+    let twilio_action = Action::new(
+        "notifications",
+        "acme-corp",
+        "twilio",
+        "send_sms",
+        serde_json::json!({
+            "to": "+15559876543",
+            "body": "Server alert!",
+            "from": "+15551234567"
+        }),
+    );
+
+    println!("  Dispatching SMS to +15559876543...");
+    let outcome = harness.dispatch(&twilio_action).await?;
+    println!("  Action ID: {}", twilio_action.id);
+    println!("  Outcome:   {:?}", outcome);
+    println!(
+        "  Provider called: {} time(s)\n",
+        harness.provider("twilio").unwrap().call_count()
+    );
+    results.push(("twilio", outcome));
+
+    // =========================================================================
+    // Microsoft Teams
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  MICROSOFT TEAMS");
+    println!("------------------------------------------------------------------\n");
+
+    let teams_action = Action::new(
+        "notifications",
+        "acme-corp",
+        "teams",
+        "send_message",
+        serde_json::json!({
+            "text": "Deployment complete",
+            "title": "CI/CD",
+            "theme_color": "00FF00"
+        }),
+    );
+
+    println!("  Dispatching Teams message...");
+    let outcome = harness.dispatch(&teams_action).await?;
+    println!("  Action ID: {}", teams_action.id);
+    println!("  Outcome:   {:?}", outcome);
+    println!(
+        "  Provider called: {} time(s)\n",
+        harness.provider("teams").unwrap().call_count()
+    );
+    results.push(("teams", outcome));
+
+    // =========================================================================
+    // Discord
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  DISCORD");
+    println!("------------------------------------------------------------------\n");
+
+    let discord_action = Action::new(
+        "notifications",
+        "acme-corp",
+        "discord",
+        "send_message",
+        serde_json::json!({
+            "content": "Build passed!",
+            "embeds": [
+                {
+                    "title": "Build #42",
+                    "description": "All tests passed",
+                    "color": 65280
+                }
+            ]
+        }),
+    );
+
+    println!("  Dispatching Discord message with embed...");
+    let outcome = harness.dispatch(&discord_action).await?;
+    println!("  Action ID: {}", discord_action.id);
+    println!("  Outcome:   {:?}", outcome);
+    println!(
+        "  Provider called: {} time(s)\n",
+        harness.provider("discord").unwrap().call_count()
+    );
+    results.push(("discord", outcome));
+
+    // =========================================================================
+    // Summary
+    // =========================================================================
+    println!("══════════════════════════════════════════════════════════════");
+    println!("  SUMMARY");
+    println!("══════════════════════════════════════════════════════════════\n");
+
+    let mut all_passed = true;
+    for (name, outcome) in &results {
+        let passed = matches!(outcome, ActionOutcome::Executed(_));
+        let status = if passed { "PASS" } else { "FAIL" };
+        println!("  [{status}] {name}: {outcome:?}");
+        if !passed {
+            all_passed = false;
+        }
+    }
+
+    println!();
+    println!(
+        "  Total dispatched: {}  |  Twilio calls: {}  |  Teams calls: {}  |  Discord calls: {}",
+        results.len(),
+        harness.provider("twilio").unwrap().call_count(),
+        harness.provider("teams").unwrap().call_count(),
+        harness.provider("discord").unwrap().call_count(),
+    );
+
+    harness.teardown().await?;
+    println!("\n  Simulation cluster shut down");
+
+    if all_passed {
+        println!("\n  All providers dispatched successfully.");
+    } else {
+        println!("\n  Some providers failed. See details above.");
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/docs/acteon-design-document.md
+++ b/docs/acteon-design-document.md
@@ -13,7 +13,7 @@ github.com/penserai/acteon
 
 # **Executive Summary**
 
-Acteon is a distributed action gateway system built in Rust that executes actions across multiple providers (Slack, PagerDuty, Twilio, AWS SQS/SNS, LLM gateways, and more) with sophisticated control plane capabilities including deduplication, suppression, rerouting, and throttling.
+Acteon is a distributed action gateway system built in Rust that executes actions across multiple providers (Slack, PagerDuty, Twilio, Microsoft Teams, Discord, AWS SQS/SNS, LLM gateways, and more) with sophisticated control plane capabilities including deduplication, suppression, rerouting, and throttling.
 
 The system is designed with pluggable infrastructure at every layer: swappable state backends (Redis, DynamoDB, Zookeeper), a polyglot rule engine supporting multiple DSLs (CEL, Rego, Drools-like, YAML), and an extensible provider architecture.
 
@@ -509,14 +509,16 @@ pub trait Provider: Send \+ Sync {
 
 | Provider | Description | Status |
 | :---- | :---- | :---- |
-| Slack | Messages, reactions, channel management | Planned |
-| PagerDuty | Incidents, alerts, escalations | Planned |
-| Twilio | SMS, voice, WhatsApp | Planned |
+| Slack | Messages, reactions, channel management | Implemented |
+| PagerDuty | Incidents, alerts, escalations | Implemented |
+| Twilio | SMS, MMS | Implemented |
+| Microsoft Teams | Incoming webhooks (MessageCard, Adaptive Card) | Implemented |
+| Discord | Webhooks (content, rich embeds) | Implemented |
 | AWS SQS | Queue messaging | Planned |
 | AWS SNS | Pub/sub notifications | Planned |
 | LLM Gateway | OpenAI, Anthropic, local models | Planned |
-| Webhook | Generic HTTP callbacks | Planned |
-| Email (SMTP) | Transactional email | Planned |
+| Webhook | Generic HTTP callbacks | Implemented |
+| Email (SMTP) | Transactional email | Implemented |
 
 ## **Provider Registry**
 
@@ -612,9 +614,11 @@ engine.load\_directory(Path::new("./rules"))?;
 let gateway \= Acteon::builder()  
     .state(state)  
     .rules(engine)  
-    .provider(Slack::from\_env())  
-    .provider(PagerDuty::from\_env())  
-    .provider(Twilio::from\_env())  
+    .provider(Slack::from\_env())
+    .provider(PagerDuty::from\_env())
+    .provider(Twilio::from\_env())
+    .provider(Teams::from\_env())
+    .provider(Discord::from\_env())
     .build()  
     .await?;  
    

--- a/docs/architecture/native-providers.md
+++ b/docs/architecture/native-providers.md
@@ -1,0 +1,290 @@
+# Native Providers Architecture
+
+## Overview
+
+The Twilio, Microsoft Teams, and Discord providers are implemented as separate crates under `crates/integrations/` and follow a uniform architecture. Each crate contains four modules:
+
+```
+crates/integrations/{twilio,teams,discord}/src/
+  config.rs    -- Provider-specific configuration struct
+  error.rs     -- Provider-specific error enum + From<XxxError> for ProviderError
+  provider.rs  -- Provider trait implementation (execute + health_check)
+  types.rs     -- Request/response types (serialization structs)
+  lib.rs       -- Public re-exports
+```
+
+All three providers implement the `Provider` trait defined in `crates/provider/src/provider.rs`, which makes them compatible with the `DynProvider` blanket impl and the provider registry.
+
+---
+
+## 1. Provider Trait Implementation
+
+Each provider struct holds a configuration and a `reqwest::Client`:
+
+```rust
+pub struct TwilioProvider {
+    config: TwilioConfig,
+    client: Client,
+}
+
+impl Provider for TwilioProvider {
+    fn name(&self) -> &str { "twilio" }
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> { ... }
+    async fn health_check(&self) -> Result<(), ProviderError> { ... }
+}
+```
+
+The `Provider` trait is not object-safe (native `async fn`), but the blanket `DynProvider` impl enables `Arc<dyn DynProvider>` for dynamic dispatch in the registry.
+
+Each provider follows the same execution flow:
+
+1. Deserialize `action.payload` into a provider-specific `MessagePayload` struct
+2. Validate required fields (return `InvalidPayload` on failure)
+3. Build the outgoing HTTP request (provider-specific format)
+4. Inject trace context via `acteon_provider::inject_trace_context()`
+5. Send the HTTP request, check for rate limiting (HTTP 429)
+6. Parse the response and return `ProviderResponse::success(body)`
+
+---
+
+## 2. Error Taxonomy
+
+Each provider defines a local error enum with four variants:
+
+```rust
+pub enum TwilioError {   // Same pattern for TeamsError, DiscordError
+    Http(reqwest::Error),
+    Api(String),
+    InvalidPayload(String),
+    RateLimited,
+}
+```
+
+These map to `ProviderError` via a `From` implementation:
+
+| Provider Error | ProviderError | Retryable | Description |
+|----------------|---------------|-----------|-------------|
+| `Http(reqwest::Error)` | `Connection(String)` | Yes | Network/transport-level failure (DNS, TCP, TLS) |
+| `Api(String)` | `ExecutionFailed(String)` | No | API returned non-success response (auth error, bad request) |
+| `InvalidPayload(String)` | `Serialization(String)` | No | Missing or malformed fields in action payload |
+| `RateLimited` | `RateLimited` | Yes | HTTP 429 Too Many Requests |
+
+The `is_retryable()` method on `ProviderError` returns `true` for `Connection`, `Timeout`, and `RateLimited`, enabling the gateway's retry and circuit breaker infrastructure to distinguish transient from permanent failures.
+
+### Error Flow
+
+```
+TwilioError::Api("Authentication Error")
+    |
+    v  (From<TwilioError> for ProviderError)
+ProviderError::ExecutionFailed("Authentication Error")
+    |
+    v  (is_retryable() == false)
+Gateway: fail immediately, no retry
+```
+
+```
+TwilioError::RateLimited
+    |
+    v  (From<TwilioError> for ProviderError)
+ProviderError::RateLimited
+    |
+    v  (is_retryable() == true)
+Gateway: retry with backoff, update circuit breaker
+```
+
+---
+
+## 3. Trace Context Propagation
+
+All three providers use `acteon_provider::inject_trace_context()` to propagate W3C Trace Context headers on outgoing HTTP requests:
+
+```rust
+let response = acteon_provider::inject_trace_context(
+    self.client.post(&url).json(&body),
+)
+.send()
+.await?;
+```
+
+The `inject_trace_context()` function (defined in `crates/provider/src/trace_context.rs`) reads the current OpenTelemetry span context and injects `traceparent` and `tracestate` headers into the `reqwest::RequestBuilder`. When no global propagator is registered (OpenTelemetry disabled), this is a no-op.
+
+This enables end-to-end distributed tracing from the Acteon gateway through to the downstream API (Twilio, Teams connector, Discord).
+
+The feature is gated behind the `trace-context` Cargo feature flag on the `acteon-provider` crate.
+
+---
+
+## 4. Twilio: Form Encoding
+
+Twilio is the only native provider that uses `application/x-www-form-urlencoded` instead of JSON. The `TwilioSendMessageRequest` struct uses `serde::Serialize` with `#[serde(rename = "...")]` to match Twilio's PascalCase field names:
+
+```rust
+#[derive(Serialize)]
+pub struct TwilioSendMessageRequest {
+    #[serde(rename = "To")]
+    pub to: String,
+    #[serde(rename = "From")]
+    pub from: String,
+    #[serde(rename = "Body")]
+    pub body: String,
+    #[serde(rename = "MediaUrl", skip_serializing_if = "Option::is_none")]
+    pub media_url: Option<String>,
+}
+```
+
+The request is sent with `.form(request)` instead of `.json(request)`:
+
+```rust
+self.client
+    .post(&url)
+    .basic_auth(&self.config.account_sid, Some(&self.config.auth_token))
+    .form(request)  // <-- form encoding, not JSON
+```
+
+This produces a request body like:
+
+```
+To=%2B15559876543&From=%2B15551234567&Body=Hello+from+Acteon%21
+```
+
+Twilio also uses HTTP Basic Authentication (`Authorization: Basic base64(sid:token)`) rather than bearer tokens or webhook URL credentials.
+
+---
+
+## 5. Teams: Response Parsing
+
+Teams incoming webhooks return a non-standard response: the literal string `"1"` with `Content-Type: text/plain` on success (HTTP 200). This is not JSON.
+
+The provider handles this by reading the response as text and wrapping it:
+
+```rust
+// Teams returns literal "1" with HTTP 200 on success (not JSON).
+let response_text = response.text().await.unwrap_or_default();
+
+let response_body = serde_json::json!({
+    "ok": true,
+    "response": response_text,
+});
+```
+
+The Teams provider supports two message formats:
+
+1. **MessageCard** (`text` field): Builds an Office 365 MessageCard with `@type: "MessageCard"` and `@context: "https://schema.org/extensions"`. Optional `title`, `summary`, and `theme_color`.
+
+2. **Adaptive Card** (`adaptive_card` field): Wraps the provided JSON in a Teams attachment envelope:
+
+```json
+{
+  "type": "message",
+  "attachments": [{
+    "contentType": "application/vnd.microsoft.card.adaptive",
+    "content": { ... adaptive card JSON ... }
+  }]
+}
+```
+
+At least one of `text` or `adaptive_card` must be present. If `adaptive_card` is provided, it takes precedence.
+
+---
+
+## 6. Discord: 204 vs 200 Response Handling
+
+Discord webhook behavior depends on the `?wait=true` query parameter:
+
+- **Without `?wait=true`** (default): Returns HTTP 204 No Content with an empty body
+- **With `?wait=true`**: Returns HTTP 200 with a JSON body containing the created message object
+
+The provider handles both cases:
+
+```rust
+let response_body = if status == reqwest::StatusCode::NO_CONTENT {
+    serde_json::json!({ "ok": true })
+} else {
+    match response.json::<DiscordWebhookResponse>().await {
+        Ok(resp) => serde_json::json!({
+            "ok": true,
+            "id": resp.id,
+            "channel_id": resp.channel_id,
+        }),
+        Err(_) => serde_json::json!({ "ok": true }),
+    }
+};
+```
+
+The `DiscordConfig.wait` field controls whether `?wait=true` is appended to the webhook URL. When enabled, the response includes the message `id` and `channel_id`, which can be useful for message tracking or threading.
+
+The `effective_url()` method handles URL construction, including the edge case where the webhook URL already contains query parameters:
+
+```rust
+fn effective_url(&self) -> String {
+    if self.config.wait {
+        if self.config.webhook_url.contains('?') {
+            format!("{}&wait=true", self.config.webhook_url)
+        } else {
+            format!("{}?wait=true", self.config.webhook_url)
+        }
+    } else {
+        self.config.webhook_url.clone()
+    }
+}
+```
+
+### Discord Health Check
+
+Discord supports `GET` on webhook URLs, which returns the webhook metadata (type, id, name, channel_id) without posting a message. This makes the health check non-intrusive -- no messages are sent to the channel.
+
+This contrasts with Teams, where the only way to verify the webhook is to actually send a message.
+
+---
+
+## 7. Module / File Layout
+
+### Crate Structure
+
+```
+crates/integrations/twilio/
+  Cargo.toml
+  src/
+    config.rs     -- TwilioConfig (account_sid, auth_token, from_number, api_base_url)
+    error.rs      -- TwilioError enum + From<TwilioError> for ProviderError
+    provider.rs   -- TwilioProvider: Provider impl, MessagePayload, send_message()
+    types.rs      -- TwilioSendMessageRequest (form-encoded), TwilioApiResponse
+    lib.rs        -- pub mod + re-exports
+
+crates/integrations/teams/
+  Cargo.toml
+  src/
+    config.rs     -- TeamsConfig (webhook_url)
+    error.rs      -- TeamsError enum + From<TeamsError> for ProviderError
+    provider.rs   -- TeamsProvider: Provider impl, MessagePayload, build_body()
+    types.rs      -- TeamsMessageCard (Office 365 MessageCard schema)
+    lib.rs        -- pub mod + re-exports
+
+crates/integrations/discord/
+  Cargo.toml
+  src/
+    config.rs     -- DiscordConfig (webhook_url, wait, default_username, default_avatar_url)
+    error.rs      -- DiscordError enum + From<DiscordError> for ProviderError
+    provider.rs   -- DiscordProvider: Provider impl, MessagePayload, effective_url()
+    types.rs      -- DiscordWebhookRequest, DiscordEmbed, DiscordWebhookResponse
+    lib.rs        -- pub mod + re-exports
+```
+
+### Server Integration
+
+The server config (`crates/server/src/config.rs`) uses a flat `ProviderConfig` struct with optional fields for all provider types. The `provider_type` field (`"twilio"`, `"teams"`, `"discord"`) determines which fields are required.
+
+---
+
+## 8. Design Decisions
+
+| Decision | Alternative | Rationale |
+|----------|-------------|-----------|
+| Separate crate per provider | Single `integrations` crate | Independent compilation, feature-gated dependencies, clear ownership |
+| Local error enum per provider | Reuse `ProviderError` directly | Provider-specific error messages, clean `From` conversion boundary |
+| Form encoding for Twilio | JSON (rejected by Twilio API) | Twilio's REST API mandates `x-www-form-urlencoded` |
+| `text()` parsing for Teams | `json()` parsing (would fail on `"1"`) | Teams returns non-JSON success response |
+| GET health check for Discord | POST minimal message (like Teams) | Non-intrusive -- no channel messages during health checks |
+| POST health check for Teams | None available | Teams webhooks have no read-only endpoint |
+| `reqwest::Client` per provider | Shared global client | Provider-specific timeouts and connection pool isolation |

--- a/docs/book/concepts/architecture.md
+++ b/docs/book/concepts/architecture.md
@@ -30,6 +30,10 @@ flowchart TB
     subgraph Providers["Provider Layer (acteon-provider)"]
         Email["Email SMTP"]
         Slack["Slack"]
+        PD["PagerDuty"]
+        Twilio["Twilio SMS"]
+        Teams["Teams"]
+        Discord["Discord"]
         WH["Webhooks"]
         Custom["Custom Providers"]
     end
@@ -113,6 +117,11 @@ All crates live under the `crates/` directory with logical groupings:
 |-------|---------|-------------|
 | `crates/integrations/email` | `acteon-email` | Email/SMTP provider via Lettre |
 | `crates/integrations/slack` | `acteon-slack` | Slack message provider |
+| `crates/integrations/pagerduty` | `acteon-pagerduty` | PagerDuty Events API v2 provider |
+| `crates/integrations/twilio` | `acteon-twilio` | Twilio SMS provider |
+| `crates/integrations/teams` | `acteon-teams` | Microsoft Teams incoming webhooks |
+| `crates/integrations/discord` | `acteon-discord` | Discord webhook provider |
+| `crates/integrations/webhook` | `acteon-webhook` | Generic HTTP webhook provider |
 | `crates/llm` | `acteon-llm` | LLM-based guardrail evaluation |
 
 ## Data Flow

--- a/docs/book/features/native-providers.md
+++ b/docs/book/features/native-providers.md
@@ -1,0 +1,407 @@
+# Native Providers
+
+Acteon ships with built-in provider integrations for **Twilio** (SMS), **Microsoft Teams**, and **Discord**, alongside the existing Webhook, Email, Slack, and PagerDuty providers. Native providers are first-class citizens -- they implement the same `Provider` trait, participate in circuit breaking, health checks, and per-provider metrics, and require no external plugins.
+
+## Overview
+
+| Provider | Transport | Auth Mechanism | Payload Format |
+|----------|-----------|----------------|----------------|
+| Twilio | REST API (form-encoded) | HTTP Basic Auth (Account SID + Auth Token) | `application/x-www-form-urlencoded` |
+| Teams | Incoming Webhook | Webhook URL (URL is the credential) | `application/json` (MessageCard or Adaptive Card) |
+| Discord | Webhook | Webhook URL (URL is the credential) | `application/json` |
+
+All three providers:
+
+- Support `ENC[...]` encrypted secrets in TOML configuration
+- Propagate W3C Trace Context (`traceparent`/`tracestate` headers) to downstream APIs
+- Report per-provider health metrics (success rate, latency percentiles, error tracking)
+- Handle HTTP 429 (Too Many Requests) as retryable `RateLimited` errors
+- Use a 30-second HTTP client timeout by default
+
+## TOML Configuration
+
+### Twilio
+
+```toml
+[[providers]]
+name = "sms"
+type = "twilio"
+account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+auth_token = "ENC[AES256_GCM,data:abc123...]"
+from_number = "+15551234567"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used in action dispatch |
+| `type` | Yes | Must be `"twilio"` |
+| `account_sid` | Yes | Twilio Account SID (starts with `AC`) |
+| `auth_token` | Yes | Twilio Auth Token. Supports `ENC[...]` for encrypted storage |
+| `from_number` | No | Default sender phone number in E.164 format. Can be overridden per-action via the `from` payload field |
+
+### Microsoft Teams
+
+```toml
+[[providers]]
+name = "teams-alerts"
+type = "teams"
+webhook_url = "https://outlook.office.com/webhook/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used in action dispatch |
+| `type` | Yes | Must be `"teams"` |
+| `webhook_url` | Yes | Incoming Webhook URL from Teams channel configuration |
+
+### Discord
+
+```toml
+[[providers]]
+name = "discord-alerts"
+type = "discord"
+webhook_url = "https://discord.com/api/webhooks/123456789/abcdefg"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used in action dispatch |
+| `type` | Yes | Must be `"discord"` |
+| `webhook_url` | Yes | Discord webhook URL (from channel integrations settings) |
+
+Discord also supports optional configuration for default username and avatar, configurable via the Rust API:
+
+```rust
+DiscordConfig::new("https://discord.com/api/webhooks/123/abc")
+    .with_wait(true)               // Return created message object (200 instead of 204)
+    .with_default_username("Acteon Bot")
+    .with_default_avatar_url("https://example.com/avatar.png")
+```
+
+## Payload Format
+
+### Twilio SMS
+
+Send an SMS message. Requires `to` (destination) and `body` (message text). The `from` field is optional if a default `from_number` is configured.
+
+```json
+{
+  "to": "+15559876543",
+  "body": "Server alert: CPU usage at 95%",
+  "from": "+15551234567"
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `to` | Yes | string | Destination phone number in E.164 format |
+| `body` | Yes | string | SMS message text |
+| `from` | No | string | Sender phone number (falls back to configured `from_number`) |
+| `media_url` | No | string | URL for MMS media attachment |
+
+**Response body** on success:
+
+```json
+{
+  "sid": "SMxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+  "status": "queued"
+}
+```
+
+### Microsoft Teams
+
+Send a message to a Teams channel. Requires at least one of `text` (MessageCard) or `adaptive_card` (Adaptive Card).
+
+**Simple MessageCard:**
+
+```json
+{
+  "text": "Deployment complete",
+  "title": "CI/CD Pipeline",
+  "theme_color": "00FF00"
+}
+```
+
+**Adaptive Card:**
+
+```json
+{
+  "adaptive_card": {
+    "type": "AdaptiveCard",
+    "version": "1.4",
+    "body": [
+      {
+        "type": "TextBlock",
+        "text": "Build #42 passed all tests",
+        "weight": "Bolder",
+        "size": "Medium"
+      }
+    ]
+  }
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `text` | One of `text` or `adaptive_card` | string | Message body text (supports basic Markdown) |
+| `title` | No | string | Card title (MessageCard only) |
+| `summary` | No | string | Summary text for notifications (MessageCard only) |
+| `theme_color` | No | string | Hex color code without `#` prefix, e.g. `"FF0000"` |
+| `adaptive_card` | One of `text` or `adaptive_card` | object | Full Adaptive Card JSON object |
+
+When `adaptive_card` is provided, it is wrapped in the Teams attachment envelope automatically. When `text` is provided, it is formatted as an Office 365 MessageCard with the `@type: "MessageCard"` schema.
+
+**Response body** on success:
+
+```json
+{
+  "ok": true,
+  "response": "1"
+}
+```
+
+### Discord
+
+Send a message to a Discord channel. Requires at least one of `content` (plain text) or `embeds` (rich embed objects).
+
+**Simple text message:**
+
+```json
+{
+  "content": "Build passed!"
+}
+```
+
+**Rich embed message:**
+
+```json
+{
+  "content": "Build status update",
+  "embeds": [
+    {
+      "title": "Build #42",
+      "description": "All tests passed",
+      "color": 65280,
+      "fields": [
+        {
+          "name": "Duration",
+          "value": "3m 42s",
+          "inline": true
+        },
+        {
+          "name": "Branch",
+          "value": "main",
+          "inline": true
+        }
+      ],
+      "footer": {
+        "text": "Acteon CI"
+      }
+    }
+  ]
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `content` | One of `content` or `embeds` | string | Plain text message content |
+| `username` | No | string | Override the webhook's default username |
+| `avatar_url` | No | string | Override the webhook's default avatar URL |
+| `tts` | No | bool | Whether to send as text-to-speech |
+| `embeds` | One of `content` or `embeds` | array | Array of embed objects (max 10) |
+
+**Embed object fields:**
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `title` | No | string | Embed title |
+| `description` | No | string | Embed description |
+| `color` | No | integer | Color as a decimal integer (e.g., `16711680` for red, `65280` for green) |
+| `fields` | No | array | Array of `{name, value, inline?}` field objects |
+| `footer` | No | object | Footer with `text` field |
+| `timestamp` | No | string | ISO 8601 timestamp |
+
+**Response body** on success (without `?wait=true`):
+
+```json
+{
+  "ok": true
+}
+```
+
+**Response body** on success (with `?wait=true`):
+
+```json
+{
+  "ok": true,
+  "id": "1234567890",
+  "channel_id": "9876543210"
+}
+```
+
+## Secret Management
+
+The Twilio `auth_token` field supports the `ENC[...]` envelope for encrypted secrets. This integrates with Acteon's payload encryption at rest infrastructure:
+
+```toml
+[[providers]]
+name = "sms"
+type = "twilio"
+account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+auth_token = "ENC[AES256_GCM,data:base64encodedciphertext...]"
+```
+
+For Teams and Discord, the webhook URL itself is the authentication credential. While webhook URLs are not wrapped in `ENC[...]` (they are used as-is for HTTP requests), they should be treated as secrets:
+
+- Do not commit webhook URLs to version control
+- Use environment variable substitution or external secret managers
+- Rotate webhook URLs periodically via the Teams/Discord admin panels
+
+## Health Check Behavior
+
+Each provider implements a `health_check()` method that validates connectivity and credentials.
+
+### Twilio
+
+Performs a `GET` request to the Account API endpoint:
+
+```
+GET https://api.twilio.com/2010-04-01/Accounts/{AccountSid}.json
+```
+
+This verifies that the Account SID and Auth Token are valid and the Twilio API is reachable. An HTTP 200 response with account details indicates a healthy provider. Rate-limited responses (HTTP 429) are reported as `ProviderError::RateLimited`.
+
+### Microsoft Teams
+
+Sends a minimal message to the webhook URL:
+
+```
+POST {webhook_url}
+Content-Type: application/json
+
+{"text": "health check"}
+```
+
+Teams incoming webhooks do not have a dedicated health endpoint, so the provider sends a lightweight message. Any successful HTTP response from the webhook host confirms the URL is reachable and valid. This does result in a "health check" message appearing in the Teams channel.
+
+### Discord
+
+Performs a `GET` request to the webhook URL:
+
+```
+GET {webhook_url}
+```
+
+Discord returns the webhook object (name, channel, guild) on GET requests without executing the webhook. This provides a non-intrusive health check -- no message is posted to the channel.
+
+## Error Handling
+
+All three providers map their internal errors to the standard `ProviderError` enum:
+
+| Internal Error | ProviderError Variant | Retryable |
+|----------------|----------------------|-----------|
+| HTTP transport failure | `Connection` | Yes |
+| API error response | `ExecutionFailed` | No |
+| Invalid/missing payload fields | `Serialization` | No |
+| HTTP 429 Too Many Requests | `RateLimited` | Yes |
+
+Retryable errors participate in the circuit breaker and retry infrastructure. Non-retryable errors (invalid payloads, API rejections) fail immediately without retry.
+
+## Example: Dispatching via the API
+
+```bash
+# Send SMS via Twilio
+curl -X POST http://localhost:8080/v1/actions \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "alerts",
+    "tenant": "acme-corp",
+    "provider": "sms",
+    "action_type": "send_sms",
+    "payload": {
+      "to": "+15559876543",
+      "body": "Server alert: disk usage at 90%"
+    }
+  }'
+
+# Send Teams notification
+curl -X POST http://localhost:8080/v1/actions \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "alerts",
+    "tenant": "acme-corp",
+    "provider": "teams-alerts",
+    "action_type": "notify",
+    "payload": {
+      "text": "Deployment complete",
+      "title": "CI/CD",
+      "theme_color": "00FF00"
+    }
+  }'
+
+# Send Discord notification with embed
+curl -X POST http://localhost:8080/v1/actions \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "alerts",
+    "tenant": "acme-corp",
+    "provider": "discord-alerts",
+    "action_type": "notify",
+    "payload": {
+      "content": "Build passed!",
+      "embeds": [{
+        "title": "Build #42",
+        "description": "All tests passed",
+        "color": 65280
+      }]
+    }
+  }'
+```
+
+## Example: Rust Client
+
+```rust
+use acteon_client::ActeonClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = ActeonClient::new("http://localhost:8080", "your-api-token")?;
+
+    // Send SMS
+    client.dispatch_action(
+        "alerts", "acme-corp", "sms", "send_sms",
+        serde_json::json!({
+            "to": "+15559876543",
+            "body": "Server alert!"
+        }),
+    ).await?;
+
+    // Send Teams message
+    client.dispatch_action(
+        "alerts", "acme-corp", "teams-alerts", "notify",
+        serde_json::json!({
+            "text": "Deployment complete",
+            "title": "CI/CD",
+            "theme_color": "00FF00"
+        }),
+    ).await?;
+
+    // Send Discord message
+    client.dispatch_action(
+        "alerts", "acme-corp", "discord-alerts", "notify",
+        serde_json::json!({
+            "content": "Build passed!",
+            "embeds": [{
+                "title": "Build #42",
+                "description": "All tests passed",
+                "color": 65280
+            }]
+        }),
+    ).await?;
+
+    Ok(())
+}
+```

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -36,7 +36,7 @@ flowchart LR
     C -->|Suppress| F[Block Action]
     C -->|Throttle| G[Rate Limit]
     C -->|Reroute| H[Different Provider]
-    D --> I[Email / SMS / Slack / Webhook]
+    D --> I[Email / Twilio / Slack / Teams / Discord / Webhook]
 ```
 
 ---
@@ -239,6 +239,9 @@ graph TB
     EX --> PROV
     PROV --> Email[Email SMTP]
     PROV --> Slack[Slack]
+    PROV --> Twilio[Twilio SMS]
+    PROV --> Teams[Teams]
+    PROV --> Discord[Discord]
     PROV --> WH[Webhooks]
     RE -.-> MEM & RED & PG & DDB & CH
     EX -.-> AUD_PG & AUD_CH & AUD_ES

--- a/docs/brainstorm-new-features.md
+++ b/docs/brainstorm-new-features.md
@@ -419,7 +419,7 @@ Ranked by impact-to-effort ratio:
 | 20 | Grafana Dashboard Templates | Low | Medium | **DONE** |
 | 21 | Parallel Chain Steps | Large | Medium | Not started |
 | 22 | Sub-Chains | Medium | Medium | Not started |
-| 23 | Native Providers (Twilio, Teams, Discord) | Medium ea. | Medium | Not started |
+| 23 | Native Providers (Twilio, Teams, Discord) | Medium ea. | Medium | **DONE** |
 | 24 | Weighted/Canary Routing | Medium | Medium | Not started |
 | 25 | Kafka/RabbitMQ Producers | Medium | Medium | Not started |
 | 26 | Cost-Aware Routing | Medium | Medium | Not started |


### PR DESCRIPTION
## Summary

- Add three new integration crates (`acteon-twilio`, `acteon-teams`, `acteon-discord`) implementing the `Provider` trait for SMS, Teams incoming webhooks, and Discord webhooks
- Harden all 7 provider configs against secret leakage by replacing derived `Debug` with manual impls that redact auth tokens, webhook URLs, passwords, and routing keys
- Wire new providers into server config and startup with `ENC[...]` decryption support
- Add payload helpers to all 5 polyglot SDKs (Python, Node.js, Go, Java, Rust)
- Add feature docs, architecture docs, and simulation example

## What's included

### New crates (3)
| Crate | Transport | Auth | Payload |
|---|---|---|---|
| `acteon-twilio` | Form-encoded POST | HTTP Basic (SID:token) | `to`, `body`, `from`, `media_url` |
| `acteon-teams` | JSON POST to webhook | URL-embedded | `text` (MessageCard) or `adaptive_card` |
| `acteon-discord` | JSON POST to webhook | URL-embedded | `content` and/or `embeds` |

### Secret redaction (all providers)
Replaced `#[derive(Debug)]` with manual `Debug` impls on `TwilioConfig`, `TeamsConfig`, `DiscordConfig`, `SlackConfig`, `PagerDutyConfig`, `EmailConfig`, and `AuthMethod` — secrets now render as `[REDACTED]` in logs.

### Server integration
- `ProviderConfig` extended with `account_sid`, `auth_token`, `from_number`, `webhook_url` fields
- Provider match block handles `"twilio"`, `"teams"`, `"discord"` with validation and `ENC[...]` support

### SDKs
- **Python**: `twilio_sms_payload()`, `teams_message_payload()`, `teams_adaptive_card_payload()`, `discord_message_payload()`
- **Node.js**: Interfaces + factory functions for all 3 providers
- **Go**: `NewTwilio/Teams/Discord*Payload` functions
- **Java**: Builder classes for all 3 providers

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --no-deps -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all 1,450+ tests pass (includes 30+ new provider tests + 7 redaction tests)
- [x] `npm run lint && npm run build` — clean
- [x] `cargo run -p acteon-simulation --example native_providers_simulation` — all 3 providers pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)