### PR TITLE
feat: add incident response pipeline example + migrate CLI subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,16 @@ The server starts on `http://127.0.0.1:8080` with the in-memory state backend an
 ### CLI options
 
 ```
-cargo run -p acteon-server -- [OPTIONS]
+cargo run -p acteon-server -- [OPTIONS] [COMMAND]
 
 Options:
   -c, --config <PATH>   Path to TOML config file [default: acteon.toml]
       --host <HOST>      Override bind host
       --port <PORT>      Override bind port
+
+Commands:
+  encrypt   Encrypt a value for use in auth.toml (reads from stdin)
+  migrate   Run database migrations for configured backends, then exit
 ```
 
 Examples:
@@ -149,6 +153,9 @@ cargo run -p acteon-server -- --port 3000
 
 # With a config file
 cargo run -p acteon-server -- -c my-config.toml
+
+# Run database migrations before first start
+scripts/migrate.sh -c my-config.toml
 ```
 
 ### Configuration
@@ -247,19 +254,23 @@ cargo run -p acteon-server -- -c examples/redis.toml
 
 # PostgreSQL state + audit
 docker compose --profile postgres up -d
-cargo run -p acteon-server -- -c examples/postgres.toml
+scripts/migrate.sh -c examples/postgres.toml
+cargo run -p acteon-server --features postgres -- -c examples/postgres.toml
 
 # ClickHouse state + audit
 docker compose --profile clickhouse up -d
-cargo run -p acteon-server -- -c examples/clickhouse.toml
+scripts/migrate.sh -c examples/clickhouse.toml
+cargo run -p acteon-server --features clickhouse -- -c examples/clickhouse.toml
 
 # Redis state + Elasticsearch audit
 docker compose --profile elasticsearch up -d
+scripts/migrate.sh -c examples/elasticsearch-audit.toml
 cargo run -p acteon-server -- -c examples/elasticsearch-audit.toml
 
 # DynamoDB Local state
 docker compose --profile dynamodb up -d
-cargo run -p acteon-server -- -c examples/dynamodb.toml
+scripts/migrate.sh -c examples/dynamodb.toml
+cargo run -p acteon-server --features dynamodb -- -c examples/dynamodb.toml
 ```
 
 ### Combining backends
@@ -280,6 +291,7 @@ url = "postgres://acteon:acteon@localhost:5432/acteon"
 
 ```sh
 docker compose --profile postgres up -d
+scripts/migrate.sh -c acteon.toml
 cargo run -p acteon-server -- -c acteon.toml
 ```
 

--- a/docs/book/backends/clickhouse-audit.md
+++ b/docs/book/backends/clickhouse-audit.md
@@ -42,5 +42,6 @@ prefix = "acteon_"
 
 ```bash
 docker compose --profile clickhouse up -d
+scripts/migrate.sh -c examples/clickhouse.toml
 cargo run -p acteon-server --features clickhouse -- -c examples/clickhouse.toml
 ```

--- a/docs/book/backends/dynamodb.md
+++ b/docs/book/backends/dynamodb.md
@@ -100,5 +100,6 @@ cargo build -p acteon-server --features dynamodb
 
 ```bash
 docker compose --profile dynamodb up -d
+scripts/migrate.sh -c examples/dynamodb.toml
 cargo run -p acteon-server --features dynamodb -- -c examples/dynamodb.toml
 ```

--- a/docs/book/backends/elasticsearch-audit.md
+++ b/docs/book/backends/elasticsearch-audit.md
@@ -51,6 +51,7 @@ prefix = "acteon-"
 
 ```bash
 docker compose --profile elasticsearch up -d
+scripts/migrate.sh -c examples/elasticsearch-audit.toml
 cargo run -p acteon-server --features elasticsearch -- -c examples/elasticsearch-audit.toml
 ```
 
@@ -73,5 +74,6 @@ store_payload = true
 
 ```bash
 docker compose --profile elasticsearch up -d
+scripts/migrate.sh -c examples/elasticsearch-audit.toml
 cargo run -p acteon-server --features elasticsearch -- -c examples/elasticsearch-audit.toml
 ```

--- a/docs/book/backends/index.md
+++ b/docs/book/backends/index.md
@@ -56,5 +56,6 @@ url = "postgres://acteon:acteon@localhost:5432/acteon"
 ```bash
 # Start both backends
 docker compose --profile postgres up -d
+scripts/migrate.sh -c acteon.toml
 cargo run -p acteon-server -- -c acteon.toml
 ```

--- a/docs/book/backends/postgres-audit.md
+++ b/docs/book/backends/postgres-audit.md
@@ -56,5 +56,6 @@ curl "http://localhost:8080/v1/audit?limit=100&offset=200"
 
 ```bash
 docker compose --profile postgres up -d
+scripts/migrate.sh -c examples/postgres.toml
 cargo run -p acteon-server --features postgres -- -c examples/postgres.toml
 ```

--- a/docs/book/backends/postgres.md
+++ b/docs/book/backends/postgres.md
@@ -92,5 +92,6 @@ cargo build -p acteon-server --features postgres
 
 ```bash
 docker compose --profile postgres up -d
+scripts/migrate.sh -c examples/postgres.toml
 cargo run -p acteon-server --features postgres -- -c examples/postgres.toml
 ```

--- a/docs/book/getting-started/configuration.md
+++ b/docs/book/getting-started/configuration.md
@@ -5,15 +5,33 @@ Acteon is configured via a TOML file (default: `acteon.toml`). Every section is 
 ## CLI Options
 
 ```
-cargo run -p acteon-server -- [OPTIONS]
+cargo run -p acteon-server -- [OPTIONS] [COMMAND]
 
 Options:
   -c, --config <PATH>   Path to TOML config file [default: acteon.toml]
       --host <HOST>      Override bind host
       --port <PORT>      Override bind port
+
+Commands:
+  encrypt   Encrypt a value for use in auth.toml (reads from stdin)
+  migrate   Run database migrations for configured backends, then exit
 ```
 
 CLI flags override values in the config file.
+
+### Database Migrations
+
+Before starting the server for the first time (or after upgrading), run migrations to create or update database schemas:
+
+```bash
+# Using the wrapper script (auto-detects backend from config)
+scripts/migrate.sh -c acteon.toml
+
+# Or directly via cargo
+cargo run -p acteon-server --features postgres -- -c acteon.toml migrate
+```
+
+Migrations are idempotent and safe to run multiple times. They use `CREATE TABLE IF NOT EXISTS` and `ALTER TABLE ADD COLUMN IF NOT EXISTS` patterns. Backends that don't require schemas (memory, Redis) are no-ops.
 
 ## Full Configuration
 
@@ -358,5 +376,6 @@ cargo run -p acteon-server -- -c examples/redis.toml
 
 # Start with PostgreSQL
 docker compose --profile postgres up -d
-cargo run -p acteon-server -- -c examples/postgres.toml
+scripts/migrate.sh -c examples/postgres.toml
+cargo run -p acteon-server --features postgres -- -c examples/postgres.toml
 ```

--- a/docs/book/reference/deployment.md
+++ b/docs/book/reference/deployment.md
@@ -1,5 +1,24 @@
 # Deployment
 
+## Database Migrations
+
+Before starting the server for the first time (or after upgrading), run migrations to initialize database schemas:
+
+```bash
+# Using the wrapper script (auto-detects backend from config)
+scripts/migrate.sh -c acteon.toml
+
+# Or directly via the server binary
+cargo run -p acteon-server --features postgres -- -c acteon.toml migrate
+
+# In Docker
+docker run --rm \
+  -v $(pwd)/acteon.toml:/app/acteon.toml \
+  acteon -c /app/acteon.toml migrate
+```
+
+Migrations are idempotent — they use `IF NOT EXISTS` patterns and are safe to run on every deploy. Backends that don't require schemas (memory, Redis) are no-ops.
+
 ## Docker
 
 ### Building
@@ -14,7 +33,11 @@ docker build -t acteon .
 # With in-memory backend
 docker run -p 8080:8080 acteon
 
-# With config file
+# With config file (run migrations first, then start)
+docker run --rm \
+  -v $(pwd)/acteon.toml:/app/acteon.toml \
+  acteon -c /app/acteon.toml migrate
+
 docker run -p 8080:8080 \
   -v $(pwd)/acteon.toml:/app/acteon.toml \
   -v $(pwd)/rules:/app/rules \

--- a/examples/agent-swarm-coordination/README.md
+++ b/examples/agent-swarm-coordination/README.md
@@ -52,20 +52,26 @@ cd /path/to/acteon
 docker compose --profile postgres up -d
 ```
 
-### 2. Build and Start Acteon
+### 2. Build and Run Migrations
 
 ```bash
 # Build the server and MCP server
 cargo build -p acteon-server --features postgres
 cargo build -p acteon-mcp-server --release
 
-# Start Acteon
+# Run database migrations (creates tables/indexes in PostgreSQL)
+scripts/migrate.sh -c examples/agent-swarm-coordination/acteon.toml
+```
+
+### 3. Start Acteon
+
+```bash
 cargo run -p acteon-server --features postgres -- -c examples/agent-swarm-coordination/acteon.toml
 ```
 
 Wait for `Listening on 127.0.0.1:8080`.
 
-### 3. Initialize the Dummy Project
+### 4. Initialize the Dummy Project
 
 ```bash
 cd examples/agent-swarm-coordination/dummy-project
@@ -74,7 +80,7 @@ git add .
 git commit -m "initial commit"
 ```
 
-### 4. Configure Environment
+### 5. Configure Environment
 
 ```bash
 # Point hooks at the running Acteon instance
@@ -88,13 +94,13 @@ export DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/YOUR/WEBHOOK"
 export PATH="$PWD/target/release:$PATH"
 ```
 
-### 5. Make Hooks Executable
+### 6. Make Hooks Executable
 
 ```bash
 chmod +x examples/agent-swarm-coordination/hooks/*.sh
 ```
 
-### 6. Start Claude Code
+### 7. Start Claude Code
 
 ```bash
 cd examples/agent-swarm-coordination/dummy-project
@@ -104,7 +110,7 @@ claude
 Claude Code will load the `.claude/settings.json` hooks and `.mcp.json`
 MCP server configuration automatically.
 
-### 7. Try It Out
+### 8. Try It Out
 
 In the Claude Code session, try these prompts to see the different behaviors:
 
@@ -165,7 +171,7 @@ allowed again. Each throttle rule maintains its own counter scoped to the
 rule name, namespace, and tenant -- so different rules never interfere with
 each other.
 
-### 8. Query Acteon via MCP
+### 9. Query Acteon via MCP
 
 Within the same Claude Code session, the Acteon MCP server is connected.
 Ask Claude to query it:
@@ -183,7 +189,7 @@ Ask Claude to query it:
 Claude Code will use the `mcp__acteon__query_audit`, `mcp__acteon__list_rules`,
 and other MCP tools to fetch live data from the running Acteon instance.
 
-### 9. End the Session
+### 10. End the Session
 
 When you exit Claude Code (Ctrl+C or `/exit`), the `Stop` hook fires and
 sends a Discord notification via Acteon with a summary of the session.

--- a/examples/agent-swarm-coordination/acteon.toml
+++ b/examples/agent-swarm-coordination/acteon.toml
@@ -6,7 +6,9 @@
 #
 # Start PostgreSQL:
 #   docker compose --profile postgres up -d
-#   (or use a local PostgreSQL: createdb acteon)
+#
+# Run migrations:
+#   scripts/migrate.sh -c examples/agent-swarm-coordination/acteon.toml
 #
 # Start Acteon:
 #   cargo run -p acteon-server --features postgres -- -c examples/agent-swarm-coordination/acteon.toml

--- a/examples/agent-swarm-coordination/swarm/run-swarm.sh
+++ b/examples/agent-swarm-coordination/swarm/run-swarm.sh
@@ -59,7 +59,8 @@ echo ""
 # Check Acteon is reachable
 if ! curl -sf "$ACTEON_URL/healthz" > /dev/null 2>&1; then
   echo "ERROR: Acteon is not reachable at $ACTEON_URL"
-  echo "Start it with: cargo run -p acteon-server --features postgres -- -c $EXAMPLE_DIR/acteon.toml"
+  echo "Run migrations: scripts/migrate.sh -c $EXAMPLE_DIR/acteon.toml"
+  echo "Start it with:  cargo run -p acteon-server --features postgres -- -c $EXAMPLE_DIR/acteon.toml"
   exit 1
 fi
 echo "[ok] Acteon is running at $ACTEON_URL"

--- a/examples/incident-response-pipeline/README.md
+++ b/examples/incident-response-pipeline/README.md
@@ -1,0 +1,150 @@
+# Incident Response Pipeline
+
+An end-to-end example exercising 14 Acteon features through an ops incident response scenario. Alerts flow from monitoring systems through Acteon, which triages them via chain workflows, routes notifications to multiple providers, tracks alert lifecycle through event states, and protects against alert storms via throttling, dedup, and quotas.
+
+## Features Exercised
+
+| # | Feature | How |
+|---|---------|-----|
+| 1 | **Chains** | `incident-triage` chain: classify → escalate → create-ticket |
+| 2 | **Sub-chains** | Critical path invokes `war-room-setup` sub-chain (3 steps) |
+| 3 | **Conditional branching** | Branch on `body.logged` after classify step |
+| 4 | **Event state management** | Seed event, transition `open → ack → investigating → resolved` via API |
+| 5 | **Circuit breakers + fallback** | PagerDuty → webhook-fallback; email-alerts → slack-alerts |
+| 6 | **Recurring actions** | Health-check alert every 60s via `POST /v1/recurring` |
+| 7 | **Data retention** | Audit 7 days, events 1 day via `POST /v1/retention` |
+| 8 | **Event grouping** | Low-severity alerts batched 30s before notification |
+| 9 | **Quotas** | 100/hour for ops-team via `POST /v1/quotas` |
+| 10 | **Throttle** | Alert storm protection: 20/min per tenant |
+| 11 | **Dedup** | Same fingerprint deduplicated within 5 min |
+| 12 | **Suppress** | Block alerts from `test` environment |
+| 13 | **Modify** | Enrich all alerts with `pipeline_version` metadata |
+| 14 | **Audit + redaction** | Full audit with `api_key`/`webhook_url` redacted |
+
+## Prerequisites
+
+- PostgreSQL (for durable state + audit)
+- `jq` (for script output formatting)
+- `psql` (for event seeding in `manage-incident.sh`)
+
+## Quick Start
+
+```bash
+# 1. Start PostgreSQL
+docker compose --profile postgres up -d
+# (or use a local PostgreSQL: createdb acteon)
+
+# 2. Build and start Acteon
+cargo run -p acteon-server --features postgres -- \
+  -c examples/incident-response-pipeline/acteon.toml
+
+# 3. Setup API resources (quotas, retention, recurring)
+cd examples/incident-response-pipeline
+bash scripts/setup.sh
+
+# 4. Fire 20 sample alerts
+bash scripts/send-alerts.sh
+
+# 5. Manage incident lifecycle (event state transitions)
+bash scripts/manage-incident.sh
+
+# 6. View comprehensive report
+bash scripts/show-report.sh
+
+# 7. Cleanup API resources
+bash scripts/teardown.sh
+```
+
+## File Structure
+
+```
+incident-response-pipeline/
+├── acteon.toml              # Server config (chains, circuit breakers, background, audit)
+├── rules/
+│   ├── triage.yaml          # Suppress test env, throttle storms, trigger chains
+│   ├── routing.yaml         # Dedup, modify metadata, group low-severity, allow
+│   └── safety.yaml          # Catch-all deny
+├── scripts/
+│   ├── setup.sh             # Create quotas + retention + recurring via API
+│   ├── send-alerts.sh       # Fire 20 sample alerts exercising all features
+│   ├── manage-incident.sh   # Transition events through lifecycle via API
+│   ├── show-report.sh       # Query audit/chains/events/health/quotas/groups
+│   └── teardown.sh          # Clean up API-created resources
+└── README.md
+```
+
+## Architecture
+
+```
+                    ┌─────────────────────┐
+  Monitoring ──────►│   Acteon Gateway     │
+  (Datadog,         │                     │
+   Prometheus,      │  Rules Engine       │
+   Grafana)         │  ┌─suppress test──┐ │
+                    │  ├─throttle 20/m──┤ │     ┌──────────────┐
+                    │  ├─dedup 5min─────┤ │────►│ slack-alerts  │
+                    │  ├─modify meta────┤ │     ├──────────────┤
+                    │  ├─group low──────┤ │────►│ pagerduty    │──┐ fallback
+                    │  └─chain hi/crit──┘ │     ├──────────────┤  │
+                    │                     │────►│ email-alerts  │  │
+                    │  Chain Engine       │     ├──────────────┤  │
+                    │  ┌─classify────────┐│     │ ticket-system│  │
+                    │  ├─escalate────────┤│     ├──────────────┤  │
+                    │  ├─war-room (sub)──┤│     │ webhook-fb   │◄─┘
+                    │  └─create-ticket───┘│     └──────────────┘
+                    │                     │
+                    │  Background Jobs    │
+                    │  ├─group flush     │
+                    │  ├─recurring check │
+                    │  └─retention reaper│
+                    └─────────────────────┘
+```
+
+## Chain Flow
+
+The `incident-triage` chain handles critical and high severity alerts:
+
+```
+classify (slack-alerts)
+    │
+    ├─ body.logged == true ──► escalate (pagerduty)
+    │                              │
+    │                              ├─ success == true ──► war-room (sub-chain)
+    │                              │                          ├─ create-channel
+    │                              │                          ├─ page-oncall
+    │                              │                          └─ open-ticket
+    │                              │
+    │                              └─ (default) ──► create-ticket
+    │
+    └─ (no branch match) ──► escalate (next step)
+```
+
+## Expected Outcomes from `send-alerts.sh`
+
+| Alerts | Count | Expected Outcome |
+|--------|-------|-----------------|
+| Critical | 2 | `chain_started` (full chain + sub-chain) |
+| High | 3 | `chain_started` (chain, simpler path) |
+| Low | 5 | `grouped` (batched by service, 30s) |
+| Storm | 5 | Some `throttled` (if >20/min reached) |
+| Duplicate | 3 | 2 `deduplicated` (same dedup_key) |
+| Test-env | 2 | `suppressed` (environment=test) |
+
+## Circuit Breaker Demo
+
+The `webhook-fallback` provider intentionally targets `http://localhost:9999/fallback`, which will fail unless you run a local echo server. After 2 failures, the circuit breaker trips:
+
+- **PagerDuty** circuit opens → falls back to `webhook-fallback`
+- **email-alerts** circuit opens → falls back to `slack-alerts`
+
+To see the webhook-fallback succeed, optionally run:
+```bash
+python3 -m http.server 9999
+```
+
+## Notes
+
+- **Log providers** return `{"provider": "<name>", "logged": true}`. Chain branching uses `body.logged == true` as a condition field.
+- **Event seeding** in `manage-incident.sh` requires `psql` access to write initial state. If `psql` is unavailable, the script falls back to dispatching an alert.
+- **Quota window** uses `"hourly"` string format. Other options: `"daily"`, `"weekly"`, `"monthly"`.
+- All audit payloads containing `api_key`, `webhook_url`, or `pagerduty_key` fields are automatically redacted to `[REDACTED]`.

--- a/examples/incident-response-pipeline/README.md
+++ b/examples/incident-response-pipeline/README.md
@@ -25,33 +25,34 @@ An end-to-end example exercising 14 Acteon features through an ops incident resp
 
 - PostgreSQL (for durable state + audit)
 - `jq` (for script output formatting)
-- `psql` (for event seeding in `manage-incident.sh`)
 
 ## Quick Start
 
 ```bash
 # 1. Start PostgreSQL
 docker compose --profile postgres up -d
-# (or use a local PostgreSQL: createdb acteon)
 
-# 2. Build and start Acteon
+# 2. Run database migrations
+scripts/migrate.sh -c examples/incident-response-pipeline/acteon.toml
+
+# 3. Start Acteon
 cargo run -p acteon-server --features postgres -- \
   -c examples/incident-response-pipeline/acteon.toml
 
-# 3. Setup API resources (quotas, retention, recurring)
+# 4. Setup API resources (quotas, retention, recurring)
 cd examples/incident-response-pipeline
 bash scripts/setup.sh
 
-# 4. Fire 20 sample alerts
+# 5. Fire 20 sample alerts
 bash scripts/send-alerts.sh
 
-# 5. Manage incident lifecycle (event state transitions)
+# 6. Manage incident lifecycle (event state transitions)
 bash scripts/manage-incident.sh
 
-# 6. View comprehensive report
+# 7. View comprehensive report
 bash scripts/show-report.sh
 
-# 7. Cleanup API resources
+# 8. Cleanup API resources
 bash scripts/teardown.sh
 ```
 
@@ -145,6 +146,6 @@ python3 -m http.server 9999
 ## Notes
 
 - **Log providers** return `{"provider": "<name>", "logged": true}`. Chain branching uses `body.logged == true` as a condition field.
-- **Event seeding** in `manage-incident.sh` requires `psql` access to write initial state. If `psql` is unavailable, the script falls back to dispatching an alert.
+- **Event seeding** in `manage-incident.sh` dispatches an alert through the API to create initial event state.
 - **Quota window** uses `"hourly"` string format. Other options: `"daily"`, `"weekly"`, `"monthly"`.
 - All audit payloads containing `api_key`, `webhook_url`, or `pagerduty_key` fields are automatically redacted to `[REDACTED]`.

--- a/examples/incident-response-pipeline/acteon.toml
+++ b/examples/incident-response-pipeline/acteon.toml
@@ -7,7 +7,9 @@
 #
 # Requires PostgreSQL for durable state + audit:
 #   docker compose --profile postgres up -d
-#   (or use a local PostgreSQL: createdb acteon)
+#
+# Run migrations:
+#   scripts/migrate.sh -c examples/incident-response-pipeline/acteon.toml
 #
 # Start Acteon:
 #   cargo run -p acteon-server --features postgres -- -c examples/incident-response-pipeline/acteon.toml

--- a/examples/incident-response-pipeline/acteon.toml
+++ b/examples/incident-response-pipeline/acteon.toml
@@ -1,0 +1,185 @@
+# Incident Response Pipeline example.
+#
+# Exercises 14 Acteon features: chains, sub-chains, conditional branching,
+# event state management, circuit breakers with fallback, recurring actions,
+# data retention, event grouping, quotas, throttle, dedup, suppress, modify,
+# and audit with redaction.
+#
+# Requires PostgreSQL for durable state + audit:
+#   docker compose --profile postgres up -d
+#   (or use a local PostgreSQL: createdb acteon)
+#
+# Start Acteon:
+#   cargo run -p acteon-server --features postgres -- -c examples/incident-response-pipeline/acteon.toml
+
+[server]
+host = "127.0.0.1"
+port = 8080
+
+# HMAC secret for signing approval URLs (hex-encoded, 256-bit).
+approval_secret = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+# ─── State (PostgreSQL) ───────────────────────────────────────────────────────
+[state]
+backend = "postgres"
+url = "postgres://localhost:5432/acteon"
+
+# ─── Audit (PostgreSQL, 7-day TTL, payload stored, redaction enabled) ─────────
+[audit]
+enabled = true
+backend = "postgres"
+url = "postgres://localhost:5432/acteon"
+store_payload = true
+ttl_seconds = 604800
+
+[audit.redact]
+enabled = true
+fields = ["api_key", "webhook_url", "pagerduty_key"]
+placeholder = "[REDACTED]"
+
+# ─── Providers ────────────────────────────────────────────────────────────────
+# Log providers simulate real integrations; webhook-fallback intentionally
+# targets a non-existent server to demonstrate circuit breaker tripping.
+
+[[providers]]
+name = "pagerduty"
+type = "log"
+
+[[providers]]
+name = "slack-alerts"
+type = "log"
+
+[[providers]]
+name = "email-alerts"
+type = "log"
+
+# This webhook targets a server that likely isn't running -- the circuit
+# breaker will trip after 2 failures, demonstrating fallback routing.
+# Optionally run: python3 -m http.server 9999
+[[providers]]
+name = "webhook-fallback"
+type = "webhook"
+url = "http://localhost:9999/fallback"
+
+[[providers]]
+name = "ticket-system"
+type = "log"
+
+# ─── Rules ────────────────────────────────────────────────────────────────────
+[rules]
+directory = "examples/incident-response-pipeline/rules"
+
+# ─── Executor ─────────────────────────────────────────────────────────────────
+[executor]
+max_retries = 2
+timeout_seconds = 15
+max_concurrent = 16
+
+# ─── Circuit Breaker ─────────────────────────────────────────────────────────
+[circuit_breaker]
+enabled = true
+failure_threshold = 3
+success_threshold = 1
+recovery_timeout_seconds = 30
+
+# PagerDuty trips after 2 failures, falls back to webhook-fallback
+[circuit_breaker.providers.pagerduty]
+failure_threshold = 2
+recovery_timeout_seconds = 60
+fallback_provider = "webhook-fallback"
+
+# email-alerts trips after 2 failures, falls back to slack-alerts
+[circuit_breaker.providers.email-alerts]
+failure_threshold = 2
+recovery_timeout_seconds = 60
+fallback_provider = "slack-alerts"
+
+# ─── Chains ──────────────────────────────────────────────────────────────────
+[chains]
+max_concurrent_advances = 8
+completed_chain_ttl_seconds = 3600
+
+# Main chain: classify → (branch) → escalate → (branch) → war-room | ticket
+[[chains.definitions]]
+name = "incident-triage"
+timeout_seconds = 300
+
+[[chains.definitions.steps]]
+name = "classify"
+provider = "slack-alerts"
+action_type = "classify_alert"
+payload_template = { alert_id = "{{origin.payload.alert_id}}", severity = "{{origin.payload.severity}}" }
+
+  [[chains.definitions.steps.branches]]
+  field = "body.logged"
+  operator = "eq"
+  value = true
+  target = "escalate"
+
+[[chains.definitions.steps]]
+name = "escalate"
+provider = "pagerduty"
+action_type = "create_incident"
+payload_template = { service = "{{origin.payload.service}}", severity = "{{origin.payload.severity}}" }
+
+  [[chains.definitions.steps.branches]]
+  field = "success"
+  operator = "eq"
+  value = true
+  target = "war-room"
+
+  default_next = "create-ticket"
+
+[[chains.definitions.steps]]
+name = "war-room"
+sub_chain = "war-room-setup"
+
+[[chains.definitions.steps]]
+name = "create-ticket"
+provider = "ticket-system"
+action_type = "create_ticket"
+payload_template = { alert_id = "{{origin.payload.alert_id}}", service = "{{origin.payload.service}}" }
+
+# Sub-chain: war room setup (3 steps)
+[[chains.definitions]]
+name = "war-room-setup"
+timeout_seconds = 120
+
+[[chains.definitions.steps]]
+name = "create-channel"
+provider = "slack-alerts"
+action_type = "create_channel"
+payload_template = { name = "inc-{{origin.payload.alert_id}}" }
+
+[[chains.definitions.steps]]
+name = "page-oncall"
+provider = "pagerduty"
+action_type = "page_oncall"
+payload_template = { urgency = "high", service = "{{origin.payload.service}}" }
+
+[[chains.definitions.steps]]
+name = "open-ticket"
+provider = "ticket-system"
+action_type = "create_ticket"
+payload_template = { alert_id = "{{origin.payload.alert_id}}", type = "war-room" }
+
+# ─── Background Processing ───────────────────────────────────────────────────
+[background]
+enabled = true
+group_flush_interval_seconds = 10
+timeout_check_interval_seconds = 10
+cleanup_interval_seconds = 60
+enable_group_flush = true
+enable_timeout_processing = true
+enable_recurring_actions = true
+recurring_check_interval_seconds = 30
+max_recurring_actions_per_tenant = 10
+enable_retention_reaper = true
+retention_check_interval_seconds = 60
+namespace = "incidents"
+tenant = "ops-team"
+
+# ─── Quotas ──────────────────────────────────────────────────────────────────
+# Quota enforcement enabled; policies created via the API in scripts/setup.sh.
+[quotas]
+enabled = true

--- a/examples/incident-response-pipeline/rules/routing.yaml
+++ b/examples/incident-response-pipeline/rules/routing.yaml
@@ -1,0 +1,56 @@
+# Routing rules: dedup, enrich metadata, group low-severity, allow ops actions.
+
+rules:
+  # ── Deduplicate alerts with the same fingerprint ───────────────────────────
+  - name: dedup-alerts
+    priority: 3
+    description: "Deduplicate alerts sharing the same dedup_key within 5 minutes"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "ops-team"
+        - field: action.action_type
+          eq: "alert"
+    action:
+      type: deduplicate
+      ttl_seconds: 300
+
+  # ── Enrich all ops-team actions with pipeline version ──────────────────────
+  - name: enrich-alert-metadata
+    priority: 4
+    description: "Add pipeline_version metadata to all ops-team actions"
+    condition:
+      field: action.tenant
+      eq: "ops-team"
+    action:
+      type: modify
+      changes:
+        pipeline_version: "1.0.0"
+
+  # ── Group low-severity alerts into batches ─────────────────────────────────
+  - name: group-low-severity
+    priority: 6
+    description: "Batch low-severity alerts by service, flush every 30 seconds"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "ops-team"
+        - field: action.action_type
+          eq: "alert"
+        - field: action.payload.severity
+          eq: "low"
+    action:
+      type: group
+      group_by:
+        - payload.service
+      group_wait_seconds: 30
+
+  # ── Allow all remaining ops-team actions ───────────────────────────────────
+  - name: allow-ops-actions
+    priority: 10
+    description: "Allow any ops-team action that passed prior rules"
+    condition:
+      field: action.tenant
+      eq: "ops-team"
+    action:
+      type: allow

--- a/examples/incident-response-pipeline/rules/safety.yaml
+++ b/examples/incident-response-pipeline/rules/safety.yaml
@@ -1,0 +1,12 @@
+# Safety rules: deny-by-default catch-all.
+
+rules:
+  # ── Catch-all: suppress anything not explicitly allowed ────────────────────
+  - name: deny-unmatched
+    priority: 100
+    description: "Block any action not matched by a higher-priority rule"
+    condition:
+      field: action.tenant
+      eq: "ops-team"
+    action:
+      type: suppress

--- a/examples/incident-response-pipeline/rules/triage.yaml
+++ b/examples/incident-response-pipeline/rules/triage.yaml
@@ -1,0 +1,43 @@
+# Triage rules: suppress test alerts, throttle alert storms, route to chains.
+
+rules:
+  # ── Suppress alerts from test environments ─────────────────────────────────
+  - name: suppress-test-env
+    priority: 1
+    description: "Block all alerts originating from test environments"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "ops-team"
+        - field: action.payload.environment
+          eq: "test"
+    action:
+      type: suppress
+
+  # ── Throttle alert storms ──────────────────────────────────────────────────
+  - name: throttle-alert-storm
+    priority: 2
+    description: "Limit ops-team to 20 alerts per minute to prevent alert fatigue"
+    condition:
+      field: action.tenant
+      eq: "ops-team"
+    action:
+      type: throttle
+      max_count: 20
+      window_seconds: 60
+
+  # ── Route critical/high alerts to incident triage chain ────────────────────
+  - name: trigger-incident-triage
+    priority: 5
+    description: "Start incident triage chain for critical and high severity alerts"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "ops-team"
+        - field: action.action_type
+          eq: "alert"
+        - field: action.payload.severity
+          in_list: ["critical", "high"]
+    action:
+      type: chain
+      chain: "incident-triage"

--- a/examples/incident-response-pipeline/scripts/manage-incident.sh
+++ b/examples/incident-response-pipeline/scripts/manage-incident.sh
@@ -1,18 +1,16 @@
 #!/bin/bash
 # Demonstrates event lifecycle management via the Acteon API.
 #
-# 1. Seeds an initial event via psql INSERT
+# 1. Seeds an initial event via dispatch API
 # 2. Transitions: open → acknowledged → investigating → resolved
 # 3. Lists events at each stage
 #
 # Usage: bash scripts/manage-incident.sh
 # Environment:
 #   ACTEON_URL  - Acteon gateway URL (default: http://localhost:8080)
-#   DATABASE_URL - PostgreSQL URL (default: postgres://localhost:5432/acteon)
 set -euo pipefail
 
 ACTEON_URL="${ACTEON_URL:-http://localhost:8080}"
-DATABASE_URL="${DATABASE_URL:-postgres://localhost:5432/acteon}"
 
 FINGERPRINT="incident-db-001"
 NAMESPACE="incidents"
@@ -21,32 +19,18 @@ TENANT="ops-team"
 echo "=== Incident Response Pipeline: Event Lifecycle ==="
 echo ""
 
-# ── Step 1: Seed initial event via psql ──────────────────────────────────────
-echo "Step 1: Seeding initial event (state=open) via psql..."
-STATE_KEY="${NAMESPACE}:${TENANT}:event_state:${FINGERPRINT}"
-UPDATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-STATE_VALUE='{"state":"open","fingerprint":"'"$FINGERPRINT"'","updated_at":"'"$UPDATED_AT"'"}'
-
-psql "$DATABASE_URL" -c "
-  INSERT INTO acteon_state (key, value, updated_at)
-  VALUES ('$STATE_KEY', '$STATE_VALUE', NOW())
-  ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW();
-" 2>/dev/null && echo "  Seeded: $FINGERPRINT (state=open)" || {
-  echo "  WARNING: psql failed. Is PostgreSQL running?"
-  echo "  Trying to create the event via a dispatch instead..."
-  # Fallback: dispatch an action that will create state
-  curl -sf -X POST "$ACTEON_URL/v1/dispatch" \
-    -H "Content-Type: application/json" \
-    -d '{
-      "id": "seed-event-001",
-      "namespace": "'"$NAMESPACE"'",
-      "tenant": "'"$TENANT"'",
-      "provider": "slack-alerts",
-      "action_type": "alert",
-      "payload": {"alert_id": "'"$FINGERPRINT"'", "severity": "critical", "service": "database", "environment": "production"}
-    }' > /dev/null 2>&1
-  echo "  Dispatched alert as fallback."
-}
+# ── Step 1: Seed initial event via dispatch API ──────────────────────────────
+echo "Step 1: Seeding initial event via dispatch..."
+curl -sf -X POST "$ACTEON_URL/v1/dispatch" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "seed-event-001",
+    "namespace": "'"$NAMESPACE"'",
+    "tenant": "'"$TENANT"'",
+    "provider": "slack-alerts",
+    "action_type": "alert",
+    "payload": {"alert_id": "'"$FINGERPRINT"'", "severity": "critical", "service": "database", "environment": "production"}
+  }' > /dev/null 2>&1 && echo "  Dispatched alert for $FINGERPRINT" || echo "  WARNING: dispatch failed. Is the server running?"
 echo ""
 
 # ── Step 2: List events (should show open) ───────────────────────────────────

--- a/examples/incident-response-pipeline/scripts/manage-incident.sh
+++ b/examples/incident-response-pipeline/scripts/manage-incident.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Demonstrates event lifecycle management via the Acteon API.
+#
+# 1. Seeds an initial event via psql INSERT
+# 2. Transitions: open → acknowledged → investigating → resolved
+# 3. Lists events at each stage
+#
+# Usage: bash scripts/manage-incident.sh
+# Environment:
+#   ACTEON_URL  - Acteon gateway URL (default: http://localhost:8080)
+#   DATABASE_URL - PostgreSQL URL (default: postgres://localhost:5432/acteon)
+set -euo pipefail
+
+ACTEON_URL="${ACTEON_URL:-http://localhost:8080}"
+DATABASE_URL="${DATABASE_URL:-postgres://localhost:5432/acteon}"
+
+FINGERPRINT="incident-db-001"
+NAMESPACE="incidents"
+TENANT="ops-team"
+
+echo "=== Incident Response Pipeline: Event Lifecycle ==="
+echo ""
+
+# ── Step 1: Seed initial event via psql ──────────────────────────────────────
+echo "Step 1: Seeding initial event (state=open) via psql..."
+STATE_KEY="${NAMESPACE}:${TENANT}:event_state:${FINGERPRINT}"
+UPDATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+STATE_VALUE='{"state":"open","fingerprint":"'"$FINGERPRINT"'","updated_at":"'"$UPDATED_AT"'"}'
+
+psql "$DATABASE_URL" -c "
+  INSERT INTO acteon_state (key, value, updated_at)
+  VALUES ('$STATE_KEY', '$STATE_VALUE', NOW())
+  ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW();
+" 2>/dev/null && echo "  Seeded: $FINGERPRINT (state=open)" || {
+  echo "  WARNING: psql failed. Is PostgreSQL running?"
+  echo "  Trying to create the event via a dispatch instead..."
+  # Fallback: dispatch an action that will create state
+  curl -sf -X POST "$ACTEON_URL/v1/dispatch" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "id": "seed-event-001",
+      "namespace": "'"$NAMESPACE"'",
+      "tenant": "'"$TENANT"'",
+      "provider": "slack-alerts",
+      "action_type": "alert",
+      "payload": {"alert_id": "'"$FINGERPRINT"'", "severity": "critical", "service": "database", "environment": "production"}
+    }' > /dev/null 2>&1
+  echo "  Dispatched alert as fallback."
+}
+echo ""
+
+# ── Step 2: List events (should show open) ───────────────────────────────────
+echo "Step 2: Listing events (expect open)..."
+curl -sf "$ACTEON_URL/v1/events?namespace=$NAMESPACE&tenant=$TENANT" | jq . 2>/dev/null || echo "  (no events yet)"
+echo ""
+
+# ── Step 3: Transition open → acknowledged ───────────────────────────────────
+echo "Step 3: Transitioning $FINGERPRINT: open → acknowledged..."
+curl -sf -X PUT "$ACTEON_URL/v1/events/$FINGERPRINT/transition" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "acknowledged",
+    "namespace": "'"$NAMESPACE"'",
+    "tenant": "'"$TENANT"'"
+  }' | jq .
+echo ""
+
+# ── Step 4: Transition acknowledged → investigating ──────────────────────────
+echo "Step 4: Transitioning $FINGERPRINT: acknowledged → investigating..."
+curl -sf -X PUT "$ACTEON_URL/v1/events/$FINGERPRINT/transition" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "investigating",
+    "namespace": "'"$NAMESPACE"'",
+    "tenant": "'"$TENANT"'"
+  }' | jq .
+echo ""
+
+# ── Step 5: Transition investigating → resolved ─────────────────────────────
+echo "Step 5: Transitioning $FINGERPRINT: investigating → resolved..."
+curl -sf -X PUT "$ACTEON_URL/v1/events/$FINGERPRINT/transition" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "resolved",
+    "namespace": "'"$NAMESPACE"'",
+    "tenant": "'"$TENANT"'"
+  }' | jq .
+echo ""
+
+# ── Step 6: Final event listing ──────────────────────────────────────────────
+echo "Step 6: Final event listing..."
+curl -sf "$ACTEON_URL/v1/events?namespace=$NAMESPACE&tenant=$TENANT" | jq .
+echo ""
+
+echo "=== Event lifecycle complete: open → acknowledged → investigating → resolved ==="

--- a/examples/incident-response-pipeline/scripts/send-alerts.sh
+++ b/examples/incident-response-pipeline/scripts/send-alerts.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Fires 20 sample alerts exercising all Acteon features.
+#
+# Categories:
+#   2 critical  → triggers chain + sub-chain
+#   3 high      → triggers chain (simpler path)
+#   5 low       → grouped by service, 30s batch
+#   5 storm     → rapid-fire, hits throttle at ~20/min
+#   3 duplicate → same dedup_key, deduplicated
+#   2 test-env  → environment=test, suppressed
+#
+# Usage: bash scripts/send-alerts.sh
+# Environment:
+#   ACTEON_URL - Acteon gateway URL (default: http://localhost:8080)
+set -euo pipefail
+
+ACTEON_URL="${ACTEON_URL:-http://localhost:8080}"
+
+dispatch() {
+  local label="$1"
+  shift
+  echo -n "  $label: "
+  RESPONSE=$(curl -sf -X POST "$ACTEON_URL/v1/dispatch" \
+    -H "Content-Type: application/json" \
+    -d "$1" 2>&1) || { echo "FAILED"; return; }
+  # Extract the outcome key from the response
+  OUTCOME=$(echo "$RESPONSE" | jq -r 'keys[0] // "unknown"' 2>/dev/null || echo "unknown")
+  echo "$OUTCOME"
+}
+
+CREATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+echo "=== Incident Response Pipeline: Sending Alerts ==="
+echo ""
+
+# ── Critical alerts (2) → chain + sub-chain ──────────────────────────────────
+echo "Critical alerts (chain + sub-chain):"
+dispatch "critical-db-001" '{
+  "id": "crit-db-001",
+  "namespace": "incidents",
+  "tenant": "ops-team",
+  "provider": "pagerduty",
+  "action_type": "alert",
+  "payload": {"alert_id": "ALERT-001", "severity": "critical", "service": "database", "environment": "production", "api_key": "pg-key-12345"},
+  "metadata": {"source": "datadog"},
+  "created_at": "'"$CREATED_AT"'"
+}'
+
+dispatch "critical-api-002" '{
+  "id": "crit-api-002",
+  "namespace": "incidents",
+  "tenant": "ops-team",
+  "provider": "pagerduty",
+  "action_type": "alert",
+  "payload": {"alert_id": "ALERT-002", "severity": "critical", "service": "api-gateway", "environment": "production", "webhook_url": "https://hooks.example.com/abc"},
+  "metadata": {"source": "prometheus"},
+  "created_at": "'"$CREATED_AT"'"
+}'
+echo ""
+
+# ── High-severity alerts (3) → chain, simpler path ──────────────────────────
+echo "High-severity alerts (chain):"
+for i in 1 2 3; do
+  dispatch "high-cache-00$i" '{
+    "id": "high-cache-00'"$i"'",
+    "namespace": "incidents",
+    "tenant": "ops-team",
+    "provider": "pagerduty",
+    "action_type": "alert",
+    "payload": {"alert_id": "ALERT-10'"$i"'", "severity": "high", "service": "cache-layer", "environment": "production"},
+    "metadata": {"source": "grafana"},
+    "created_at": "'"$CREATED_AT"'"
+  }'
+done
+echo ""
+
+# ── Low-severity alerts (5) → grouped by service, 30s batch ─────────────────
+echo "Low-severity alerts (grouped):"
+SERVICES=("cdn" "search" "cdn" "auth" "search")
+for i in 0 1 2 3 4; do
+  SVC="${SERVICES[$i]}"
+  dispatch "low-$SVC-$i" '{
+    "id": "low-'"$SVC"'-00'"$i"'",
+    "namespace": "incidents",
+    "tenant": "ops-team",
+    "provider": "slack-alerts",
+    "action_type": "alert",
+    "payload": {"alert_id": "ALERT-20'"$i"'", "severity": "low", "service": "'"$SVC"'", "environment": "production"},
+    "metadata": {"source": "cloudwatch"},
+    "created_at": "'"$CREATED_AT"'"
+  }'
+done
+echo ""
+
+# ── Storm alerts (5) → rapid-fire, hits throttle limit ──────────────────────
+echo "Storm alerts (throttle test):"
+for i in $(seq 1 5); do
+  dispatch "storm-$i" '{
+    "id": "storm-'"$i"'",
+    "namespace": "incidents",
+    "tenant": "ops-team",
+    "provider": "slack-alerts",
+    "action_type": "alert",
+    "payload": {"alert_id": "STORM-'"$i"'", "severity": "medium", "service": "payment-service", "environment": "production"},
+    "metadata": {"source": "synthetic-storm"},
+    "created_at": "'"$CREATED_AT"'"
+  }'
+done
+echo ""
+
+# ── Duplicate alerts (3) → same dedup_key, deduplicated ─────────────────────
+echo "Duplicate alerts (dedup test):"
+for i in 1 2 3; do
+  dispatch "dup-$i" '{
+    "id": "dup-net-00'"$i"'",
+    "namespace": "incidents",
+    "tenant": "ops-team",
+    "provider": "email-alerts",
+    "action_type": "alert",
+    "payload": {"alert_id": "ALERT-300", "severity": "high", "service": "network", "environment": "production"},
+    "metadata": {"source": "nagios"},
+    "dedup_key": "network-alert-300",
+    "created_at": "'"$CREATED_AT"'"
+  }'
+done
+echo ""
+
+# ── Test-environment alerts (2) → suppressed ─────────────────────────────────
+echo "Test-environment alerts (suppressed):"
+for i in 1 2; do
+  dispatch "test-env-$i" '{
+    "id": "test-env-00'"$i"'",
+    "namespace": "incidents",
+    "tenant": "ops-team",
+    "provider": "slack-alerts",
+    "action_type": "alert",
+    "payload": {"alert_id": "TEST-00'"$i"'", "severity": "critical", "service": "staging-db", "environment": "test"},
+    "metadata": {"source": "ci-pipeline"},
+    "created_at": "'"$CREATED_AT"'"
+  }'
+done
+echo ""
+
+echo "=== Done: 20 alerts dispatched ==="
+echo ""
+echo "Expected outcomes:"
+echo "  - 2 suppressed (test environment)"
+echo "  - 2-3 deduplicated (same dedup_key)"
+echo "  - 5 grouped (low severity, batched 30s)"
+echo "  - Some throttled (if >20/min reached)"
+echo "  - 5+ chain_started (critical + high severity)"
+echo "  - Remaining executed"
+echo ""
+echo "Run 'bash scripts/show-report.sh' to see results."

--- a/examples/incident-response-pipeline/scripts/setup.sh
+++ b/examples/incident-response-pipeline/scripts/setup.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Creates API-managed resources: quota, retention policy, and recurring action.
+#
+# Usage: bash scripts/setup.sh
+# Environment:
+#   ACTEON_URL - Acteon gateway URL (default: http://localhost:8080)
+set -euo pipefail
+
+ACTEON_URL="${ACTEON_URL:-http://localhost:8080}"
+
+echo "=== Incident Response Pipeline: Setup ==="
+echo ""
+
+# ── Quota: 100 actions/hour for ops-team ─────────────────────────────────────
+echo "Creating quota (100 actions/hour)..."
+curl -sf -X POST "$ACTEON_URL/v1/quotas" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "incidents",
+    "tenant": "ops-team",
+    "max_actions": 100,
+    "window": "hourly",
+    "overage_behavior": "block",
+    "enabled": true,
+    "description": "100 actions per hour for ops-team"
+  }' | jq .
+echo ""
+
+# ── Retention: audit 7 days, events 1 day ────────────────────────────────────
+echo "Creating retention policy (audit 7d, events 1d)..."
+curl -sf -X POST "$ACTEON_URL/v1/retention" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "incidents",
+    "tenant": "ops-team",
+    "enabled": true,
+    "audit_ttl_seconds": 604800,
+    "event_ttl_seconds": 86400,
+    "compliance_hold": false,
+    "description": "7-day audit, 1-day events"
+  }' | jq .
+echo ""
+
+# ── Recurring: health check every minute ─────────────────────────────────────
+echo "Creating recurring action (health check every 60s)..."
+curl -sf -X POST "$ACTEON_URL/v1/recurring" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "incidents",
+    "tenant": "ops-team",
+    "cron_expr": "* * * * *",
+    "timezone": "UTC",
+    "enabled": true,
+    "action_template": {
+      "provider": "slack-alerts",
+      "action_type": "alert",
+      "payload": {
+        "severity": "low",
+        "service": "health-monitor",
+        "alert_id": "health-check-{{execution_time}}"
+      }
+    },
+    "description": "Health check alert every minute"
+  }' | jq .
+echo ""
+
+echo "Setup complete. Resources created:"
+echo "  - Quota: 100/hour for incidents:ops-team"
+echo "  - Retention: audit 7d, events 1d for incidents:ops-team"
+echo "  - Recurring: health-check every 60s via slack-alerts"

--- a/examples/incident-response-pipeline/scripts/show-report.sh
+++ b/examples/incident-response-pipeline/scripts/show-report.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Queries 8 API endpoints and displays a comprehensive pipeline report.
+#
+# Usage: bash scripts/show-report.sh
+# Environment:
+#   ACTEON_URL - Acteon gateway URL (default: http://localhost:8080)
+set -euo pipefail
+
+ACTEON_URL="${ACTEON_URL:-http://localhost:8080}"
+NAMESPACE="incidents"
+TENANT="ops-team"
+
+echo "╔══════════════════════════════════════════════════════════════════╗"
+echo "║          Incident Response Pipeline — Report                    ║"
+echo "╚══════════════════════════════════════════════════════════════════╝"
+echo ""
+
+# ── 1. Audit trail ──────────────────────────────────────────────────────────
+echo "━━━ 1. Audit Trail ━━━"
+AUDIT=$(curl -sf "$ACTEON_URL/v1/audit?namespace=$NAMESPACE&tenant=$TENANT&limit=200" 2>/dev/null) || AUDIT='{"records":[]}'
+RECORDS=$(echo "$AUDIT" | jq '.records // []')
+TOTAL=$(echo "$RECORDS" | jq 'length')
+
+echo "Total dispatches: $TOTAL"
+echo ""
+echo "Outcome breakdown:"
+echo "$RECORDS" | jq -r '
+  group_by(.outcome) |
+  map({outcome: .[0].outcome, count: length}) |
+  sort_by(-.count) |
+  .[] |
+  "  \(.outcome): \(.count)"
+'
+echo ""
+
+# Show redaction in action (if any payloads stored)
+REDACTED=$(echo "$RECORDS" | jq '[.[] | select(.payload != null) | .payload | to_entries[] | select(.value == "[REDACTED]") | .key] | unique')
+if [ "$REDACTED" != "[]" ] && [ "$REDACTED" != "null" ]; then
+  echo "Redacted fields found in payloads: $REDACTED"
+  echo ""
+fi
+
+# ── 2. Chains ───────────────────────────────────────────────────────────────
+echo "━━━ 2. Chains ━━━"
+CHAINS=$(curl -sf "$ACTEON_URL/v1/chains?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || CHAINS='[]'
+CHAIN_COUNT=$(echo "$CHAINS" | jq 'if type == "array" then length else 0 end')
+echo "Active/completed chains: $CHAIN_COUNT"
+if [ "$CHAIN_COUNT" -gt 0 ]; then
+  echo "$CHAINS" | jq -r '
+    if type == "array" then
+      .[] |
+      "  [\(.status // "?")] \(.chain_name // "?") — started: \(.started_at // "?") step: \(.current_step_index // 0)"
+    else
+      empty
+    end
+  ' 2>/dev/null || true
+fi
+echo ""
+
+# ── 3. Events ───────────────────────────────────────────────────────────────
+echo "━━━ 3. Events ━━━"
+EVENTS=$(curl -sf "$ACTEON_URL/v1/events?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || EVENTS='[]'
+EVENT_COUNT=$(echo "$EVENTS" | jq 'if type == "array" then length else 0 end')
+echo "Tracked events: $EVENT_COUNT"
+if [ "$EVENT_COUNT" -gt 0 ]; then
+  echo "$EVENTS" | jq -r '
+    if type == "array" then
+      .[] |
+      "  [\(.state // "?")] fingerprint=\(.fingerprint // "?") updated=\(.updated_at // "?")"
+    else
+      empty
+    end
+  ' 2>/dev/null || true
+fi
+echo ""
+
+# ── 4. Provider Health ──────────────────────────────────────────────────────
+echo "━━━ 4. Provider Health ━━━"
+HEALTH=$(curl -sf "$ACTEON_URL/v1/providers/health" 2>/dev/null) || HEALTH='{}'
+echo "$HEALTH" | jq -r '
+  to_entries[] |
+  "  \(.key): status=\(.value.status // "?") circuit=\(.value.circuit_breaker // "?")"
+' 2>/dev/null || echo "  (no health data)"
+echo ""
+
+# ── 5. Quotas ───────────────────────────────────────────────────────────────
+echo "━━━ 5. Quotas ━━━"
+QUOTAS=$(curl -sf "$ACTEON_URL/v1/quotas?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || QUOTAS='[]'
+QUOTA_COUNT=$(echo "$QUOTAS" | jq 'if type == "array" then length else 0 end')
+echo "Quota policies: $QUOTA_COUNT"
+if [ "$QUOTA_COUNT" -gt 0 ]; then
+  echo "$QUOTAS" | jq -r '
+    if type == "array" then
+      .[] |
+      "  \(.description // "unnamed"): \(.max_actions // "?")/\(.window // "?") [\(if .enabled then "enabled" else "disabled" end)]"
+    else
+      empty
+    end
+  ' 2>/dev/null || true
+fi
+echo ""
+
+# ── 6. Groups ───────────────────────────────────────────────────────────────
+echo "━━━ 6. Event Groups ━━━"
+GROUPS=$(curl -sf "$ACTEON_URL/v1/groups" 2>/dev/null) || GROUPS='[]'
+GROUP_COUNT=$(echo "$GROUPS" | jq 'if type == "array" then length else 0 end')
+echo "Active groups: $GROUP_COUNT"
+if [ "$GROUP_COUNT" -gt 0 ]; then
+  echo "$GROUPS" | jq -r '
+    if type == "array" then
+      .[] |
+      "  group=\(.group_key // "?") count=\(.count // 0) created=\(.created_at // "?")"
+    else
+      empty
+    end
+  ' 2>/dev/null || true
+fi
+echo ""
+
+# ── 7. Recurring Actions ────────────────────────────────────────────────────
+echo "━━━ 7. Recurring Actions ━━━"
+RECURRING=$(curl -sf "$ACTEON_URL/v1/recurring?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || RECURRING='[]'
+REC_COUNT=$(echo "$RECURRING" | jq 'if type == "array" then length else 0 end')
+echo "Recurring actions: $REC_COUNT"
+if [ "$REC_COUNT" -gt 0 ]; then
+  echo "$RECURRING" | jq -r '
+    if type == "array" then
+      .[] |
+      "  \(.description // "unnamed"): cron=\(.cron_expr // "?") executions=\(.execution_count // 0) [\(if .enabled then "active" else "paused" end)]"
+    else
+      empty
+    end
+  ' 2>/dev/null || true
+fi
+echo ""
+
+# ── 8. Retention Policies ───────────────────────────────────────────────────
+echo "━━━ 8. Retention Policies ━━━"
+RETENTION=$(curl -sf "$ACTEON_URL/v1/retention?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || RETENTION='[]'
+RET_COUNT=$(echo "$RETENTION" | jq 'if type == "array" then length else 0 end')
+echo "Retention policies: $RET_COUNT"
+if [ "$RET_COUNT" -gt 0 ]; then
+  echo "$RETENTION" | jq -r '
+    if type == "array" then
+      .[] |
+      "  \(.description // "unnamed"): audit=\(.audit_ttl_seconds // "?")s events=\(.event_ttl_seconds // "?")s [\(if .enabled then "enabled" else "disabled" end)]"
+    else
+      empty
+    end
+  ' 2>/dev/null || true
+fi
+echo ""
+
+echo "═══════════════════════════════════════════════════════════════════"
+echo "Report complete."

--- a/examples/incident-response-pipeline/scripts/teardown.sh
+++ b/examples/incident-response-pipeline/scripts/teardown.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Cleans up API-created resources (quotas, retention policies, recurring actions).
+#
+# Usage: bash scripts/teardown.sh
+# Environment:
+#   ACTEON_URL - Acteon gateway URL (default: http://localhost:8080)
+set -euo pipefail
+
+ACTEON_URL="${ACTEON_URL:-http://localhost:8080}"
+NAMESPACE="incidents"
+TENANT="ops-team"
+
+echo "=== Incident Response Pipeline: Teardown ==="
+echo ""
+
+# ── Delete quotas ────────────────────────────────────────────────────────────
+echo "Deleting quotas..."
+QUOTAS=$(curl -sf "$ACTEON_URL/v1/quotas?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || QUOTAS='[]'
+echo "$QUOTAS" | jq -r 'if type == "array" then .[].id else empty end' 2>/dev/null | while read -r ID; do
+  echo "  Deleting quota $ID..."
+  curl -sf -X DELETE "$ACTEON_URL/v1/quotas/$ID" > /dev/null 2>&1 && echo "    done" || echo "    failed"
+done
+echo ""
+
+# ── Delete retention policies ────────────────────────────────────────────────
+echo "Deleting retention policies..."
+RETENTION=$(curl -sf "$ACTEON_URL/v1/retention?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || RETENTION='[]'
+echo "$RETENTION" | jq -r 'if type == "array" then .[].id else empty end' 2>/dev/null | while read -r ID; do
+  echo "  Deleting retention policy $ID..."
+  curl -sf -X DELETE "$ACTEON_URL/v1/retention/$ID" > /dev/null 2>&1 && echo "    done" || echo "    failed"
+done
+echo ""
+
+# ── Delete recurring actions ─────────────────────────────────────────────────
+echo "Deleting recurring actions..."
+RECURRING=$(curl -sf "$ACTEON_URL/v1/recurring?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || RECURRING='[]'
+echo "$RECURRING" | jq -r 'if type == "array" then .[].id else empty end' 2>/dev/null | while read -r ID; do
+  echo "  Deleting recurring action $ID..."
+  curl -sf -X DELETE "$ACTEON_URL/v1/recurring/$ID" > /dev/null 2>&1 && echo "    done" || echo "    failed"
+done
+echo ""
+
+echo "=== Teardown complete ==="

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -97,7 +97,7 @@ fi
 # ── Auto-detect backend from config if not specified ─────────────────────────
 if [[ -z "$BACKEND" ]]; then
   # Extract state.backend from TOML (simple grep — works for flat config)
-  BACKEND=$(grep -E '^\s*backend\s*=' "$CONFIG_FILE" | head -1 | sed 's/.*=\s*"\([^"]*\)".*/\1/' || true)
+  BACKEND=$(grep -E '^[[:space:]]*backend[[:space:]]*=' "$CONFIG_FILE" | head -1 | sed 's/.*=[[:space:]]*"\([^"]*\)".*/\1/' || true)
   if [[ -z "$BACKEND" ]]; then
     BACKEND="memory"
   fi

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Run database migrations for the configured Acteon state and audit backends.
+#
+# This script wraps `acteon-server migrate` with convenience flags for
+# backend selection and config file discovery.
+#
+# Usage:
+#   scripts/migrate.sh [OPTIONS]
+#
+# Examples:
+#   scripts/migrate.sh --backend postgres -c acteon.toml
+#   scripts/migrate.sh --backend clickhouse -c config/acteon.toml
+#   scripts/migrate.sh -c examples/incident-response-pipeline/acteon.toml
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Defaults
+BACKEND=""
+CONFIG_FILE=""
+CARGO_ARGS=""
+DRY_RUN=false
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run database migrations for configured Acteon state and audit backends.
+
+Options:
+  -c, --config FILE       Path to acteon.toml config file (default: acteon.toml)
+  -b, --backend BACKEND   State backend: postgres, clickhouse, dynamodb, redis, memory
+                           (auto-detected from config if omitted; sets cargo feature flag)
+  -n, --dry-run           Build the binary but don't run migrations
+  -h, --help              Show this help message
+
+Environment:
+  DATABASE_URL            PostgreSQL connection string (used by postgres backend)
+  CLICKHOUSE_URL          ClickHouse connection string (used by clickhouse backend)
+  AWS_REGION              AWS region (used by dynamodb backend)
+
+Examples:
+  # Migrate using the example incident pipeline config
+  $(basename "$0") -c examples/incident-response-pipeline/acteon.toml
+
+  # Migrate with explicit backend (skips auto-detection)
+  $(basename "$0") --backend postgres -c acteon.toml
+
+  # Dry-run: just build, don't run
+  $(basename "$0") --dry-run -c acteon.toml
+EOF
+  exit 0
+}
+
+# ── Parse arguments ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      ;;
+    -c|--config)
+      CONFIG_FILE="$2"
+      shift 2
+      ;;
+    -b|--backend)
+      BACKEND="$2"
+      shift 2
+      ;;
+    -n|--dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Run '$(basename "$0") --help' for usage."
+      exit 1
+      ;;
+  esac
+done
+
+# ── Resolve config file ─────────────────────────────────────────────────────
+if [[ -z "$CONFIG_FILE" ]]; then
+  CONFIG_FILE="acteon.toml"
+fi
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  # Try relative to project root
+  if [[ -f "$PROJECT_ROOT/$CONFIG_FILE" ]]; then
+    CONFIG_FILE="$PROJECT_ROOT/$CONFIG_FILE"
+  else
+    echo "Error: config file not found: $CONFIG_FILE"
+    exit 1
+  fi
+fi
+
+# ── Auto-detect backend from config if not specified ─────────────────────────
+if [[ -z "$BACKEND" ]]; then
+  # Extract state.backend from TOML (simple grep — works for flat config)
+  BACKEND=$(grep -E '^\s*backend\s*=' "$CONFIG_FILE" | head -1 | sed 's/.*=\s*"\([^"]*\)".*/\1/' || true)
+  if [[ -z "$BACKEND" ]]; then
+    BACKEND="memory"
+  fi
+  echo "Auto-detected backend: $BACKEND"
+fi
+
+# ── Map backend to cargo feature flag ────────────────────────────────────────
+case "$BACKEND" in
+  postgres)
+    CARGO_ARGS="--features postgres"
+    ;;
+  clickhouse)
+    CARGO_ARGS="--features clickhouse"
+    ;;
+  dynamodb)
+    CARGO_ARGS="--features dynamodb"
+    ;;
+  redis|memory)
+    # No feature flag needed
+    CARGO_ARGS=""
+    ;;
+  *)
+    echo "Error: unknown backend '$BACKEND'"
+    echo "Supported backends: postgres, clickhouse, dynamodb, redis, memory"
+    exit 1
+    ;;
+esac
+
+# ── Run migrations ───────────────────────────────────────────────────────────
+echo "=== Acteon Database Migration ==="
+echo "  Config:  $CONFIG_FILE"
+echo "  Backend: $BACKEND"
+echo ""
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "Dry-run: building acteon-server..."
+  # shellcheck disable=SC2086
+  cargo build -p acteon-server $CARGO_ARGS
+  echo "Build successful. Run without --dry-run to execute migrations."
+  exit 0
+fi
+
+# shellcheck disable=SC2086
+cargo run -p acteon-server $CARGO_ARGS -- -c "$CONFIG_FILE" migrate


### PR DESCRIPTION
## Summary

- Adds `acteon-server migrate` CLI subcommand that initializes database schemas for configured state and audit backends without starting the full HTTP server
- Adds `scripts/migrate.sh` bash wrapper with `--help`, `--backend` auto-detection, and `--dry-run` support
- Adds a new runnable example at `examples/incident-response-pipeline/` exercising 14 Acteon features through an ops incident response scenario
- Removes all `psql`/`createdb` dependencies from examples and docs — everything uses the new migrate command or dispatch API
- Updates all backend docs, deployment guide, README, and both example READMEs to include the migrate step

## Migrate subcommand

```bash
# Using the wrapper script (auto-detects backend from config)
scripts/migrate.sh -c acteon.toml

# Or directly
cargo run -p acteon-server --features postgres -- -c acteon.toml migrate
```

Works for all backends: PostgreSQL, ClickHouse, DynamoDB, Elasticsearch (memory/Redis are no-ops). Idempotent — safe to run on every deploy.

## Features Exercised (incident-response-pipeline)

Chains, sub-chains, conditional branching, event state management, circuit breakers + fallback, recurring actions, data retention, event grouping, quotas, throttle, dedup, suppress, modify, audit + redaction

## Test plan

- [x] `cargo clippy --workspace --no-deps -- -D warnings` passes
- [x] `cargo test -p acteon-server --lib --bins --tests` passes (189 tests)
- [x] `scripts/migrate.sh` tested against real PostgreSQL — clean migration (5 tables + indexes created)
- [x] Idempotent re-run verified (all "already exists, skipping")
- [x] Server starts normally after migrate, dispatch + audit roundtrip confirmed
- [x] `scripts/migrate.sh --help` renders correctly
- [x] macOS compatibility verified (POSIX `[[:space:]]` instead of `\s` in sed)
- [ ] Manual: run full incident-response-pipeline scripts in sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)