### PR TITLE
feat: add AWS provider crate and refactor email to pluggable backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "acteon-aws"
+version = "0.1.0"
+dependencies = [
+ "acteon-core",
+ "acteon-provider",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-eventbridge",
+ "aws-sdk-lambda",
+ "aws-sdk-sesv2",
+ "aws-sdk-sns",
+ "aws-sdk-sqs",
+ "aws-sdk-sts",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "acteon-cli"
 version = "0.1.0"
 dependencies = [
@@ -164,8 +185,10 @@ dependencies = [
 name = "acteon-email"
 version = "0.1.0"
 dependencies = [
+ "acteon-aws",
  "acteon-core",
  "acteon-provider",
+ "async-trait",
  "lettre",
  "serde",
  "serde_json",
@@ -378,9 +401,11 @@ dependencies = [
  "acteon-audit-elasticsearch",
  "acteon-audit-memory",
  "acteon-audit-postgres",
+ "acteon-aws",
  "acteon-core",
  "acteon-crypto",
  "acteon-discord",
+ "acteon-email",
  "acteon-embedding",
  "acteon-executor",
  "acteon-gateway",
@@ -979,6 +1004,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
+ "aws-smithy-eventstream",
  "aws-smithy-http 0.62.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -999,6 +1025,123 @@ name = "aws-sdk-dynamodb"
 version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6df2a8b03419775bfaf4f3ebbb65a9772e9e69eed4467a1b33f22226722340fb"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-eventbridge"
+version = "1.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e365cd5adbdb070a5d4f52233d298917ec133b1a01aa9592e45b5872674bdb"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-lambda"
+version = "1.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0633fae71a1dd5de35778e3f90928a32ab75456f5cb9c9699f9eaf3ca8c004"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sesv2"
+version = "1.111.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779d5c35e02584d8ab4dc91ea0ab9bec0a1405e1bd21d0ae8cd52a7aa6996ce9"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sns"
+version = "1.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9131036b60a04dcd9e5a665f464f47058a57b5d3f48f45fa79ce52fd6722939f"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sqs"
+version = "1.92.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a930bbcf95be5e2e1424c1df814265e86e5796ad0eac3104ebeb0180279ab7"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1094,19 +1237,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69e523e1c4e8e7e8ff219d732988e22bfeae8a1cafdbe6d9eca1546fa080be7c"
 dependencies = [
  "aws-credential-types",
+ "aws-smithy-eventstream",
  "aws-smithy-http 0.62.6",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
+ "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
  "hmac",
  "http 0.2.12",
  "http 1.4.0",
+ "p256",
  "percent-encoding",
+ "ring",
  "sha2",
+ "subtle",
  "time",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -1121,11 +1270,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b9c7354a3b13c66f60fe4616d6d1969c9fd36b1b5333a5dfb3ee716b33c588"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
 dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -1456,6 +1617,12 @@ checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base64"
@@ -2077,6 +2244,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,6 +2375,16 @@ dependencies = [
 
 [[package]]
 name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
@@ -2284,12 +2483,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 1.6.4",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8 0.9.0",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2388,6 +2619,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "filetime"
@@ -2662,6 +2903,17 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -3947,6 +4199,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4079,9 +4342,19 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -4090,8 +4363,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -4501,6 +4774,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4561,10 +4845,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -4819,6 +5103,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der 0.6.1",
+ "generic-array",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5028,6 +5326,16 @@ dependencies = [
 
 [[package]]
 name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
+name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
@@ -5106,12 +5414,22 @@ dependencies = [
 
 [[package]]
 name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,13 +92,13 @@ dependencies = [
  "acteon-core",
  "acteon-provider",
  "aws-config",
- "aws-credential-types",
  "aws-sdk-eventbridge",
  "aws-sdk-lambda",
+ "aws-sdk-s3",
  "aws-sdk-sesv2",
  "aws-sdk-sns",
  "aws-sdk-sqs",
- "aws-sdk-sts",
+ "base64 0.22.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -488,7 +488,7 @@ dependencies = [
  "chrono-tz",
  "criterion",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
@@ -1091,6 +1091,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-s3"
+version = "1.119.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "lru",
+ "percent-encoding",
+ "regex-lite",
+ "sha2",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "aws-sdk-sesv2"
 version = "1.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1301,26 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.63.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae"
+dependencies = [
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
 ]
 
 [[package]]
@@ -2139,6 +2193,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc-fast"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
+dependencies = [
+ "crc",
+ "digest",
+ "rand 0.9.2",
+ "regex",
+ "rustversion",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,7 +2317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -2261,7 +2328,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2272,7 +2339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -2517,7 +2584,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8 0.9.0",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -2626,7 +2693,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2911,7 +2978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3746,6 +3813,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3964,7 +4040,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -4184,7 +4260,7 @@ dependencies = [
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -4245,7 +4321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -4547,8 +4623,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4558,7 +4644,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4568,6 +4664,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4846,7 +4951,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8 0.10.2",
- "rand_core",
+ "rand_core 0.6.4",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
@@ -4899,7 +5004,7 @@ dependencies = [
  "http 0.2.12",
  "mime",
  "mime_guess",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
 ]
 
@@ -5331,7 +5436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5341,7 +5446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5555,7 +5660,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
@@ -5595,7 +5700,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -6049,7 +6154,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ members = [
     # Embedding
     "crates/embedding",
 
+    # AWS providers
+    "crates/aws",
+
     # Integrations
     "crates/integrations/email",
     "crates/integrations/slack",
@@ -104,6 +107,9 @@ acteon-llm = { path = "crates/llm" }
 # Embedding
 acteon-embedding = { path = "crates/embedding" }
 
+# AWS providers
+acteon-aws = { path = "crates/aws" }
+
 # Integrations
 acteon-email = { path = "crates/integrations/email" }
 acteon-slack = { path = "crates/integrations/slack" }
@@ -158,8 +164,15 @@ moka = { version = "0.12", features = ["future"] }
 redis = { version = "0.27", features = ["tokio-comp", "connection-manager", "script"] }
 deadpool-redis = "0.18"
 
-# DynamoDB
+# AWS
 aws-sdk-dynamodb = "1"
+aws-sdk-sns = "1"
+aws-sdk-lambda = "1"
+aws-sdk-eventbridge = "1"
+aws-sdk-sqs = "1"
+aws-sdk-sesv2 = "1"
+aws-sdk-sts = "1"
+aws-credential-types = { version = "1", features = ["hardcoded-credentials"] }
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 
 # PostgreSQL

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,8 +171,7 @@ aws-sdk-lambda = "1"
 aws-sdk-eventbridge = "1"
 aws-sdk-sqs = "1"
 aws-sdk-sesv2 = "1"
-aws-sdk-sts = "1"
-aws-credential-types = { version = "1", features = ["hardcoded-credentials"] }
+aws-sdk-s3 = "1"
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 
 # PostgreSQL

--- a/clients/go/acteon/models.go
+++ b/clients/go/acteon/models.go
@@ -1175,3 +1175,163 @@ func NewDiscordMessagePayloadWithOptions(content, username, avatarURL string, em
 	}
 	return p
 }
+
+// =============================================================================
+// AWS Provider Payload Helpers
+// =============================================================================
+
+// NewSnsPublishPayload creates a payload for the AWS SNS provider.
+func NewSnsPublishPayload(message string) map[string]any {
+	return map[string]any{
+		"message": message,
+	}
+}
+
+// NewSnsPublishPayloadWithOptions creates an SNS payload with optional fields.
+func NewSnsPublishPayloadWithOptions(message, subject, topicArn, messageGroupID, messageDedupID string) map[string]any {
+	p := NewSnsPublishPayload(message)
+	if subject != "" {
+		p["subject"] = subject
+	}
+	if topicArn != "" {
+		p["topic_arn"] = topicArn
+	}
+	if messageGroupID != "" {
+		p["message_group_id"] = messageGroupID
+	}
+	if messageDedupID != "" {
+		p["message_dedup_id"] = messageDedupID
+	}
+	return p
+}
+
+// NewLambdaInvokePayload creates a payload for the AWS Lambda provider.
+func NewLambdaInvokePayload(payloadData any) map[string]any {
+	p := map[string]any{}
+	if payloadData != nil {
+		p["payload"] = payloadData
+	}
+	return p
+}
+
+// NewLambdaInvokePayloadWithOptions creates a Lambda payload with optional fields.
+func NewLambdaInvokePayloadWithOptions(payloadData any, functionName, invocationType string) map[string]any {
+	p := NewLambdaInvokePayload(payloadData)
+	if functionName != "" {
+		p["function_name"] = functionName
+	}
+	if invocationType != "" {
+		p["invocation_type"] = invocationType
+	}
+	return p
+}
+
+// NewEventBridgePutEventPayload creates a payload for the AWS EventBridge provider.
+func NewEventBridgePutEventPayload(source, detailType string, detail any) map[string]any {
+	return map[string]any{
+		"source":      source,
+		"detail_type": detailType,
+		"detail":      detail,
+	}
+}
+
+// NewEventBridgePutEventPayloadWithOptions creates an EventBridge payload with optional fields.
+func NewEventBridgePutEventPayloadWithOptions(source, detailType string, detail any, eventBusName string, resources []string) map[string]any {
+	p := NewEventBridgePutEventPayload(source, detailType, detail)
+	if eventBusName != "" {
+		p["event_bus_name"] = eventBusName
+	}
+	if len(resources) > 0 {
+		p["resources"] = resources
+	}
+	return p
+}
+
+// NewSqsSendMessagePayload creates a payload for the AWS SQS provider.
+func NewSqsSendMessagePayload(messageBody string) map[string]any {
+	return map[string]any{
+		"message_body": messageBody,
+	}
+}
+
+// NewSqsSendMessagePayloadWithOptions creates an SQS payload with optional fields.
+func NewSqsSendMessagePayloadWithOptions(messageBody, queueURL string, delaySeconds int, messageGroupID, messageDedupID string, messageAttributes map[string]string) map[string]any {
+	p := NewSqsSendMessagePayload(messageBody)
+	if queueURL != "" {
+		p["queue_url"] = queueURL
+	}
+	if delaySeconds > 0 {
+		p["delay_seconds"] = delaySeconds
+	}
+	if messageGroupID != "" {
+		p["message_group_id"] = messageGroupID
+	}
+	if messageDedupID != "" {
+		p["message_dedup_id"] = messageDedupID
+	}
+	if len(messageAttributes) > 0 {
+		p["message_attributes"] = messageAttributes
+	}
+	return p
+}
+
+// NewS3PutObjectPayload creates a payload for the AWS S3 put-object action.
+func NewS3PutObjectPayload(key, body string) map[string]any {
+	return map[string]any{
+		"key":  key,
+		"body": body,
+	}
+}
+
+// NewS3PutObjectPayloadWithOptions creates an S3 put-object payload with optional fields.
+func NewS3PutObjectPayloadWithOptions(key, bucket, body, bodyBase64, contentType string, metadata map[string]string) map[string]any {
+	p := map[string]any{"key": key}
+	if bucket != "" {
+		p["bucket"] = bucket
+	}
+	if body != "" {
+		p["body"] = body
+	}
+	if bodyBase64 != "" {
+		p["body_base64"] = bodyBase64
+	}
+	if contentType != "" {
+		p["content_type"] = contentType
+	}
+	if len(metadata) > 0 {
+		p["metadata"] = metadata
+	}
+	return p
+}
+
+// NewS3GetObjectPayload creates a payload for the AWS S3 get-object action.
+func NewS3GetObjectPayload(key string) map[string]any {
+	return map[string]any{
+		"key": key,
+	}
+}
+
+// NewS3GetObjectPayloadWithBucket creates an S3 get-object payload with a bucket override.
+func NewS3GetObjectPayloadWithBucket(key, bucket string) map[string]any {
+	p := NewS3GetObjectPayload(key)
+	if bucket != "" {
+		p["bucket"] = bucket
+	}
+	return p
+}
+
+// NewS3DeleteObjectPayload creates a payload for the AWS S3 delete-object action.
+func NewS3DeleteObjectPayload(key string) map[string]any {
+	return map[string]any{
+		"key": key,
+	}
+}
+
+// NewS3DeleteObjectPayloadWithBucket creates an S3 delete-object payload with a bucket override.
+func NewS3DeleteObjectPayloadWithBucket(key, bucket string) map[string]any {
+	p := NewS3DeleteObjectPayload(key)
+	if bucket != "" {
+		p["bucket"] = bucket
+	}
+	return p
+}

--- a/clients/java/src/main/java/com/acteon/client/models/EventBridgePutEventPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/EventBridgePutEventPayload.java
@@ -1,0 +1,42 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS EventBridge provider ({@code aws-eventbridge}, action type {@code put_event}).
+ */
+public class EventBridgePutEventPayload {
+    private final String source;
+    private final String detailType;
+    private final Object detail;
+    private String eventBusName;
+    private List<String> resources;
+
+    public EventBridgePutEventPayload(String source, String detailType, Object detail) {
+        this.source = source;
+        this.detailType = detailType;
+        this.detail = detail;
+    }
+
+    public EventBridgePutEventPayload withEventBusName(String eventBusName) {
+        this.eventBusName = eventBusName;
+        return this;
+    }
+
+    public EventBridgePutEventPayload withResources(List<String> resources) {
+        this.resources = resources;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("source", source);
+        payload.put("detail_type", detailType);
+        payload.put("detail", detail);
+        if (eventBusName != null) payload.put("event_bus_name", eventBusName);
+        if (resources != null) payload.put("resources", resources);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/LambdaInvokePayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/LambdaInvokePayload.java
@@ -1,0 +1,42 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS Lambda provider ({@code aws-lambda}, action type {@code invoke}).
+ */
+public class LambdaInvokePayload {
+    private Object payloadData;
+    private String functionName;
+    private String invocationType;
+
+    public LambdaInvokePayload() {}
+
+    public LambdaInvokePayload(Object payloadData) {
+        this.payloadData = payloadData;
+    }
+
+    public LambdaInvokePayload withPayload(Object payloadData) {
+        this.payloadData = payloadData;
+        return this;
+    }
+
+    public LambdaInvokePayload withFunctionName(String functionName) {
+        this.functionName = functionName;
+        return this;
+    }
+
+    public LambdaInvokePayload withInvocationType(String invocationType) {
+        this.invocationType = invocationType;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        if (payloadData != null) payload.put("payload", payloadData);
+        if (functionName != null) payload.put("function_name", functionName);
+        if (invocationType != null) payload.put("invocation_type", invocationType);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/S3DeleteObjectPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/S3DeleteObjectPayload.java
@@ -1,0 +1,28 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS S3 delete-object action ({@code aws-s3}, action type {@code delete_object}).
+ */
+public class S3DeleteObjectPayload {
+    private final String key;
+    private String bucket;
+
+    public S3DeleteObjectPayload(String key) {
+        this.key = key;
+    }
+
+    public S3DeleteObjectPayload withBucket(String bucket) {
+        this.bucket = bucket;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("key", key);
+        if (bucket != null) payload.put("bucket", bucket);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/S3GetObjectPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/S3GetObjectPayload.java
@@ -1,0 +1,28 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS S3 get-object action ({@code aws-s3}, action type {@code get_object}).
+ */
+public class S3GetObjectPayload {
+    private final String key;
+    private String bucket;
+
+    public S3GetObjectPayload(String key) {
+        this.key = key;
+    }
+
+    public S3GetObjectPayload withBucket(String bucket) {
+        this.bucket = bucket;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("key", key);
+        if (bucket != null) payload.put("bucket", bucket);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/S3PutObjectPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/S3PutObjectPayload.java
@@ -1,0 +1,56 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS S3 put-object action ({@code aws-s3}, action type {@code put_object}).
+ */
+public class S3PutObjectPayload {
+    private final String key;
+    private String bucket;
+    private String body;
+    private String bodyBase64;
+    private String contentType;
+    private Map<String, String> metadata;
+
+    public S3PutObjectPayload(String key) {
+        this.key = key;
+    }
+
+    public S3PutObjectPayload withBucket(String bucket) {
+        this.bucket = bucket;
+        return this;
+    }
+
+    public S3PutObjectPayload withBody(String body) {
+        this.body = body;
+        return this;
+    }
+
+    public S3PutObjectPayload withBodyBase64(String bodyBase64) {
+        this.bodyBase64 = bodyBase64;
+        return this;
+    }
+
+    public S3PutObjectPayload withContentType(String contentType) {
+        this.contentType = contentType;
+        return this;
+    }
+
+    public S3PutObjectPayload withMetadata(Map<String, String> metadata) {
+        this.metadata = metadata;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("key", key);
+        if (bucket != null) payload.put("bucket", bucket);
+        if (body != null) payload.put("body", body);
+        if (bodyBase64 != null) payload.put("body_base64", bodyBase64);
+        if (contentType != null) payload.put("content_type", contentType);
+        if (metadata != null) payload.put("metadata", metadata);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/SnsPublishPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/SnsPublishPayload.java
@@ -1,0 +1,49 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS SNS provider ({@code aws-sns}, action type {@code publish}).
+ */
+public class SnsPublishPayload {
+    private final String message;
+    private String subject;
+    private String topicArn;
+    private String messageGroupId;
+    private String messageDedupId;
+
+    public SnsPublishPayload(String message) {
+        this.message = message;
+    }
+
+    public SnsPublishPayload withSubject(String subject) {
+        this.subject = subject;
+        return this;
+    }
+
+    public SnsPublishPayload withTopicArn(String topicArn) {
+        this.topicArn = topicArn;
+        return this;
+    }
+
+    public SnsPublishPayload withMessageGroupId(String messageGroupId) {
+        this.messageGroupId = messageGroupId;
+        return this;
+    }
+
+    public SnsPublishPayload withMessageDedupId(String messageDedupId) {
+        this.messageDedupId = messageDedupId;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("message", message);
+        if (subject != null) payload.put("subject", subject);
+        if (topicArn != null) payload.put("topic_arn", topicArn);
+        if (messageGroupId != null) payload.put("message_group_id", messageGroupId);
+        if (messageDedupId != null) payload.put("message_dedup_id", messageDedupId);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/SqsSendMessagePayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/SqsSendMessagePayload.java
@@ -1,0 +1,56 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS SQS provider ({@code aws-sqs}, action type {@code send_message}).
+ */
+public class SqsSendMessagePayload {
+    private final String messageBody;
+    private String queueUrl;
+    private Integer delaySeconds;
+    private String messageGroupId;
+    private String messageDedupId;
+    private Map<String, String> messageAttributes;
+
+    public SqsSendMessagePayload(String messageBody) {
+        this.messageBody = messageBody;
+    }
+
+    public SqsSendMessagePayload withQueueUrl(String queueUrl) {
+        this.queueUrl = queueUrl;
+        return this;
+    }
+
+    public SqsSendMessagePayload withDelaySeconds(int delaySeconds) {
+        this.delaySeconds = delaySeconds;
+        return this;
+    }
+
+    public SqsSendMessagePayload withMessageGroupId(String messageGroupId) {
+        this.messageGroupId = messageGroupId;
+        return this;
+    }
+
+    public SqsSendMessagePayload withMessageDedupId(String messageDedupId) {
+        this.messageDedupId = messageDedupId;
+        return this;
+    }
+
+    public SqsSendMessagePayload withMessageAttributes(Map<String, String> messageAttributes) {
+        this.messageAttributes = messageAttributes;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("message_body", messageBody);
+        if (queueUrl != null) payload.put("queue_url", queueUrl);
+        if (delaySeconds != null) payload.put("delay_seconds", delaySeconds);
+        if (messageGroupId != null) payload.put("message_group_id", messageGroupId);
+        if (messageDedupId != null) payload.put("message_dedup_id", messageDedupId);
+        if (messageAttributes != null) payload.put("message_attributes", messageAttributes);
+        return payload;
+    }
+}

--- a/clients/nodejs/src/models.ts
+++ b/clients/nodejs/src/models.ts
@@ -1962,3 +1962,181 @@ export function createDiscordMessagePayload(
   if (options.tts !== undefined) payload.tts = options.tts;
   return payload;
 }
+
+// =============================================================================
+// AWS Provider Payload Helpers
+// =============================================================================
+
+/** Payload for the AWS SNS publish action. */
+export interface SnsPublishPayload {
+  message: string;
+  subject?: string;
+  topic_arn?: string;
+  message_group_id?: string;
+  message_dedup_id?: string;
+}
+
+/** Create a payload for the AWS SNS provider. */
+export function createSnsPublishPayload(
+  message: string,
+  options?: {
+    subject?: string;
+    topicArn?: string;
+    messageGroupId?: string;
+    messageDedupId?: string;
+  }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { message };
+  if (options?.subject) payload.subject = options.subject;
+  if (options?.topicArn) payload.topic_arn = options.topicArn;
+  if (options?.messageGroupId)
+    payload.message_group_id = options.messageGroupId;
+  if (options?.messageDedupId)
+    payload.message_dedup_id = options.messageDedupId;
+  return payload;
+}
+
+/** Payload for the AWS Lambda invoke action. */
+export interface LambdaInvokePayload {
+  payload?: unknown;
+  function_name?: string;
+  invocation_type?: "RequestResponse" | "Event" | "DryRun";
+}
+
+/** Create a payload for the AWS Lambda provider. */
+export function createLambdaInvokePayload(
+  payloadData?: unknown,
+  options?: {
+    functionName?: string;
+    invocationType?: "RequestResponse" | "Event" | "DryRun";
+  }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  if (payloadData !== undefined) payload.payload = payloadData;
+  if (options?.functionName) payload.function_name = options.functionName;
+  if (options?.invocationType)
+    payload.invocation_type = options.invocationType;
+  return payload;
+}
+
+/** Payload for the AWS EventBridge put-event action. */
+export interface EventBridgePutEventPayload {
+  source: string;
+  detail_type: string;
+  detail: unknown;
+  event_bus_name?: string;
+  resources?: string[];
+}
+
+/** Create a payload for the AWS EventBridge provider. */
+export function createEventBridgePutEventPayload(
+  source: string,
+  detailType: string,
+  detail: unknown,
+  options?: { eventBusName?: string; resources?: string[] }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    source,
+    detail_type: detailType,
+    detail,
+  };
+  if (options?.eventBusName) payload.event_bus_name = options.eventBusName;
+  if (options?.resources) payload.resources = options.resources;
+  return payload;
+}
+
+/** Payload for the AWS SQS send-message action. */
+export interface SqsSendMessagePayload {
+  message_body: string;
+  queue_url?: string;
+  delay_seconds?: number;
+  message_group_id?: string;
+  message_dedup_id?: string;
+  message_attributes?: Record<string, string>;
+}
+
+/** Create a payload for the AWS SQS provider. */
+export function createSqsSendMessagePayload(
+  messageBody: string,
+  options?: {
+    queueUrl?: string;
+    delaySeconds?: number;
+    messageGroupId?: string;
+    messageDedupId?: string;
+    messageAttributes?: Record<string, string>;
+  }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { message_body: messageBody };
+  if (options?.queueUrl) payload.queue_url = options.queueUrl;
+  if (options?.delaySeconds !== undefined)
+    payload.delay_seconds = options.delaySeconds;
+  if (options?.messageGroupId)
+    payload.message_group_id = options.messageGroupId;
+  if (options?.messageDedupId)
+    payload.message_dedup_id = options.messageDedupId;
+  if (options?.messageAttributes)
+    payload.message_attributes = options.messageAttributes;
+  return payload;
+}
+
+/** Payload for the AWS S3 put-object action. */
+export interface S3PutObjectPayload {
+  key: string;
+  bucket?: string;
+  body?: string;
+  body_base64?: string;
+  content_type?: string;
+  metadata?: Record<string, string>;
+}
+
+/** Create a payload for the AWS S3 put-object action. */
+export function createS3PutObjectPayload(
+  key: string,
+  options?: {
+    bucket?: string;
+    body?: string;
+    bodyBase64?: string;
+    contentType?: string;
+    metadata?: Record<string, string>;
+  }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { key };
+  if (options?.bucket) payload.bucket = options.bucket;
+  if (options?.body !== undefined) payload.body = options.body;
+  if (options?.bodyBase64) payload.body_base64 = options.bodyBase64;
+  if (options?.contentType) payload.content_type = options.contentType;
+  if (options?.metadata) payload.metadata = options.metadata;
+  return payload;
+}
+
+/** Payload for the AWS S3 get-object action. */
+export interface S3GetObjectPayload {
+  key: string;
+  bucket?: string;
+}
+
+/** Create a payload for the AWS S3 get-object action. */
+export function createS3GetObjectPayload(
+  key: string,
+  options?: { bucket?: string }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { key };
+  if (options?.bucket) payload.bucket = options.bucket;
+  return payload;
+}
+
+/** Payload for the AWS S3 delete-object action. */
+export interface S3DeleteObjectPayload {
+  key: string;
+  bucket?: string;
+}
+
+/** Create a payload for the AWS S3 delete-object action. */
+export function createS3DeleteObjectPayload(
+  key: string,
+  options?: { bucket?: string }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { key };
+  if (options?.bucket) payload.bucket = options.bucket;
+  return payload;
+}

--- a/clients/python/acteon_client/models.py
+++ b/clients/python/acteon_client/models.py
@@ -2193,3 +2193,213 @@ def discord_message_payload(
     if tts is not None:
         payload["tts"] = tts
     return payload
+
+
+# =============================================================================
+# AWS Provider Payload Helpers
+# =============================================================================
+
+
+def sns_publish_payload(
+    message: str,
+    *,
+    subject: Optional[str] = None,
+    topic_arn: Optional[str] = None,
+    message_group_id: Optional[str] = None,
+    message_dedup_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a payload for the AWS SNS provider.
+
+    Args:
+        message: Message body to publish.
+        subject: Subject for email-protocol subscriptions.
+        topic_arn: Override the topic ARN configured on the provider.
+        message_group_id: Message group ID (for FIFO topics).
+        message_dedup_id: Message deduplication ID (for FIFO topics).
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-sns`` provider.
+    """
+    payload: dict[str, Any] = {"message": message}
+    if subject is not None:
+        payload["subject"] = subject
+    if topic_arn is not None:
+        payload["topic_arn"] = topic_arn
+    if message_group_id is not None:
+        payload["message_group_id"] = message_group_id
+    if message_dedup_id is not None:
+        payload["message_dedup_id"] = message_dedup_id
+    return payload
+
+
+def lambda_invoke_payload(
+    payload_data: Any = None,
+    *,
+    function_name: Optional[str] = None,
+    invocation_type: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a payload for the AWS Lambda provider.
+
+    Args:
+        payload_data: JSON-serializable data to pass to the Lambda function.
+        function_name: Override the function name configured on the provider.
+        invocation_type: ``"RequestResponse"``, ``"Event"``, or ``"DryRun"``.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-lambda`` provider.
+    """
+    payload: dict[str, Any] = {}
+    if payload_data is not None:
+        payload["payload"] = payload_data
+    if function_name is not None:
+        payload["function_name"] = function_name
+    if invocation_type is not None:
+        payload["invocation_type"] = invocation_type
+    return payload
+
+
+def eventbridge_put_event_payload(
+    source: str,
+    detail_type: str,
+    detail: Any,
+    *,
+    event_bus_name: Optional[str] = None,
+    resources: Optional[List[str]] = None,
+) -> dict[str, Any]:
+    """Build a payload for the AWS ``EventBridge`` provider.
+
+    Args:
+        source: Event source (e.g., ``"com.myapp.orders"``).
+        detail_type: Event detail type (e.g., ``"OrderCreated"``).
+        detail: Event detail as a JSON-serializable value.
+        event_bus_name: Override the event bus name configured on the provider.
+        resources: List of resource ARNs associated with the event.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-eventbridge`` provider.
+    """
+    payload: dict[str, Any] = {
+        "source": source,
+        "detail_type": detail_type,
+        "detail": detail,
+    }
+    if event_bus_name is not None:
+        payload["event_bus_name"] = event_bus_name
+    if resources is not None:
+        payload["resources"] = resources
+    return payload
+
+
+def sqs_send_message_payload(
+    message_body: str,
+    *,
+    queue_url: Optional[str] = None,
+    delay_seconds: Optional[int] = None,
+    message_group_id: Optional[str] = None,
+    message_dedup_id: Optional[str] = None,
+    message_attributes: Optional[dict[str, str]] = None,
+) -> dict[str, Any]:
+    """Build a payload for the AWS SQS provider.
+
+    Args:
+        message_body: Message body text.
+        queue_url: Override the queue URL configured on the provider.
+        delay_seconds: Delivery delay in seconds (0-900).
+        message_group_id: Message group ID (for FIFO queues).
+        message_dedup_id: Message deduplication ID (for FIFO queues).
+        message_attributes: Message attributes as key-value pairs.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-sqs`` provider.
+    """
+    payload: dict[str, Any] = {"message_body": message_body}
+    if queue_url is not None:
+        payload["queue_url"] = queue_url
+    if delay_seconds is not None:
+        payload["delay_seconds"] = delay_seconds
+    if message_group_id is not None:
+        payload["message_group_id"] = message_group_id
+    if message_dedup_id is not None:
+        payload["message_dedup_id"] = message_dedup_id
+    if message_attributes is not None:
+        payload["message_attributes"] = message_attributes
+    return payload
+
+
+def s3_put_object_payload(
+    key: str,
+    *,
+    bucket: Optional[str] = None,
+    body: Optional[str] = None,
+    body_base64: Optional[str] = None,
+    content_type: Optional[str] = None,
+    metadata: Optional[dict[str, str]] = None,
+) -> dict[str, Any]:
+    """Build a payload for the AWS S3 put-object action.
+
+    Args:
+        key: S3 object key.
+        bucket: Override the bucket name configured on the provider.
+        body: Object body as a UTF-8 string.
+        body_base64: Object body as base64-encoded bytes.
+        content_type: Content type (e.g., ``"application/json"``).
+        metadata: Object metadata as key-value pairs.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-s3`` provider
+        with action type ``put_object``.
+    """
+    payload: dict[str, Any] = {"key": key}
+    if bucket is not None:
+        payload["bucket"] = bucket
+    if body is not None:
+        payload["body"] = body
+    if body_base64 is not None:
+        payload["body_base64"] = body_base64
+    if content_type is not None:
+        payload["content_type"] = content_type
+    if metadata is not None:
+        payload["metadata"] = metadata
+    return payload
+
+
+def s3_get_object_payload(
+    key: str,
+    *,
+    bucket: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a payload for the AWS S3 get-object action.
+
+    Args:
+        key: S3 object key.
+        bucket: Override the bucket name configured on the provider.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-s3`` provider
+        with action type ``get_object``.
+    """
+    payload: dict[str, Any] = {"key": key}
+    if bucket is not None:
+        payload["bucket"] = bucket
+    return payload
+
+
+def s3_delete_object_payload(
+    key: str,
+    *,
+    bucket: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a payload for the AWS S3 delete-object action.
+
+    Args:
+        key: S3 object key.
+        bucket: Override the bucket name configured on the provider.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-s3`` provider
+        with action type ``delete_object``.
+    """
+    payload: dict[str, Any] = {"key": key}
+    if bucket is not None:
+        payload["bucket"] = bucket
+    return payload

--- a/crates/aws/Cargo.toml
+++ b/crates/aws/Cargo.toml
@@ -14,19 +14,20 @@ lambda = ["dep:aws-sdk-lambda"]
 eventbridge = ["dep:aws-sdk-eventbridge"]
 sqs = ["dep:aws-sdk-sqs"]
 ses = ["dep:aws-sdk-sesv2"]
-full = ["sns", "lambda", "eventbridge", "sqs", "ses"]
+s3 = ["dep:aws-sdk-s3"]
+full = ["sns", "lambda", "eventbridge", "sqs", "ses", "s3"]
 
 [dependencies]
 acteon-core = { workspace = true }
 acteon-provider = { workspace = true }
 aws-config = { workspace = true }
-aws-credential-types = { workspace = true }
 aws-sdk-sns = { workspace = true, optional = true }
 aws-sdk-lambda = { workspace = true, optional = true }
 aws-sdk-eventbridge = { workspace = true, optional = true }
 aws-sdk-sqs = { workspace = true, optional = true }
 aws-sdk-sesv2 = { workspace = true, optional = true }
-aws-sdk-sts = { workspace = true }
+aws-sdk-s3 = { workspace = true, optional = true }
+base64 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/aws/Cargo.toml
+++ b/crates/aws/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "acteon-aws"
+description = "AWS service providers for Acteon (SNS, Lambda, EventBridge, SQS, SES)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+integration = []
+sns = ["dep:aws-sdk-sns"]
+lambda = ["dep:aws-sdk-lambda"]
+eventbridge = ["dep:aws-sdk-eventbridge"]
+sqs = ["dep:aws-sdk-sqs"]
+ses = ["dep:aws-sdk-sesv2"]
+full = ["sns", "lambda", "eventbridge", "sqs", "ses"]
+
+[dependencies]
+acteon-core = { workspace = true }
+acteon-provider = { workspace = true }
+aws-config = { workspace = true }
+aws-credential-types = { workspace = true }
+aws-sdk-sns = { workspace = true, optional = true }
+aws-sdk-lambda = { workspace = true, optional = true }
+aws-sdk-eventbridge = { workspace = true, optional = true }
+aws-sdk-sqs = { workspace = true, optional = true }
+aws-sdk-sesv2 = { workspace = true, optional = true }
+aws-sdk-sts = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/aws/src/auth.rs
+++ b/crates/aws/src/auth.rs
@@ -1,0 +1,101 @@
+use tracing::{debug, info};
+
+use crate::config::AwsBaseConfig;
+
+/// Build an AWS SDK configuration from the given [`AwsBaseConfig`].
+///
+/// Uses the standard AWS SDK environment credential chain and optionally:
+/// - Overrides the endpoint URL for local development (e.g. `LocalStack`)
+/// - Assumes an IAM role via STS if `role_arn` is configured
+///
+/// # Examples
+///
+/// ```no_run
+/// use acteon_aws::config::AwsBaseConfig;
+/// use acteon_aws::auth::build_sdk_config;
+///
+/// # async fn example() {
+/// let config = AwsBaseConfig::new("us-east-1")
+///     .with_endpoint_url("http://localhost:4566");
+/// let sdk_config = build_sdk_config(&config).await;
+/// # }
+/// ```
+pub async fn build_sdk_config(config: &AwsBaseConfig) -> aws_config::SdkConfig {
+    let mut loader = aws_config::from_env().region(aws_config::Region::new(config.region.clone()));
+
+    if let Some(endpoint) = &config.endpoint_url {
+        debug!(endpoint = %endpoint, "using custom AWS endpoint");
+        loader = loader.endpoint_url(endpoint);
+    }
+
+    // If a role ARN is specified, assume it via STS. We first load the base
+    // config to create an STS client, then use the assumed-role credentials
+    // to build the final config.
+    if let Some(role_arn) = &config.role_arn {
+        info!(role_arn = %role_arn, "assuming IAM role via STS");
+        let base_config = loader.load().await;
+        let sts_client = aws_sdk_sts::Client::new(&base_config);
+
+        match sts_client
+            .assume_role()
+            .role_arn(role_arn)
+            .role_session_name("acteon-aws-provider")
+            .send()
+            .await
+        {
+            Ok(response) => {
+                if let Some(creds) = response.credentials() {
+                    let static_creds = aws_credential_types::Credentials::from_keys(
+                        creds.access_key_id(),
+                        creds.secret_access_key(),
+                        Some(creds.session_token().to_owned()),
+                    );
+
+                    let mut assumed_loader = aws_config::from_env()
+                        .region(aws_config::Region::new(config.region.clone()))
+                        .credentials_provider(static_creds);
+
+                    if let Some(endpoint) = &config.endpoint_url {
+                        assumed_loader = assumed_loader.endpoint_url(endpoint);
+                    }
+
+                    info!("STS assume-role succeeded");
+                    return assumed_loader.load().await;
+                }
+                tracing::warn!("STS response had no credentials, falling back to base config");
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "STS assume-role failed, falling back to base config");
+            }
+        }
+        return base_config;
+    }
+
+    loader.load().await
+}
+
+#[cfg(all(test, feature = "integration"))]
+mod integration_tests {
+    use super::*;
+
+    // These tests require a TLS root certificate store and are only run in
+    // integration test mode. The AWS SDK panics on `load()` if no system
+    // root certificates are available.
+
+    #[tokio::test]
+    async fn build_sdk_config_sets_region() {
+        let config = AwsBaseConfig::new("ap-northeast-1");
+        let sdk_config = build_sdk_config(&config).await;
+        assert_eq!(
+            sdk_config.region().map(|r| r.as_ref()),
+            Some("ap-northeast-1")
+        );
+    }
+
+    #[tokio::test]
+    async fn build_sdk_config_with_endpoint() {
+        let config = AwsBaseConfig::new("us-west-2").with_endpoint_url("http://localhost:4566");
+        let sdk_config = build_sdk_config(&config).await;
+        assert_eq!(sdk_config.region().map(|r| r.as_ref()), Some("us-west-2"));
+    }
+}

--- a/crates/aws/src/config.rs
+++ b/crates/aws/src/config.rs
@@ -1,0 +1,132 @@
+use serde::{Deserialize, Serialize};
+
+/// Shared base configuration for all AWS providers.
+///
+/// Contains common settings like region, optional STS assume-role ARN for
+/// cross-account access, and an endpoint URL override for local development
+/// (e.g. `LocalStack`).
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AwsBaseConfig {
+    /// AWS region (e.g. `"us-east-1"`).
+    pub region: String,
+
+    /// Optional IAM role ARN to assume via STS for cross-account access.
+    pub role_arn: Option<String>,
+
+    /// Optional endpoint URL override for local development (e.g. `LocalStack`).
+    pub endpoint_url: Option<String>,
+}
+
+impl std::fmt::Debug for AwsBaseConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AwsBaseConfig")
+            .field("region", &self.region)
+            .field("role_arn", &self.role_arn.as_ref().map(|_| "[REDACTED]"))
+            .field("endpoint_url", &self.endpoint_url)
+            .finish()
+    }
+}
+
+impl AwsBaseConfig {
+    /// Create a new `AwsBaseConfig` with the given region.
+    pub fn new(region: impl Into<String>) -> Self {
+        Self {
+            region: region.into(),
+            role_arn: None,
+            endpoint_url: None,
+        }
+    }
+
+    /// Set an IAM role ARN to assume via STS.
+    #[must_use]
+    pub fn with_role_arn(mut self, role_arn: impl Into<String>) -> Self {
+        self.role_arn = Some(role_arn.into());
+        self
+    }
+
+    /// Set an endpoint URL override for local development.
+    #[must_use]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.endpoint_url = Some(endpoint_url.into());
+        self
+    }
+}
+
+impl Default for AwsBaseConfig {
+    fn default() -> Self {
+        Self {
+            region: "us-east-1".to_owned(),
+            role_arn: None,
+            endpoint_url: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_config_sets_region() {
+        let config = AwsBaseConfig::new("eu-west-1");
+        assert_eq!(config.region, "eu-west-1");
+        assert!(config.role_arn.is_none());
+        assert!(config.endpoint_url.is_none());
+    }
+
+    #[test]
+    fn with_role_arn_sets_value() {
+        let config =
+            AwsBaseConfig::new("us-east-1").with_role_arn("arn:aws:iam::123456789012:role/test");
+        assert_eq!(
+            config.role_arn.as_deref(),
+            Some("arn:aws:iam::123456789012:role/test")
+        );
+    }
+
+    #[test]
+    fn with_endpoint_url_sets_value() {
+        let config = AwsBaseConfig::new("us-east-1").with_endpoint_url("http://localhost:4566");
+        assert_eq!(
+            config.endpoint_url.as_deref(),
+            Some("http://localhost:4566")
+        );
+    }
+
+    #[test]
+    fn default_config() {
+        let config = AwsBaseConfig::default();
+        assert_eq!(config.region, "us-east-1");
+        assert!(config.role_arn.is_none());
+        assert!(config.endpoint_url.is_none());
+    }
+
+    #[test]
+    fn debug_redacts_role_arn() {
+        let config =
+            AwsBaseConfig::new("us-east-1").with_role_arn("arn:aws:iam::123456789012:role/test");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("123456789012"));
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let config = AwsBaseConfig::new("ap-southeast-1")
+            .with_role_arn("arn:aws:iam::111111111111:role/cross")
+            .with_endpoint_url("http://localhost:4566");
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: AwsBaseConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.region, "ap-southeast-1");
+        assert_eq!(
+            deserialized.role_arn.as_deref(),
+            Some("arn:aws:iam::111111111111:role/cross")
+        );
+        assert_eq!(
+            deserialized.endpoint_url.as_deref(),
+            Some("http://localhost:4566")
+        );
+    }
+}

--- a/crates/aws/src/config.rs
+++ b/crates/aws/src/config.rs
@@ -15,6 +15,14 @@ pub struct AwsBaseConfig {
 
     /// Optional endpoint URL override for local development (e.g. `LocalStack`).
     pub endpoint_url: Option<String>,
+
+    /// Optional STS session name (defaults to `"acteon-aws-provider"`).
+    #[serde(default)]
+    pub session_name: Option<String>,
+
+    /// Optional external ID for cross-account trust policies.
+    #[serde(default)]
+    pub external_id: Option<String>,
 }
 
 impl std::fmt::Debug for AwsBaseConfig {
@@ -23,6 +31,8 @@ impl std::fmt::Debug for AwsBaseConfig {
             .field("region", &self.region)
             .field("role_arn", &self.role_arn.as_ref().map(|_| "[REDACTED]"))
             .field("endpoint_url", &self.endpoint_url)
+            .field("session_name", &self.session_name)
+            .field("external_id", &self.external_id)
             .finish()
     }
 }
@@ -34,6 +44,8 @@ impl AwsBaseConfig {
             region: region.into(),
             role_arn: None,
             endpoint_url: None,
+            session_name: None,
+            external_id: None,
         }
     }
 
@@ -50,6 +62,20 @@ impl AwsBaseConfig {
         self.endpoint_url = Some(endpoint_url.into());
         self
     }
+
+    /// Set the STS session name for assume-role.
+    #[must_use]
+    pub fn with_session_name(mut self, session_name: impl Into<String>) -> Self {
+        self.session_name = Some(session_name.into());
+        self
+    }
+
+    /// Set the external ID for cross-account trust policies.
+    #[must_use]
+    pub fn with_external_id(mut self, external_id: impl Into<String>) -> Self {
+        self.external_id = Some(external_id.into());
+        self
+    }
 }
 
 impl Default for AwsBaseConfig {
@@ -58,6 +84,8 @@ impl Default for AwsBaseConfig {
             region: "us-east-1".to_owned(),
             role_arn: None,
             endpoint_url: None,
+            session_name: None,
+            external_id: None,
         }
     }
 }

--- a/crates/aws/src/error.rs
+++ b/crates/aws/src/error.rs
@@ -1,0 +1,156 @@
+use acteon_provider::ProviderError;
+use thiserror::Error;
+
+/// Errors specific to AWS provider operations.
+#[derive(Debug, Error)]
+pub enum AwsProviderError {
+    /// The AWS SDK returned an error from the service.
+    #[error("AWS service error: {0}")]
+    ServiceError(String),
+
+    /// The request was throttled by the AWS service.
+    #[error("AWS request throttled")]
+    Throttled,
+
+    /// A network or connection error occurred communicating with AWS.
+    #[error("AWS connection error: {0}")]
+    Connection(String),
+
+    /// The request timed out.
+    #[error("AWS request timed out")]
+    Timeout,
+
+    /// The action payload was invalid or missing required fields.
+    #[error("invalid payload: {0}")]
+    InvalidPayload(String),
+
+    /// AWS credential resolution failed.
+    #[error("credential error: {0}")]
+    CredentialError(String),
+
+    /// Configuration is invalid.
+    #[error("invalid configuration: {0}")]
+    Configuration(String),
+}
+
+impl From<AwsProviderError> for ProviderError {
+    fn from(err: AwsProviderError) -> Self {
+        match err {
+            AwsProviderError::ServiceError(msg) => ProviderError::ExecutionFailed(msg),
+            AwsProviderError::Throttled => ProviderError::RateLimited,
+            AwsProviderError::Connection(msg) => ProviderError::Connection(msg),
+            AwsProviderError::Timeout => ProviderError::Timeout(std::time::Duration::from_secs(30)),
+            AwsProviderError::InvalidPayload(msg) => ProviderError::Serialization(msg),
+            AwsProviderError::CredentialError(msg) | AwsProviderError::Configuration(msg) => {
+                ProviderError::Configuration(msg)
+            }
+        }
+    }
+}
+
+/// Classify an AWS SDK error string into the appropriate [`AwsProviderError`].
+///
+/// This helper inspects the error message for common patterns (throttling,
+/// timeout, connection) and maps them to the correct variant.
+pub fn classify_sdk_error(error_str: &str) -> AwsProviderError {
+    let lower = error_str.to_lowercase();
+    if lower.contains("throttl") || lower.contains("rate exceed") || lower.contains("too many") {
+        AwsProviderError::Throttled
+    } else if lower.contains("timeout") || lower.contains("timed out") {
+        AwsProviderError::Timeout
+    } else if lower.contains("connection")
+        || lower.contains("connect")
+        || lower.contains("dns")
+        || lower.contains("network")
+    {
+        AwsProviderError::Connection(error_str.to_owned())
+    } else {
+        AwsProviderError::ServiceError(error_str.to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn throttled_maps_to_rate_limited() {
+        let err: ProviderError = AwsProviderError::Throttled.into();
+        assert!(matches!(err, ProviderError::RateLimited));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn timeout_maps_to_timeout() {
+        let err: ProviderError = AwsProviderError::Timeout.into();
+        assert!(matches!(err, ProviderError::Timeout(_)));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn connection_maps_to_connection() {
+        let err: ProviderError = AwsProviderError::Connection("reset".into()).into();
+        assert!(matches!(err, ProviderError::Connection(_)));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn service_error_maps_to_execution_failed() {
+        let err: ProviderError = AwsProviderError::ServiceError("topic not found".into()).into();
+        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn invalid_payload_maps_to_serialization() {
+        let err: ProviderError = AwsProviderError::InvalidPayload("missing field".into()).into();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn credential_error_maps_to_configuration() {
+        let err: ProviderError = AwsProviderError::CredentialError("no credentials".into()).into();
+        assert!(matches!(err, ProviderError::Configuration(_)));
+    }
+
+    #[test]
+    fn classify_throttled() {
+        let err = classify_sdk_error("Throttling: Rate exceeded");
+        assert!(matches!(err, AwsProviderError::Throttled));
+    }
+
+    #[test]
+    fn classify_timeout() {
+        let err = classify_sdk_error("Request timed out after 30s");
+        assert!(matches!(err, AwsProviderError::Timeout));
+    }
+
+    #[test]
+    fn classify_connection() {
+        let err = classify_sdk_error("Connection refused: localhost:4566");
+        assert!(matches!(err, AwsProviderError::Connection(_)));
+    }
+
+    #[test]
+    fn classify_generic_service_error() {
+        let err = classify_sdk_error("TopicNotFoundException: Topic does not exist");
+        assert!(matches!(err, AwsProviderError::ServiceError(_)));
+    }
+
+    #[test]
+    fn error_display() {
+        assert_eq!(
+            AwsProviderError::Throttled.to_string(),
+            "AWS request throttled"
+        );
+        assert_eq!(
+            AwsProviderError::Timeout.to_string(),
+            "AWS request timed out"
+        );
+        assert_eq!(
+            AwsProviderError::ServiceError("bad".into()).to_string(),
+            "AWS service error: bad"
+        );
+    }
+}

--- a/crates/aws/src/eventbridge.rs
+++ b/crates/aws/src/eventbridge.rs
@@ -1,0 +1,275 @@
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::ProviderError;
+use acteon_provider::provider::Provider;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, instrument};
+
+use crate::auth::build_sdk_config;
+use crate::config::AwsBaseConfig;
+use crate::error::classify_sdk_error;
+
+/// Configuration for the AWS `EventBridge` provider.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct EventBridgeConfig {
+    /// Shared AWS configuration (region, role ARN, endpoint URL).
+    #[serde(flatten)]
+    pub aws: AwsBaseConfig,
+
+    /// Default event bus name. Defaults to `"default"` if not set.
+    pub event_bus_name: Option<String>,
+}
+
+impl std::fmt::Debug for EventBridgeConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventBridgeConfig")
+            .field("aws", &self.aws)
+            .field("event_bus_name", &self.event_bus_name)
+            .finish()
+    }
+}
+
+impl EventBridgeConfig {
+    /// Create a new `EventBridgeConfig` with the given AWS region.
+    pub fn new(region: impl Into<String>) -> Self {
+        Self {
+            aws: AwsBaseConfig::new(region),
+            event_bus_name: None,
+        }
+    }
+
+    /// Set the default event bus name.
+    #[must_use]
+    pub fn with_event_bus_name(mut self, name: impl Into<String>) -> Self {
+        self.event_bus_name = Some(name.into());
+        self
+    }
+
+    /// Set the endpoint URL override (for `LocalStack`).
+    #[must_use]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.aws.endpoint_url = Some(endpoint_url.into());
+        self
+    }
+
+    /// Set the IAM role ARN to assume.
+    #[must_use]
+    pub fn with_role_arn(mut self, role_arn: impl Into<String>) -> Self {
+        self.aws.role_arn = Some(role_arn.into());
+        self
+    }
+}
+
+/// Payload for the `put_events` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventBridgePutPayload {
+    /// Event bus name. Overrides config default.
+    pub event_bus_name: Option<String>,
+
+    /// Event source (e.g. `"com.myapp.orders"`).
+    pub source: String,
+
+    /// Event detail type (e.g. `"OrderCreated"`).
+    pub detail_type: String,
+
+    /// Event detail as a JSON object.
+    pub detail: serde_json::Value,
+
+    /// Optional list of resource ARNs associated with the event.
+    #[serde(default)]
+    pub resources: Vec<String>,
+}
+
+/// AWS `EventBridge` provider for publishing events.
+pub struct EventBridgeProvider {
+    config: EventBridgeConfig,
+    client: aws_sdk_eventbridge::Client,
+}
+
+impl std::fmt::Debug for EventBridgeProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventBridgeProvider")
+            .field("config", &self.config)
+            .field("client", &"<EventBridgeClient>")
+            .finish()
+    }
+}
+
+impl EventBridgeProvider {
+    /// Create a new `EventBridgeProvider` by building an AWS SDK client.
+    pub async fn new(config: EventBridgeConfig) -> Self {
+        let sdk_config = build_sdk_config(&config.aws).await;
+        let client = aws_sdk_eventbridge::Client::new(&sdk_config);
+        Self { config, client }
+    }
+
+    /// Create an `EventBridgeProvider` with a pre-built client (for testing).
+    pub fn with_client(config: EventBridgeConfig, client: aws_sdk_eventbridge::Client) -> Self {
+        Self { config, client }
+    }
+}
+
+impl Provider for EventBridgeProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "aws-eventbridge"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "aws-eventbridge"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing EventBridge payload");
+        let payload: EventBridgePutPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let event_bus = payload
+            .event_bus_name
+            .as_deref()
+            .or(self.config.event_bus_name.as_deref())
+            .unwrap_or("default");
+
+        let detail_json = serde_json::to_string(&payload.detail)
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        debug!(
+            event_bus = %event_bus,
+            source = %payload.source,
+            detail_type = %payload.detail_type,
+            "putting event to EventBridge"
+        );
+
+        let mut entry = aws_sdk_eventbridge::types::PutEventsRequestEntry::builder()
+            .event_bus_name(event_bus)
+            .source(&payload.source)
+            .detail_type(&payload.detail_type)
+            .detail(&detail_json);
+
+        for resource in &payload.resources {
+            entry = entry.resources(resource);
+        }
+
+        let result = self
+            .client
+            .put_events()
+            .entries(entry.build())
+            .send()
+            .await
+            .map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "EventBridge put_events failed");
+                let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+                aws_err
+            })?;
+
+        let failed_count = result.failed_entry_count();
+        if failed_count > 0 {
+            let error_msg = result
+                .entries()
+                .iter()
+                .filter_map(|e| e.error_message())
+                .collect::<Vec<_>>()
+                .join("; ");
+            error!(
+                failed_count = failed_count,
+                "some EventBridge entries failed"
+            );
+            return Err(ProviderError::ExecutionFailed(format!(
+                "{failed_count} entries failed: {error_msg}"
+            )));
+        }
+
+        let event_id = result
+            .entries()
+            .first()
+            .and_then(|e| e.event_id())
+            .unwrap_or("unknown")
+            .to_owned();
+
+        info!(event_id = %event_id, event_bus = %event_bus, "event published to EventBridge");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "event_id": event_id,
+            "event_bus": event_bus,
+            "status": "published"
+        })))
+    }
+
+    #[instrument(skip(self), fields(provider = "aws-eventbridge"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        debug!("performing EventBridge health check");
+        self.client
+            .list_event_buses()
+            .limit(1)
+            .send()
+            .await
+            .map_err(|e| {
+                error!(error = %e, "EventBridge health check failed");
+                ProviderError::Connection(format!("EventBridge health check failed: {e}"))
+            })?;
+        info!("EventBridge health check passed");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_new_sets_region() {
+        let config = EventBridgeConfig::new("us-east-1");
+        assert_eq!(config.aws.region, "us-east-1");
+        assert!(config.event_bus_name.is_none());
+    }
+
+    #[test]
+    fn config_with_event_bus_name() {
+        let config = EventBridgeConfig::new("us-east-1").with_event_bus_name("custom-bus");
+        assert_eq!(config.event_bus_name.as_deref(), Some("custom-bus"));
+    }
+
+    #[test]
+    fn config_debug_format() {
+        let config =
+            EventBridgeConfig::new("us-east-1").with_role_arn("arn:aws:iam::123:role/test");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("EventBridgeConfig"));
+        assert!(debug.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config = EventBridgeConfig::new("eu-west-1").with_event_bus_name("my-bus");
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: EventBridgeConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.aws.region, "eu-west-1");
+        assert_eq!(deserialized.event_bus_name.as_deref(), Some("my-bus"));
+    }
+
+    #[test]
+    fn deserialize_put_payload() {
+        let json = serde_json::json!({
+            "source": "com.myapp.orders",
+            "detail_type": "OrderCreated",
+            "detail": {"order_id": "123", "amount": 99.99},
+            "resources": ["arn:aws:s3:::my-bucket"]
+        });
+        let payload: EventBridgePutPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.source, "com.myapp.orders");
+        assert_eq!(payload.detail_type, "OrderCreated");
+        assert_eq!(payload.resources.len(), 1);
+    }
+
+    #[test]
+    fn deserialize_minimal_put_payload() {
+        let json = serde_json::json!({
+            "source": "test",
+            "detail_type": "TestEvent",
+            "detail": {}
+        });
+        let payload: EventBridgePutPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.source, "test");
+        assert!(payload.resources.is_empty());
+        assert!(payload.event_bus_name.is_none());
+    }
+}

--- a/crates/aws/src/eventbridge.rs
+++ b/crates/aws/src/eventbridge.rs
@@ -57,6 +57,20 @@ impl EventBridgeConfig {
         self.aws.role_arn = Some(role_arn.into());
         self
     }
+
+    /// Set the STS session name for assume-role.
+    #[must_use]
+    pub fn with_session_name(mut self, session_name: impl Into<String>) -> Self {
+        self.aws.session_name = Some(session_name.into());
+        self
+    }
+
+    /// Set the external ID for cross-account trust policies.
+    #[must_use]
+    pub fn with_external_id(mut self, external_id: impl Into<String>) -> Self {
+        self.aws.external_id = Some(external_id.into());
+        self
+    }
 }
 
 /// Payload for the `put_events` action type.

--- a/crates/aws/src/lambda.rs
+++ b/crates/aws/src/lambda.rs
@@ -70,6 +70,20 @@ impl LambdaConfig {
         self.aws.role_arn = Some(role_arn.into());
         self
     }
+
+    /// Set the STS session name for assume-role.
+    #[must_use]
+    pub fn with_session_name(mut self, session_name: impl Into<String>) -> Self {
+        self.aws.session_name = Some(session_name.into());
+        self
+    }
+
+    /// Set the external ID for cross-account trust policies.
+    #[must_use]
+    pub fn with_external_id(mut self, external_id: impl Into<String>) -> Self {
+        self.aws.external_id = Some(external_id.into());
+        self
+    }
 }
 
 /// Invocation type for Lambda functions.

--- a/crates/aws/src/lambda.rs
+++ b/crates/aws/src/lambda.rs
@@ -1,0 +1,336 @@
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::ProviderError;
+use acteon_provider::provider::Provider;
+use aws_sdk_lambda::primitives::Blob;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, instrument};
+
+use crate::auth::build_sdk_config;
+use crate::config::AwsBaseConfig;
+use crate::error::classify_sdk_error;
+
+/// Configuration for the AWS Lambda provider.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct LambdaConfig {
+    /// Shared AWS configuration (region, role ARN, endpoint URL).
+    #[serde(flatten)]
+    pub aws: AwsBaseConfig,
+
+    /// Default Lambda function name or ARN. Can be overridden per-action.
+    pub function_name: Option<String>,
+
+    /// Default function version or alias qualifier (e.g. `"$LATEST"`, `"prod"`).
+    pub qualifier: Option<String>,
+}
+
+impl std::fmt::Debug for LambdaConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LambdaConfig")
+            .field("aws", &self.aws)
+            .field("function_name", &self.function_name)
+            .field("qualifier", &self.qualifier)
+            .finish()
+    }
+}
+
+impl LambdaConfig {
+    /// Create a new `LambdaConfig` with the given AWS region.
+    pub fn new(region: impl Into<String>) -> Self {
+        Self {
+            aws: AwsBaseConfig::new(region),
+            function_name: None,
+            qualifier: None,
+        }
+    }
+
+    /// Set the default function name or ARN.
+    #[must_use]
+    pub fn with_function_name(mut self, function_name: impl Into<String>) -> Self {
+        self.function_name = Some(function_name.into());
+        self
+    }
+
+    /// Set the default qualifier (version or alias).
+    #[must_use]
+    pub fn with_qualifier(mut self, qualifier: impl Into<String>) -> Self {
+        self.qualifier = Some(qualifier.into());
+        self
+    }
+
+    /// Set the endpoint URL override (for `LocalStack`).
+    #[must_use]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.aws.endpoint_url = Some(endpoint_url.into());
+        self
+    }
+
+    /// Set the IAM role ARN to assume.
+    #[must_use]
+    pub fn with_role_arn(mut self, role_arn: impl Into<String>) -> Self {
+        self.aws.role_arn = Some(role_arn.into());
+        self
+    }
+}
+
+/// Invocation type for Lambda functions.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum InvocationType {
+    /// Synchronous invocation (waits for response).
+    #[default]
+    RequestResponse,
+    /// Asynchronous invocation (fire-and-forget).
+    Event,
+    /// Dry-run invocation (validates input without executing).
+    DryRun,
+}
+
+impl InvocationType {
+    fn as_sdk_type(&self) -> aws_sdk_lambda::types::InvocationType {
+        match self {
+            Self::RequestResponse => aws_sdk_lambda::types::InvocationType::RequestResponse,
+            Self::Event => aws_sdk_lambda::types::InvocationType::Event,
+            Self::DryRun => aws_sdk_lambda::types::InvocationType::DryRun,
+        }
+    }
+}
+
+/// Payload for the `invoke_function` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LambdaInvokePayload {
+    /// Lambda function name or ARN. Overrides config default.
+    pub function_name: Option<String>,
+
+    /// Function version or alias qualifier. Overrides config default.
+    pub qualifier: Option<String>,
+
+    /// JSON payload to pass to the function.
+    pub payload: Option<serde_json::Value>,
+
+    /// Invocation type. Defaults to `request_response` (synchronous).
+    #[serde(default)]
+    pub invocation_type: InvocationType,
+}
+
+/// AWS Lambda provider for invoking Lambda functions.
+pub struct LambdaProvider {
+    config: LambdaConfig,
+    client: aws_sdk_lambda::Client,
+}
+
+impl std::fmt::Debug for LambdaProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LambdaProvider")
+            .field("config", &self.config)
+            .field("client", &"<LambdaClient>")
+            .finish()
+    }
+}
+
+impl LambdaProvider {
+    /// Create a new `LambdaProvider` by building an AWS SDK client.
+    pub async fn new(config: LambdaConfig) -> Self {
+        let sdk_config = build_sdk_config(&config.aws).await;
+        let client = aws_sdk_lambda::Client::new(&sdk_config);
+        Self { config, client }
+    }
+
+    /// Create a `LambdaProvider` with a pre-built client (for testing).
+    pub fn with_client(config: LambdaConfig, client: aws_sdk_lambda::Client) -> Self {
+        Self { config, client }
+    }
+}
+
+impl Provider for LambdaProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "aws-lambda"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "aws-lambda"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing Lambda payload");
+        let payload: LambdaInvokePayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let function_name = payload
+            .function_name
+            .as_deref()
+            .or(self.config.function_name.as_deref())
+            .ok_or_else(|| {
+                ProviderError::Configuration(
+                    "no function_name in payload or provider config".to_owned(),
+                )
+            })?;
+
+        let qualifier = payload
+            .qualifier
+            .as_deref()
+            .or(self.config.qualifier.as_deref());
+
+        debug!(
+            function_name = %function_name,
+            invocation_type = ?payload.invocation_type,
+            "invoking Lambda function"
+        );
+
+        let mut request = self
+            .client
+            .invoke()
+            .function_name(function_name)
+            .invocation_type(payload.invocation_type.as_sdk_type());
+
+        if let Some(qualifier) = qualifier {
+            request = request.qualifier(qualifier);
+        }
+
+        if let Some(ref invoke_payload) = payload.payload {
+            let payload_bytes = serde_json::to_vec(invoke_payload)
+                .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+            request = request.payload(Blob::new(payload_bytes));
+        }
+
+        let result = request.send().await.map_err(|e| {
+            let err_str = e.to_string();
+            error!(error = %err_str, "Lambda invoke failed");
+            let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+            aws_err
+        })?;
+
+        let status_code = result.status_code();
+        let function_error = result.function_error().map(String::from);
+
+        // Parse the response payload if present.
+        let response_payload = result
+            .payload()
+            .and_then(|blob| {
+                let bytes = blob.as_ref();
+                serde_json::from_slice::<serde_json::Value>(bytes).ok()
+            })
+            .unwrap_or(serde_json::Value::Null);
+
+        if let Some(ref err) = function_error {
+            error!(function_error = %err, "Lambda function returned an error");
+            return Err(ProviderError::ExecutionFailed(format!(
+                "Lambda function error: {err}"
+            )));
+        }
+
+        info!(
+            function_name = %function_name,
+            status_code = status_code,
+            "Lambda invocation succeeded"
+        );
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "function_name": function_name,
+            "status_code": status_code,
+            "response": response_payload
+        })))
+    }
+
+    #[instrument(skip(self), fields(provider = "aws-lambda"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        debug!("performing Lambda health check");
+        // List functions with a limit to verify connectivity.
+        self.client
+            .list_functions()
+            .max_items(1)
+            .send()
+            .await
+            .map_err(|e| {
+                error!(error = %e, "Lambda health check failed");
+                ProviderError::Connection(format!("Lambda health check failed: {e}"))
+            })?;
+        info!("Lambda health check passed");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_new_sets_region() {
+        let config = LambdaConfig::new("eu-central-1");
+        assert_eq!(config.aws.region, "eu-central-1");
+        assert!(config.function_name.is_none());
+        assert!(config.qualifier.is_none());
+    }
+
+    #[test]
+    fn config_builder_chain() {
+        let config = LambdaConfig::new("us-west-2")
+            .with_function_name("my-function")
+            .with_qualifier("prod")
+            .with_endpoint_url("http://localhost:4566");
+        assert_eq!(config.function_name.as_deref(), Some("my-function"));
+        assert_eq!(config.qualifier.as_deref(), Some("prod"));
+        assert_eq!(
+            config.aws.endpoint_url.as_deref(),
+            Some("http://localhost:4566")
+        );
+    }
+
+    #[test]
+    fn config_debug_format() {
+        let config = LambdaConfig::new("us-east-1")
+            .with_function_name("handler")
+            .with_role_arn("arn:aws:iam::123:role/test");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("LambdaConfig"));
+        assert!(debug.contains("handler"));
+        assert!(debug.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config = LambdaConfig::new("us-east-1").with_function_name("my-fn");
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: LambdaConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.aws.region, "us-east-1");
+        assert_eq!(deserialized.function_name.as_deref(), Some("my-fn"));
+    }
+
+    #[test]
+    fn deserialize_invoke_payload() {
+        let json = serde_json::json!({
+            "function_name": "my-handler",
+            "payload": {"key": "value"},
+            "invocation_type": "event"
+        });
+        let payload: LambdaInvokePayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.function_name.as_deref(), Some("my-handler"));
+        assert!(payload.payload.is_some());
+        assert!(matches!(payload.invocation_type, InvocationType::Event));
+    }
+
+    #[test]
+    fn deserialize_minimal_invoke_payload() {
+        let json = serde_json::json!({});
+        let payload: LambdaInvokePayload = serde_json::from_value(json).unwrap();
+        assert!(payload.function_name.is_none());
+        assert!(payload.payload.is_none());
+        assert!(matches!(
+            payload.invocation_type,
+            InvocationType::RequestResponse
+        ));
+    }
+
+    #[test]
+    fn invocation_type_default_is_request_response() {
+        let inv_type = InvocationType::default();
+        assert!(matches!(inv_type, InvocationType::RequestResponse));
+    }
+
+    #[test]
+    fn invocation_type_serde_roundtrip() {
+        for variant in &["request_response", "event", "dry_run"] {
+            let json = serde_json::json!(variant);
+            let _: InvocationType = serde_json::from_value(json).unwrap();
+        }
+    }
+}

--- a/crates/aws/src/lib.rs
+++ b/crates/aws/src/lib.rs
@@ -1,0 +1,50 @@
+//! AWS service providers for the Acteon action gateway.
+//!
+//! This crate provides feature-gated integrations with AWS services:
+//!
+//! - **SNS** (`sns` feature) — Publish messages to SNS topics
+//! - **Lambda** (`lambda` feature) — Invoke Lambda functions
+//! - **`EventBridge`** (`eventbridge` feature) — Put events to `EventBridge`
+//! - **SQS** (`sqs` feature) — Send messages to SQS queues
+//! - **SES** (`ses` feature) — Send emails via SES v2
+//!
+//! All providers share a common [`AwsBaseConfig`](config::AwsBaseConfig) for
+//! region, endpoint override, and optional STS assume-role credentials.
+
+pub mod auth;
+pub mod config;
+pub mod error;
+
+#[cfg(feature = "sns")]
+pub mod sns;
+
+#[cfg(feature = "lambda")]
+pub mod lambda;
+
+#[cfg(feature = "eventbridge")]
+pub mod eventbridge;
+
+#[cfg(feature = "sqs")]
+pub mod sqs;
+
+#[cfg(feature = "ses")]
+pub mod ses;
+
+// Re-exports for convenience.
+pub use config::AwsBaseConfig;
+pub use error::AwsProviderError;
+
+#[cfg(feature = "sns")]
+pub use sns::{SnsConfig, SnsProvider};
+
+#[cfg(feature = "lambda")]
+pub use lambda::{LambdaConfig, LambdaProvider};
+
+#[cfg(feature = "eventbridge")]
+pub use eventbridge::{EventBridgeConfig, EventBridgeProvider};
+
+#[cfg(feature = "sqs")]
+pub use sqs::{SqsConfig, SqsProvider};
+
+#[cfg(feature = "ses")]
+pub use ses::{SesClient, SesConfig};

--- a/crates/aws/src/lib.rs
+++ b/crates/aws/src/lib.rs
@@ -9,7 +9,7 @@
 //! - **SES** (`ses` feature) — Send emails via SES v2
 //! - **S3** (`s3` feature) — Put/get/delete objects in S3 buckets
 //!
-//! All providers share a common [`AwsBaseConfig`](config::AwsBaseConfig) for
+//! All providers share a common [`AwsBaseConfig`] for
 //! region, endpoint override, and optional STS assume-role credentials.
 
 pub mod auth;

--- a/crates/aws/src/lib.rs
+++ b/crates/aws/src/lib.rs
@@ -7,6 +7,7 @@
 //! - **`EventBridge`** (`eventbridge` feature) — Put events to `EventBridge`
 //! - **SQS** (`sqs` feature) — Send messages to SQS queues
 //! - **SES** (`ses` feature) — Send emails via SES v2
+//! - **S3** (`s3` feature) — Put/get/delete objects in S3 buckets
 //!
 //! All providers share a common [`AwsBaseConfig`](config::AwsBaseConfig) for
 //! region, endpoint override, and optional STS assume-role credentials.
@@ -30,6 +31,9 @@ pub mod sqs;
 #[cfg(feature = "ses")]
 pub mod ses;
 
+#[cfg(feature = "s3")]
+pub mod s3;
+
 // Re-exports for convenience.
 pub use config::AwsBaseConfig;
 pub use error::AwsProviderError;
@@ -48,3 +52,6 @@ pub use sqs::{SqsConfig, SqsProvider};
 
 #[cfg(feature = "ses")]
 pub use ses::{SesClient, SesConfig};
+
+#[cfg(feature = "s3")]
+pub use s3::{S3Config, S3Provider};

--- a/crates/aws/src/s3.rs
+++ b/crates/aws/src/s3.rs
@@ -1,0 +1,510 @@
+use std::collections::HashMap;
+
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::ProviderError;
+use acteon_provider::provider::Provider;
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, instrument};
+
+use crate::auth::build_sdk_config;
+use crate::config::AwsBaseConfig;
+use crate::error::classify_sdk_error;
+
+/// Configuration for the AWS S3 provider.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct S3Config {
+    /// Shared AWS configuration (region, role ARN, endpoint URL).
+    #[serde(flatten)]
+    pub aws: AwsBaseConfig,
+
+    /// Default S3 bucket name. Can be overridden per-action in the payload.
+    pub bucket: Option<String>,
+
+    /// Default key prefix for all objects (e.g. `"acteon/artifacts/"`).
+    pub prefix: Option<String>,
+}
+
+impl std::fmt::Debug for S3Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3Config")
+            .field("aws", &self.aws)
+            .field("bucket", &self.bucket)
+            .field("prefix", &self.prefix)
+            .finish()
+    }
+}
+
+impl S3Config {
+    /// Create a new `S3Config` with the given AWS region.
+    pub fn new(region: impl Into<String>) -> Self {
+        Self {
+            aws: AwsBaseConfig::new(region),
+            bucket: None,
+            prefix: None,
+        }
+    }
+
+    /// Set the default bucket name.
+    #[must_use]
+    pub fn with_bucket(mut self, bucket: impl Into<String>) -> Self {
+        self.bucket = Some(bucket.into());
+        self
+    }
+
+    /// Set the default key prefix.
+    #[must_use]
+    pub fn with_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = Some(prefix.into());
+        self
+    }
+
+    /// Set the endpoint URL override (for `LocalStack`).
+    #[must_use]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.aws.endpoint_url = Some(endpoint_url.into());
+        self
+    }
+
+    /// Set the IAM role ARN to assume.
+    #[must_use]
+    pub fn with_role_arn(mut self, role_arn: impl Into<String>) -> Self {
+        self.aws.role_arn = Some(role_arn.into());
+        self
+    }
+
+    /// Set the STS session name for assume-role.
+    #[must_use]
+    pub fn with_session_name(mut self, session_name: impl Into<String>) -> Self {
+        self.aws.session_name = Some(session_name.into());
+        self
+    }
+
+    /// Set the external ID for cross-account trust policies.
+    #[must_use]
+    pub fn with_external_id(mut self, external_id: impl Into<String>) -> Self {
+        self.aws.external_id = Some(external_id.into());
+        self
+    }
+}
+
+/// Payload for the `put_object` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct S3PutPayload {
+    /// S3 bucket name. Overrides config default.
+    pub bucket: Option<String>,
+
+    /// Object key (path within the bucket).
+    pub key: String,
+
+    /// Object body as a UTF-8 string.
+    /// Mutually exclusive with `body_base64`.
+    pub body: Option<String>,
+
+    /// Object body as base64-encoded bytes.
+    /// Mutually exclusive with `body`.
+    pub body_base64: Option<String>,
+
+    /// Optional `Content-Type` header for the object.
+    pub content_type: Option<String>,
+
+    /// Optional metadata key-value pairs attached to the object.
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+/// Payload for the `get_object` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct S3GetPayload {
+    /// S3 bucket name. Overrides config default.
+    pub bucket: Option<String>,
+
+    /// Object key to retrieve.
+    pub key: String,
+}
+
+/// Payload for the `delete_object` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct S3DeletePayload {
+    /// S3 bucket name. Overrides config default.
+    pub bucket: Option<String>,
+
+    /// Object key to delete.
+    pub key: String,
+}
+
+/// AWS S3 provider for storing and retrieving objects.
+pub struct S3Provider {
+    config: S3Config,
+    client: aws_sdk_s3::Client,
+}
+
+impl std::fmt::Debug for S3Provider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3Provider")
+            .field("config", &self.config)
+            .field("client", &"<S3Client>")
+            .finish()
+    }
+}
+
+impl S3Provider {
+    /// Create a new `S3Provider` by building an AWS SDK client.
+    pub async fn new(config: S3Config) -> Self {
+        let sdk_config = build_sdk_config(&config.aws).await;
+        let client = aws_sdk_s3::Client::new(&sdk_config);
+        Self { config, client }
+    }
+
+    /// Create an `S3Provider` with a pre-built client (for testing).
+    pub fn with_client(config: S3Config, client: aws_sdk_s3::Client) -> Self {
+        Self { config, client }
+    }
+
+    /// Resolve the bucket name from the payload or config default.
+    fn resolve_bucket<'a>(&'a self, payload_bucket: Option<&'a str>) -> Option<&'a str> {
+        payload_bucket.or(self.config.bucket.as_deref())
+    }
+
+    /// Apply the configured prefix to a key.
+    fn prefixed_key(&self, key: &str) -> String {
+        match &self.config.prefix {
+            Some(prefix) => format!("{prefix}{key}"),
+            None => key.to_owned(),
+        }
+    }
+}
+
+impl Provider for S3Provider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "aws-s3"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "aws-s3"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        match action.action_type.as_str() {
+            "put_object" => self.put_object(action).await,
+            "get_object" => self.get_object(action).await,
+            "delete_object" => self.delete_object(action).await,
+            other => Err(ProviderError::Configuration(format!(
+                "unknown S3 action type '{other}' (expected 'put_object', 'get_object', or 'delete_object')"
+            ))),
+        }
+    }
+
+    #[instrument(skip(self), fields(provider = "aws-s3"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        debug!("performing S3 health check");
+        self.client
+            .list_buckets()
+            .max_buckets(1)
+            .send()
+            .await
+            .map_err(|e| {
+                error!(error = %e, "S3 health check failed");
+                ProviderError::Connection(format!("S3 health check failed: {e}"))
+            })?;
+        info!("S3 health check passed");
+        Ok(())
+    }
+}
+
+impl S3Provider {
+    async fn put_object(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing S3 put_object payload");
+        let payload: S3PutPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let bucket = self
+            .resolve_bucket(payload.bucket.as_deref())
+            .ok_or_else(|| {
+                ProviderError::Configuration("no bucket in payload or provider config".to_owned())
+            })?;
+
+        let key = self.prefixed_key(&payload.key);
+
+        // Resolve the body from either string or base64.
+        let body_bytes: Vec<u8> = if let Some(ref b64) = payload.body_base64 {
+            base64::engine::general_purpose::STANDARD
+                .decode(b64)
+                .map_err(|e| ProviderError::Serialization(format!("invalid base64 body: {e}")))?
+        } else if let Some(ref text) = payload.body {
+            text.as_bytes().to_vec()
+        } else {
+            Vec::new()
+        };
+
+        debug!(bucket = %bucket, key = %key, size = body_bytes.len(), "uploading object to S3");
+
+        let mut request = self
+            .client
+            .put_object()
+            .bucket(bucket)
+            .key(&key)
+            .body(aws_sdk_s3::primitives::ByteStream::from(body_bytes));
+
+        if let Some(ref ct) = payload.content_type {
+            request = request.content_type(ct);
+        }
+
+        for (mk, mv) in &payload.metadata {
+            request = request.metadata(mk, mv);
+        }
+
+        request.send().await.map_err(|e| {
+            let err_str = e.to_string();
+            error!(error = %err_str, "S3 put_object failed");
+            let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+            aws_err
+        })?;
+
+        info!(bucket = %bucket, key = %key, "S3 object uploaded");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "bucket": bucket,
+            "key": key,
+            "status": "uploaded"
+        })))
+    }
+
+    async fn get_object(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing S3 get_object payload");
+        let payload: S3GetPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let bucket = self
+            .resolve_bucket(payload.bucket.as_deref())
+            .ok_or_else(|| {
+                ProviderError::Configuration("no bucket in payload or provider config".to_owned())
+            })?;
+
+        let key = self.prefixed_key(&payload.key);
+
+        debug!(bucket = %bucket, key = %key, "downloading object from S3");
+
+        let result = self
+            .client
+            .get_object()
+            .bucket(bucket)
+            .key(&key)
+            .send()
+            .await
+            .map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "S3 get_object failed");
+                let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+                aws_err
+            })?;
+
+        let content_type = result
+            .content_type()
+            .unwrap_or("application/octet-stream")
+            .to_owned();
+        let content_length = result.content_length().unwrap_or(0);
+
+        // Read the body as bytes and return as a UTF-8 string if possible,
+        // otherwise base64-encode it.
+        let body_bytes = result
+            .body
+            .collect()
+            .await
+            .map_err(|e| ProviderError::ExecutionFailed(format!("failed to read S3 body: {e}")))?
+            .into_bytes();
+
+        let (body_field, body_value) = match std::str::from_utf8(&body_bytes) {
+            Ok(text) => ("body", serde_json::Value::String(text.to_owned())),
+            Err(_) => (
+                "body_base64",
+                serde_json::Value::String(
+                    base64::engine::general_purpose::STANDARD.encode(&body_bytes),
+                ),
+            ),
+        };
+
+        info!(bucket = %bucket, key = %key, content_length = content_length, "S3 object downloaded");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "bucket": bucket,
+            "key": key,
+            "content_type": content_type,
+            "content_length": content_length,
+            body_field: body_value,
+            "status": "downloaded"
+        })))
+    }
+
+    async fn delete_object(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing S3 delete_object payload");
+        let payload: S3DeletePayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let bucket = self
+            .resolve_bucket(payload.bucket.as_deref())
+            .ok_or_else(|| {
+                ProviderError::Configuration("no bucket in payload or provider config".to_owned())
+            })?;
+
+        let key = self.prefixed_key(&payload.key);
+
+        debug!(bucket = %bucket, key = %key, "deleting object from S3");
+
+        self.client
+            .delete_object()
+            .bucket(bucket)
+            .key(&key)
+            .send()
+            .await
+            .map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "S3 delete_object failed");
+                let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+                aws_err
+            })?;
+
+        info!(bucket = %bucket, key = %key, "S3 object deleted");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "bucket": bucket,
+            "key": key,
+            "status": "deleted"
+        })))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_new_sets_region() {
+        let config = S3Config::new("us-west-2");
+        assert_eq!(config.aws.region, "us-west-2");
+        assert!(config.bucket.is_none());
+        assert!(config.prefix.is_none());
+    }
+
+    #[test]
+    fn config_with_bucket() {
+        let config = S3Config::new("us-east-1").with_bucket("my-bucket");
+        assert_eq!(config.bucket.as_deref(), Some("my-bucket"));
+    }
+
+    #[test]
+    fn config_with_prefix() {
+        let config = S3Config::new("us-east-1").with_prefix("acteon/");
+        assert_eq!(config.prefix.as_deref(), Some("acteon/"));
+    }
+
+    #[test]
+    fn config_builder_chain() {
+        let config = S3Config::new("eu-west-1")
+            .with_bucket("data-bucket")
+            .with_prefix("logs/")
+            .with_endpoint_url("http://localhost:4566")
+            .with_role_arn("arn:aws:iam::123:role/s3-access")
+            .with_session_name("test-session")
+            .with_external_id("ext-123");
+        assert_eq!(config.bucket.as_deref(), Some("data-bucket"));
+        assert_eq!(config.prefix.as_deref(), Some("logs/"));
+        assert_eq!(
+            config.aws.endpoint_url.as_deref(),
+            Some("http://localhost:4566")
+        );
+        assert!(config.aws.role_arn.is_some());
+        assert_eq!(config.aws.session_name.as_deref(), Some("test-session"));
+        assert_eq!(config.aws.external_id.as_deref(), Some("ext-123"));
+    }
+
+    #[test]
+    fn config_debug_format() {
+        let config = S3Config::new("us-east-1")
+            .with_bucket("my-bucket")
+            .with_role_arn("arn:aws:iam::123:role/test");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("S3Config"));
+        assert!(debug.contains("[REDACTED]"));
+        assert!(debug.contains("my-bucket"));
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config = S3Config::new("ap-southeast-1")
+            .with_bucket("archive-bucket")
+            .with_prefix("data/");
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: S3Config = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.aws.region, "ap-southeast-1");
+        assert_eq!(deserialized.bucket.as_deref(), Some("archive-bucket"));
+        assert_eq!(deserialized.prefix.as_deref(), Some("data/"));
+    }
+
+    #[test]
+    fn deserialize_put_payload() {
+        let json = serde_json::json!({
+            "key": "reports/2026/report.json",
+            "body": "{\"total\": 42}",
+            "content_type": "application/json",
+            "bucket": "my-bucket",
+            "metadata": {
+                "source": "acteon"
+            }
+        });
+        let payload: S3PutPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.key, "reports/2026/report.json");
+        assert_eq!(payload.body.as_deref(), Some("{\"total\": 42}"));
+        assert_eq!(payload.content_type.as_deref(), Some("application/json"));
+        assert_eq!(payload.bucket.as_deref(), Some("my-bucket"));
+        assert_eq!(payload.metadata.get("source").unwrap(), "acteon");
+    }
+
+    #[test]
+    fn deserialize_put_payload_base64() {
+        let json = serde_json::json!({
+            "key": "images/logo.png",
+            "body_base64": "iVBORw0KGgo=",
+            "content_type": "image/png"
+        });
+        let payload: S3PutPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.key, "images/logo.png");
+        assert!(payload.body.is_none());
+        assert_eq!(payload.body_base64.as_deref(), Some("iVBORw0KGgo="));
+    }
+
+    #[test]
+    fn deserialize_minimal_put_payload() {
+        let json = serde_json::json!({
+            "key": "test.txt"
+        });
+        let payload: S3PutPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.key, "test.txt");
+        assert!(payload.body.is_none());
+        assert!(payload.body_base64.is_none());
+        assert!(payload.content_type.is_none());
+        assert!(payload.bucket.is_none());
+        assert!(payload.metadata.is_empty());
+    }
+
+    #[test]
+    fn deserialize_get_payload() {
+        let json = serde_json::json!({
+            "key": "reports/latest.json",
+            "bucket": "data-bucket"
+        });
+        let payload: S3GetPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.key, "reports/latest.json");
+        assert_eq!(payload.bucket.as_deref(), Some("data-bucket"));
+    }
+
+    #[test]
+    fn deserialize_delete_payload() {
+        let json = serde_json::json!({
+            "key": "old/data.csv"
+        });
+        let payload: S3DeletePayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.key, "old/data.csv");
+        assert!(payload.bucket.is_none());
+    }
+}

--- a/crates/aws/src/ses.rs
+++ b/crates/aws/src/ses.rs
@@ -57,6 +57,20 @@ impl SesConfig {
         self.aws.role_arn = Some(role_arn.into());
         self
     }
+
+    /// Set the STS session name for assume-role.
+    #[must_use]
+    pub fn with_session_name(mut self, session_name: impl Into<String>) -> Self {
+        self.aws.session_name = Some(session_name.into());
+        self
+    }
+
+    /// Set the external ID for cross-account trust policies.
+    #[must_use]
+    pub fn with_external_id(mut self, external_id: impl Into<String>) -> Self {
+        self.aws.external_id = Some(external_id.into());
+        self
+    }
 }
 
 /// AWS `SESv2` client wrapper for sending emails.

--- a/crates/aws/src/ses.rs
+++ b/crates/aws/src/ses.rs
@@ -1,0 +1,254 @@
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info};
+
+use crate::auth::build_sdk_config;
+use crate::config::AwsBaseConfig;
+use crate::error::classify_sdk_error;
+
+/// Configuration for the AWS SES email backend.
+///
+/// Used by the email provider's SES backend to send emails via the
+/// `SESv2` `SendEmail` API.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SesConfig {
+    /// Shared AWS configuration (region, role ARN, endpoint URL).
+    #[serde(flatten)]
+    pub aws: AwsBaseConfig,
+
+    /// Optional SES configuration set name for tracking.
+    pub configuration_set: Option<String>,
+}
+
+impl std::fmt::Debug for SesConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SesConfig")
+            .field("aws", &self.aws)
+            .field("configuration_set", &self.configuration_set)
+            .finish()
+    }
+}
+
+impl SesConfig {
+    /// Create a new `SesConfig` with the given AWS region.
+    pub fn new(region: impl Into<String>) -> Self {
+        Self {
+            aws: AwsBaseConfig::new(region),
+            configuration_set: None,
+        }
+    }
+
+    /// Set the SES configuration set name.
+    #[must_use]
+    pub fn with_configuration_set(mut self, name: impl Into<String>) -> Self {
+        self.configuration_set = Some(name.into());
+        self
+    }
+
+    /// Set the endpoint URL override (for `LocalStack`).
+    #[must_use]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.aws.endpoint_url = Some(endpoint_url.into());
+        self
+    }
+
+    /// Set the IAM role ARN to assume.
+    #[must_use]
+    pub fn with_role_arn(mut self, role_arn: impl Into<String>) -> Self {
+        self.aws.role_arn = Some(role_arn.into());
+        self
+    }
+}
+
+/// AWS `SESv2` client wrapper for sending emails.
+///
+/// This struct is used by the email provider's SES backend. It is not a
+/// standalone provider -- the unified `EmailProvider` delegates to it.
+pub struct SesClient {
+    config: SesConfig,
+    client: aws_sdk_sesv2::Client,
+}
+
+impl std::fmt::Debug for SesClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SesClient")
+            .field("config", &self.config)
+            .field("client", &"<SesV2Client>")
+            .finish()
+    }
+}
+
+impl SesClient {
+    /// Create a new `SesClient` by building an AWS SDK client.
+    pub async fn new(config: SesConfig) -> Self {
+        let sdk_config = build_sdk_config(&config.aws).await;
+        let client = aws_sdk_sesv2::Client::new(&sdk_config);
+        Self { config, client }
+    }
+
+    /// Create a `SesClient` with a pre-built client (for testing).
+    pub fn with_client(config: SesConfig, client: aws_sdk_sesv2::Client) -> Self {
+        Self { config, client }
+    }
+
+    /// Send an email via SES.
+    ///
+    /// # Arguments
+    ///
+    /// * `from` - Sender email address
+    /// * `to` - Recipient email address
+    /// * `subject` - Email subject
+    /// * `body_text` - Optional plain-text body
+    /// * `body_html` - Optional HTML body
+    /// * `cc` - Optional CC address
+    /// * `bcc` - Optional BCC address
+    /// * `reply_to` - Optional reply-to address
+    #[allow(clippy::too_many_arguments)]
+    pub async fn send_email(
+        &self,
+        from: &str,
+        to: &str,
+        subject: &str,
+        body_text: Option<&str>,
+        body_html: Option<&str>,
+        cc: Option<&str>,
+        bcc: Option<&str>,
+        reply_to: Option<&str>,
+    ) -> Result<String, acteon_provider::ProviderError> {
+        debug!(from = %from, to = %to, subject = %subject, "sending email via SES");
+
+        let mut destination = aws_sdk_sesv2::types::Destination::builder().to_addresses(to);
+        if let Some(cc_addr) = cc {
+            destination = destination.cc_addresses(cc_addr);
+        }
+        if let Some(bcc_addr) = bcc {
+            destination = destination.bcc_addresses(bcc_addr);
+        }
+
+        let subject_content = aws_sdk_sesv2::types::Content::builder()
+            .data(subject)
+            .charset("UTF-8")
+            .build()
+            .map_err(|e| acteon_provider::ProviderError::Serialization(e.to_string()))?;
+
+        let mut body_builder = aws_sdk_sesv2::types::Body::builder();
+        if let Some(text) = body_text {
+            body_builder = body_builder.text(
+                aws_sdk_sesv2::types::Content::builder()
+                    .data(text)
+                    .charset("UTF-8")
+                    .build()
+                    .map_err(|e| acteon_provider::ProviderError::Serialization(e.to_string()))?,
+            );
+        }
+        if let Some(html) = body_html {
+            body_builder = body_builder.html(
+                aws_sdk_sesv2::types::Content::builder()
+                    .data(html)
+                    .charset("UTF-8")
+                    .build()
+                    .map_err(|e| acteon_provider::ProviderError::Serialization(e.to_string()))?,
+            );
+        }
+
+        let message = aws_sdk_sesv2::types::Message::builder()
+            .subject(subject_content)
+            .body(body_builder.build())
+            .build();
+
+        let email_content = aws_sdk_sesv2::types::EmailContent::builder()
+            .simple(message)
+            .build();
+
+        let mut request = self
+            .client
+            .send_email()
+            .from_email_address(from)
+            .destination(destination.build())
+            .content(email_content);
+
+        if let Some(reply) = reply_to {
+            request = request.reply_to_addresses(reply);
+        }
+
+        if let Some(ref config_set) = self.config.configuration_set {
+            request = request.configuration_set_name(config_set);
+        }
+
+        let result = request.send().await.map_err(|e| {
+            let err_str = e.to_string();
+            error!(error = %err_str, "SES send_email failed");
+            let aws_err: acteon_provider::ProviderError = classify_sdk_error(&err_str).into();
+            aws_err
+        })?;
+
+        let message_id = result.message_id().unwrap_or("unknown").to_owned();
+        info!(message_id = %message_id, "SES email sent");
+
+        Ok(message_id)
+    }
+
+    /// Perform a health check by calling the SES `GetAccount` API.
+    pub async fn health_check(&self) -> Result<(), acteon_provider::ProviderError> {
+        debug!("performing SES health check");
+        self.client.get_account().send().await.map_err(|e| {
+            error!(error = %e, "SES health check failed");
+            acteon_provider::ProviderError::Connection(format!("SES health check failed: {e}"))
+        })?;
+        info!("SES health check passed");
+        Ok(())
+    }
+
+    /// Get a reference to the config.
+    pub fn config(&self) -> &SesConfig {
+        &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_new_sets_region() {
+        let config = SesConfig::new("us-east-1");
+        assert_eq!(config.aws.region, "us-east-1");
+        assert!(config.configuration_set.is_none());
+    }
+
+    #[test]
+    fn config_with_configuration_set() {
+        let config = SesConfig::new("us-east-1").with_configuration_set("tracking-set");
+        assert_eq!(config.configuration_set.as_deref(), Some("tracking-set"));
+    }
+
+    #[test]
+    fn config_builder_chain() {
+        let config = SesConfig::new("eu-west-1")
+            .with_configuration_set("my-set")
+            .with_endpoint_url("http://localhost:4566")
+            .with_role_arn("arn:aws:iam::123:role/ses");
+        assert_eq!(config.aws.region, "eu-west-1");
+        assert_eq!(config.configuration_set.as_deref(), Some("my-set"));
+        assert!(config.aws.endpoint_url.is_some());
+        assert!(config.aws.role_arn.is_some());
+    }
+
+    #[test]
+    fn config_debug_format() {
+        let config = SesConfig::new("us-east-1").with_role_arn("arn:aws:iam::123:role/test");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("SesConfig"));
+        assert!(debug.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config = SesConfig::new("us-west-2").with_configuration_set("test-set");
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: SesConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.aws.region, "us-west-2");
+        assert_eq!(deserialized.configuration_set.as_deref(), Some("test-set"));
+    }
+}

--- a/crates/aws/src/sns.rs
+++ b/crates/aws/src/sns.rs
@@ -1,0 +1,275 @@
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::ProviderError;
+use acteon_provider::provider::Provider;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, instrument};
+
+use crate::auth::build_sdk_config;
+use crate::config::AwsBaseConfig;
+use crate::error::classify_sdk_error;
+
+/// Configuration for the AWS SNS provider.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SnsConfig {
+    /// Shared AWS configuration (region, role ARN, endpoint URL).
+    #[serde(flatten)]
+    pub aws: AwsBaseConfig,
+
+    /// Default SNS topic ARN. Can be overridden per-action in the payload.
+    pub topic_arn: Option<String>,
+}
+
+impl std::fmt::Debug for SnsConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SnsConfig")
+            .field("aws", &self.aws)
+            .field("topic_arn", &self.topic_arn)
+            .finish()
+    }
+}
+
+impl SnsConfig {
+    /// Create a new `SnsConfig` with the given AWS region.
+    pub fn new(region: impl Into<String>) -> Self {
+        Self {
+            aws: AwsBaseConfig::new(region),
+            topic_arn: None,
+        }
+    }
+
+    /// Set the default topic ARN.
+    #[must_use]
+    pub fn with_topic_arn(mut self, topic_arn: impl Into<String>) -> Self {
+        self.topic_arn = Some(topic_arn.into());
+        self
+    }
+
+    /// Set the endpoint URL override (for `LocalStack`).
+    #[must_use]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.aws.endpoint_url = Some(endpoint_url.into());
+        self
+    }
+
+    /// Set the IAM role ARN to assume.
+    #[must_use]
+    pub fn with_role_arn(mut self, role_arn: impl Into<String>) -> Self {
+        self.aws.role_arn = Some(role_arn.into());
+        self
+    }
+}
+
+/// Payload for the `publish_message` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnsPublishPayload {
+    /// SNS topic ARN. Overrides the default topic ARN from config.
+    pub topic_arn: Option<String>,
+
+    /// Message body.
+    pub message: String,
+
+    /// Optional message subject (used for email endpoints).
+    pub subject: Option<String>,
+
+    /// Optional message group ID (for FIFO topics).
+    pub message_group_id: Option<String>,
+
+    /// Optional message deduplication ID (for FIFO topics).
+    pub message_dedup_id: Option<String>,
+}
+
+/// AWS SNS provider for publishing messages to SNS topics.
+pub struct SnsProvider {
+    config: SnsConfig,
+    client: aws_sdk_sns::Client,
+}
+
+impl std::fmt::Debug for SnsProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SnsProvider")
+            .field("config", &self.config)
+            .field("client", &"<SnsClient>")
+            .finish()
+    }
+}
+
+impl SnsProvider {
+    /// Create a new `SnsProvider` by building an AWS SDK client.
+    pub async fn new(config: SnsConfig) -> Self {
+        let sdk_config = build_sdk_config(&config.aws).await;
+        let client = aws_sdk_sns::Client::new(&sdk_config);
+        Self { config, client }
+    }
+
+    /// Create an `SnsProvider` with a pre-built client (for testing).
+    pub fn with_client(config: SnsConfig, client: aws_sdk_sns::Client) -> Self {
+        Self { config, client }
+    }
+}
+
+impl Provider for SnsProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "aws-sns"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "aws-sns"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing SNS payload");
+        let payload: SnsPublishPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let topic_arn = payload
+            .topic_arn
+            .as_deref()
+            .or(self.config.topic_arn.as_deref())
+            .ok_or_else(|| {
+                ProviderError::Configuration(
+                    "no topic_arn in payload or provider config".to_owned(),
+                )
+            })?;
+
+        debug!(topic_arn = %topic_arn, "publishing to SNS topic");
+
+        let mut request = self
+            .client
+            .publish()
+            .topic_arn(topic_arn)
+            .message(&payload.message);
+
+        if let Some(ref subject) = payload.subject {
+            request = request.subject(subject);
+        }
+        if let Some(ref group_id) = payload.message_group_id {
+            request = request.message_group_id(group_id);
+        }
+        if let Some(ref dedup_id) = payload.message_dedup_id {
+            request = request.message_deduplication_id(dedup_id);
+        }
+
+        let result = request.send().await.map_err(|e| {
+            let err_str = e.to_string();
+            error!(error = %err_str, "SNS publish failed");
+            let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+            aws_err
+        })?;
+
+        let message_id = result.message_id().unwrap_or("unknown").to_owned();
+        info!(message_id = %message_id, topic_arn = %topic_arn, "SNS message published");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "message_id": message_id,
+            "topic_arn": topic_arn,
+            "status": "published"
+        })))
+    }
+
+    #[instrument(skip(self), fields(provider = "aws-sns"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        debug!("performing SNS health check");
+        // List topics with a limit of 1 to verify connectivity.
+        self.client.list_topics().send().await.map_err(|e| {
+            error!(error = %e, "SNS health check failed");
+            ProviderError::Connection(format!("SNS health check failed: {e}"))
+        })?;
+        info!("SNS health check passed");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_new_sets_region() {
+        let config = SnsConfig::new("eu-west-1");
+        assert_eq!(config.aws.region, "eu-west-1");
+        assert!(config.topic_arn.is_none());
+    }
+
+    #[test]
+    fn config_with_topic_arn() {
+        let config = SnsConfig::new("us-east-1")
+            .with_topic_arn("arn:aws:sns:us-east-1:123456789012:my-topic");
+        assert_eq!(
+            config.topic_arn.as_deref(),
+            Some("arn:aws:sns:us-east-1:123456789012:my-topic")
+        );
+    }
+
+    #[test]
+    fn config_with_endpoint_url() {
+        let config = SnsConfig::new("us-east-1").with_endpoint_url("http://localhost:4566");
+        assert_eq!(
+            config.aws.endpoint_url.as_deref(),
+            Some("http://localhost:4566")
+        );
+    }
+
+    #[test]
+    fn config_debug_format() {
+        let config = SnsConfig::new("us-east-1")
+            .with_topic_arn("arn:aws:sns:us-east-1:123:topic")
+            .with_role_arn("arn:aws:iam::123:role/test");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("SnsConfig"));
+        assert!(debug.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config =
+            SnsConfig::new("ap-southeast-1").with_topic_arn("arn:aws:sns:ap-southeast-1:123:topic");
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: SnsConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.aws.region, "ap-southeast-1");
+        assert_eq!(
+            deserialized.topic_arn.as_deref(),
+            Some("arn:aws:sns:ap-southeast-1:123:topic")
+        );
+    }
+
+    #[test]
+    fn deserialize_publish_payload() {
+        let json = serde_json::json!({
+            "message": "Hello from Acteon",
+            "subject": "Alert",
+            "topic_arn": "arn:aws:sns:us-east-1:123:topic"
+        });
+        let payload: SnsPublishPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.message, "Hello from Acteon");
+        assert_eq!(payload.subject.as_deref(), Some("Alert"));
+        assert_eq!(
+            payload.topic_arn.as_deref(),
+            Some("arn:aws:sns:us-east-1:123:topic")
+        );
+    }
+
+    #[test]
+    fn deserialize_minimal_publish_payload() {
+        let json = serde_json::json!({
+            "message": "test"
+        });
+        let payload: SnsPublishPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.message, "test");
+        assert!(payload.topic_arn.is_none());
+        assert!(payload.subject.is_none());
+        assert!(payload.message_group_id.is_none());
+    }
+
+    #[test]
+    fn deserialize_fifo_publish_payload() {
+        let json = serde_json::json!({
+            "message": "ordered message",
+            "topic_arn": "arn:aws:sns:us-east-1:123:topic.fifo",
+            "message_group_id": "group-1",
+            "message_dedup_id": "dedup-abc"
+        });
+        let payload: SnsPublishPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.message_group_id.as_deref(), Some("group-1"));
+        assert_eq!(payload.message_dedup_id.as_deref(), Some("dedup-abc"));
+    }
+}

--- a/crates/aws/src/sns.rs
+++ b/crates/aws/src/sns.rs
@@ -57,6 +57,20 @@ impl SnsConfig {
         self.aws.role_arn = Some(role_arn.into());
         self
     }
+
+    /// Set the STS session name for assume-role.
+    #[must_use]
+    pub fn with_session_name(mut self, session_name: impl Into<String>) -> Self {
+        self.aws.session_name = Some(session_name.into());
+        self
+    }
+
+    /// Set the external ID for cross-account trust policies.
+    #[must_use]
+    pub fn with_external_id(mut self, external_id: impl Into<String>) -> Self {
+        self.aws.external_id = Some(external_id.into());
+        self
+    }
 }
 
 /// Payload for the `publish_message` action type.

--- a/crates/aws/src/sqs.rs
+++ b/crates/aws/src/sqs.rs
@@ -1,0 +1,278 @@
+use std::collections::HashMap;
+
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::ProviderError;
+use acteon_provider::provider::Provider;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, instrument};
+
+use crate::auth::build_sdk_config;
+use crate::config::AwsBaseConfig;
+use crate::error::classify_sdk_error;
+
+/// Configuration for the AWS SQS provider.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SqsConfig {
+    /// Shared AWS configuration (region, role ARN, endpoint URL).
+    #[serde(flatten)]
+    pub aws: AwsBaseConfig,
+
+    /// Default SQS queue URL. Can be overridden per-action in the payload.
+    pub queue_url: Option<String>,
+}
+
+impl std::fmt::Debug for SqsConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqsConfig")
+            .field("aws", &self.aws)
+            .field("queue_url", &self.queue_url)
+            .finish()
+    }
+}
+
+impl SqsConfig {
+    /// Create a new `SqsConfig` with the given AWS region.
+    pub fn new(region: impl Into<String>) -> Self {
+        Self {
+            aws: AwsBaseConfig::new(region),
+            queue_url: None,
+        }
+    }
+
+    /// Set the default queue URL.
+    #[must_use]
+    pub fn with_queue_url(mut self, queue_url: impl Into<String>) -> Self {
+        self.queue_url = Some(queue_url.into());
+        self
+    }
+
+    /// Set the endpoint URL override (for `LocalStack`).
+    #[must_use]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.aws.endpoint_url = Some(endpoint_url.into());
+        self
+    }
+
+    /// Set the IAM role ARN to assume.
+    #[must_use]
+    pub fn with_role_arn(mut self, role_arn: impl Into<String>) -> Self {
+        self.aws.role_arn = Some(role_arn.into());
+        self
+    }
+}
+
+/// Payload for the `send_message` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SqsSendPayload {
+    /// SQS queue URL. Overrides config default.
+    pub queue_url: Option<String>,
+
+    /// Message body (string or JSON that gets serialized to string).
+    pub message_body: String,
+
+    /// Optional delay in seconds before the message becomes visible (0-900).
+    pub delay_seconds: Option<i32>,
+
+    /// Optional message group ID (required for FIFO queues).
+    pub message_group_id: Option<String>,
+
+    /// Optional message deduplication ID (for FIFO queues).
+    pub message_dedup_id: Option<String>,
+
+    /// Optional string message attributes.
+    #[serde(default)]
+    pub message_attributes: HashMap<String, String>,
+}
+
+/// AWS SQS provider for sending messages to SQS queues.
+pub struct SqsProvider {
+    config: SqsConfig,
+    client: aws_sdk_sqs::Client,
+}
+
+impl std::fmt::Debug for SqsProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqsProvider")
+            .field("config", &self.config)
+            .field("client", &"<SqsClient>")
+            .finish()
+    }
+}
+
+impl SqsProvider {
+    /// Create a new `SqsProvider` by building an AWS SDK client.
+    pub async fn new(config: SqsConfig) -> Self {
+        let sdk_config = build_sdk_config(&config.aws).await;
+        let client = aws_sdk_sqs::Client::new(&sdk_config);
+        Self { config, client }
+    }
+
+    /// Create an `SqsProvider` with a pre-built client (for testing).
+    pub fn with_client(config: SqsConfig, client: aws_sdk_sqs::Client) -> Self {
+        Self { config, client }
+    }
+}
+
+impl Provider for SqsProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "aws-sqs"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "aws-sqs"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing SQS payload");
+        let payload: SqsSendPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let queue_url = payload
+            .queue_url
+            .as_deref()
+            .or(self.config.queue_url.as_deref())
+            .ok_or_else(|| {
+                ProviderError::Configuration(
+                    "no queue_url in payload or provider config".to_owned(),
+                )
+            })?;
+
+        debug!(queue_url = %queue_url, "sending message to SQS queue");
+
+        let mut request = self
+            .client
+            .send_message()
+            .queue_url(queue_url)
+            .message_body(&payload.message_body);
+
+        if let Some(delay) = payload.delay_seconds {
+            request = request.delay_seconds(delay);
+        }
+        if let Some(ref group_id) = payload.message_group_id {
+            request = request.message_group_id(group_id);
+        }
+        if let Some(ref dedup_id) = payload.message_dedup_id {
+            request = request.message_deduplication_id(dedup_id);
+        }
+
+        for (key, value) in &payload.message_attributes {
+            let attr = aws_sdk_sqs::types::MessageAttributeValue::builder()
+                .data_type("String")
+                .string_value(value)
+                .build()
+                .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+            request = request.message_attributes(key, attr);
+        }
+
+        let result = request.send().await.map_err(|e| {
+            let err_str = e.to_string();
+            error!(error = %err_str, "SQS send_message failed");
+            let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+            aws_err
+        })?;
+
+        let message_id = result.message_id().unwrap_or("unknown").to_owned();
+        info!(message_id = %message_id, queue_url = %queue_url, "SQS message sent");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "message_id": message_id,
+            "queue_url": queue_url,
+            "status": "sent"
+        })))
+    }
+
+    #[instrument(skip(self), fields(provider = "aws-sqs"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        debug!("performing SQS health check");
+        self.client
+            .list_queues()
+            .max_results(1)
+            .send()
+            .await
+            .map_err(|e| {
+                error!(error = %e, "SQS health check failed");
+                ProviderError::Connection(format!("SQS health check failed: {e}"))
+            })?;
+        info!("SQS health check passed");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_new_sets_region() {
+        let config = SqsConfig::new("us-west-2");
+        assert_eq!(config.aws.region, "us-west-2");
+        assert!(config.queue_url.is_none());
+    }
+
+    #[test]
+    fn config_with_queue_url() {
+        let config = SqsConfig::new("us-east-1")
+            .with_queue_url("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue");
+        assert!(config.queue_url.is_some());
+    }
+
+    #[test]
+    fn config_debug_format() {
+        let config = SqsConfig::new("us-east-1").with_role_arn("arn:aws:iam::123:role/test");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("SqsConfig"));
+        assert!(debug.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config =
+            SqsConfig::new("eu-west-1").with_queue_url("https://sqs.eu-west-1.amazonaws.com/123/q");
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: SqsConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.aws.region, "eu-west-1");
+        assert!(deserialized.queue_url.is_some());
+    }
+
+    #[test]
+    fn deserialize_send_payload() {
+        let json = serde_json::json!({
+            "message_body": "Hello, SQS!",
+            "delay_seconds": 10,
+            "queue_url": "https://sqs.us-east-1.amazonaws.com/123/q"
+        });
+        let payload: SqsSendPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.message_body, "Hello, SQS!");
+        assert_eq!(payload.delay_seconds, Some(10));
+        assert!(payload.queue_url.is_some());
+    }
+
+    #[test]
+    fn deserialize_minimal_send_payload() {
+        let json = serde_json::json!({
+            "message_body": "test"
+        });
+        let payload: SqsSendPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.message_body, "test");
+        assert!(payload.queue_url.is_none());
+        assert!(payload.delay_seconds.is_none());
+        assert!(payload.message_group_id.is_none());
+        assert!(payload.message_attributes.is_empty());
+    }
+
+    #[test]
+    fn deserialize_fifo_send_payload() {
+        let json = serde_json::json!({
+            "message_body": "ordered",
+            "message_group_id": "group-1",
+            "message_dedup_id": "dedup-abc",
+            "message_attributes": {
+                "env": "production"
+            }
+        });
+        let payload: SqsSendPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.message_group_id.as_deref(), Some("group-1"));
+        assert_eq!(payload.message_dedup_id.as_deref(), Some("dedup-abc"));
+        assert_eq!(payload.message_attributes.get("env").unwrap(), "production");
+    }
+}

--- a/crates/aws/src/sqs.rs
+++ b/crates/aws/src/sqs.rs
@@ -59,6 +59,20 @@ impl SqsConfig {
         self.aws.role_arn = Some(role_arn.into());
         self
     }
+
+    /// Set the STS session name for assume-role.
+    #[must_use]
+    pub fn with_session_name(mut self, session_name: impl Into<String>) -> Self {
+        self.aws.session_name = Some(session_name.into());
+        self
+    }
+
+    /// Set the external ID for cross-account trust policies.
+    #[must_use]
+    pub fn with_external_id(mut self, external_id: impl Into<String>) -> Self {
+        self.aws.external_id = Some(external_id.into());
+        self
+    }
 }
 
 /// Payload for the `send_message` action type.

--- a/crates/client/src/aws.rs
+++ b/crates/client/src/aws.rs
@@ -1,0 +1,993 @@
+//! Convenience helpers for creating AWS-targeted actions.
+//!
+//! Provides builder types for each supported AWS provider:
+//! [`sns`], [`lambda`], [`eventbridge`], [`sqs`], and [`s3`].
+//!
+//! # Example
+//!
+//! ```no_run
+//! use acteon_client::aws;
+//!
+//! // Publish to SNS
+//! let action = aws::sns::publish("notifications", "tenant-1")
+//!     .message("Server alert: CPU high")
+//!     .subject("Alert")
+//!     .build();
+//!
+//! // Invoke Lambda
+//! let action = aws::lambda::invoke("compute", "tenant-1")
+//!     .payload(serde_json::json!({"key": "value"}))
+//!     .build();
+//!
+//! // Put to S3
+//! let action = aws::s3::put_object("storage", "tenant-1")
+//!     .bucket("my-bucket")
+//!     .key("path/to/object.json")
+//!     .body(r#"{"hello":"world"}"#)
+//!     .content_type("application/json")
+//!     .build();
+//! ```
+
+// =============================================================================
+// SNS
+// =============================================================================
+
+/// Helpers for creating SNS actions.
+pub mod sns {
+    use acteon_core::Action;
+
+    /// Create a builder for an SNS publish action.
+    pub fn publish(namespace: impl Into<String>, tenant: impl Into<String>) -> SnsPublishBuilder {
+        SnsPublishBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            message: String::new(),
+            subject: None,
+            topic_arn: None,
+            message_group_id: None,
+            message_dedup_id: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an SNS publish action.
+    #[derive(Debug)]
+    pub struct SnsPublishBuilder {
+        namespace: String,
+        tenant: String,
+        message: String,
+        subject: Option<String>,
+        topic_arn: Option<String>,
+        message_group_id: Option<String>,
+        message_dedup_id: Option<String>,
+        dedup_key: Option<String>,
+    }
+
+    impl SnsPublishBuilder {
+        /// Set the message body.
+        #[must_use]
+        pub fn message(mut self, message: impl Into<String>) -> Self {
+            self.message = message.into();
+            self
+        }
+
+        /// Set the message subject (for email-protocol subscriptions).
+        #[must_use]
+        pub fn subject(mut self, subject: impl Into<String>) -> Self {
+            self.subject = Some(subject.into());
+            self
+        }
+
+        /// Override the topic ARN configured on the provider.
+        #[must_use]
+        pub fn topic_arn(mut self, arn: impl Into<String>) -> Self {
+            self.topic_arn = Some(arn.into());
+            self
+        }
+
+        /// Set the message group ID (for FIFO topics).
+        #[must_use]
+        pub fn message_group_id(mut self, id: impl Into<String>) -> Self {
+            self.message_group_id = Some(id.into());
+            self
+        }
+
+        /// Set the message deduplication ID (for FIFO topics).
+        #[must_use]
+        pub fn message_dedup_id(mut self, id: impl Into<String>) -> Self {
+            self.message_dedup_id = Some(id.into());
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the SNS publish Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `message` has not been set.
+        pub fn build(self) -> Action {
+            assert!(!self.message.is_empty(), "SNS message must be set");
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "message".to_string(),
+                serde_json::Value::String(self.message),
+            );
+
+            if let Some(v) = self.subject {
+                payload.insert("subject".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.topic_arn {
+                payload.insert("topic_arn".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.message_group_id {
+                payload.insert("message_group_id".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.message_dedup_id {
+                payload.insert("message_dedup_id".to_string(), serde_json::Value::String(v));
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-sns",
+                "publish",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+}
+
+// =============================================================================
+// Lambda
+// =============================================================================
+
+/// Helpers for creating Lambda actions.
+pub mod lambda {
+    use acteon_core::Action;
+
+    /// Create a builder for a Lambda invoke action.
+    pub fn invoke(namespace: impl Into<String>, tenant: impl Into<String>) -> LambdaInvokeBuilder {
+        LambdaInvokeBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            function_name: None,
+            payload: serde_json::Value::Object(serde_json::Map::new()),
+            invocation_type: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for a Lambda invoke action.
+    #[derive(Debug)]
+    pub struct LambdaInvokeBuilder {
+        namespace: String,
+        tenant: String,
+        function_name: Option<String>,
+        payload: serde_json::Value,
+        invocation_type: Option<String>,
+        dedup_key: Option<String>,
+    }
+
+    impl LambdaInvokeBuilder {
+        /// Override the function name configured on the provider.
+        #[must_use]
+        pub fn function_name(mut self, name: impl Into<String>) -> Self {
+            self.function_name = Some(name.into());
+            self
+        }
+
+        /// Set the JSON payload to pass to the Lambda function.
+        #[must_use]
+        pub fn payload(mut self, payload: serde_json::Value) -> Self {
+            self.payload = payload;
+            self
+        }
+
+        /// Set the invocation type: `"RequestResponse"`, `"Event"`, or `"DryRun"`.
+        #[must_use]
+        pub fn invocation_type(mut self, typ: impl Into<String>) -> Self {
+            self.invocation_type = Some(typ.into());
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the Lambda invoke Action.
+        pub fn build(self) -> Action {
+            let mut payload = serde_json::Map::new();
+            payload.insert("payload".to_string(), self.payload);
+
+            if let Some(v) = self.function_name {
+                payload.insert("function_name".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.invocation_type {
+                payload.insert("invocation_type".to_string(), serde_json::Value::String(v));
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-lambda",
+                "invoke",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+}
+
+// =============================================================================
+// EventBridge
+// =============================================================================
+
+/// Helpers for creating `EventBridge` actions.
+pub mod eventbridge {
+    use acteon_core::Action;
+
+    /// Create a builder for an `EventBridge` put-event action.
+    pub fn put_event(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> EventBridgePutBuilder {
+        EventBridgePutBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            source: String::new(),
+            detail_type: String::new(),
+            detail: serde_json::Value::Object(serde_json::Map::new()),
+            event_bus_name: None,
+            resources: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an `EventBridge` put-event action.
+    #[derive(Debug)]
+    pub struct EventBridgePutBuilder {
+        namespace: String,
+        tenant: String,
+        source: String,
+        detail_type: String,
+        detail: serde_json::Value,
+        event_bus_name: Option<String>,
+        resources: Option<Vec<String>>,
+        dedup_key: Option<String>,
+    }
+
+    impl EventBridgePutBuilder {
+        /// Set the event source (e.g., `"com.myapp.orders"`).
+        #[must_use]
+        pub fn source(mut self, source: impl Into<String>) -> Self {
+            self.source = source.into();
+            self
+        }
+
+        /// Set the detail type (e.g., `"OrderCreated"`).
+        #[must_use]
+        pub fn detail_type(mut self, detail_type: impl Into<String>) -> Self {
+            self.detail_type = detail_type.into();
+            self
+        }
+
+        /// Set the event detail as a JSON value.
+        #[must_use]
+        pub fn detail(mut self, detail: serde_json::Value) -> Self {
+            self.detail = detail;
+            self
+        }
+
+        /// Override the event bus name configured on the provider.
+        #[must_use]
+        pub fn event_bus_name(mut self, name: impl Into<String>) -> Self {
+            self.event_bus_name = Some(name.into());
+            self
+        }
+
+        /// Set the list of resource ARNs associated with this event.
+        #[must_use]
+        pub fn resources(mut self, resources: Vec<String>) -> Self {
+            self.resources = Some(resources);
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the `EventBridge` put-event Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `source` or `detail_type` have not been set.
+        pub fn build(self) -> Action {
+            assert!(!self.source.is_empty(), "EventBridge source must be set");
+            assert!(
+                !self.detail_type.is_empty(),
+                "EventBridge detail_type must be set"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert("source".to_string(), serde_json::Value::String(self.source));
+            payload.insert(
+                "detail_type".to_string(),
+                serde_json::Value::String(self.detail_type),
+            );
+            payload.insert("detail".to_string(), self.detail);
+
+            if let Some(v) = self.event_bus_name {
+                payload.insert("event_bus_name".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.resources {
+                payload.insert(
+                    "resources".to_string(),
+                    serde_json::to_value(v).expect("Vec<String> serialization cannot fail"),
+                );
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-eventbridge",
+                "put_event",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+}
+
+// =============================================================================
+// SQS
+// =============================================================================
+
+/// Helpers for creating SQS actions.
+pub mod sqs {
+    use acteon_core::Action;
+    use std::collections::HashMap;
+
+    /// Create a builder for an SQS send-message action.
+    pub fn send_message(namespace: impl Into<String>, tenant: impl Into<String>) -> SqsSendBuilder {
+        SqsSendBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            message_body: String::new(),
+            queue_url: None,
+            delay_seconds: None,
+            message_group_id: None,
+            message_dedup_id: None,
+            message_attributes: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an SQS send-message action.
+    #[derive(Debug)]
+    pub struct SqsSendBuilder {
+        namespace: String,
+        tenant: String,
+        message_body: String,
+        queue_url: Option<String>,
+        delay_seconds: Option<u32>,
+        message_group_id: Option<String>,
+        message_dedup_id: Option<String>,
+        message_attributes: Option<HashMap<String, String>>,
+        dedup_key: Option<String>,
+    }
+
+    impl SqsSendBuilder {
+        /// Set the message body.
+        #[must_use]
+        pub fn message_body(mut self, body: impl Into<String>) -> Self {
+            self.message_body = body.into();
+            self
+        }
+
+        /// Override the queue URL configured on the provider.
+        #[must_use]
+        pub fn queue_url(mut self, url: impl Into<String>) -> Self {
+            self.queue_url = Some(url.into());
+            self
+        }
+
+        /// Set the message delivery delay in seconds (0-900).
+        #[must_use]
+        pub fn delay_seconds(mut self, seconds: u32) -> Self {
+            self.delay_seconds = Some(seconds);
+            self
+        }
+
+        /// Set the message group ID (for FIFO queues).
+        #[must_use]
+        pub fn message_group_id(mut self, id: impl Into<String>) -> Self {
+            self.message_group_id = Some(id.into());
+            self
+        }
+
+        /// Set the message deduplication ID (for FIFO queues).
+        #[must_use]
+        pub fn message_dedup_id(mut self, id: impl Into<String>) -> Self {
+            self.message_dedup_id = Some(id.into());
+            self
+        }
+
+        /// Set message attributes as key-value string pairs.
+        #[must_use]
+        pub fn message_attributes(mut self, attrs: HashMap<String, String>) -> Self {
+            self.message_attributes = Some(attrs);
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the SQS send-message Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `message_body` has not been set.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.message_body.is_empty(),
+                "SQS message_body must be set"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "message_body".to_string(),
+                serde_json::Value::String(self.message_body),
+            );
+
+            if let Some(v) = self.queue_url {
+                payload.insert("queue_url".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.delay_seconds {
+                payload.insert(
+                    "delay_seconds".to_string(),
+                    serde_json::Value::Number(v.into()),
+                );
+            }
+            if let Some(v) = self.message_group_id {
+                payload.insert("message_group_id".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.message_dedup_id {
+                payload.insert("message_dedup_id".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.message_attributes {
+                payload.insert(
+                    "message_attributes".to_string(),
+                    serde_json::to_value(v)
+                        .expect("HashMap<String, String> serialization cannot fail"),
+                );
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-sqs",
+                "send_message",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+}
+
+// =============================================================================
+// S3
+// =============================================================================
+
+/// Helpers for creating S3 actions.
+pub mod s3 {
+    use acteon_core::Action;
+    use std::collections::HashMap;
+
+    /// Create a builder for an S3 put-object action.
+    pub fn put_object(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> S3PutObjectBuilder {
+        S3PutObjectBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            bucket: None,
+            key: String::new(),
+            body: None,
+            body_base64: None,
+            content_type: None,
+            metadata: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Create a builder for an S3 get-object action.
+    pub fn get_object(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> S3GetObjectBuilder {
+        S3GetObjectBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            bucket: None,
+            key: String::new(),
+            dedup_key: None,
+        }
+    }
+
+    /// Create a builder for an S3 delete-object action.
+    pub fn delete_object(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> S3DeleteObjectBuilder {
+        S3DeleteObjectBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            bucket: None,
+            key: String::new(),
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an S3 put-object action.
+    #[derive(Debug)]
+    pub struct S3PutObjectBuilder {
+        namespace: String,
+        tenant: String,
+        bucket: Option<String>,
+        key: String,
+        body: Option<String>,
+        body_base64: Option<String>,
+        content_type: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+        dedup_key: Option<String>,
+    }
+
+    impl S3PutObjectBuilder {
+        /// Override the bucket name configured on the provider.
+        #[must_use]
+        pub fn bucket(mut self, bucket: impl Into<String>) -> Self {
+            self.bucket = Some(bucket.into());
+            self
+        }
+
+        /// Set the object key.
+        #[must_use]
+        pub fn key(mut self, key: impl Into<String>) -> Self {
+            self.key = key.into();
+            self
+        }
+
+        /// Set the object body as a UTF-8 string.
+        #[must_use]
+        pub fn body(mut self, body: impl Into<String>) -> Self {
+            self.body = Some(body.into());
+            self
+        }
+
+        /// Set the object body as base64-encoded bytes.
+        #[must_use]
+        pub fn body_base64(mut self, data: impl Into<String>) -> Self {
+            self.body_base64 = Some(data.into());
+            self
+        }
+
+        /// Set the content type (e.g., `"application/json"`).
+        #[must_use]
+        pub fn content_type(mut self, ct: impl Into<String>) -> Self {
+            self.content_type = Some(ct.into());
+            self
+        }
+
+        /// Set object metadata as key-value string pairs.
+        #[must_use]
+        pub fn metadata(mut self, metadata: HashMap<String, String>) -> Self {
+            self.metadata = Some(metadata);
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the S3 put-object Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `key` has not been set.
+        pub fn build(self) -> Action {
+            assert!(!self.key.is_empty(), "S3 object key must be set");
+
+            let mut payload = serde_json::Map::new();
+            payload.insert("key".to_string(), serde_json::Value::String(self.key));
+
+            if let Some(v) = self.bucket {
+                payload.insert("bucket".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.body {
+                payload.insert("body".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.body_base64 {
+                payload.insert("body_base64".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.content_type {
+                payload.insert("content_type".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.metadata {
+                payload.insert(
+                    "metadata".to_string(),
+                    serde_json::to_value(v)
+                        .expect("HashMap<String, String> serialization cannot fail"),
+                );
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-s3",
+                "put_object",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Builder for an S3 get-object action.
+    #[derive(Debug)]
+    pub struct S3GetObjectBuilder {
+        namespace: String,
+        tenant: String,
+        bucket: Option<String>,
+        key: String,
+        dedup_key: Option<String>,
+    }
+
+    impl S3GetObjectBuilder {
+        /// Override the bucket name configured on the provider.
+        #[must_use]
+        pub fn bucket(mut self, bucket: impl Into<String>) -> Self {
+            self.bucket = Some(bucket.into());
+            self
+        }
+
+        /// Set the object key.
+        #[must_use]
+        pub fn key(mut self, key: impl Into<String>) -> Self {
+            self.key = key.into();
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the S3 get-object Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `key` has not been set.
+        pub fn build(self) -> Action {
+            assert!(!self.key.is_empty(), "S3 object key must be set");
+
+            let mut payload = serde_json::Map::new();
+            payload.insert("key".to_string(), serde_json::Value::String(self.key));
+
+            if let Some(v) = self.bucket {
+                payload.insert("bucket".to_string(), serde_json::Value::String(v));
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-s3",
+                "get_object",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Builder for an S3 delete-object action.
+    #[derive(Debug)]
+    pub struct S3DeleteObjectBuilder {
+        namespace: String,
+        tenant: String,
+        bucket: Option<String>,
+        key: String,
+        dedup_key: Option<String>,
+    }
+
+    impl S3DeleteObjectBuilder {
+        /// Override the bucket name configured on the provider.
+        #[must_use]
+        pub fn bucket(mut self, bucket: impl Into<String>) -> Self {
+            self.bucket = Some(bucket.into());
+            self
+        }
+
+        /// Set the object key.
+        #[must_use]
+        pub fn key(mut self, key: impl Into<String>) -> Self {
+            self.key = key.into();
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the S3 delete-object Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `key` has not been set.
+        pub fn build(self) -> Action {
+            assert!(!self.key.is_empty(), "S3 object key must be set");
+
+            let mut payload = serde_json::Map::new();
+            payload.insert("key".to_string(), serde_json::Value::String(self.key));
+
+            if let Some(v) = self.bucket {
+                payload.insert("bucket".to_string(), serde_json::Value::String(v));
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-s3",
+                "delete_object",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{eventbridge, lambda, s3, sns, sqs};
+    use std::collections::HashMap;
+
+    #[test]
+    fn sns_publish_basic() {
+        let a = sns::publish("ns", "t1").message("hello world").build();
+
+        assert_eq!(a.provider.as_str(), "aws-sns");
+        assert_eq!(a.action_type, "publish");
+        assert_eq!(a.payload["message"], "hello world");
+    }
+
+    #[test]
+    fn sns_publish_with_options() {
+        let a = sns::publish("ns", "t1")
+            .message("alert")
+            .subject("Important")
+            .topic_arn("arn:aws:sns:us-east-1:123456789012:my-topic")
+            .message_group_id("group-1")
+            .message_dedup_id("dedup-1")
+            .dedup_key("action-dedup")
+            .build();
+
+        assert_eq!(a.payload["subject"], "Important");
+        assert_eq!(
+            a.payload["topic_arn"],
+            "arn:aws:sns:us-east-1:123456789012:my-topic"
+        );
+        assert_eq!(a.payload["message_group_id"], "group-1");
+        assert_eq!(a.payload["message_dedup_id"], "dedup-1");
+        assert_eq!(a.dedup_key.as_deref(), Some("action-dedup"));
+    }
+
+    #[test]
+    #[should_panic(expected = "SNS message must be set")]
+    fn sns_panics_without_message() {
+        sns::publish("ns", "t1").build();
+    }
+
+    #[test]
+    fn lambda_invoke_basic() {
+        let a = lambda::invoke("ns", "t1")
+            .payload(serde_json::json!({"key": "value"}))
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-lambda");
+        assert_eq!(a.action_type, "invoke");
+        assert_eq!(a.payload["payload"]["key"], "value");
+    }
+
+    #[test]
+    fn lambda_invoke_with_options() {
+        let a = lambda::invoke("ns", "t1")
+            .function_name("my-function")
+            .payload(serde_json::json!({}))
+            .invocation_type("Event")
+            .build();
+
+        assert_eq!(a.payload["function_name"], "my-function");
+        assert_eq!(a.payload["invocation_type"], "Event");
+    }
+
+    #[test]
+    fn eventbridge_put_event() {
+        let a = eventbridge::put_event("ns", "t1")
+            .source("com.myapp")
+            .detail_type("OrderCreated")
+            .detail(serde_json::json!({"order_id": "123"}))
+            .resources(vec!["arn:aws:resource:1".to_string()])
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-eventbridge");
+        assert_eq!(a.action_type, "put_event");
+        assert_eq!(a.payload["source"], "com.myapp");
+        assert_eq!(a.payload["detail_type"], "OrderCreated");
+        assert_eq!(a.payload["detail"]["order_id"], "123");
+        assert_eq!(a.payload["resources"][0], "arn:aws:resource:1");
+    }
+
+    #[test]
+    #[should_panic(expected = "EventBridge source must be set")]
+    fn eventbridge_panics_without_source() {
+        eventbridge::put_event("ns", "t1").detail_type("X").build();
+    }
+
+    #[test]
+    #[should_panic(expected = "EventBridge detail_type must be set")]
+    fn eventbridge_panics_without_detail_type() {
+        eventbridge::put_event("ns", "t1").source("src").build();
+    }
+
+    #[test]
+    fn sqs_send_message_basic() {
+        let a = sqs::send_message("ns", "t1")
+            .message_body(r#"{"event":"test"}"#)
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-sqs");
+        assert_eq!(a.action_type, "send_message");
+        assert_eq!(a.payload["message_body"], r#"{"event":"test"}"#);
+    }
+
+    #[test]
+    fn sqs_send_message_with_options() {
+        let a = sqs::send_message("ns", "t1")
+            .message_body("hello")
+            .queue_url("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .delay_seconds(10)
+            .message_group_id("g1")
+            .message_dedup_id("d1")
+            .build();
+
+        assert_eq!(
+            a.payload["queue_url"],
+            "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue"
+        );
+        assert_eq!(a.payload["delay_seconds"], 10);
+        assert_eq!(a.payload["message_group_id"], "g1");
+        assert_eq!(a.payload["message_dedup_id"], "d1");
+    }
+
+    #[test]
+    #[should_panic(expected = "SQS message_body must be set")]
+    fn sqs_panics_without_body() {
+        sqs::send_message("ns", "t1").build();
+    }
+
+    #[test]
+    fn s3_put_object_basic() {
+        let a = s3::put_object("ns", "t1")
+            .key("path/to/file.txt")
+            .body("file contents")
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-s3");
+        assert_eq!(a.action_type, "put_object");
+        assert_eq!(a.payload["key"], "path/to/file.txt");
+        assert_eq!(a.payload["body"], "file contents");
+    }
+
+    #[test]
+    fn s3_put_object_with_options() {
+        let mut meta = HashMap::new();
+        meta.insert("author".to_string(), "test".to_string());
+
+        let a = s3::put_object("ns", "t1")
+            .bucket("my-bucket")
+            .key("data.json")
+            .body(r#"{"key":"value"}"#)
+            .content_type("application/json")
+            .metadata(meta)
+            .build();
+
+        assert_eq!(a.payload["bucket"], "my-bucket");
+        assert_eq!(a.payload["content_type"], "application/json");
+        assert_eq!(a.payload["metadata"]["author"], "test");
+    }
+
+    #[test]
+    fn s3_get_object() {
+        let a = s3::get_object("ns", "t1")
+            .bucket("my-bucket")
+            .key("path/file.txt")
+            .build();
+
+        assert_eq!(a.action_type, "get_object");
+        assert_eq!(a.payload["bucket"], "my-bucket");
+        assert_eq!(a.payload["key"], "path/file.txt");
+    }
+
+    #[test]
+    fn s3_delete_object() {
+        let a = s3::delete_object("ns", "t1").key("path/file.txt").build();
+
+        assert_eq!(a.action_type, "delete_object");
+        assert_eq!(a.payload["key"], "path/file.txt");
+    }
+
+    #[test]
+    #[should_panic(expected = "S3 object key must be set")]
+    fn s3_panics_without_key() {
+        s3::put_object("ns", "t1").build();
+    }
+}

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -57,6 +57,7 @@
 //!     .unwrap();
 //! ```
 
+pub mod aws;
 mod error;
 pub mod stream;
 pub mod webhook;

--- a/crates/integrations/email/Cargo.toml
+++ b/crates/integrations/email/Cargo.toml
@@ -1,14 +1,20 @@
 [package]
 name = "acteon-email"
-description = "SMTP email provider for Acteon"
+description = "Email provider for Acteon with pluggable backends (SMTP, SES)"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[features]
+default = []
+ses = ["dep:acteon-aws"]
+
 [dependencies]
 acteon-core = { workspace = true }
 acteon-provider = { workspace = true }
+acteon-aws = { workspace = true, features = ["ses"], optional = true }
+async-trait = { workspace = true }
 lettre = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/integrations/email/src/backend.rs
+++ b/crates/integrations/email/src/backend.rs
@@ -1,0 +1,49 @@
+use acteon_provider::ProviderError;
+use async_trait::async_trait;
+
+/// A unified email message representation shared across all backends.
+#[derive(Debug, Clone)]
+pub struct EmailMessage {
+    /// Sender email address.
+    pub from: String,
+    /// Recipient email address.
+    pub to: String,
+    /// Email subject line.
+    pub subject: String,
+    /// Optional plain-text body.
+    pub body: Option<String>,
+    /// Optional HTML body.
+    pub html_body: Option<String>,
+    /// Optional CC address.
+    pub cc: Option<String>,
+    /// Optional BCC address.
+    pub bcc: Option<String>,
+    /// Optional reply-to address.
+    pub reply_to: Option<String>,
+}
+
+/// Result of a successful email send operation.
+#[derive(Debug, Clone)]
+pub struct EmailResult {
+    /// Provider-assigned message identifier (if available).
+    pub message_id: Option<String>,
+    /// Human-readable status (e.g. `"sent"`, `"queued"`).
+    pub status: String,
+}
+
+/// Trait for pluggable email delivery backends.
+///
+/// Implementations handle the actual transport of email messages (SMTP, SES,
+/// etc.) while the [`EmailProvider`](crate::provider::EmailProvider) handles
+/// payload deserialization and the `Provider` trait interface.
+#[async_trait]
+pub trait EmailBackend: Send + Sync + std::fmt::Debug {
+    /// Send an email message through this backend.
+    async fn send(&self, message: &EmailMessage) -> Result<EmailResult, ProviderError>;
+
+    /// Perform a health check to verify the backend is operational.
+    async fn health_check(&self) -> Result<(), ProviderError>;
+
+    /// Return the backend name (e.g. `"smtp"`, `"ses"`).
+    fn backend_name(&self) -> &'static str;
+}

--- a/crates/integrations/email/src/config.rs
+++ b/crates/integrations/email/src/config.rs
@@ -1,23 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-/// Configuration for the SMTP email provider.
+/// SMTP-specific configuration settings.
 ///
-/// Holds all settings needed to establish a connection to an SMTP server
-/// and send emails. Sensible defaults are provided for common SMTP
-/// configurations (port 587, TLS enabled).
-///
-/// # Examples
-///
-/// ```
-/// use acteon_email::EmailConfig;
-///
-/// let config = EmailConfig::new("smtp.example.com", "noreply@example.com");
-/// assert_eq!(config.smtp_host, "smtp.example.com");
-/// assert_eq!(config.smtp_port, 587);
-/// assert!(config.tls);
-/// ```
+/// Holds all settings needed to establish a connection to an SMTP server.
 #[derive(Clone, Serialize, Deserialize)]
-pub struct EmailConfig {
+pub struct SmtpConfig {
     /// SMTP server hostname.
     pub smtp_host: String,
 
@@ -30,49 +17,172 @@ pub struct EmailConfig {
     /// Optional SMTP password for authentication.
     pub password: Option<String>,
 
-    /// The `From` address used in outgoing emails.
-    pub from_address: String,
-
     /// Whether to use TLS for the SMTP connection. Defaults to `true`.
     pub tls: bool,
 }
 
-impl std::fmt::Debug for EmailConfig {
+impl std::fmt::Debug for SmtpConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("EmailConfig")
+        f.debug_struct("SmtpConfig")
             .field("smtp_host", &self.smtp_host)
             .field("smtp_port", &self.smtp_port)
             .field("username", &self.username)
             .field("password", &self.password.as_ref().map(|_| "[REDACTED]"))
-            .field("from_address", &self.from_address)
             .field("tls", &self.tls)
             .finish()
     }
 }
 
+impl Default for SmtpConfig {
+    fn default() -> Self {
+        Self {
+            smtp_host: "localhost".to_owned(),
+            smtp_port: 587,
+            username: None,
+            password: None,
+            tls: true,
+        }
+    }
+}
+
+/// Full email provider configuration.
+///
+/// Wraps a `from_address` and a backend-specific config. The backend
+/// defaults to SMTP for backward compatibility.
+///
+/// # Examples
+///
+/// ```
+/// use acteon_email::EmailConfig;
+///
+/// // SMTP (default)
+/// let config = EmailConfig::new("smtp.example.com", "noreply@example.com");
+/// assert_eq!(config.smtp_host(), Some("smtp.example.com"));
+/// assert!(config.tls());
+/// ```
+#[derive(Clone, Serialize, Deserialize)]
+pub struct EmailConfig {
+    /// The `From` address used in outgoing emails.
+    pub from_address: String,
+
+    /// Backend selection: `"smtp"` (default) or `"ses"`.
+    #[serde(default = "default_backend")]
+    pub backend: String,
+
+    // ---- SMTP fields (backward-compatible) ----
+    /// SMTP server hostname.
+    #[serde(default)]
+    pub smtp_host: String,
+
+    /// SMTP server port. Defaults to 587.
+    #[serde(default = "default_smtp_port")]
+    pub smtp_port: u16,
+
+    /// Optional SMTP username for authentication.
+    pub username: Option<String>,
+
+    /// Optional SMTP password for authentication.
+    pub password: Option<String>,
+
+    /// Whether to use TLS for SMTP. Defaults to `true`.
+    #[serde(default = "default_tls")]
+    pub tls: bool,
+
+    // ---- SES fields ----
+    /// AWS region for SES backend.
+    #[serde(default)]
+    pub aws_region: Option<String>,
+
+    /// Optional IAM role ARN for SES cross-account access.
+    #[serde(default)]
+    pub aws_role_arn: Option<String>,
+
+    /// Optional AWS endpoint URL override for SES (e.g. `LocalStack`).
+    #[serde(default)]
+    pub aws_endpoint_url: Option<String>,
+
+    /// Optional SES configuration set name for email tracking.
+    #[serde(default)]
+    pub ses_configuration_set: Option<String>,
+}
+
+fn default_backend() -> String {
+    "smtp".to_owned()
+}
+
+fn default_smtp_port() -> u16 {
+    587
+}
+
+fn default_tls() -> bool {
+    true
+}
+
+impl std::fmt::Debug for EmailConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EmailConfig")
+            .field("from_address", &self.from_address)
+            .field("backend", &self.backend)
+            .field("smtp_host", &self.smtp_host)
+            .field("smtp_port", &self.smtp_port)
+            .field("username", &self.username)
+            .field("password", &self.password.as_ref().map(|_| "[REDACTED]"))
+            .field("tls", &self.tls)
+            .field("aws_region", &self.aws_region)
+            .field(
+                "aws_role_arn",
+                &self.aws_role_arn.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("aws_endpoint_url", &self.aws_endpoint_url)
+            .field("ses_configuration_set", &self.ses_configuration_set)
+            .finish()
+    }
+}
+
 impl EmailConfig {
-    /// Create a new `EmailConfig` with the given SMTP host and sender address.
+    /// Create a new SMTP-based `EmailConfig` with the given host and sender.
     ///
-    /// Uses default values for port (587), TLS (enabled), and no authentication.
+    /// This constructor preserves backward compatibility with the original API.
     ///
     /// # Examples
     ///
     /// ```
     /// use acteon_email::EmailConfig;
     ///
-    /// let config = EmailConfig::new("mail.example.com", "sender@example.com");
+    /// let config = EmailConfig::new("smtp.example.com", "noreply@example.com");
     /// assert_eq!(config.smtp_port, 587);
     /// assert!(config.tls);
-    /// assert!(config.username.is_none());
     /// ```
     pub fn new(smtp_host: impl Into<String>, from_address: impl Into<String>) -> Self {
         Self {
+            from_address: from_address.into(),
+            backend: "smtp".to_owned(),
             smtp_host: smtp_host.into(),
             smtp_port: 587,
             username: None,
             password: None,
-            from_address: from_address.into(),
             tls: true,
+            aws_region: None,
+            aws_role_arn: None,
+            aws_endpoint_url: None,
+            ses_configuration_set: None,
+        }
+    }
+
+    /// Create a new SES-based `EmailConfig`.
+    pub fn ses(region: impl Into<String>, from_address: impl Into<String>) -> Self {
+        Self {
+            from_address: from_address.into(),
+            backend: "ses".to_owned(),
+            smtp_host: String::new(),
+            smtp_port: 587,
+            username: None,
+            password: None,
+            tls: true,
+            aws_region: Some(region.into()),
+            aws_role_arn: None,
+            aws_endpoint_url: None,
+            ses_configuration_set: None,
         }
     }
 
@@ -95,23 +205,103 @@ impl EmailConfig {
         self
     }
 
-    /// Set whether TLS should be used.
+    /// Set whether TLS should be used for SMTP.
     #[must_use]
     pub fn with_tls(mut self, tls: bool) -> Self {
         self.tls = tls;
         self
+    }
+
+    /// Set the SES configuration set name.
+    #[must_use]
+    pub fn with_ses_configuration_set(mut self, name: impl Into<String>) -> Self {
+        self.ses_configuration_set = Some(name.into());
+        self
+    }
+
+    /// Set the AWS endpoint URL override.
+    #[must_use]
+    pub fn with_aws_endpoint_url(mut self, url: impl Into<String>) -> Self {
+        self.aws_endpoint_url = Some(url.into());
+        self
+    }
+
+    /// Set the AWS role ARN for cross-account SES access.
+    #[must_use]
+    pub fn with_aws_role_arn(mut self, role_arn: impl Into<String>) -> Self {
+        self.aws_role_arn = Some(role_arn.into());
+        self
+    }
+
+    /// Returns `true` if this config uses the SMTP backend.
+    pub fn is_smtp(&self) -> bool {
+        self.backend == "smtp"
+    }
+
+    /// Returns `true` if this config uses the SES backend.
+    pub fn is_ses(&self) -> bool {
+        self.backend == "ses"
+    }
+
+    /// Extract the SMTP-specific config.
+    pub fn smtp_config(&self) -> SmtpConfig {
+        SmtpConfig {
+            smtp_host: self.smtp_host.clone(),
+            smtp_port: self.smtp_port,
+            username: self.username.clone(),
+            password: self.password.clone(),
+            tls: self.tls,
+        }
+    }
+
+    /// Extract the SES-specific config (requires the `ses` feature).
+    #[cfg(feature = "ses")]
+    pub fn ses_config(&self) -> acteon_aws::ses::SesConfig {
+        let mut config =
+            acteon_aws::ses::SesConfig::new(self.aws_region.as_deref().unwrap_or("us-east-1"));
+        if let Some(ref set) = self.ses_configuration_set {
+            config = config.with_configuration_set(set);
+        }
+        if let Some(ref url) = self.aws_endpoint_url {
+            config = config.with_endpoint_url(url);
+        }
+        if let Some(ref arn) = self.aws_role_arn {
+            config = config.with_role_arn(arn);
+        }
+        config
+    }
+
+    // Backward-compat accessors used by existing code.
+
+    /// Get the SMTP host (for backward compatibility).
+    pub fn smtp_host(&self) -> Option<&str> {
+        if self.smtp_host.is_empty() {
+            None
+        } else {
+            Some(&self.smtp_host)
+        }
+    }
+
+    /// Get TLS setting.
+    pub fn tls(&self) -> bool {
+        self.tls
     }
 }
 
 impl Default for EmailConfig {
     fn default() -> Self {
         Self {
+            from_address: "noreply@localhost".to_owned(),
+            backend: "smtp".to_owned(),
             smtp_host: "localhost".to_owned(),
             smtp_port: 587,
             username: None,
             password: None,
-            from_address: "noreply@localhost".to_owned(),
             tls: true,
+            aws_region: None,
+            aws_role_arn: None,
+            aws_endpoint_url: None,
+            ses_configuration_set: None,
         }
     }
 }
@@ -129,6 +319,7 @@ mod tests {
         assert!(config.username.is_none());
         assert!(config.password.is_none());
         assert_eq!(config.from_address, "noreply@localhost");
+        assert!(config.is_smtp());
     }
 
     #[test]
@@ -138,6 +329,16 @@ mod tests {
         assert_eq!(config.from_address, "me@gmail.com");
         assert_eq!(config.smtp_port, 587);
         assert!(config.tls);
+        assert!(config.is_smtp());
+    }
+
+    #[test]
+    fn ses_config_constructor() {
+        let config = EmailConfig::ses("us-east-1", "noreply@example.com");
+        assert!(config.is_ses());
+        assert!(!config.is_smtp());
+        assert_eq!(config.aws_region.as_deref(), Some("us-east-1"));
+        assert_eq!(config.from_address, "noreply@example.com");
     }
 
     #[test]
@@ -161,9 +362,23 @@ mod tests {
     }
 
     #[test]
+    fn smtp_config_extraction() {
+        let config = EmailConfig::new("smtp.example.com", "sender@example.com")
+            .with_credentials("user", "pass")
+            .with_port(465)
+            .with_tls(false);
+
+        let smtp = config.smtp_config();
+        assert_eq!(smtp.smtp_host, "smtp.example.com");
+        assert_eq!(smtp.smtp_port, 465);
+        assert_eq!(smtp.username.as_deref(), Some("user"));
+        assert!(!smtp.tls);
+    }
+
+    #[test]
     fn config_serde_roundtrip() {
         let config = EmailConfig::new("smtp.example.com", "test@example.com")
-            .with_credentials("user", "secret")
+            .with_credentials("user", "myvalue")
             .with_port(465)
             .with_tls(false);
 
@@ -173,7 +388,7 @@ mod tests {
         assert_eq!(deserialized.smtp_host, "smtp.example.com");
         assert_eq!(deserialized.smtp_port, 465);
         assert_eq!(deserialized.username.as_deref(), Some("user"));
-        assert_eq!(deserialized.password.as_deref(), Some("secret"));
+        assert_eq!(deserialized.password.as_deref(), Some("myvalue"));
         assert_eq!(deserialized.from_address, "test@example.com");
         assert!(!deserialized.tls);
     }
@@ -192,5 +407,23 @@ mod tests {
             debug.contains("smtp.example.com"),
             "non-secret fields should be visible"
         );
+    }
+
+    #[test]
+    fn ses_config_debug_redacts_role_arn() {
+        let config = EmailConfig::ses("us-east-1", "noreply@example.com")
+            .with_aws_role_arn("arn:aws:iam::123:role/test");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("123:role/test"));
+    }
+
+    #[test]
+    fn smtp_host_accessor() {
+        let config = EmailConfig::new("smtp.example.com", "test@example.com");
+        assert_eq!(config.smtp_host(), Some("smtp.example.com"));
+
+        let ses_config = EmailConfig::ses("us-east-1", "test@example.com");
+        assert!(ses_config.smtp_host().is_none());
     }
 }

--- a/crates/integrations/email/src/config.rs
+++ b/crates/integrations/email/src/config.rs
@@ -104,6 +104,14 @@ pub struct EmailConfig {
     /// Optional SES configuration set name for email tracking.
     #[serde(default)]
     pub ses_configuration_set: Option<String>,
+
+    /// Optional STS session name for SES assume-role.
+    #[serde(default)]
+    pub aws_session_name: Option<String>,
+
+    /// Optional external ID for SES cross-account trust policies.
+    #[serde(default)]
+    pub aws_external_id: Option<String>,
 }
 
 fn default_backend() -> String {
@@ -135,6 +143,8 @@ impl std::fmt::Debug for EmailConfig {
             )
             .field("aws_endpoint_url", &self.aws_endpoint_url)
             .field("ses_configuration_set", &self.ses_configuration_set)
+            .field("aws_session_name", &self.aws_session_name)
+            .field("aws_external_id", &self.aws_external_id)
             .finish()
     }
 }
@@ -166,6 +176,8 @@ impl EmailConfig {
             aws_role_arn: None,
             aws_endpoint_url: None,
             ses_configuration_set: None,
+            aws_session_name: None,
+            aws_external_id: None,
         }
     }
 
@@ -183,6 +195,8 @@ impl EmailConfig {
             aws_role_arn: None,
             aws_endpoint_url: None,
             ses_configuration_set: None,
+            aws_session_name: None,
+            aws_external_id: None,
         }
     }
 
@@ -233,6 +247,20 @@ impl EmailConfig {
         self
     }
 
+    /// Set the STS session name for SES assume-role.
+    #[must_use]
+    pub fn with_aws_session_name(mut self, session_name: impl Into<String>) -> Self {
+        self.aws_session_name = Some(session_name.into());
+        self
+    }
+
+    /// Set the external ID for SES cross-account trust policies.
+    #[must_use]
+    pub fn with_aws_external_id(mut self, external_id: impl Into<String>) -> Self {
+        self.aws_external_id = Some(external_id.into());
+        self
+    }
+
     /// Returns `true` if this config uses the SMTP backend.
     pub fn is_smtp(&self) -> bool {
         self.backend == "smtp"
@@ -268,6 +296,12 @@ impl EmailConfig {
         if let Some(ref arn) = self.aws_role_arn {
             config = config.with_role_arn(arn);
         }
+        if let Some(ref name) = self.aws_session_name {
+            config = config.with_session_name(name);
+        }
+        if let Some(ref ext_id) = self.aws_external_id {
+            config = config.with_external_id(ext_id);
+        }
         config
     }
 
@@ -302,6 +336,8 @@ impl Default for EmailConfig {
             aws_role_arn: None,
             aws_endpoint_url: None,
             ses_configuration_set: None,
+            aws_session_name: None,
+            aws_external_id: None,
         }
     }
 }

--- a/crates/integrations/email/src/lib.rs
+++ b/crates/integrations/email/src/lib.rs
@@ -1,7 +1,15 @@
+pub mod backend;
 pub mod config;
 pub mod provider;
+pub mod smtp;
 pub mod types;
 
-pub use config::EmailConfig;
+#[cfg(feature = "ses")]
+pub mod ses;
+
+pub use config::{EmailConfig, SmtpConfig};
 pub use provider::EmailProvider;
 pub use types::EmailPayload;
+
+// Re-export backend trait for external use.
+pub use backend::{EmailBackend, EmailMessage, EmailResult};

--- a/crates/integrations/email/src/provider.rs
+++ b/crates/integrations/email/src/provider.rs
@@ -1,19 +1,19 @@
 use acteon_core::{Action, ProviderResponse};
 use acteon_provider::ProviderError;
 use acteon_provider::provider::Provider;
-use lettre::message::{Mailbox, MultiPart, SinglePart};
-use lettre::transport::smtp::authentication::Credentials;
-use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, info, instrument};
 
+use crate::backend::{EmailBackend, EmailMessage};
 use crate::config::EmailConfig;
+use crate::smtp::SmtpBackend;
 use crate::types::EmailPayload;
 
-/// An email provider that sends messages via SMTP using `lettre`.
+/// An email provider that sends messages through a pluggable backend.
 ///
+/// Supports SMTP (default) and SES (with the `ses` feature) backends.
 /// Implements the [`Provider`] trait from `acteon-provider`, mapping action
-/// payloads to email messages and dispatching them through a configured SMTP
-/// transport.
+/// payloads to email messages and dispatching them through the configured
+/// backend.
 ///
 /// # Examples
 ///
@@ -26,15 +26,15 @@ use crate::types::EmailPayload;
 /// assert_eq!(acteon_provider::Provider::name(&provider), "email");
 /// ```
 pub struct EmailProvider {
-    config: EmailConfig,
-    transport: AsyncSmtpTransport<Tokio1Executor>,
+    from_address: String,
+    backend: Box<dyn EmailBackend>,
 }
 
 impl std::fmt::Debug for EmailProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EmailProvider")
-            .field("config", &self.config)
-            .field("transport", &"<AsyncSmtpTransport>")
+            .field("from_address", &self.from_address)
+            .field("backend", &self.backend)
             .finish()
     }
 }
@@ -42,123 +42,61 @@ impl std::fmt::Debug for EmailProvider {
 impl EmailProvider {
     /// Create a new `EmailProvider` from the given configuration.
     ///
-    /// Builds an [`AsyncSmtpTransport`] configured with the SMTP host, port,
-    /// TLS settings, and optional credentials from the [`EmailConfig`].
+    /// Automatically selects the SMTP backend. For SES, use
+    /// [`EmailProvider::ses`] instead.
     ///
-    /// Returns a [`ProviderError::Configuration`] if the transport cannot be
-    /// built (e.g. invalid host).
-    pub fn new(config: EmailConfig) -> Result<Self, ProviderError> {
-        let transport = build_transport(&config)?;
-        Ok(Self { config, transport })
+    /// Returns a [`ProviderError::Configuration`] if the SMTP transport
+    /// cannot be built.
+    pub fn new(config: &EmailConfig) -> Result<Self, ProviderError> {
+        let from_address = config.from_address.clone();
+        let smtp_config = config.smtp_config();
+        let backend = SmtpBackend::new(smtp_config)?;
+        Ok(Self {
+            from_address,
+            backend: Box::new(backend),
+        })
     }
 
-    /// Create an `EmailProvider` with a pre-built transport.
+    /// Create a new `EmailProvider` with an SMTP backend.
+    pub fn smtp(config: &EmailConfig) -> Result<Self, ProviderError> {
+        Self::new(config)
+    }
+
+    /// Create a new `EmailProvider` with an SES backend.
+    #[cfg(feature = "ses")]
+    pub async fn ses(config: &EmailConfig) -> Self {
+        let from_address = config.from_address.clone();
+        let ses_config = config.ses_config();
+        let backend = crate::ses::SesBackend::new(ses_config).await;
+        Self {
+            from_address,
+            backend: Box::new(backend),
+        }
+    }
+
+    /// Create an `EmailProvider` with a pre-built backend (for testing).
+    pub fn with_backend(from_address: impl Into<String>, backend: Box<dyn EmailBackend>) -> Self {
+        Self {
+            from_address: from_address.into(),
+            backend,
+        }
+    }
+
+    /// Create an `EmailProvider` with a pre-built SMTP transport (for testing).
     ///
-    /// This is primarily useful for testing, allowing injection of a custom
-    /// or mock transport.
+    /// Preserves the original API for test backward compatibility.
     pub fn with_transport(
-        config: EmailConfig,
-        transport: AsyncSmtpTransport<Tokio1Executor>,
+        config: &EmailConfig,
+        transport: lettre::AsyncSmtpTransport<lettre::Tokio1Executor>,
     ) -> Self {
-        Self { config, transport }
+        let from_address = config.from_address.clone();
+        let smtp_config = config.smtp_config();
+        let backend = SmtpBackend::with_transport(smtp_config, transport);
+        Self {
+            from_address,
+            backend: Box::new(backend),
+        }
     }
-}
-
-/// Build a `lettre::Message` from the email payload and sender config.
-///
-/// This is a free function so it can be tested independently of the async
-/// SMTP transport (which requires a Tokio runtime to construct).
-fn build_message(config: &EmailConfig, payload: &EmailPayload) -> Result<Message, ProviderError> {
-    let from_mailbox: Mailbox = config
-        .from_address
-        .parse()
-        .map_err(|e| ProviderError::Configuration(format!("invalid from address: {e}")))?;
-
-    let to_mailbox: Mailbox = payload
-        .to
-        .parse()
-        .map_err(|e| ProviderError::ExecutionFailed(format!("invalid recipient address: {e}")))?;
-
-    let mut builder = Message::builder()
-        .from(from_mailbox)
-        .to(to_mailbox)
-        .subject(&payload.subject);
-
-    if let Some(ref reply_to) = payload.reply_to {
-        let reply_mailbox: Mailbox = reply_to.parse().map_err(|e| {
-            ProviderError::ExecutionFailed(format!("invalid reply-to address: {e}"))
-        })?;
-        builder = builder.reply_to(reply_mailbox);
-    }
-
-    if let Some(ref cc) = payload.cc {
-        let cc_mailbox: Mailbox = cc
-            .parse()
-            .map_err(|e| ProviderError::ExecutionFailed(format!("invalid CC address: {e}")))?;
-        builder = builder.cc(cc_mailbox);
-    }
-
-    if let Some(ref bcc) = payload.bcc {
-        let bcc_mailbox: Mailbox = bcc
-            .parse()
-            .map_err(|e| ProviderError::ExecutionFailed(format!("invalid BCC address: {e}")))?;
-        builder = builder.bcc(bcc_mailbox);
-    }
-
-    let message = match (&payload.body, &payload.html_body) {
-        (Some(text), Some(html)) => builder
-            .multipart(
-                MultiPart::alternative()
-                    .singlepart(
-                        SinglePart::builder()
-                            .header(lettre::message::header::ContentType::TEXT_PLAIN)
-                            .body(text.clone()),
-                    )
-                    .singlepart(
-                        SinglePart::builder()
-                            .header(lettre::message::header::ContentType::TEXT_HTML)
-                            .body(html.clone()),
-                    ),
-            )
-            .map_err(|e| ProviderError::ExecutionFailed(format!("failed to build email: {e}")))?,
-        (Some(text), None) => builder
-            .body(text.clone())
-            .map_err(|e| ProviderError::ExecutionFailed(format!("failed to build email: {e}")))?,
-        (None, Some(html)) => builder
-            .singlepart(
-                SinglePart::builder()
-                    .header(lettre::message::header::ContentType::TEXT_HTML)
-                    .body(html.clone()),
-            )
-            .map_err(|e| ProviderError::ExecutionFailed(format!("failed to build email: {e}")))?,
-        (None, None) => builder
-            .body(String::new())
-            .map_err(|e| ProviderError::ExecutionFailed(format!("failed to build email: {e}")))?,
-    };
-
-    Ok(message)
-}
-
-/// Build an async SMTP transport from the given configuration.
-fn build_transport(
-    config: &EmailConfig,
-) -> Result<AsyncSmtpTransport<Tokio1Executor>, ProviderError> {
-    let builder = if config.tls {
-        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&config.smtp_host)
-            .map_err(|e| ProviderError::Configuration(format!("SMTP TLS relay error: {e}")))?
-    } else {
-        AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&config.smtp_host)
-    };
-
-    let builder = builder.port(config.smtp_port);
-
-    let builder = if let (Some(user), Some(pass)) = (&config.username, &config.password) {
-        builder.credentials(Credentials::new(user.clone(), pass.clone()))
-    } else {
-        builder
-    };
-
-    Ok(builder.build())
 }
 
 impl Provider for EmailProvider {
@@ -173,52 +111,56 @@ impl Provider for EmailProvider {
         let payload: EmailPayload = serde_json::from_value(action.payload.clone())
             .map_err(|e| ProviderError::Serialization(e.to_string()))?;
 
-        debug!(to = %payload.to, subject = %payload.subject, "building email message");
-        let message = build_message(&self.config, &payload)?;
+        let message = EmailMessage {
+            from: self.from_address.clone(),
+            to: payload.to.clone(),
+            subject: payload.subject.clone(),
+            body: payload.body.clone(),
+            html_body: payload.html_body.clone(),
+            cc: payload.cc.clone(),
+            bcc: payload.bcc.clone(),
+            reply_to: payload.reply_to.clone(),
+        };
 
-        info!(to = %payload.to, subject = %payload.subject, "sending email");
-        self.transport.send(message).await.map_err(|e| {
-            error!(error = %e, "SMTP send failed");
-            map_smtp_error(&e)
-        })?;
+        debug!(
+            to = %message.to,
+            subject = %message.subject,
+            backend = self.backend.backend_name(),
+            "sending email"
+        );
 
-        info!(to = %payload.to, "email sent successfully");
-        Ok(ProviderResponse::success(serde_json::json!({
+        let result = self.backend.send(&message).await?;
+
+        info!(
+            to = %payload.to,
+            backend = self.backend.backend_name(),
+            "email sent successfully"
+        );
+
+        let mut response = serde_json::json!({
             "to": payload.to,
             "subject": payload.subject,
-            "status": "sent"
-        })))
+            "status": result.status,
+            "backend": self.backend.backend_name()
+        });
+
+        if let Some(ref msg_id) = result.message_id {
+            response["message_id"] = serde_json::Value::String(msg_id.clone());
+        }
+
+        Ok(ProviderResponse::success(response))
     }
 
     #[instrument(skip(self), fields(provider = "email"))]
     async fn health_check(&self) -> Result<(), ProviderError> {
-        debug!("performing SMTP health check");
-        self.transport.test_connection().await.map_err(|e| {
-            error!(error = %e, "SMTP health check failed");
-            ProviderError::Connection(format!("SMTP health check failed: {e}"))
-        })?;
-        info!("SMTP health check passed");
-        Ok(())
-    }
-}
-
-/// Map a lettre SMTP error to the appropriate `ProviderError` variant.
-fn map_smtp_error(error: &lettre::transport::smtp::Error) -> ProviderError {
-    let message = error.to_string();
-
-    if error.is_transient() {
-        ProviderError::Connection(format!("transient SMTP error: {message}"))
-    } else if error.is_permanent() {
-        ProviderError::ExecutionFailed(format!("permanent SMTP error: {message}"))
-    } else {
-        // Covers TLS, connection, response parsing, and other errors.
-        ProviderError::Connection(format!("SMTP error: {message}"))
+        self.backend.health_check().await
     }
 }
 
 #[cfg(test)]
 mod tests {
     use acteon_core::Action;
+    use lettre::{AsyncSmtpTransport, Tokio1Executor};
 
     use super::*;
 
@@ -233,192 +175,6 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Message building tests (synchronous -- no transport needed)
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn build_message_plain_text() {
-        let config = test_config();
-        let payload = EmailPayload {
-            to: "recipient@example.com".to_owned(),
-            subject: "Test Subject".to_owned(),
-            body: Some("Hello, world!".to_owned()),
-            html_body: None,
-            cc: None,
-            bcc: None,
-            reply_to: None,
-        };
-
-        let message = build_message(&config, &payload);
-        assert!(message.is_ok());
-    }
-
-    #[test]
-    fn build_message_html_only() {
-        let config = test_config();
-        let payload = EmailPayload {
-            to: "recipient@example.com".to_owned(),
-            subject: "HTML Test".to_owned(),
-            body: None,
-            html_body: Some("<h1>Hello</h1>".to_owned()),
-            cc: None,
-            bcc: None,
-            reply_to: None,
-        };
-
-        let message = build_message(&config, &payload);
-        assert!(message.is_ok());
-    }
-
-    #[test]
-    fn build_message_multipart() {
-        let config = test_config();
-        let payload = EmailPayload {
-            to: "recipient@example.com".to_owned(),
-            subject: "Multipart".to_owned(),
-            body: Some("Plain text".to_owned()),
-            html_body: Some("<p>HTML text</p>".to_owned()),
-            cc: None,
-            bcc: None,
-            reply_to: None,
-        };
-
-        let message = build_message(&config, &payload);
-        assert!(message.is_ok());
-    }
-
-    #[test]
-    fn build_message_with_all_recipients() {
-        let config = test_config();
-        let payload = EmailPayload {
-            to: "to@example.com".to_owned(),
-            subject: "Full".to_owned(),
-            body: Some("body".to_owned()),
-            html_body: None,
-            cc: Some("cc@example.com".to_owned()),
-            bcc: Some("bcc@example.com".to_owned()),
-            reply_to: Some("reply@example.com".to_owned()),
-        };
-
-        let message = build_message(&config, &payload);
-        assert!(message.is_ok());
-    }
-
-    #[test]
-    fn build_message_invalid_from_address() {
-        let mut config = test_config();
-        config.from_address = "not-valid".to_owned();
-
-        let payload = EmailPayload {
-            to: "recipient@example.com".to_owned(),
-            subject: "Test".to_owned(),
-            body: Some("body".to_owned()),
-            html_body: None,
-            cc: None,
-            bcc: None,
-            reply_to: None,
-        };
-
-        let result = build_message(&config, &payload);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err, ProviderError::Configuration(_)));
-    }
-
-    #[test]
-    fn build_message_invalid_to_address() {
-        let config = test_config();
-        let payload = EmailPayload {
-            to: "not-valid".to_owned(),
-            subject: "Test".to_owned(),
-            body: Some("body".to_owned()),
-            html_body: None,
-            cc: None,
-            bcc: None,
-            reply_to: None,
-        };
-
-        let result = build_message(&config, &payload);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
-    }
-
-    #[test]
-    fn build_message_empty_body() {
-        let config = test_config();
-        let payload = EmailPayload {
-            to: "recipient@example.com".to_owned(),
-            subject: "Empty".to_owned(),
-            body: None,
-            html_body: None,
-            cc: None,
-            bcc: None,
-            reply_to: None,
-        };
-
-        let message = build_message(&config, &payload);
-        assert!(message.is_ok());
-    }
-
-    #[test]
-    fn build_message_invalid_cc_address() {
-        let config = test_config();
-        let payload = EmailPayload {
-            to: "recipient@example.com".to_owned(),
-            subject: "Test".to_owned(),
-            body: Some("body".to_owned()),
-            html_body: None,
-            cc: Some("bad-cc".to_owned()),
-            bcc: None,
-            reply_to: None,
-        };
-
-        let result = build_message(&config, &payload);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
-    }
-
-    #[test]
-    fn build_message_invalid_bcc_address() {
-        let config = test_config();
-        let payload = EmailPayload {
-            to: "recipient@example.com".to_owned(),
-            subject: "Test".to_owned(),
-            body: Some("body".to_owned()),
-            html_body: None,
-            cc: None,
-            bcc: Some("bad-bcc".to_owned()),
-            reply_to: None,
-        };
-
-        let result = build_message(&config, &payload);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
-    }
-
-    #[test]
-    fn build_message_invalid_reply_to_address() {
-        let config = test_config();
-        let payload = EmailPayload {
-            to: "recipient@example.com".to_owned(),
-            subject: "Test".to_owned(),
-            body: Some("body".to_owned()),
-            html_body: None,
-            cc: None,
-            bcc: None,
-            reply_to: Some("bad-reply".to_owned()),
-        };
-
-        let result = build_message(&config, &payload);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
-    }
-
-    // -----------------------------------------------------------------------
     // Provider / transport tests (require tokio runtime)
     // -----------------------------------------------------------------------
 
@@ -428,7 +184,7 @@ mod tests {
         let transport = AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous("localhost")
             .port(2525)
             .build();
-        let provider = EmailProvider::with_transport(config, transport);
+        let provider = EmailProvider::with_transport(&config, transport);
         assert_eq!(Provider::name(&provider), "email");
     }
 
@@ -438,7 +194,7 @@ mod tests {
         let transport = AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous("localhost")
             .port(2525)
             .build();
-        let provider = EmailProvider::with_transport(config, transport);
+        let provider = EmailProvider::with_transport(&config, transport);
 
         // Missing required fields "to" and "subject"
         let action = make_action(serde_json::json!({"invalid": "data"}));
@@ -454,7 +210,7 @@ mod tests {
         let transport = AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous("localhost")
             .port(2525)
             .build();
-        let provider = EmailProvider::with_transport(config, transport);
+        let provider = EmailProvider::with_transport(&config, transport);
 
         let action = make_action(serde_json::json!({
             "to": "not-an-email",
@@ -468,49 +224,15 @@ mod tests {
 
     #[tokio::test]
     async fn new_with_tls_and_empty_host_builds_transport() {
-        // lettre accepts empty hostnames at build time; the error surfaces
-        // at connection time. Verify the provider can still be constructed.
         let config = EmailConfig::new("", "sender@example.com");
-        let result = EmailProvider::new(config);
-        // This currently succeeds because lettre defers DNS resolution.
-        // The connection error will surface during execute/health_check.
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn build_transport_no_tls_no_credentials() {
-        // Verify a basic transport can be built without TLS or credentials.
-        let config = EmailConfig {
-            smtp_host: "localhost".to_owned(),
-            smtp_port: 2525,
-            username: None,
-            password: None,
-            from_address: "sender@example.com".to_owned(),
-            tls: false,
-        };
-        let result = build_transport(&config);
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn build_transport_no_tls_with_credentials() {
-        // Verify a transport can be built with credentials but without TLS.
-        let config = EmailConfig {
-            smtp_host: "localhost".to_owned(),
-            smtp_port: 2525,
-            username: Some("user".to_owned()),
-            password: Some("pass".to_owned()),
-            from_address: "sender@example.com".to_owned(),
-            tls: false,
-        };
-        let result = build_transport(&config);
+        let result = EmailProvider::new(&config);
         assert!(result.is_ok());
     }
 
     #[tokio::test]
     async fn new_without_tls_succeeds() {
         let config = EmailConfig::new("localhost", "sender@example.com").with_tls(false);
-        let result = EmailProvider::new(config);
+        let result = EmailProvider::new(&config);
         assert!(result.is_ok());
     }
 
@@ -519,7 +241,7 @@ mod tests {
         let config = EmailConfig::new("localhost", "sender@example.com")
             .with_tls(false)
             .with_credentials("user", "pass");
-        let result = EmailProvider::new(config);
+        let result = EmailProvider::new(&config);
         assert!(result.is_ok());
     }
 
@@ -529,9 +251,17 @@ mod tests {
         let transport = AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous("localhost")
             .port(2525)
             .build();
-        let provider = EmailProvider::with_transport(config, transport);
+        let provider = EmailProvider::with_transport(&config, transport);
         let debug_str = format!("{provider:?}");
         assert!(debug_str.contains("EmailProvider"));
-        assert!(debug_str.contains("AsyncSmtpTransport"));
+        assert!(debug_str.contains("SmtpBackend"));
+    }
+
+    #[tokio::test]
+    async fn smtp_constructor_alias() {
+        let config = test_config();
+        let provider = EmailProvider::smtp(&config);
+        assert!(provider.is_ok());
+        assert_eq!(Provider::name(&provider.unwrap()), "email");
     }
 }

--- a/crates/integrations/email/src/provider.rs
+++ b/crates/integrations/email/src/provider.rs
@@ -22,7 +22,7 @@ use crate::types::EmailPayload;
 ///
 /// let config = EmailConfig::new("smtp.example.com", "noreply@example.com")
 ///     .with_credentials("user", "pass");
-/// let provider = EmailProvider::new(config).unwrap();
+/// let provider = EmailProvider::new(&config).unwrap();
 /// assert_eq!(acteon_provider::Provider::name(&provider), "email");
 /// ```
 pub struct EmailProvider {

--- a/crates/integrations/email/src/ses.rs
+++ b/crates/integrations/email/src/ses.rs
@@ -1,0 +1,79 @@
+use acteon_provider::ProviderError;
+use async_trait::async_trait;
+use tracing::{debug, info};
+
+use crate::backend::{EmailBackend, EmailMessage, EmailResult};
+
+/// SES email delivery backend using the `acteon-aws` SES client.
+///
+/// Delegates to [`acteon_aws::ses::SesClient`] for the actual AWS API calls.
+pub struct SesBackend {
+    client: acteon_aws::ses::SesClient,
+}
+
+impl std::fmt::Debug for SesBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SesBackend")
+            .field("client", &self.client)
+            .finish()
+    }
+}
+
+impl SesBackend {
+    /// Create a new `SesBackend` by building an AWS SES client.
+    pub async fn new(config: acteon_aws::ses::SesConfig) -> Self {
+        let client = acteon_aws::ses::SesClient::new(config).await;
+        Self { client }
+    }
+
+    /// Create a `SesBackend` with a pre-built SES client (for testing).
+    pub fn with_client(client: acteon_aws::ses::SesClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl EmailBackend for SesBackend {
+    async fn send(&self, message: &EmailMessage) -> Result<EmailResult, ProviderError> {
+        debug!(to = %message.to, subject = %message.subject, "sending email via SES");
+
+        let message_id = self
+            .client
+            .send_email(
+                &message.from,
+                &message.to,
+                &message.subject,
+                message.body.as_deref(),
+                message.html_body.as_deref(),
+                message.cc.as_deref(),
+                message.bcc.as_deref(),
+                message.reply_to.as_deref(),
+            )
+            .await?;
+
+        info!(message_id = %message_id, to = %message.to, "email sent via SES");
+
+        Ok(EmailResult {
+            message_id: Some(message_id),
+            status: "sent".to_owned(),
+        })
+    }
+
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        self.client.health_check().await
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "ses"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn ses_backend_debug_does_not_panic() {
+        // We can't easily construct a real SesBackend without AWS credentials,
+        // but we can verify the types and debug impl compile.
+        let _config = acteon_aws::ses::SesConfig::new("us-east-1");
+    }
+}

--- a/crates/integrations/email/src/smtp.rs
+++ b/crates/integrations/email/src/smtp.rs
@@ -1,0 +1,303 @@
+use acteon_provider::ProviderError;
+use async_trait::async_trait;
+use lettre::message::{Mailbox, MultiPart, SinglePart};
+use lettre::transport::smtp::authentication::Credentials;
+use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
+use tracing::{debug, error, info};
+
+use crate::backend::{EmailBackend, EmailMessage, EmailResult};
+use crate::config::SmtpConfig;
+
+/// SMTP email delivery backend using `lettre`.
+pub struct SmtpBackend {
+    config: SmtpConfig,
+    transport: AsyncSmtpTransport<Tokio1Executor>,
+}
+
+impl std::fmt::Debug for SmtpBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SmtpBackend")
+            .field("config", &self.config)
+            .field("transport", &"<AsyncSmtpTransport>")
+            .finish()
+    }
+}
+
+impl SmtpBackend {
+    /// Create a new `SmtpBackend` from the given SMTP configuration.
+    pub fn new(config: SmtpConfig) -> Result<Self, ProviderError> {
+        let transport = build_transport(&config)?;
+        Ok(Self { config, transport })
+    }
+
+    /// Create a `SmtpBackend` with a pre-built transport (for testing).
+    pub fn with_transport(
+        config: SmtpConfig,
+        transport: AsyncSmtpTransport<Tokio1Executor>,
+    ) -> Self {
+        Self { config, transport }
+    }
+}
+
+#[async_trait]
+impl EmailBackend for SmtpBackend {
+    async fn send(&self, message: &EmailMessage) -> Result<EmailResult, ProviderError> {
+        debug!(to = %message.to, subject = %message.subject, "building SMTP message");
+        let lettre_message = build_message(message)?;
+
+        info!(to = %message.to, subject = %message.subject, "sending email via SMTP");
+        self.transport.send(lettre_message).await.map_err(|e| {
+            error!(error = %e, "SMTP send failed");
+            map_smtp_error(&e)
+        })?;
+
+        info!(to = %message.to, "email sent successfully via SMTP");
+        Ok(EmailResult {
+            message_id: None,
+            status: "sent".to_owned(),
+        })
+    }
+
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        debug!("performing SMTP health check");
+        self.transport.test_connection().await.map_err(|e| {
+            error!(error = %e, "SMTP health check failed");
+            ProviderError::Connection(format!("SMTP health check failed: {e}"))
+        })?;
+        info!("SMTP health check passed");
+        Ok(())
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "smtp"
+    }
+}
+
+/// Build a `lettre::Message` from the unified [`EmailMessage`].
+fn build_message(msg: &EmailMessage) -> Result<Message, ProviderError> {
+    let from_mailbox: Mailbox = msg
+        .from
+        .parse()
+        .map_err(|e| ProviderError::Configuration(format!("invalid from address: {e}")))?;
+
+    let to_mailbox: Mailbox = msg
+        .to
+        .parse()
+        .map_err(|e| ProviderError::ExecutionFailed(format!("invalid recipient address: {e}")))?;
+
+    let mut builder = Message::builder()
+        .from(from_mailbox)
+        .to(to_mailbox)
+        .subject(&msg.subject);
+
+    if let Some(ref reply_to) = msg.reply_to {
+        let reply_mailbox: Mailbox = reply_to.parse().map_err(|e| {
+            ProviderError::ExecutionFailed(format!("invalid reply-to address: {e}"))
+        })?;
+        builder = builder.reply_to(reply_mailbox);
+    }
+
+    if let Some(ref cc) = msg.cc {
+        let cc_mailbox: Mailbox = cc
+            .parse()
+            .map_err(|e| ProviderError::ExecutionFailed(format!("invalid CC address: {e}")))?;
+        builder = builder.cc(cc_mailbox);
+    }
+
+    if let Some(ref bcc) = msg.bcc {
+        let bcc_mailbox: Mailbox = bcc
+            .parse()
+            .map_err(|e| ProviderError::ExecutionFailed(format!("invalid BCC address: {e}")))?;
+        builder = builder.bcc(bcc_mailbox);
+    }
+
+    let message = match (&msg.body, &msg.html_body) {
+        (Some(text), Some(html)) => builder
+            .multipart(
+                MultiPart::alternative()
+                    .singlepart(
+                        SinglePart::builder()
+                            .header(lettre::message::header::ContentType::TEXT_PLAIN)
+                            .body(text.clone()),
+                    )
+                    .singlepart(
+                        SinglePart::builder()
+                            .header(lettre::message::header::ContentType::TEXT_HTML)
+                            .body(html.clone()),
+                    ),
+            )
+            .map_err(|e| ProviderError::ExecutionFailed(format!("failed to build email: {e}")))?,
+        (Some(text), None) => builder
+            .body(text.clone())
+            .map_err(|e| ProviderError::ExecutionFailed(format!("failed to build email: {e}")))?,
+        (None, Some(html)) => builder
+            .singlepart(
+                SinglePart::builder()
+                    .header(lettre::message::header::ContentType::TEXT_HTML)
+                    .body(html.clone()),
+            )
+            .map_err(|e| ProviderError::ExecutionFailed(format!("failed to build email: {e}")))?,
+        (None, None) => builder
+            .body(String::new())
+            .map_err(|e| ProviderError::ExecutionFailed(format!("failed to build email: {e}")))?,
+    };
+
+    Ok(message)
+}
+
+/// Build an async SMTP transport from the given configuration.
+fn build_transport(
+    config: &SmtpConfig,
+) -> Result<AsyncSmtpTransport<Tokio1Executor>, ProviderError> {
+    let builder = if config.tls {
+        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&config.smtp_host)
+            .map_err(|e| ProviderError::Configuration(format!("SMTP TLS relay error: {e}")))?
+    } else {
+        AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&config.smtp_host)
+    };
+
+    let builder = builder.port(config.smtp_port);
+
+    let builder = if let (Some(user), Some(pass)) = (&config.username, &config.password) {
+        builder.credentials(Credentials::new(user.clone(), pass.clone()))
+    } else {
+        builder
+    };
+
+    Ok(builder.build())
+}
+
+/// Map a lettre SMTP error to the appropriate `ProviderError` variant.
+fn map_smtp_error(error: &lettre::transport::smtp::Error) -> ProviderError {
+    let message = error.to_string();
+
+    if error.is_transient() {
+        ProviderError::Connection(format!("transient SMTP error: {message}"))
+    } else if error.is_permanent() {
+        ProviderError::ExecutionFailed(format!("permanent SMTP error: {message}"))
+    } else {
+        ProviderError::Connection(format!("SMTP error: {message}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lettre::{AsyncSmtpTransport, Tokio1Executor};
+
+    use super::*;
+
+    fn test_smtp_config() -> SmtpConfig {
+        SmtpConfig {
+            smtp_host: "localhost".to_owned(),
+            smtp_port: 2525,
+            username: None,
+            password: None,
+            tls: false,
+        }
+    }
+
+    fn test_message() -> EmailMessage {
+        EmailMessage {
+            from: "sender@example.com".to_owned(),
+            to: "recipient@example.com".to_owned(),
+            subject: "Test Subject".to_owned(),
+            body: Some("Hello, world!".to_owned()),
+            html_body: None,
+            cc: None,
+            bcc: None,
+            reply_to: None,
+        }
+    }
+
+    #[test]
+    fn build_message_plain_text() {
+        let msg = test_message();
+        assert!(build_message(&msg).is_ok());
+    }
+
+    #[test]
+    fn build_message_html_only() {
+        let mut msg = test_message();
+        msg.body = None;
+        msg.html_body = Some("<h1>Hello</h1>".to_owned());
+        assert!(build_message(&msg).is_ok());
+    }
+
+    #[test]
+    fn build_message_multipart() {
+        let mut msg = test_message();
+        msg.html_body = Some("<p>Hello</p>".to_owned());
+        assert!(build_message(&msg).is_ok());
+    }
+
+    #[test]
+    fn build_message_with_all_recipients() {
+        let mut msg = test_message();
+        msg.cc = Some("cc@example.com".to_owned());
+        msg.bcc = Some("bcc@example.com".to_owned());
+        msg.reply_to = Some("reply@example.com".to_owned());
+        assert!(build_message(&msg).is_ok());
+    }
+
+    #[test]
+    fn build_message_invalid_from() {
+        let mut msg = test_message();
+        msg.from = "not-valid".to_owned();
+        let err = build_message(&msg).unwrap_err();
+        assert!(matches!(err, ProviderError::Configuration(_)));
+    }
+
+    #[test]
+    fn build_message_invalid_to() {
+        let mut msg = test_message();
+        msg.to = "not-valid".to_owned();
+        let err = build_message(&msg).unwrap_err();
+        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn build_message_empty_body() {
+        let mut msg = test_message();
+        msg.body = None;
+        msg.html_body = None;
+        assert!(build_message(&msg).is_ok());
+    }
+
+    #[tokio::test]
+    async fn build_transport_no_tls() {
+        let config = test_smtp_config();
+        assert!(build_transport(&config).is_ok());
+    }
+
+    #[tokio::test]
+    async fn build_transport_with_credentials() {
+        let mut config = test_smtp_config();
+        config.username = Some("user".to_owned());
+        config.password = Some("pass".to_owned());
+        assert!(build_transport(&config).is_ok());
+    }
+
+    #[tokio::test]
+    async fn smtp_backend_new() {
+        let config = test_smtp_config();
+        let backend = SmtpBackend::new(config);
+        assert!(backend.is_ok());
+    }
+
+    #[tokio::test]
+    async fn smtp_backend_name() {
+        let config = test_smtp_config();
+        let backend = SmtpBackend::new(config).unwrap();
+        assert_eq!(backend.backend_name(), "smtp");
+    }
+
+    #[tokio::test]
+    async fn smtp_backend_debug() {
+        let transport = AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous("localhost")
+            .port(2525)
+            .build();
+        let backend = SmtpBackend::with_transport(test_smtp_config(), transport);
+        let debug = format!("{backend:?}");
+        assert!(debug.contains("SmtpBackend"));
+    }
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -40,6 +40,8 @@ acteon-state-clickhouse = { workspace = true, optional = true }
 acteon-rules = { workspace = true }
 acteon-rules-yaml = { workspace = true }
 acteon-provider = { workspace = true, features = ["webhook"] }
+acteon-email = { workspace = true, features = ["ses"] }
+acteon-aws = { workspace = true, features = ["full"] }
 acteon-twilio = { workspace = true }
 acteon-teams = { workspace = true }
 acteon-discord = { workspace = true }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -86,7 +86,8 @@ pub struct ActeonConfig {
 pub struct ProviderConfig {
     /// Unique name for this provider.
     pub name: String,
-    /// Provider type: `"webhook"`, `"log"`, `"twilio"`, `"teams"`, or `"discord"`.
+    /// Provider type: `"webhook"`, `"log"`, `"twilio"`, `"teams"`, `"discord"`,
+    /// `"email"`, `"aws-sns"`, `"aws-lambda"`, `"aws-eventbridge"`, or `"aws-sqs"`.
     #[serde(rename = "type")]
     pub provider_type: String,
     /// Target URL (required for `"webhook"` type).
@@ -106,6 +107,45 @@ pub struct ProviderConfig {
     pub token: Option<String>,
     /// Default channel or recipient.
     pub default_channel: Option<String>,
+    /// SMTP username for email authentication.
+    pub username: Option<String>,
+    /// SMTP authentication credential. Supports `ENC[...]`.
+    #[serde(alias = "smtp_password")]
+    pub password: Option<String>,
+
+    // ---- Email provider fields ----
+    /// Email backend: `"smtp"` (default) or `"ses"`.
+    #[serde(default)]
+    pub email_backend: Option<String>,
+    /// SMTP server hostname (used by `"email"` type with SMTP backend).
+    pub smtp_host: Option<String>,
+    /// SMTP server port (used by `"email"` type with SMTP backend).
+    pub smtp_port: Option<u16>,
+    /// Sender email address (used by `"email"` type).
+    pub from_address: Option<String>,
+    /// Whether to use TLS for SMTP.
+    #[serde(default)]
+    pub tls: Option<bool>,
+
+    // ---- AWS provider fields ----
+    /// AWS region (used by all `"aws-*"` types and `"email"` with SES backend).
+    pub aws_region: Option<String>,
+    /// AWS IAM role ARN for STS assume-role (used by `"aws-*"` types).
+    pub aws_role_arn: Option<String>,
+    /// AWS endpoint URL override for `LocalStack` (used by `"aws-*"` types).
+    pub aws_endpoint_url: Option<String>,
+    /// SNS topic ARN (used by `"aws-sns"` type).
+    pub topic_arn: Option<String>,
+    /// Lambda function name or ARN (used by `"aws-lambda"` type).
+    pub function_name: Option<String>,
+    /// Lambda function qualifier (used by `"aws-lambda"` type).
+    pub qualifier: Option<String>,
+    /// `EventBridge` event bus name (used by `"aws-eventbridge"` type).
+    pub event_bus_name: Option<String>,
+    /// SQS queue URL (used by `"aws-sqs"` type).
+    pub queue_url: Option<String>,
+    /// SES configuration set name (used by `"email"` with SES backend).
+    pub ses_configuration_set: Option<String>,
 }
 
 /// Configuration for the state store backend.
@@ -1766,6 +1806,10 @@ pub struct ProviderSnapshot {
     pub has_auth_token: bool,
     /// Whether a webhook URL is configured (Teams, Discord).
     pub has_webhook_url: bool,
+    /// Email backend type (if configured).
+    pub email_backend: Option<String>,
+    /// AWS region (if configured).
+    pub aws_region: Option<String>,
 }
 
 impl From<&ProviderConfig> for ProviderSnapshot {
@@ -1778,6 +1822,8 @@ impl From<&ProviderConfig> for ProviderSnapshot {
             has_token: cfg.token.is_some(),
             has_auth_token: cfg.auth_token.is_some(),
             has_webhook_url: cfg.webhook_url.is_some(),
+            email_backend: cfg.email_backend.clone(),
+            aws_region: cfg.aws_region.clone(),
         }
     }
 }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -87,7 +87,8 @@ pub struct ProviderConfig {
     /// Unique name for this provider.
     pub name: String,
     /// Provider type: `"webhook"`, `"log"`, `"twilio"`, `"teams"`, `"discord"`,
-    /// `"email"`, `"aws-sns"`, `"aws-lambda"`, `"aws-eventbridge"`, or `"aws-sqs"`.
+    /// `"email"`, `"aws-sns"`, `"aws-lambda"`, `"aws-eventbridge"`, `"aws-sqs"`,
+    /// or `"aws-s3"`.
     #[serde(rename = "type")]
     pub provider_type: String,
     /// Target URL (required for `"webhook"` type).
@@ -146,6 +147,14 @@ pub struct ProviderConfig {
     pub queue_url: Option<String>,
     /// SES configuration set name (used by `"email"` with SES backend).
     pub ses_configuration_set: Option<String>,
+    /// STS session name for assume-role (used by `"aws-*"` types).
+    pub aws_session_name: Option<String>,
+    /// STS external ID for cross-account trust policies (used by `"aws-*"` types).
+    pub aws_external_id: Option<String>,
+    /// S3 bucket name (used by `"aws-s3"` type).
+    pub bucket_name: Option<String>,
+    /// S3 object key prefix (used by `"aws-s3"` type).
+    pub object_prefix: Option<String>,
 }
 
 /// Configuration for the state store backend.

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -704,6 +704,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         if let Some(ref set) = provider_cfg.ses_configuration_set {
                             email_config = email_config.with_ses_configuration_set(set);
                         }
+                        if let Some(ref name) = provider_cfg.aws_session_name {
+                            email_config = email_config.with_aws_session_name(name);
+                        }
+                        if let Some(ref ext_id) = provider_cfg.aws_external_id {
+                            email_config = email_config.with_aws_external_id(ext_id);
+                        }
                         std::sync::Arc::new(acteon_email::EmailProvider::ses(&email_config).await)
                     }
                     other => {
@@ -727,6 +733,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if let Some(ref arn) = provider_cfg.aws_role_arn {
                     sns_config = sns_config.with_role_arn(arn);
                 }
+                if let Some(ref name) = provider_cfg.aws_session_name {
+                    sns_config = sns_config.with_session_name(name);
+                }
+                if let Some(ref ext_id) = provider_cfg.aws_external_id {
+                    sns_config = sns_config.with_external_id(ext_id);
+                }
                 std::sync::Arc::new(acteon_aws::SnsProvider::new(sns_config).await)
             }
             "aws-lambda" => {
@@ -744,6 +756,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if let Some(ref arn) = provider_cfg.aws_role_arn {
                     lambda_config = lambda_config.with_role_arn(arn);
                 }
+                if let Some(ref name) = provider_cfg.aws_session_name {
+                    lambda_config = lambda_config.with_session_name(name);
+                }
+                if let Some(ref ext_id) = provider_cfg.aws_external_id {
+                    lambda_config = lambda_config.with_external_id(ext_id);
+                }
                 std::sync::Arc::new(acteon_aws::LambdaProvider::new(lambda_config).await)
             }
             "aws-eventbridge" => {
@@ -757,6 +775,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 if let Some(ref arn) = provider_cfg.aws_role_arn {
                     eb_config = eb_config.with_role_arn(arn);
+                }
+                if let Some(ref name) = provider_cfg.aws_session_name {
+                    eb_config = eb_config.with_session_name(name);
+                }
+                if let Some(ref ext_id) = provider_cfg.aws_external_id {
+                    eb_config = eb_config.with_external_id(ext_id);
                 }
                 std::sync::Arc::new(acteon_aws::EventBridgeProvider::new(eb_config).await)
             }
@@ -772,11 +796,40 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if let Some(ref arn) = provider_cfg.aws_role_arn {
                     sqs_config = sqs_config.with_role_arn(arn);
                 }
+                if let Some(ref name) = provider_cfg.aws_session_name {
+                    sqs_config = sqs_config.with_session_name(name);
+                }
+                if let Some(ref ext_id) = provider_cfg.aws_external_id {
+                    sqs_config = sqs_config.with_external_id(ext_id);
+                }
                 std::sync::Arc::new(acteon_aws::SqsProvider::new(sqs_config).await)
+            }
+            "aws-s3" => {
+                let region = provider_cfg.aws_region.as_deref().unwrap_or("us-east-1");
+                let mut s3_config = acteon_aws::S3Config::new(region);
+                if let Some(ref bucket) = provider_cfg.bucket_name {
+                    s3_config = s3_config.with_bucket(bucket);
+                }
+                if let Some(ref prefix) = provider_cfg.object_prefix {
+                    s3_config = s3_config.with_prefix(prefix);
+                }
+                if let Some(ref url) = provider_cfg.aws_endpoint_url {
+                    s3_config = s3_config.with_endpoint_url(url);
+                }
+                if let Some(ref arn) = provider_cfg.aws_role_arn {
+                    s3_config = s3_config.with_role_arn(arn);
+                }
+                if let Some(ref name) = provider_cfg.aws_session_name {
+                    s3_config = s3_config.with_session_name(name);
+                }
+                if let Some(ref ext_id) = provider_cfg.aws_external_id {
+                    s3_config = s3_config.with_external_id(ext_id);
+                }
+                std::sync::Arc::new(acteon_aws::S3Provider::new(s3_config).await)
             }
             other => {
                 return Err(format!(
-                        "provider '{}': unknown type '{other}' (expected 'webhook', 'log', 'twilio', 'teams', 'discord', 'email', 'aws-sns', 'aws-lambda', 'aws-eventbridge', or 'aws-sqs')",
+                        "provider '{}': unknown type '{other}' (expected 'webhook', 'log', 'twilio', 'teams', 'discord', 'email', 'aws-sns', 'aws-lambda', 'aws-eventbridge', 'aws-sqs', or 'aws-s3')",
                         provider_cfg.name
                     )
                     .into());

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -657,9 +657,126 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 std::sync::Arc::new(acteon_discord::DiscordProvider::new(discord_config))
             }
+            "email" => {
+                let from_address = provider_cfg.from_address.as_deref().ok_or_else(|| {
+                    format!(
+                        "provider '{}': email type requires a 'from_address' field",
+                        provider_cfg.name
+                    )
+                })?;
+                let backend = provider_cfg.email_backend.as_deref().unwrap_or("smtp");
+                match backend {
+                    "smtp" => {
+                        let smtp_host = provider_cfg.smtp_host.as_deref().ok_or_else(|| {
+                            format!(
+                                "provider '{}': email/smtp backend requires a 'smtp_host' field",
+                                provider_cfg.name
+                            )
+                        })?;
+                        let mut email_config =
+                            acteon_email::EmailConfig::new(smtp_host, from_address);
+                        if let Some(port) = provider_cfg.smtp_port {
+                            email_config = email_config.with_port(port);
+                        }
+                        if let Some(tls) = provider_cfg.tls {
+                            email_config = email_config.with_tls(tls);
+                        }
+                        if let (Some(user), Some(pass_raw)) =
+                            (&provider_cfg.username, &provider_cfg.password)
+                        {
+                            let pass = require_decrypt(pass_raw, master_key.as_ref())?;
+                            email_config = email_config.with_credentials(user, pass);
+                        }
+                        std::sync::Arc::new(
+                            acteon_email::EmailProvider::new(&email_config)
+                                .map_err(|e| format!("provider '{}': {e}", provider_cfg.name))?,
+                        )
+                    }
+                    "ses" => {
+                        let region = provider_cfg.aws_region.as_deref().unwrap_or("us-east-1");
+                        let mut email_config = acteon_email::EmailConfig::ses(region, from_address);
+                        if let Some(ref url) = provider_cfg.aws_endpoint_url {
+                            email_config = email_config.with_aws_endpoint_url(url);
+                        }
+                        if let Some(ref arn) = provider_cfg.aws_role_arn {
+                            email_config = email_config.with_aws_role_arn(arn);
+                        }
+                        if let Some(ref set) = provider_cfg.ses_configuration_set {
+                            email_config = email_config.with_ses_configuration_set(set);
+                        }
+                        std::sync::Arc::new(acteon_email::EmailProvider::ses(&email_config).await)
+                    }
+                    other => {
+                        return Err(format!(
+                            "provider '{}': unknown email backend '{other}' (expected 'smtp' or 'ses')",
+                            provider_cfg.name
+                        )
+                        .into());
+                    }
+                }
+            }
+            "aws-sns" => {
+                let region = provider_cfg.aws_region.as_deref().unwrap_or("us-east-1");
+                let mut sns_config = acteon_aws::SnsConfig::new(region);
+                if let Some(ref arn) = provider_cfg.topic_arn {
+                    sns_config = sns_config.with_topic_arn(arn);
+                }
+                if let Some(ref url) = provider_cfg.aws_endpoint_url {
+                    sns_config = sns_config.with_endpoint_url(url);
+                }
+                if let Some(ref arn) = provider_cfg.aws_role_arn {
+                    sns_config = sns_config.with_role_arn(arn);
+                }
+                std::sync::Arc::new(acteon_aws::SnsProvider::new(sns_config).await)
+            }
+            "aws-lambda" => {
+                let region = provider_cfg.aws_region.as_deref().unwrap_or("us-east-1");
+                let mut lambda_config = acteon_aws::LambdaConfig::new(region);
+                if let Some(ref name) = provider_cfg.function_name {
+                    lambda_config = lambda_config.with_function_name(name);
+                }
+                if let Some(ref q) = provider_cfg.qualifier {
+                    lambda_config = lambda_config.with_qualifier(q);
+                }
+                if let Some(ref url) = provider_cfg.aws_endpoint_url {
+                    lambda_config = lambda_config.with_endpoint_url(url);
+                }
+                if let Some(ref arn) = provider_cfg.aws_role_arn {
+                    lambda_config = lambda_config.with_role_arn(arn);
+                }
+                std::sync::Arc::new(acteon_aws::LambdaProvider::new(lambda_config).await)
+            }
+            "aws-eventbridge" => {
+                let region = provider_cfg.aws_region.as_deref().unwrap_or("us-east-1");
+                let mut eb_config = acteon_aws::EventBridgeConfig::new(region);
+                if let Some(ref bus) = provider_cfg.event_bus_name {
+                    eb_config = eb_config.with_event_bus_name(bus);
+                }
+                if let Some(ref url) = provider_cfg.aws_endpoint_url {
+                    eb_config = eb_config.with_endpoint_url(url);
+                }
+                if let Some(ref arn) = provider_cfg.aws_role_arn {
+                    eb_config = eb_config.with_role_arn(arn);
+                }
+                std::sync::Arc::new(acteon_aws::EventBridgeProvider::new(eb_config).await)
+            }
+            "aws-sqs" => {
+                let region = provider_cfg.aws_region.as_deref().unwrap_or("us-east-1");
+                let mut sqs_config = acteon_aws::SqsConfig::new(region);
+                if let Some(ref url) = provider_cfg.queue_url {
+                    sqs_config = sqs_config.with_queue_url(url);
+                }
+                if let Some(ref url) = provider_cfg.aws_endpoint_url {
+                    sqs_config = sqs_config.with_endpoint_url(url);
+                }
+                if let Some(ref arn) = provider_cfg.aws_role_arn {
+                    sqs_config = sqs_config.with_role_arn(arn);
+                }
+                std::sync::Arc::new(acteon_aws::SqsProvider::new(sqs_config).await)
+            }
             other => {
                 return Err(format!(
-                        "provider '{}': unknown type '{other}' (expected 'webhook', 'log', 'twilio', 'teams', or 'discord')",
+                        "provider '{}': unknown type '{other}' (expected 'webhook', 'log', 'twilio', 'teams', 'discord', 'email', 'aws-sns', 'aws-lambda', 'aws-eventbridge', or 'aws-sqs')",
                         provider_cfg.name
                     )
                     .into());

--- a/docs/architecture/aws-providers.md
+++ b/docs/architecture/aws-providers.md
@@ -1,0 +1,235 @@
+# AWS Providers — Architecture
+
+## Overview
+
+The `acteon-aws` crate provides native AWS service integrations as Acteon providers.
+Each provider implements the `Provider` trait from `acteon-provider`, allowing AWS
+services to participate in the full dispatch pipeline: rule evaluation, circuit
+breaking, health checks, metrics, and audit.
+
+## Crate Structure
+
+```
+crates/aws/
+├── Cargo.toml          # Feature-gated deps: sns, lambda, eventbridge, sqs, s3, ses
+├── src/
+│   ├── lib.rs          # Module declarations + re-exports
+│   ├── auth.rs         # Shared AWS authentication (STS auto-refresh)
+│   ├── config.rs       # AwsBaseConfig (region, role_arn, endpoint_url, ...)
+│   ├── error.rs        # AWS SDK error → ProviderError classification
+│   ├── sns.rs          # SnsConfig, SnsProvider
+│   ├── lambda.rs       # LambdaConfig, LambdaProvider
+│   ├── eventbridge.rs  # EventBridgeConfig, EventBridgeProvider
+│   ├── sqs.rs          # SqsConfig, SqsProvider
+│   ├── s3.rs           # S3Config, S3Provider
+│   └── ses.rs          # SesConfig, SesClient (used by email provider)
+```
+
+Each provider module is feature-gated:
+
+| Feature | Module | AWS SDK Dependency |
+|---------|--------|-------------------|
+| `sns` | `sns.rs` | `aws-sdk-sns` |
+| `lambda` | `lambda.rs` | `aws-sdk-lambda` |
+| `eventbridge` | `eventbridge.rs` | `aws-sdk-eventbridge` |
+| `sqs` | `sqs.rs` | `aws-sdk-sqs` |
+| `s3` | `s3.rs` | `aws-sdk-s3` |
+| `ses` | `ses.rs` | `aws-sdk-sesv2` |
+| `full` | All of the above | All |
+
+## Authentication Layer
+
+### Credential Resolution
+
+`auth.rs` exports a single function:
+
+```rust
+pub async fn build_sdk_config(config: &AwsBaseConfig) -> SdkConfig
+```
+
+The credential resolution flow:
+
+```
+AwsBaseConfig
+    │
+    ├── region → aws_config::Region
+    ├── endpoint_url → loader.endpoint_url()
+    │
+    └── role_arn?
+         │
+         ├── None → default credential chain
+         │          (env vars → ~/.aws/credentials → EC2/ECS role)
+         │
+         └── Some(arn) → AssumeRoleProvider
+                          ├── session_name (default: "acteon-aws-provider")
+                          ├── external_id (optional, for cross-account)
+                          └── configure(&base_config) → inherits endpoint overrides
+                              → auto-refresh before expiry
+```
+
+### STS Auto-Refresh (Critical Fix)
+
+The previous implementation manually called STS `AssumeRole` once, extracted
+temporary credentials, and froze them as `Credentials::from_keys()`. These static
+credentials expired after ~1 hour, causing `ExpiredTokenException` in long-running
+instances.
+
+The current implementation uses `AssumeRoleProvider` from `aws-config`, which:
+
+1. Calls STS `AssumeRole` on first use
+2. Caches the temporary credentials
+3. Automatically refreshes them before expiry (typically at ~75% of TTL)
+4. Is thread-safe and can be shared across multiple AWS clients
+
+This is critical for production deployments where Acteon runs as a long-lived service.
+
+### AwsBaseConfig
+
+Shared configuration for all AWS providers:
+
+```rust
+pub struct AwsBaseConfig {
+    pub region: String,              // AWS region (required)
+    pub role_arn: Option<String>,    // IAM role to assume
+    pub endpoint_url: Option<String>, // Override (LocalStack)
+    pub session_name: Option<String>, // STS session name
+    pub external_id: Option<String>,  // Cross-account external ID
+}
+```
+
+Each provider config (e.g., `SnsConfig`, `S3Config`) contains an `AwsBaseConfig`
+via `#[serde(flatten)]`, inheriting all base fields plus adding provider-specific
+fields (topic ARN, bucket name, etc.).
+
+## Error Classification
+
+`error.rs` maps AWS SDK error strings to `ProviderError` variants:
+
+| AWS Error Pattern | Classification | Retryable |
+|-------------------|---------------|-----------|
+| `"dispatch failure"`, `"connection"` | `AwsErrorKind::Connection` → `ProviderError::Connection` | Yes |
+| `"throttl"`, `"too many"`, `"rate"` | `AwsErrorKind::Throttled` → `ProviderError::RateLimited` | Yes |
+| `"timeout"`, `"timed out"` | `AwsErrorKind::Timeout` → `ProviderError::Timeout` | Yes |
+| `"credential"`, `"expired"` | `AwsErrorKind::Credential` → `ProviderError::Configuration` | No |
+| `"invalid"`, `"malformed"` | `AwsErrorKind::InvalidPayload` → `ProviderError::Serialization` | No |
+| Everything else | `AwsErrorKind::ServiceError` → `ProviderError::ExecutionFailed` | Depends |
+
+This classification determines whether the circuit breaker counts a failure toward
+its trip threshold and whether the executor retries the request.
+
+## Provider Pattern
+
+All AWS providers follow the same implementation pattern:
+
+```rust
+pub struct XxxProvider {
+    config: XxxConfig,
+    client: aws_sdk_xxx::Client,
+}
+
+impl XxxProvider {
+    pub async fn new(config: XxxConfig) -> Self {
+        let sdk_config = build_sdk_config(&config.aws).await;
+        let client = aws_sdk_xxx::Client::new(&sdk_config);
+        Self { config, client }
+    }
+
+    pub fn with_client(config: XxxConfig, client: aws_sdk_xxx::Client) -> Self {
+        Self { config, client }
+    }
+}
+
+impl Provider for XxxProvider {
+    fn name(&self) -> &str { "aws-xxx" }
+
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        // 1. Deserialize action.payload into typed struct
+        // 2. Resolve defaults from config (topic_arn, bucket, etc.)
+        // 3. Build AWS SDK request
+        // 4. Send request, map errors via classify_sdk_error()
+        // 5. Return ProviderResponse::success(json!({...}))
+    }
+
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        // Lightweight read-only API call (list with max 1)
+    }
+}
+```
+
+### Config Pattern
+
+Each config struct:
+
+- Uses `#[serde(flatten)]` for `AwsBaseConfig`
+- Implements manual `Debug` that redacts `role_arn` via `AwsBaseConfig`'s `Debug`
+- Provides `with_*()` builder methods (all `#[must_use]`)
+- Delegates common fields to `AwsBaseConfig` methods
+
+### SES Integration
+
+SES is unique -- it's not a standalone provider but a backend for the email provider.
+The `acteon-email` crate's `EmailConfig` has a `backend` field (`"smtp"` or `"ses"`).
+When `"ses"`, it constructs an `SesConfig` and creates an `SesClient` internally.
+The `SesClient` wraps `aws_sdk_sesv2::Client` and implements `send_email()` and
+`health_check()` methods directly, rather than implementing the `Provider` trait.
+
+## Server Integration
+
+### Config (`crates/server/src/config.rs`)
+
+The `ProviderConfig` struct maps TOML fields to provider construction:
+
+```toml
+[[providers]]
+name = "my-provider"
+type = "aws-sns"          # Determines which provider to construct
+aws_region = "us-east-1"
+aws_endpoint_url = "..."  # Optional, shared across all AWS types
+aws_role_arn = "..."      # Optional, shared
+aws_session_name = "..."  # Optional, shared
+aws_external_id = "..."   # Optional, shared
+topic_arn = "..."         # SNS-specific
+function_name = "..."     # Lambda-specific
+event_bus_name = "..."    # EventBridge-specific
+queue_url = "..."         # SQS-specific
+bucket_name = "..."       # S3-specific
+object_prefix = "..."     # S3-specific
+```
+
+### Wiring (`crates/server/src/main.rs`)
+
+Provider construction in `main.rs` matches on `type`:
+
+```rust
+"aws-sns" => SnsProvider::new(SnsConfig::new(region).with_topic_arn(...)...),
+"aws-lambda" => LambdaProvider::new(LambdaConfig::new(region)...),
+"aws-eventbridge" => EventBridgeProvider::new(EventBridgeConfig::new(region)...),
+"aws-sqs" => SqsProvider::new(SqsConfig::new(region)...),
+"aws-s3" => S3Provider::new(S3Config::new(region).with_bucket(...)...),
+```
+
+All AWS types share the same pattern for wiring `aws_endpoint_url`, `aws_role_arn`,
+`aws_session_name`, and `aws_external_id`.
+
+## Testing Strategy
+
+### Unit Tests (62 tests)
+
+Each provider module has unit tests covering:
+
+- Config construction and builder chain
+- Serde roundtrip (serialize → deserialize)
+- Debug output redaction
+- Payload deserialization (all action types, minimal and full payloads)
+
+### Integration Testing
+
+AWS providers are integration-tested via:
+
+1. **LocalStack** -- the `aws-event-pipeline` example exercises all providers end-to-end
+2. **Simulation framework** -- mock providers verify the gateway's routing and chain
+   orchestration without real AWS calls
+
+No mock AWS clients are needed in unit tests because the provider logic (payload
+deserialization, config resolution, key prefixing) is testable without SDK calls.
+The SDK call boundary (`client.xxx().send().await`) is the integration test surface.

--- a/docs/book/features/aws-providers.md
+++ b/docs/book/features/aws-providers.md
@@ -1,0 +1,528 @@
+# AWS Providers
+
+Acteon ships with native AWS provider integrations for **SNS**, **Lambda**, **EventBridge**, **SQS**, **S3**, and **SES** (via the email provider). All six are first-class citizens -- they implement the same `Provider` trait, participate in circuit breaking, health checks, and per-provider metrics, and require no external plugins.
+
+## Overview
+
+| Provider | AWS Service | Action Types | Use Case |
+|----------|------------|--------------|----------|
+| `aws-sns` | Simple Notification Service | `publish` | Fan-out alerts to subscriptions (email, SMS, HTTP, Lambda) |
+| `aws-lambda` | Lambda | `invoke` | Run serverless functions for data processing |
+| `aws-eventbridge` | EventBridge | `put_event` | Publish domain events to event buses |
+| `aws-sqs` | Simple Queue Service | `send_message` | Queue messages for async processing |
+| `aws-s3` | Simple Storage Service | `put_object`, `get_object`, `delete_object` | Store and retrieve objects (logs, artifacts, archives) |
+| `ses` (email) | Simple Email Service | `send_email` | Send transactional emails via SES |
+
+All AWS providers:
+
+- Share a common authentication layer with automatic STS credential refresh
+- Support IAM role assumption with `session_name` and `external_id` for cross-account access
+- Support endpoint URL overrides for LocalStack and other AWS-compatible services
+- Report per-provider health metrics (success rate, latency percentiles, error tracking)
+- Map AWS SDK errors to the standard `ProviderError` enum for circuit breaker integration
+
+## TOML Configuration
+
+### AWS SNS
+
+```toml
+[[providers]]
+name = "alert-fanout"
+type = "aws-sns"
+aws_region = "us-east-1"
+topic_arn = "arn:aws:sns:us-east-1:123456789012:alerts"
+# Optional fields:
+# aws_endpoint_url = "http://localhost:4566"   # LocalStack
+# aws_role_arn = "arn:aws:iam::123:role/sns"   # Cross-account
+# aws_session_name = "acteon-sns"              # STS session name
+# aws_external_id = "ext-123"                  # Trust policy external ID
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used in action dispatch |
+| `type` | Yes | Must be `"aws-sns"` |
+| `aws_region` | Yes | AWS region |
+| `topic_arn` | No | Default SNS topic ARN. Can be overridden per-action in the payload |
+| `aws_endpoint_url` | No | Endpoint URL override (for LocalStack) |
+| `aws_role_arn` | No | IAM role ARN to assume via STS |
+| `aws_session_name` | No | STS session name (defaults to `"acteon-aws-provider"`) |
+| `aws_external_id` | No | External ID for cross-account trust policies |
+
+### AWS Lambda
+
+```toml
+[[providers]]
+name = "anomaly-detector"
+type = "aws-lambda"
+aws_region = "us-east-1"
+function_name = "anomaly-detector"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used in action dispatch |
+| `type` | Yes | Must be `"aws-lambda"` |
+| `aws_region` | Yes | AWS region |
+| `function_name` | No | Default Lambda function name. Can be overridden per-action |
+| `aws_endpoint_url` | No | Endpoint URL override |
+| `aws_role_arn` | No | IAM role ARN to assume |
+| `aws_session_name` | No | STS session name |
+| `aws_external_id` | No | External ID for cross-account trust policies |
+
+### AWS EventBridge
+
+```toml
+[[providers]]
+name = "event-bus"
+type = "aws-eventbridge"
+aws_region = "us-east-1"
+event_bus_name = "application-events"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used in action dispatch |
+| `type` | Yes | Must be `"aws-eventbridge"` |
+| `aws_region` | Yes | AWS region |
+| `event_bus_name` | No | Default event bus name. Can be overridden per-action |
+| `aws_endpoint_url` | No | Endpoint URL override |
+| `aws_role_arn` | No | IAM role ARN to assume |
+| `aws_session_name` | No | STS session name |
+| `aws_external_id` | No | External ID for cross-account trust policies |
+
+### AWS SQS
+
+```toml
+[[providers]]
+name = "metrics-queue"
+type = "aws-sqs"
+aws_region = "us-east-1"
+queue_url = "https://sqs.us-east-1.amazonaws.com/123456789012/metrics"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used in action dispatch |
+| `type` | Yes | Must be `"aws-sqs"` |
+| `aws_region` | Yes | AWS region |
+| `queue_url` | No | Default SQS queue URL. Can be overridden per-action |
+| `aws_endpoint_url` | No | Endpoint URL override |
+| `aws_role_arn` | No | IAM role ARN to assume |
+| `aws_session_name` | No | STS session name |
+| `aws_external_id` | No | External ID for cross-account trust policies |
+
+### AWS S3
+
+```toml
+[[providers]]
+name = "archive"
+type = "aws-s3"
+aws_region = "us-east-1"
+bucket_name = "acteon-archive"
+object_prefix = "telemetry/"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used in action dispatch |
+| `type` | Yes | Must be `"aws-s3"` |
+| `aws_region` | Yes | AWS region |
+| `bucket_name` | No | Default S3 bucket name. Can be overridden per-action |
+| `object_prefix` | No | Key prefix prepended to all object keys |
+| `aws_endpoint_url` | No | Endpoint URL override |
+| `aws_role_arn` | No | IAM role ARN to assume |
+| `aws_session_name` | No | STS session name |
+| `aws_external_id` | No | External ID for cross-account trust policies |
+
+### SES Email Backend
+
+SES is configured through the email provider by setting `backend = "ses"`:
+
+```toml
+[[providers]]
+name = "email"
+type = "email"
+backend = "ses"
+from_address = "noreply@example.com"
+aws_region = "us-east-1"
+# ses_configuration_set = "tracking-set"  # Optional tracking config set
+# aws_endpoint_url = "http://localhost:4566"
+# aws_role_arn = "arn:aws:iam::123:role/ses"
+# aws_session_name = "acteon-ses"
+# aws_external_id = "ext-123"
+```
+
+See the [Email provider documentation](native-providers.md) for full payload format details.
+
+## Payload Formats
+
+### SNS: `publish`
+
+```json
+{
+  "message": "Critical temperature alert: 92°C in server room",
+  "subject": "Temperature Alert",
+  "topic_arn": "arn:aws:sns:us-east-1:123:alerts",
+  "message_group_id": "floor-3",
+  "message_deduplication_id": "temp-alert-001"
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `message` | Yes | string | Message body to publish |
+| `subject` | No | string | Subject line (for email subscriptions) |
+| `topic_arn` | No | string | Override the default topic ARN |
+| `message_group_id` | No | string | FIFO topic group ID |
+| `message_deduplication_id` | No | string | FIFO topic dedup ID |
+
+**Response:**
+
+```json
+{
+  "message_id": "abc123-def456",
+  "status": "published"
+}
+```
+
+### Lambda: `invoke`
+
+```json
+{
+  "function_name": "anomaly-detector",
+  "payload": {"device_id": "sensor-001", "value": 92},
+  "invocation_type": "RequestResponse"
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `function_name` | No | string | Override the default function name |
+| `payload` | No | object | JSON payload passed to the Lambda function |
+| `invocation_type` | No | string | `"RequestResponse"` (sync, default) or `"Event"` (async) |
+
+**Response:**
+
+```json
+{
+  "function_name": "anomaly-detector",
+  "status_code": 200,
+  "body": {"anomaly": true, "reason": "temperature_critical"}
+}
+```
+
+### EventBridge: `put_event`
+
+```json
+{
+  "source": "acteon.iot",
+  "detail_type": "SensorReading",
+  "detail": {"device_id": "sensor-001", "value": 92},
+  "event_bus_name": "building-events"
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `source` | Yes | string | Event source identifier |
+| `detail_type` | Yes | string | Event type name |
+| `detail` | Yes | object/string | Event detail (JSON object or string) |
+| `event_bus_name` | No | string | Override the default event bus |
+
+**Response:**
+
+```json
+{
+  "entries": 1,
+  "failed_count": 0,
+  "status": "published"
+}
+```
+
+### SQS: `send_message`
+
+```json
+{
+  "message_body": "{\"device_id\": \"sensor-001\", \"value\": 92}",
+  "queue_url": "https://sqs.us-east-1.amazonaws.com/123/metrics",
+  "delay_seconds": 10,
+  "message_group_id": "sensor-001",
+  "message_deduplication_id": "reading-001"
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `message_body` | Yes | string | Message body (JSON string) |
+| `queue_url` | No | string | Override the default queue URL |
+| `delay_seconds` | No | integer | Delay before the message is visible (0-900) |
+| `message_group_id` | No | string | FIFO queue group ID |
+| `message_deduplication_id` | No | string | FIFO queue dedup ID |
+
+**Response:**
+
+```json
+{
+  "message_id": "abc123-def456",
+  "status": "sent"
+}
+```
+
+### S3: `put_object`
+
+```json
+{
+  "key": "telemetry/2026/02/readings.json",
+  "body": "{\"readings\": [...]}",
+  "content_type": "application/json",
+  "bucket": "data-archive",
+  "metadata": {
+    "source": "acteon",
+    "pipeline_version": "2.0"
+  }
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `key` | Yes | string | Object key (path within the bucket) |
+| `body` | No | string | Object body as UTF-8 text. Mutually exclusive with `body_base64` |
+| `body_base64` | No | string | Object body as base64-encoded bytes. Mutually exclusive with `body` |
+| `content_type` | No | string | MIME type for the object |
+| `bucket` | No | string | Override the default bucket |
+| `metadata` | No | object | Key-value metadata pairs attached to the object |
+
+**Response:**
+
+```json
+{
+  "bucket": "data-archive",
+  "key": "telemetry/2026/02/readings.json",
+  "status": "uploaded"
+}
+```
+
+### S3: `get_object`
+
+```json
+{
+  "key": "telemetry/2026/02/readings.json",
+  "bucket": "data-archive"
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `key` | Yes | string | Object key to retrieve |
+| `bucket` | No | string | Override the default bucket |
+
+**Response** (UTF-8 content):
+
+```json
+{
+  "bucket": "data-archive",
+  "key": "telemetry/2026/02/readings.json",
+  "content_type": "application/json",
+  "content_length": 1234,
+  "body": "{\"readings\": [...]}",
+  "status": "downloaded"
+}
+```
+
+**Response** (binary content):
+
+```json
+{
+  "bucket": "data-archive",
+  "key": "images/logo.png",
+  "content_type": "image/png",
+  "content_length": 5678,
+  "body_base64": "iVBORw0KGgo...",
+  "status": "downloaded"
+}
+```
+
+### S3: `delete_object`
+
+```json
+{
+  "key": "old/data.csv",
+  "bucket": "data-archive"
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `key` | Yes | string | Object key to delete |
+| `bucket` | No | string | Override the default bucket |
+
+**Response:**
+
+```json
+{
+  "bucket": "data-archive",
+  "key": "old/data.csv",
+  "status": "deleted"
+}
+```
+
+## Authentication and Credential Refresh
+
+All AWS providers share a common authentication layer in `acteon-aws`. Credentials are resolved in this order:
+
+1. **Default credential chain** -- environment variables, `~/.aws/credentials`, EC2 instance profile, ECS task role
+2. **IAM role assumption** (if `aws_role_arn` is configured) -- uses `AssumeRoleProvider` with automatic credential refresh before expiry
+
+The `AssumeRoleProvider` handles the STS `AssumeRole` call internally and refreshes credentials transparently. This means long-running Acteon instances never encounter `ExpiredTokenException` errors, unlike manual STS calls with static credentials.
+
+### Cross-Account Access
+
+For multi-account deployments, configure role assumption with an external ID:
+
+```toml
+[[providers]]
+name = "cross-account-sns"
+type = "aws-sns"
+aws_region = "us-east-1"
+aws_role_arn = "arn:aws:iam::987654321098:role/acteon-sns-publisher"
+aws_session_name = "acteon-prod"
+aws_external_id = "acteon-trust-key"
+topic_arn = "arn:aws:sns:us-east-1:987654321098:alerts"
+```
+
+The `aws_external_id` is validated against the trust policy's `Condition` block, providing an additional layer of security for cross-account delegation.
+
+## Health Check Behavior
+
+| Provider | Health Check Method | Notes |
+|----------|-------------------|-------|
+| `aws-sns` | `ListTopics` (max 1) | Verifies API connectivity and credentials |
+| `aws-lambda` | `ListFunctions` (max 1) | Verifies API connectivity and credentials |
+| `aws-eventbridge` | `ListEventBuses` (max 1) | Verifies API connectivity and credentials |
+| `aws-sqs` | `ListQueues` (max 1) | Verifies API connectivity and credentials |
+| `aws-s3` | `ListBuckets` (max 1) | Verifies API connectivity and credentials |
+| SES (email) | `GetAccount` | Verifies SES sending is enabled |
+
+All health checks are lightweight read-only operations that do not modify any resources.
+
+## Error Handling
+
+AWS SDK errors are classified into the standard `ProviderError` enum:
+
+| AWS Error Pattern | ProviderError Variant | Retryable | Circuit Breaker |
+|-------------------|----------------------|-----------|-----------------|
+| Connection/dispatch failure | `Connection` | Yes | Counts toward trip |
+| Throttling / `TooManyRequests` | `RateLimited` | Yes | Counts toward trip |
+| Timeout | `Timeout` | Yes | Counts toward trip |
+| Credential errors | `Configuration` | No | Does not count |
+| Invalid request | `Serialization` | No | Does not count |
+| Other service errors | `ExecutionFailed` | No | Counts toward trip |
+
+## Example: Dispatching via the API
+
+```bash
+# Publish to SNS
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "alerts",
+    "tenant": "acme-corp",
+    "provider": "alert-fanout",
+    "action_type": "publish",
+    "payload": {
+      "message": "Critical alert: CPU at 99%",
+      "subject": "CPU Alert"
+    }
+  }'
+
+# Invoke Lambda
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "processing",
+    "tenant": "acme-corp",
+    "provider": "anomaly-detector",
+    "action_type": "invoke",
+    "payload": {
+      "payload": {"device_id": "sensor-001", "value": 92}
+    }
+  }'
+
+# Upload to S3
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "archive",
+    "tenant": "acme-corp",
+    "provider": "archive",
+    "action_type": "put_object",
+    "payload": {
+      "key": "reports/2026/02/daily.json",
+      "body": "{\"total\": 42}",
+      "content_type": "application/json"
+    }
+  }'
+```
+
+## Example: Rust Client
+
+```rust
+use acteon_client::ActeonClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = ActeonClient::new("http://localhost:8080", "your-api-token")?;
+
+    // Publish to SNS
+    client.dispatch_action(
+        "alerts", "acme-corp", "alert-fanout", "publish",
+        serde_json::json!({
+            "message": "Critical alert!",
+            "subject": "Alert"
+        }),
+    ).await?;
+
+    // Invoke Lambda
+    client.dispatch_action(
+        "processing", "acme-corp", "anomaly-detector", "invoke",
+        serde_json::json!({
+            "payload": {"device_id": "sensor-001", "value": 92}
+        }),
+    ).await?;
+
+    // Upload to S3
+    client.dispatch_action(
+        "archive", "acme-corp", "archive", "put_object",
+        serde_json::json!({
+            "key": "data/report.json",
+            "body": "{\"total\": 42}",
+            "content_type": "application/json"
+        }),
+    ).await?;
+
+    Ok(())
+}
+```
+
+## LocalStack Development
+
+All AWS providers support endpoint URL overrides, making it easy to develop and test locally with [LocalStack](https://localstack.cloud/):
+
+```bash
+# Start LocalStack
+docker run --rm -d --name localstack -p 4566:4566 localstack/localstack
+```
+
+Point every provider at `http://localhost:4566`:
+
+```toml
+[[providers]]
+name = "alert-fanout"
+type = "aws-sns"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+topic_arn = "arn:aws:sns:us-east-1:000000000000:alerts"
+```
+
+See the [AWS Event-Driven Pipeline Guide](../guides/aws-event-pipeline.md) for a complete runnable example using LocalStack with all six provider types.

--- a/docs/book/getting-started/configuration.md
+++ b/docs/book/getting-started/configuration.md
@@ -77,6 +77,26 @@ max_retries = 3                      # Max retry attempts per action
 timeout_seconds = 30                 # Per-action execution timeout
 max_concurrent = 10                  # Max concurrent executions
 
+# ─── Providers ───────────────────────────────────────────
+# [[providers]]
+# name = "email"
+# type = "email"
+# from_address = "noreply@example.com"
+
+# [[providers]]
+# name = "alert-fanout"
+# type = "aws-sns"
+# aws_region = "us-east-1"
+# topic_arn = "arn:aws:sns:us-east-1:123:alerts"
+# aws_endpoint_url = "http://localhost:4566"  # LocalStack
+
+# [[providers]]
+# name = "archive"
+# type = "aws-s3"
+# aws_region = "us-east-1"
+# bucket_name = "my-bucket"
+# object_prefix = "acteon/"
+
 # ─── Authentication ───────────────────────────────────────
 [auth]
 enabled = false                      # Enable authentication
@@ -348,6 +368,45 @@ Arbitrary key-value pairs added to every exported span as OpenTelemetry resource
 
 See [Distributed Tracing](../features/distributed-tracing.md) for feature documentation.
 
+### `[[providers]]`
+
+Provider configuration. Multiple providers can be defined.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Unique provider name used in action dispatch |
+| `type` | string | Yes | Provider type (see below) |
+
+**Built-in provider types:**
+
+| Type | Description | Extra Fields |
+|------|-------------|-------------|
+| `"log"` | Logs actions (no external calls) | — |
+| `"webhook"` | HTTP webhook | `url` |
+| `"slack"` | Slack webhook | `webhook_url` |
+| `"email"` | Email (SMTP or SES) | `backend`, `from_address`, `smtp_host`, `aws_region`, ... |
+| `"twilio"` | Twilio SMS | `account_sid`, `auth_token`, `from_number` |
+| `"teams"` | Microsoft Teams | `webhook_url` |
+| `"discord"` | Discord webhook | `webhook_url` |
+| `"pagerduty"` | PagerDuty events | `routing_key` |
+| `"aws-sns"` | AWS SNS | `aws_region`, `topic_arn` |
+| `"aws-lambda"` | AWS Lambda | `aws_region`, `function_name` |
+| `"aws-eventbridge"` | AWS EventBridge | `aws_region`, `event_bus_name` |
+| `"aws-sqs"` | AWS SQS | `aws_region`, `queue_url` |
+| `"aws-s3"` | AWS S3 | `aws_region`, `bucket_name`, `object_prefix` |
+
+**Common AWS fields** (all optional, shared across all `aws-*` types and `email` with `backend = "ses"`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `aws_region` | string | AWS region (required for AWS types) |
+| `aws_endpoint_url` | string | Endpoint URL override (for LocalStack) |
+| `aws_role_arn` | string | IAM role ARN to assume via STS |
+| `aws_session_name` | string | STS session name (default: `"acteon-aws-provider"`) |
+| `aws_external_id` | string | External ID for cross-account trust policies |
+
+See [AWS Providers](../features/aws-providers.md) and [Native Providers](../features/native-providers.md) for full payload format documentation.
+
 ## Environment Variables
 
 | Variable | Description |
@@ -368,6 +427,8 @@ Ready-to-use configs are in the `examples/` directory:
 | `examples/elasticsearch-audit.toml` | Redis state + Elasticsearch audit |
 | `examples/dynamodb.toml` | DynamoDB state backend |
 | `examples/full.toml` | All options documented |
+| `examples/aws-event-pipeline/acteon.toml` | AWS providers (SNS, Lambda, EventBridge, SQS) + DynamoDB |
+| `examples/agent-swarm-coordination/acteon.toml` | Claude Code agent governance with PostgreSQL |
 
 ```bash
 # Start with Redis

--- a/docs/book/guides/aws-event-pipeline.md
+++ b/docs/book/guides/aws-event-pipeline.md
@@ -1,0 +1,969 @@
+# AWS Event-Driven Pipeline
+
+This guide shows how to use Acteon as an **event-driven pipeline orchestrator** for
+AWS services. By routing IoT sensor telemetry through Acteon's dispatch pipeline,
+you gain centralized rule evaluation, multi-step chain orchestration, circuit breaker
+fallbacks, and a full audit trail -- all without writing any custom AWS glue code.
+
+!!! tip "Runnable Example"
+    The [`examples/aws-event-pipeline/`](https://github.com/penserai/acteon/tree/main/examples/aws-event-pipeline)
+    directory contains a complete, runnable setup with LocalStack, DynamoDB-backed
+    state and audit, safety rules, telemetry routing, and chain orchestration. Follow
+    the quick start below to have the full pipeline running in minutes.
+
+```mermaid
+flowchart LR
+    subgraph Sensors
+        S1[Temperature]
+        S2[Humidity]
+        S3[Motion]
+        S4[Energy]
+    end
+
+    subgraph Acteon
+        GW[Gateway]
+        RE[Rule Engine]
+        CH[Chain Engine]
+        CB[Circuit Breakers]
+    end
+
+    subgraph "AWS (LocalStack)"
+        SNS[SNS<br/>building-alerts]
+        LAM[Lambda<br/>anomaly-detector<br/>normalizer]
+        EB[EventBridge<br/>building-events]
+        SQS[SQS<br/>telemetry-metrics]
+        S3[S3<br/>archive]
+        DDB[DynamoDB<br/>state + audit]
+    end
+
+    S1 & S2 & S3 & S4 -->|dispatch| GW
+    GW --> RE --> CH --> CB
+    CB --> SNS & LAM & EB & SQS & S3
+    GW -.-> DDB
+```
+
+The scenario: a **smart building** with hundreds of IoT sensors (temperature, humidity,
+motion, energy) publishes readings to Acteon. The rule engine evaluates each reading
+and routes it to the right AWS service -- critical alerts fan out via SNS, normal
+readings flow through a Lambda processing chain, device lifecycle events publish to
+EventBridge, and metrics queue via SQS for batch processing.
+
+---
+
+## What This Example Exercises
+
+The example exercises **20 Acteon features** through a single unified scenario:
+
+| # | Feature | How |
+|---|---------|-----|
+| 1 | **AWS SNS** | Critical temperature and intrusion alerts fan out via SNS topic |
+| 2 | **AWS Lambda** | Telemetry normalization and anomaly detection via Lambda functions |
+| 3 | **AWS EventBridge** | Device lifecycle events published to custom event bus |
+| 4 | **AWS SQS** | Metrics queued for batch processing; dead-letter queue for failures |
+| 5 | **DynamoDB** | State + audit backends via LocalStack |
+| 6 | **Chains** | `telemetry-processing`: normalize → detect → publish → archive |
+| 7 | **Sub-chains** | Critical alert path invokes `critical-alert` sub-chain (SNS → EventBridge) |
+| 8 | **Conditional branching** | Branch on normalization success and anomaly detection result |
+| 9 | **Circuit breakers + fallback** | Lambda → DLQ; SNS → local-fallback |
+| 10 | **Recurring actions** | Device heartbeat check every 5 minutes |
+| 11 | **Data retention** | Audit 7 days, events 2 days |
+| 12 | **Event grouping** | Humidity readings batched by floor, 30s window |
+| 13 | **Quotas** | 500/hour for the `smartbuilding-hq` tenant |
+| 14 | **Throttle** | Telemetry ingestion: 30/min per tenant |
+| 15 | **Dedup** | Duplicate sensor readings deduplicated within 60s |
+| 16 | **Suppress** | Block telemetry from test devices |
+| 17 | **Deny** | Reject unsigned firmware updates |
+| 18 | **Schedule** | Energy reports delayed 60s for batch aggregation |
+| 19 | **Modify** | Enrich telemetry with pipeline version and building zone |
+| 20 | **Audit + redaction** | Full audit with `aws_role_arn`/`function_arn`/`queue_url` redacted |
+
+---
+
+## Prerequisites
+
+- [LocalStack](https://localstack.cloud/) (provides SNS, Lambda, EventBridge, SQS, DynamoDB)
+- `awslocal` CLI (`pip install awscli-local`)
+- `jq` (for script output formatting)
+- Rust 1.88+ and Cargo
+
+---
+
+## Quick Start
+
+### 1. Start LocalStack
+
+```bash
+docker run --rm -d --name localstack -p 4566:4566 localstack/localstack
+```
+
+### 2. Create AWS Resources
+
+```bash
+bash examples/aws-event-pipeline/scripts/setup.sh
+```
+
+This creates:
+
+- SNS topic: `building-alerts`
+- Lambda functions: `anomaly-detector`, `telemetry-normalizer` (Python 3.12)
+- EventBridge bus: `building-events`
+- SQS queues: `telemetry-metrics`, `telemetry-dlq` (dead-letter)
+- DynamoDB tables: `acteon_state`, `acteon_audit`
+
+### 3. Start Acteon
+
+```bash
+cargo run -p acteon-server --features dynamodb -- \
+  -c examples/aws-event-pipeline/acteon.toml
+```
+
+Wait for `Listening on 127.0.0.1:8080`.
+
+### 4. Create API Resources
+
+```bash
+bash examples/aws-event-pipeline/scripts/setup-api.sh
+```
+
+This creates via the REST API:
+
+- **Quota**: 500 actions/hour for `smartbuilding-hq`
+- **Retention policy**: audit 7 days, events 2 days
+- **Recurring action**: device heartbeat check every 5 minutes
+
+### 5. Fire Telemetry Events
+
+```bash
+bash examples/aws-event-pipeline/scripts/send-telemetry.sh
+```
+
+This sends ~21 sample events covering all categories (see [Expected Outcomes](#expected-outcomes)).
+
+### 6. View the Report
+
+```bash
+bash examples/aws-event-pipeline/scripts/show-report.sh
+```
+
+This queries 8 API endpoints and displays: audit trail with outcome breakdown,
+chain status, event states, provider health, quotas, groups, recurring actions,
+and retention policies.
+
+### 7. Cleanup
+
+```bash
+bash examples/aws-event-pipeline/scripts/teardown.sh
+docker stop localstack
+```
+
+---
+
+## Architecture
+
+```
+                    ┌─────────────────────────────┐
+  IoT Sensors ─────►│      Acteon Gateway          │
+  (temperature,     │                             │
+   humidity,        │  Rules Engine               │          ┌──────────────────┐
+   motion,          │  ┌─suppress test──────────┐ │         │ SNS              │
+   energy)          │  ├─deny unsigned fw───────┤ │────────►│ building-alerts  │
+                    │  ├─dedup 60s──────────────┤ │         ├──────────────────┤
+                    │  ├─throttle 30/min────────┤ │         │ Lambda           │
+                    │  ├─group humidity─────────┤ │────────►│ anomaly-detector │
+                    │  ├─schedule energy────────┤ │         │ normalizer       │
+                    │  ├─reroute critical───────┤ │         ├──────────────────┤
+                    │  ├─chain readings─────────┤ │         │ EventBridge      │
+                    │  └─allow remaining────────┘ │────────►│ building-events  │
+                    │                             │         ├──────────────────┤
+                    │  Chain Engine               │         │ SQS              │
+                    │  ┌─normalize──────────────┐ │────────►│ telemetry-metrics│
+                    │  ├─detect-anomaly────────┤ │         │ telemetry-dlq    │
+                    │  ├─publish (sub-chain)────┤ │         ├──────────────────┤
+                    │  └─archive-metrics────────┘ │         │ Log              │
+                    │                             │────────►│ local-fallback   │
+                    │  Background Jobs            │         └──────────────────┘
+                    │  ├─group flush             │
+                    │  ├─recurring heartbeat     │         ┌──────────────────┐
+                    │  └─retention reaper        │         │ DynamoDB         │
+                    │                             │────────►│ acteon_state     │
+                    └─────────────────────────────┘         │ acteon_audit     │
+                                                            └──────────────────┘
+```
+
+The gateway acts as a single entry point for all sensor telemetry. The rule engine
+decides what happens to each reading before any AWS API call is made. This means
+you can add new routing logic, change rate limits, or enable circuit breaker fallbacks
+by editing YAML rule files -- no code changes, no redeployment.
+
+---
+
+## Provider Configuration
+
+The `acteon.toml` configures seven providers -- six AWS services plus a local log fallback:
+
+```toml
+# SNS: fan-out critical alerts to operations team
+[[providers]]
+name = "alert-fanout"
+type = "aws-sns"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+topic_arn = "arn:aws:sns:us-east-1:000000000000:building-alerts"
+
+# Lambda: anomaly detection on sensor readings
+[[providers]]
+name = "anomaly-detector"
+type = "aws-lambda"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+function_name = "anomaly-detector"
+
+# Lambda: normalize raw telemetry into standard format
+[[providers]]
+name = "telemetry-normalizer"
+type = "aws-lambda"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+function_name = "telemetry-normalizer"
+
+# EventBridge: publish device lifecycle and system events
+[[providers]]
+name = "event-bus"
+type = "aws-eventbridge"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+event_bus_name = "building-events"
+
+# SQS: queue metrics for batch processing
+[[providers]]
+name = "metrics-queue"
+type = "aws-sqs"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+queue_url = "http://localhost:4566/000000000000/telemetry-metrics"
+
+# SQS: dead-letter queue for failed dispatches
+[[providers]]
+name = "dead-letter-queue"
+type = "aws-sqs"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+queue_url = "http://localhost:4566/000000000000/telemetry-dlq"
+
+# Log: local fallback when AWS providers are unavailable
+[[providers]]
+name = "local-fallback"
+type = "log"
+```
+
+Every AWS provider points at `http://localhost:4566` (LocalStack). In production,
+remove `aws_endpoint_url` to use real AWS endpoints, and optionally add
+`aws_role_arn` for cross-account access.
+
+---
+
+## Rule Design
+
+Rules are split across three files by concern:
+
+### Safety Rules (`safety.yaml`)
+
+Safety rules run at the highest priority (1) and form the **deny-by-default** layer:
+
+```yaml
+rules:
+  # Block telemetry from test devices
+  - name: suppress-test-devices
+    priority: 1
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.payload.environment
+          eq: "test"
+    action:
+      type: suppress
+
+  # Reject unsigned firmware updates
+  - name: deny-unsigned-firmware
+    priority: 1
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.action_type
+          eq: "firmware_update"
+        - field: action.payload.signed
+          eq: false
+    action:
+      type: deny
+
+  # Catch-all: block anything not explicitly allowed
+  - name: deny-unmatched
+    priority: 100
+    condition:
+      field: action.tenant
+      eq: "smartbuilding-hq"
+    action:
+      type: suppress
+```
+
+The `deny-unmatched` rule at priority 100 ensures that any reading that does not
+match a higher-priority routing or allow rule is silently dropped. This prevents
+unknown action types from reaching AWS services.
+
+### Processing Rules (`processing.yaml`)
+
+Processing rules handle deduplication, throttling, grouping, and scheduling:
+
+```yaml
+rules:
+  # Deduplicate identical sensor readings within 60s
+  - name: dedup-sensor-readings
+    priority: 2
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.action_type
+          eq: "sensor_reading"
+    action:
+      type: deduplicate
+      ttl_seconds: 60
+
+  # Limit telemetry ingestion to 30 readings per minute
+  - name: throttle-telemetry
+    priority: 3
+    condition:
+      field: action.tenant
+      eq: "smartbuilding-hq"
+    action:
+      type: throttle
+      max_count: 30
+      window_seconds: 60
+
+  # Batch humidity readings by floor, flush every 30s
+  - name: group-humidity-readings
+    priority: 4
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.payload.sensor_type
+          eq: "humidity"
+    action:
+      type: group
+      group_by:
+        - payload.floor
+      group_wait_seconds: 30
+
+  # Delay energy reports by 60s for batch aggregation
+  - name: schedule-energy-reports
+    priority: 4
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.payload.sensor_type
+          eq: "energy"
+    action:
+      type: schedule
+      delay_seconds: 60
+```
+
+### Routing Rules (`routing.yaml`)
+
+Routing rules direct telemetry to the correct AWS service:
+
+```yaml
+rules:
+  # Critical temperature → SNS alert fan-out
+  - name: critical-temperature-alert
+    priority: 5
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.payload.sensor_type
+          eq: "temperature"
+        - field: action.payload.value
+          gt: 85
+    action:
+      type: reroute
+      target_provider: "alert-fanout"
+
+  # Motion intrusion → SNS alert fan-out
+  - name: intrusion-alert
+    priority: 6
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.payload.sensor_type
+          eq: "motion"
+        - field: action.payload.event
+          eq: "intrusion"
+    action:
+      type: reroute
+      target_provider: "alert-fanout"
+
+  # Normal sensor readings → multi-step processing chain
+  - name: chain-sensor-readings
+    priority: 10
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.action_type
+          eq: "sensor_reading"
+    action:
+      type: chain
+      chain: "telemetry-processing"
+
+  # Device lifecycle → EventBridge
+  - name: lifecycle-to-eventbridge
+    priority: 12
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.action_type
+          eq: "device_lifecycle"
+    action:
+      type: reroute
+      target_provider: "event-bus"
+
+  # Firmware updates → SQS for batch processing
+  - name: firmware-to-sqs
+    priority: 14
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.action_type
+          eq: "firmware_update"
+    action:
+      type: reroute
+      target_provider: "metrics-queue"
+
+  # Enrich all telemetry with pipeline metadata
+  - name: enrich-telemetry-metadata
+    priority: 16
+    condition:
+      field: action.tenant
+      eq: "smartbuilding-hq"
+    action:
+      type: modify
+      changes:
+        pipeline_version: "2.0.0"
+        building_zone: "main-campus"
+
+  # Allow remaining actions
+  - name: allow-remaining
+    priority: 20
+    condition:
+      field: action.tenant
+      eq: "smartbuilding-hq"
+    action:
+      type: allow
+```
+
+### Rule Evaluation Order
+
+Rules are evaluated by priority (lowest number = highest priority). The first
+matching terminal rule (suppress, deny, reroute, chain, allow) determines the
+outcome. Non-terminal rules (modify, deduplicate, throttle, group, schedule)
+can execute before the terminal rule.
+
+| Priority | Rule | File | Action |
+|----------|------|------|--------|
+| 1 | `suppress-test-devices` | safety.yaml | Suppress |
+| 1 | `deny-unsigned-firmware` | safety.yaml | Deny |
+| 2 | `dedup-sensor-readings` | processing.yaml | Deduplicate 60s |
+| 3 | `throttle-telemetry` | processing.yaml | Throttle 30/min |
+| 4 | `group-humidity-readings` | processing.yaml | Group by floor, 30s |
+| 4 | `schedule-energy-reports` | processing.yaml | Schedule 60s delay |
+| 5 | `critical-temperature-alert` | routing.yaml | Reroute → SNS |
+| 6 | `intrusion-alert` | routing.yaml | Reroute → SNS |
+| 10 | `chain-sensor-readings` | routing.yaml | Chain → telemetry-processing |
+| 12 | `lifecycle-to-eventbridge` | routing.yaml | Reroute → EventBridge |
+| 14 | `firmware-to-sqs` | routing.yaml | Reroute → SQS |
+| 16 | `enrich-telemetry-metadata` | routing.yaml | Modify metadata |
+| 20 | `allow-remaining` | routing.yaml | Allow |
+| 100 | `deny-unmatched` | safety.yaml | Suppress (catch-all) |
+
+---
+
+## Chain Orchestration
+
+### Main Chain: `telemetry-processing`
+
+The `telemetry-processing` chain handles normal sensor readings through a multi-step
+pipeline with conditional branching and a sub-chain:
+
+```mermaid
+flowchart TD
+    A[normalize<br/>telemetry-normalizer Lambda] --> B{body.logged == true?}
+    B -->|yes| C[detect-anomaly<br/>anomaly-detector Lambda]
+    B -->|no| C
+    C --> D{success == true?}
+    D -->|yes| E[publish-event<br/>sub-chain: critical-alert]
+    D -->|no / default| F[archive-metrics<br/>SQS]
+```
+
+```toml
+[[chains.definitions]]
+name = "telemetry-processing"
+timeout_seconds = 300
+
+[[chains.definitions.steps]]
+name = "normalize"
+provider = "telemetry-normalizer"
+action_type = "invoke"
+payload_template = {
+    device_id = "{{origin.payload.device_id}}",
+    sensor_type = "{{origin.payload.sensor_type}}",
+    value = "{{origin.payload.value}}",
+    unit = "{{origin.payload.unit}}"
+}
+
+  [[chains.definitions.steps.branches]]
+  field = "body.logged"
+  operator = "eq"
+  value = true
+  target = "detect-anomaly"
+
+[[chains.definitions.steps]]
+name = "detect-anomaly"
+provider = "anomaly-detector"
+action_type = "invoke"
+payload_template = {
+    device_id = "{{origin.payload.device_id}}",
+    sensor_type = "{{origin.payload.sensor_type}}",
+    value = "{{origin.payload.value}}"
+}
+
+  [[chains.definitions.steps.branches]]
+  field = "success"
+  operator = "eq"
+  value = true
+  target = "publish-event"
+
+  default_next = "archive-metrics"
+
+[[chains.definitions.steps]]
+name = "publish-event"
+sub_chain = "critical-alert"
+
+[[chains.definitions.steps]]
+name = "archive-metrics"
+provider = "metrics-queue"
+action_type = "send_message"
+payload_template = {
+    device_id = "{{origin.payload.device_id}}",
+    sensor_type = "{{origin.payload.sensor_type}}",
+    value = "{{origin.payload.value}}",
+    processed = "true"
+}
+```
+
+### Sub-Chain: `critical-alert`
+
+When the anomaly detector flags a reading, the chain branches to a sub-chain that
+fans out the alert via SNS and publishes a domain event to EventBridge:
+
+```toml
+[[chains.definitions]]
+name = "critical-alert"
+timeout_seconds = 120
+
+[[chains.definitions.steps]]
+name = "fan-out-alert"
+provider = "alert-fanout"
+action_type = "publish"
+payload_template = {
+    device_id = "{{origin.payload.device_id}}",
+    sensor_type = "{{origin.payload.sensor_type}}",
+    value = "{{origin.payload.value}}",
+    severity = "critical"
+}
+
+[[chains.definitions.steps]]
+name = "publish-to-bus"
+provider = "event-bus"
+action_type = "put_event"
+payload_template = {
+    source = "acteon.iot",
+    detail_type = "CriticalAlert",
+    detail = "{{origin.payload}}"
+}
+```
+
+Sub-chains are first-class chain definitions. The parent chain's `publish-event` step
+uses `sub_chain = "critical-alert"` instead of a `provider`. When the sub-chain
+completes, execution returns to the parent chain.
+
+---
+
+## Circuit Breaker Fallbacks
+
+Two circuit breaker fallback paths protect against AWS service outages:
+
+```toml
+[circuit_breaker]
+enabled = true
+failure_threshold = 3
+success_threshold = 1
+recovery_timeout_seconds = 30
+
+# Lambda anomaly-detector → DLQ after 2 failures
+[circuit_breaker.providers.anomaly-detector]
+failure_threshold = 2
+recovery_timeout_seconds = 60
+fallback_provider = "dead-letter-queue"
+
+# SNS alert-fanout → local log after 2 failures
+[circuit_breaker.providers.alert-fanout]
+failure_threshold = 2
+recovery_timeout_seconds = 60
+fallback_provider = "local-fallback"
+```
+
+### Testing Circuit Breaker Behavior
+
+If LocalStack is not running when you start Acteon, the AWS providers will fail
+immediately. After 2 failures:
+
+- **anomaly-detector** trips → sensor readings that would go through the
+  processing chain are instead sent to the `dead-letter-queue` (SQS)
+- **alert-fanout** trips → critical alerts that would go to SNS are instead
+  logged by the `local-fallback` (log) provider
+
+After `recovery_timeout_seconds` (60s), the circuit breaker enters half-open state
+and allows one probe request through. If it succeeds, the circuit closes and normal
+routing resumes.
+
+---
+
+## Background Processing
+
+The `[background]` section enables three background processors:
+
+| Processor | Interval | Purpose |
+|-----------|----------|---------|
+| Group flush | 10s | Flush accumulated humidity batches |
+| Timeout processing | 10s | Cancel chains that exceed `timeout_seconds` |
+| Cleanup | 60s | Remove completed chains older than `completed_chain_ttl_seconds` |
+| Recurring actions | 30s | Check and execute `*/5 * * * *` heartbeat |
+| Retention reaper | 60s | Delete expired audit records and event state |
+
+```toml
+[background]
+enabled = true
+group_flush_interval_seconds = 10
+timeout_check_interval_seconds = 10
+cleanup_interval_seconds = 60
+enable_group_flush = true
+enable_timeout_processing = true
+enable_recurring_actions = true
+recurring_check_interval_seconds = 30
+max_recurring_actions_per_tenant = 10
+enable_retention_reaper = true
+retention_check_interval_seconds = 60
+namespace = "iot"
+tenant = "smartbuilding-hq"
+```
+
+---
+
+## Audit Trail and Redaction
+
+Every dispatched action is recorded in the DynamoDB audit backend with full outcome
+details. Sensitive fields are automatically redacted:
+
+```toml
+[audit]
+enabled = true
+backend = "dynamodb"
+url = "http://localhost:4566"
+region = "us-east-1"
+table_name = "acteon_audit"
+store_payload = true
+ttl_seconds = 604800  # 7 days
+
+[audit.redact]
+enabled = true
+fields = ["aws_role_arn", "function_arn", "queue_url"]
+placeholder = "[REDACTED]"
+```
+
+Query the audit trail to see what happened:
+
+```bash
+# All dispatches
+curl -s "http://localhost:8080/v1/audit?namespace=iot&tenant=smartbuilding-hq&limit=50" | jq .
+
+# Only suppressed actions
+curl -s "http://localhost:8080/v1/audit?namespace=iot&tenant=smartbuilding-hq&outcome=suppressed" | jq .
+
+# Only actions that hit a specific provider
+curl -s "http://localhost:8080/v1/audit?namespace=iot&tenant=smartbuilding-hq&provider=alert-fanout" | jq .
+```
+
+---
+
+## Expected Outcomes
+
+When running `send-telemetry.sh`, you should see these outcomes:
+
+| Events | Count | Expected Outcome |
+|--------|-------|-----------------|
+| Critical temp (>85°C) | 2 | `rerouted` to SNS |
+| Intrusion (motion) | 2 | `rerouted` to SNS |
+| Normal temp | 3 | `chain_started` (telemetry-processing) |
+| Humidity | 3 | `grouped` (batched by floor, 30s) |
+| Energy | 2 | `scheduled` (60s delay) |
+| Rapid-fire | 3 | Some `throttled` (if >30/min reached) |
+| Duplicate (same key) | 2 | 1 `deduplicated` |
+| Test device | 2 | `suppressed` |
+| Device lifecycle | 1 | `rerouted` to EventBridge |
+| Unsigned firmware | 1 | `denied` |
+
+The exact counts for throttling depend on timing -- if you run the script quickly
+after startup, the first 30 readings will pass before the throttle kicks in.
+
+---
+
+## File Structure
+
+```
+aws-event-pipeline/
+├── acteon.toml              # Server config (providers, chains, circuit breakers, DynamoDB)
+├── rules/
+│   ├── routing.yaml         # Route to SNS/Lambda/EventBridge/SQS, enrich metadata, allow
+│   ├── processing.yaml      # Dedup, throttle, group humidity, schedule energy
+│   └── safety.yaml          # Suppress test devices, deny unsigned firmware, catch-all
+├── scripts/
+│   ├── setup.sh             # Create LocalStack resources (AWS + DynamoDB)
+│   ├── setup-api.sh         # Create quotas + retention + recurring via API
+│   ├── send-telemetry.sh    # Fire ~21 sample telemetry events
+│   ├── show-report.sh       # Query audit/chains/events/health/quotas/groups
+│   └── teardown.sh          # Clean up API-created resources
+└── README.md
+```
+
+---
+
+## Extending the Pipeline
+
+### Adding S3 Archival
+
+Add an S3 provider for long-term telemetry archival:
+
+```toml
+[[providers]]
+name = "telemetry-archive"
+type = "aws-s3"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+bucket_name = "building-telemetry"
+object_prefix = "raw/"
+```
+
+Create the S3 bucket in LocalStack:
+
+```bash
+awslocal s3 mb s3://building-telemetry
+```
+
+Add a chain step that archives processed readings:
+
+```toml
+[[chains.definitions.steps]]
+name = "archive-to-s3"
+provider = "telemetry-archive"
+action_type = "put_object"
+payload_template = {
+    key = "{{origin.payload.device_id}}/{{origin.payload.sensor_type}}.json",
+    body = "{{step_result}}",
+    content_type = "application/json",
+    metadata = { source = "acteon-pipeline", device_id = "{{origin.payload.device_id}}" }
+}
+```
+
+Or dispatch S3 uploads directly via the API:
+
+```bash
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "iot",
+    "tenant": "smartbuilding-hq",
+    "provider": "telemetry-archive",
+    "action_type": "put_object",
+    "payload": {
+      "key": "reports/daily-summary.json",
+      "body": "{\"total_readings\": 1234, \"anomalies\": 3}",
+      "content_type": "application/json"
+    }
+  }'
+```
+
+### Adding SES Email Alerts
+
+Add SES for email-based alerting alongside SNS:
+
+```toml
+[[providers]]
+name = "email-alerts"
+type = "email"
+backend = "ses"
+from_address = "alerts@smartbuilding.example.com"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+```
+
+Add a routing rule for critical alerts to also send email:
+
+```yaml
+- name: email-critical-alerts
+  priority: 5
+  condition:
+    all:
+      - field: action.payload.sensor_type
+        eq: "temperature"
+      - field: action.payload.value
+        gt: 95  # Only extreme readings
+  action:
+    type: reroute
+    target_provider: "email-alerts"
+```
+
+### Adding a New Sensor Type
+
+To add a new sensor type (e.g., air quality), you only need to add rules -- no code
+changes. Create a routing rule:
+
+```yaml
+- name: air-quality-alert
+  priority: 5
+  condition:
+    all:
+      - field: action.payload.sensor_type
+        eq: "air_quality"
+      - field: action.payload.value
+        gt: 150  # AQI > 150 = unhealthy
+  action:
+    type: reroute
+    target_provider: "alert-fanout"
+```
+
+And a grouping rule for batch processing:
+
+```yaml
+- name: group-air-quality
+  priority: 4
+  condition:
+    all:
+      - field: action.payload.sensor_type
+        eq: "air_quality"
+  action:
+    type: group
+    group_by:
+      - payload.floor
+    group_wait_seconds: 60
+```
+
+---
+
+## Production Considerations
+
+### Credential Management
+
+In production, remove `aws_endpoint_url` from all providers and use IAM roles:
+
+```toml
+[[providers]]
+name = "alert-fanout"
+type = "aws-sns"
+aws_region = "us-east-1"
+aws_role_arn = "arn:aws:iam::123456789012:role/acteon-sns-publisher"
+aws_session_name = "acteon-prod"
+topic_arn = "arn:aws:sns:us-east-1:123456789012:building-alerts"
+```
+
+The `AssumeRoleProvider` automatically refreshes STS credentials before they expire,
+so long-running Acteon instances never encounter `ExpiredTokenException`.
+
+### Multi-Account Deployment
+
+For organizations with separate AWS accounts per environment, use cross-account
+role assumption with external IDs:
+
+```toml
+# Production account SNS
+[[providers]]
+name = "prod-alerts"
+type = "aws-sns"
+aws_region = "us-east-1"
+aws_role_arn = "arn:aws:iam::111111111111:role/acteon-publisher"
+aws_external_id = "acteon-prod-trust"
+topic_arn = "arn:aws:sns:us-east-1:111111111111:prod-alerts"
+
+# Staging account SQS
+[[providers]]
+name = "staging-queue"
+type = "aws-sqs"
+aws_region = "us-west-2"
+aws_role_arn = "arn:aws:iam::222222222222:role/acteon-queue"
+aws_external_id = "acteon-staging-trust"
+queue_url = "https://sqs.us-west-2.amazonaws.com/222222222222/staging-metrics"
+```
+
+### State Backend
+
+For production, replace the DynamoDB state backend with PostgreSQL or Redis for
+lower latency on dedup checks and throttle counters. Keep DynamoDB for audit if
+you want serverless scaling:
+
+```toml
+[state]
+backend = "redis"
+url = "redis://redis-cluster:6379"
+
+[audit]
+backend = "dynamodb"
+region = "us-east-1"
+table_name = "acteon_audit"
+```
+
+### Monitoring
+
+Use the [Grafana dashboards](../features/grafana-dashboards.md) to monitor:
+
+- Per-provider success rates and latency
+- Circuit breaker state transitions
+- Rule evaluation counts by outcome
+- Chain completion rates and step durations
+- Quota usage per tenant
+
+---
+
+## Comparison: Acteon vs Custom AWS Glue
+
+| Capability | Custom (Lambda + Step Functions) | Acteon |
+|-----------|--------------------------------|--------|
+| Routing logic | Lambda code or EventBridge rules | YAML rules (no code) |
+| Rate limiting | API Gateway throttling (limited) | Per-tenant, per-action-type throttling |
+| Deduplication | Custom DynamoDB logic | Built-in with configurable TTL |
+| Circuit breakers | Custom with CloudWatch alarms | Built-in with fallback providers |
+| Audit trail | Custom CloudWatch/DynamoDB logging | Built-in with field redaction |
+| Multi-step workflows | Step Functions ($0.025/1000 transitions) | Built-in chains (no extra cost) |
+| Event grouping | Custom SQS batching | Built-in with configurable flush |
+| Approval gates | Custom (SNS + Lambda + API Gateway) | Built-in with HMAC-signed URLs |
+| Human-in-the-loop | Custom UI + Lambda | Built-in approval workflow |
+| Configuration changes | Code deploy required | YAML edit + hot reload |
+
+Acteon replaces the "glue" layer between your application and AWS services. Instead
+of writing Lambda functions for routing, deduplication, throttling, and error handling,
+you declare these behaviors in YAML rules and TOML configuration.

--- a/docs/book/guides/index.md
+++ b/docs/book/guides/index.md
@@ -9,4 +9,9 @@ In-depth guides that show how to combine Acteon's features to solve real-world p
 Use Acteon as a safety and orchestration layer for multi-agent AI systems. Covers identity, permissions, prompt injection defense, rate limiting, approval workflows, and observability.
 </div>
 
+<div class="card" markdown>
+### [AWS Event-Driven Pipeline](aws-event-pipeline.md)
+Build an IoT telemetry pipeline with Acteon routing sensor data to AWS services (SNS, Lambda, EventBridge, SQS, S3). Covers chain orchestration, circuit breaker fallbacks, event grouping, and a full LocalStack development setup.
+</div>
+
 </div>

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -36,7 +36,7 @@ flowchart LR
     C -->|Suppress| F[Block Action]
     C -->|Throttle| G[Rate Limit]
     C -->|Reroute| H[Different Provider]
-    D --> I[Email / Twilio / Slack / Teams / Discord / Webhook]
+    D --> I[Email / Twilio / Slack / Teams / Discord / Webhook / SNS / Lambda / SQS / S3]
 ```
 
 ---
@@ -110,6 +110,16 @@ Use LLM-based evaluation to gate actions through AI-powered guardrails. Block or
 Route actions by meaning, not just field values. Use vector embeddings and cosine similarity to match actions against topic descriptions in natural language.
 
 [Learn more](features/semantic-routing.md)
+
+</div>
+
+<div class="card" markdown>
+
+### AWS Providers
+
+Native integrations for SNS, Lambda, EventBridge, SQS, S3, and SES with automatic STS credential refresh, cross-account role assumption, and LocalStack support for local development.
+
+[Learn more](features/aws-providers.md)
 
 </div>
 
@@ -247,12 +257,13 @@ graph TB
     RE --> LLM
     RE --> EX
     EX --> PROV
-    PROV --> Email[Email SMTP]
+    PROV --> Email[Email SMTP/SES]
     PROV --> Slack[Slack]
     PROV --> Twilio[Twilio SMS]
     PROV --> Teams[Teams]
     PROV --> Discord[Discord]
     PROV --> WH[Webhooks]
+    PROV --> AWS[AWS SNS/Lambda/SQS/S3]
     RE -.-> MEM & RED & PG & DDB & CH
     EX -.-> AUD_PG & AUD_CH & AUD_ES
 ```

--- a/examples/aws-event-pipeline/README.md
+++ b/examples/aws-event-pipeline/README.md
@@ -1,0 +1,185 @@
+# AWS Event-Driven Pipeline
+
+An end-to-end example exercising all 4 AWS providers (SNS, Lambda, EventBridge, SQS) through an IoT smart-building telemetry scenario. Sensor devices publish temperature, humidity, motion, and energy readings that Acteon routes to AWS services via LocalStack, using DynamoDB for state and audit storage.
+
+## Features Exercised
+
+| # | Feature | How |
+|---|---------|-----|
+| 1 | **AWS SNS** | Critical temperature and intrusion alerts fan out via SNS topic |
+| 2 | **AWS Lambda** | Telemetry normalization and anomaly detection via Lambda functions |
+| 3 | **AWS EventBridge** | Device lifecycle events published to custom event bus |
+| 4 | **AWS SQS** | Metrics queued for batch processing; dead-letter queue for failures |
+| 5 | **DynamoDB** | State + audit backends via LocalStack |
+| 6 | **Chains** | `telemetry-processing`: normalize → detect → publish → archive |
+| 7 | **Sub-chains** | Critical alert path invokes `critical-alert` sub-chain (SNS → EventBridge) |
+| 8 | **Conditional branching** | Branch on normalization success and anomaly detection result |
+| 9 | **Circuit breakers + fallback** | Lambda → DLQ; SNS → local-fallback |
+| 10 | **Recurring actions** | Device heartbeat check every 5 minutes |
+| 11 | **Data retention** | Audit 7 days, events 2 days |
+| 12 | **Event grouping** | Humidity readings batched by floor, 30s window |
+| 13 | **Quotas** | 500/hour for smartbuilding-hq tenant |
+| 14 | **Throttle** | Telemetry ingestion: 30/min per tenant |
+| 15 | **Dedup** | Duplicate sensor readings deduplicated within 60s |
+| 16 | **Suppress** | Block telemetry from test devices |
+| 17 | **Deny** | Reject unsigned firmware updates |
+| 18 | **Schedule** | Energy reports delayed 60s for batch aggregation |
+| 19 | **Modify** | Enrich telemetry with pipeline version and building zone |
+| 20 | **Audit + redaction** | Full audit with `aws_role_arn`/`function_arn`/`queue_url` redacted |
+
+## Prerequisites
+
+- [LocalStack](https://localstack.cloud/) (provides SNS, Lambda, EventBridge, SQS, DynamoDB)
+- `awslocal` CLI (`pip install awscli-local`)
+- `jq` (for script output formatting)
+
+## Quick Start
+
+```bash
+# 1. Start LocalStack
+docker run --rm -d --name localstack -p 4566:4566 localstack/localstack
+
+# 2. Create AWS resources (SNS topic, Lambda functions, EventBridge bus, SQS queues, DynamoDB tables)
+bash examples/aws-event-pipeline/scripts/setup.sh
+
+# 3. Start Acteon with DynamoDB backend
+cargo run -p acteon-server --features dynamodb -- \
+  -c examples/aws-event-pipeline/acteon.toml
+
+# 4. Create API resources (quota, retention, recurring heartbeat)
+bash examples/aws-event-pipeline/scripts/setup-api.sh
+
+# 5. Fire ~21 sample telemetry events
+bash examples/aws-event-pipeline/scripts/send-telemetry.sh
+
+# 6. View comprehensive report
+bash examples/aws-event-pipeline/scripts/show-report.sh
+
+# 7. Cleanup API resources
+bash examples/aws-event-pipeline/scripts/teardown.sh
+
+# 8. Stop LocalStack
+docker stop localstack
+```
+
+## File Structure
+
+```
+aws-event-pipeline/
+├── acteon.toml              # Server config (AWS providers, chains, circuit breakers, DynamoDB)
+├── rules/
+│   ├── routing.yaml         # Route to SNS/Lambda/EventBridge/SQS, enrich metadata, allow
+│   ├── processing.yaml      # Dedup, throttle, group humidity, schedule energy
+│   └── safety.yaml          # Suppress test devices, deny unsigned firmware, catch-all
+├── scripts/
+│   ├── setup.sh             # Create LocalStack resources (AWS + DynamoDB)
+│   ├── setup-api.sh         # Create quotas + retention + recurring via API
+│   ├── send-telemetry.sh    # Fire ~21 sample telemetry events
+│   ├── show-report.sh       # Query audit/chains/events/health/quotas/groups
+│   └── teardown.sh          # Clean up API-created resources
+└── README.md
+```
+
+## Architecture
+
+```
+                    ┌─────────────────────────┐
+  IoT Sensors ─────►│    Acteon Gateway        │
+  (temperature,     │                         │
+   humidity,        │  Rules Engine           │        ┌──────────────────┐
+   motion,          │  ┌─suppress test──────┐ │       │ SNS              │
+   energy)          │  ├─deny unsigned fw───┤ │──────►│ building-alerts  │
+                    │  ├─dedup 60s──────────┤ │       ├──────────────────┤
+                    │  ├─throttle 30/min────┤ │       │ Lambda           │
+                    │  ├─group humidity─────┤ │──────►│ anomaly-detector │
+                    │  ├─schedule energy────┤ │       │ normalizer       │
+                    │  ├─reroute critical───┤ │       ├──────────────────┤
+                    │  ├─chain readings─────┤ │       │ EventBridge      │
+                    │  └─allow remaining────┘ │──────►│ building-events  │
+                    │                         │       ├──────────────────┤
+                    │  Chain Engine           │       │ SQS              │
+                    │  ┌─normalize──────────┐ │──────►│ telemetry-metrics│
+                    │  ├─detect-anomaly────┤ │       │ telemetry-dlq    │
+                    │  ├─publish (sub)─────┤ │       ├──────────────────┤
+                    │  └─archive-metrics───┘ │       │ Log              │
+                    │                         │──────►│ local-fallback   │
+                    │  Background Jobs        │       └──────────────────┘
+                    │  ├─group flush         │
+                    │  ├─recurring heartbeat │       ┌──────────────────┐
+                    │  └─retention reaper    │       │ DynamoDB         │
+                    │                         │──────►│ acteon_state     │
+                    └─────────────────────────┘       │ acteon_audit     │
+                                                      └──────────────────┘
+```
+
+## Chain Flow
+
+The `telemetry-processing` chain handles normal sensor readings:
+
+```
+normalize (telemetry-normalizer Lambda)
+    │
+    ├─ body.logged == true ──► detect-anomaly (anomaly-detector Lambda)
+    │                              │
+    │                              ├─ success == true ──► publish-event (sub-chain)
+    │                              │                          ├─ fan-out-alert (SNS)
+    │                              │                          └─ publish-to-bus (EventBridge)
+    │                              │
+    │                              └─ (default) ──► archive-metrics (SQS)
+    │
+    └─ (no branch match) ──► detect-anomaly (next step)
+```
+
+## Rule Evaluation Order
+
+Rules are evaluated by priority (lowest number = highest priority):
+
+| Priority | Rule | File | Action |
+|----------|------|------|--------|
+| 1 | `suppress-test-devices` | safety.yaml | Suppress |
+| 1 | `deny-unsigned-firmware` | safety.yaml | Deny |
+| 2 | `dedup-sensor-readings` | processing.yaml | Deduplicate 60s |
+| 3 | `throttle-telemetry` | processing.yaml | Throttle 30/min |
+| 4 | `group-humidity-readings` | processing.yaml | Group by floor, 30s |
+| 4 | `schedule-energy-reports` | processing.yaml | Schedule 60s delay |
+| 5 | `critical-temperature-alert` | routing.yaml | Reroute → SNS |
+| 6 | `intrusion-alert` | routing.yaml | Reroute → SNS |
+| 10 | `chain-sensor-readings` | routing.yaml | Chain → telemetry-processing |
+| 12 | `lifecycle-to-eventbridge` | routing.yaml | Reroute → EventBridge |
+| 14 | `firmware-to-sqs` | routing.yaml | Reroute → SQS |
+| 16 | `enrich-telemetry-metadata` | routing.yaml | Modify metadata |
+| 20 | `allow-remaining` | routing.yaml | Allow |
+| 100 | `deny-unmatched` | safety.yaml | Suppress (catch-all) |
+
+## Expected Outcomes from `send-telemetry.sh`
+
+| Events | Count | Expected Outcome |
+|--------|-------|-----------------|
+| Critical temp | 2 | `rerouted` to SNS (value > 85) |
+| Intrusion | 2 | `rerouted` to SNS (motion intrusion) |
+| Normal temp | 3 | `chain_started` (telemetry-processing) |
+| Humidity | 3 | `grouped` (batched by floor, 30s) |
+| Energy | 2 | `scheduled` (60s delay) |
+| Rapid-fire | 3 | Some `throttled` (if >30/min reached) |
+| Duplicate | 2 | 1 `deduplicated` (same dedup_key) |
+| Test device | 2 | `suppressed` (environment=test) |
+| Lifecycle | 1 | `rerouted` to EventBridge |
+| Unsigned FW | 1 | `denied` (signed=false) |
+
+## Circuit Breaker Demo
+
+Two circuit breaker fallback paths are configured:
+
+- **anomaly-detector** (Lambda) trips after 2 failures → falls back to `dead-letter-queue` (SQS)
+- **alert-fanout** (SNS) trips after 2 failures → falls back to `local-fallback` (log)
+
+If LocalStack is not running, the AWS providers will fail and circuit breakers will trip, demonstrating the fallback routing.
+
+## Notes
+
+- **LocalStack** provides a full local AWS environment. All AWS provider endpoints point to `http://localhost:4566`.
+- **DynamoDB tables** (`acteon_state`, `acteon_audit`) are created by `setup.sh` with on-demand billing.
+- **Lambda functions** use mock Python handlers that simulate anomaly detection and telemetry normalization.
+- **Log provider** returns `{"provider": "<name>", "logged": true}`. Chain branching uses `body.logged == true` as a condition.
+- **Quota window** uses `"hourly"` string format. Other options: `"daily"`, `"weekly"`, `"monthly"`.
+- All audit payloads containing `aws_role_arn`, `function_arn`, or `queue_url` fields are automatically redacted.

--- a/examples/aws-event-pipeline/acteon.toml
+++ b/examples/aws-event-pipeline/acteon.toml
@@ -1,0 +1,209 @@
+# AWS Event-Driven Pipeline example.
+#
+# Exercises AWS providers (SNS, Lambda, EventBridge, SQS) in an IoT
+# smart-building telemetry scenario. Sensor data flows through Acteon,
+# which normalizes, detects anomalies, routes alerts, and archives metrics.
+#
+# Requires LocalStack for AWS services + DynamoDB:
+#   docker run --rm -d --name localstack -p 4566:4566 localstack/localstack
+#   bash examples/aws-event-pipeline/scripts/setup.sh
+#
+# Start Acteon:
+#   cargo run -p acteon-server --features dynamodb -- -c examples/aws-event-pipeline/acteon.toml
+
+[server]
+host = "127.0.0.1"
+port = 8080
+
+# HMAC secret for signing approval URLs (hex-encoded, 256-bit).
+approval_secret = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+# ─── State (DynamoDB via LocalStack) ─────────────────────────────────────────
+[state]
+backend = "dynamodb"
+url = "http://localhost:4566"
+region = "us-east-1"
+table_name = "acteon_state"
+
+# ─── Audit (DynamoDB via LocalStack, 7-day TTL, payload stored, redaction) ───
+[audit]
+enabled = true
+backend = "dynamodb"
+url = "http://localhost:4566"
+region = "us-east-1"
+table_name = "acteon_audit"
+store_payload = true
+ttl_seconds = 604800
+
+[audit.redact]
+enabled = true
+fields = ["aws_role_arn", "function_arn", "queue_url"]
+placeholder = "[REDACTED]"
+
+# ─── Providers ───────────────────────────────────────────────────────────────
+
+# SNS: fan-out critical alerts to operations team
+[[providers]]
+name = "alert-fanout"
+type = "aws-sns"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+topic_arn = "arn:aws:sns:us-east-1:000000000000:building-alerts"
+
+# Lambda: anomaly detection on sensor readings
+[[providers]]
+name = "anomaly-detector"
+type = "aws-lambda"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+function_name = "anomaly-detector"
+
+# Lambda: normalize raw telemetry into standard format
+[[providers]]
+name = "telemetry-normalizer"
+type = "aws-lambda"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+function_name = "telemetry-normalizer"
+
+# EventBridge: publish device lifecycle and system events
+[[providers]]
+name = "event-bus"
+type = "aws-eventbridge"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+event_bus_name = "building-events"
+
+# SQS: queue metrics for batch processing
+[[providers]]
+name = "metrics-queue"
+type = "aws-sqs"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+queue_url = "http://localhost:4566/000000000000/telemetry-metrics"
+
+# SQS: dead-letter queue for failed dispatches
+[[providers]]
+name = "dead-letter-queue"
+type = "aws-sqs"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+queue_url = "http://localhost:4566/000000000000/telemetry-dlq"
+
+# Log: local fallback when AWS providers are unavailable
+[[providers]]
+name = "local-fallback"
+type = "log"
+
+# ─── Rules ───────────────────────────────────────────────────────────────────
+[rules]
+directory = "examples/aws-event-pipeline/rules"
+
+# ─── Executor ────────────────────────────────────────────────────────────────
+[executor]
+max_retries = 2
+timeout_seconds = 15
+max_concurrent = 16
+
+# ─── Circuit Breaker ────────────────────────────────────────────────────────
+[circuit_breaker]
+enabled = true
+failure_threshold = 3
+success_threshold = 1
+recovery_timeout_seconds = 30
+
+# Lambda anomaly-detector trips after 2 failures, falls back to DLQ
+[circuit_breaker.providers.anomaly-detector]
+failure_threshold = 2
+recovery_timeout_seconds = 60
+fallback_provider = "dead-letter-queue"
+
+# SNS alert-fanout trips after 2 failures, falls back to local-fallback
+[circuit_breaker.providers.alert-fanout]
+failure_threshold = 2
+recovery_timeout_seconds = 60
+fallback_provider = "local-fallback"
+
+# ─── Chains ─────────────────────────────────────────────────────────────────
+[chains]
+max_concurrent_advances = 8
+completed_chain_ttl_seconds = 3600
+
+# Main chain: normalize → detect anomalies → publish → archive
+[[chains.definitions]]
+name = "telemetry-processing"
+timeout_seconds = 300
+
+[[chains.definitions.steps]]
+name = "normalize"
+provider = "telemetry-normalizer"
+action_type = "invoke"
+payload_template = { device_id = "{{origin.payload.device_id}}", sensor_type = "{{origin.payload.sensor_type}}", value = "{{origin.payload.value}}", unit = "{{origin.payload.unit}}" }
+
+  [[chains.definitions.steps.branches]]
+  field = "body.logged"
+  operator = "eq"
+  value = true
+  target = "detect-anomaly"
+
+[[chains.definitions.steps]]
+name = "detect-anomaly"
+provider = "anomaly-detector"
+action_type = "invoke"
+payload_template = { device_id = "{{origin.payload.device_id}}", sensor_type = "{{origin.payload.sensor_type}}", value = "{{origin.payload.value}}" }
+
+  [[chains.definitions.steps.branches]]
+  field = "success"
+  operator = "eq"
+  value = true
+  target = "publish-event"
+
+  default_next = "archive-metrics"
+
+[[chains.definitions.steps]]
+name = "publish-event"
+sub_chain = "critical-alert"
+
+[[chains.definitions.steps]]
+name = "archive-metrics"
+provider = "metrics-queue"
+action_type = "send_message"
+payload_template = { device_id = "{{origin.payload.device_id}}", sensor_type = "{{origin.payload.sensor_type}}", value = "{{origin.payload.value}}", processed = "true" }
+
+# Sub-chain: critical alert path (SNS → EventBridge)
+[[chains.definitions]]
+name = "critical-alert"
+timeout_seconds = 120
+
+[[chains.definitions.steps]]
+name = "fan-out-alert"
+provider = "alert-fanout"
+action_type = "publish"
+payload_template = { device_id = "{{origin.payload.device_id}}", sensor_type = "{{origin.payload.sensor_type}}", value = "{{origin.payload.value}}", severity = "critical" }
+
+[[chains.definitions.steps]]
+name = "publish-to-bus"
+provider = "event-bus"
+action_type = "put_event"
+payload_template = { source = "acteon.iot", detail_type = "CriticalAlert", detail = "{{origin.payload}}" }
+
+# ─── Background Processing ──────────────────────────────────────────────────
+[background]
+enabled = true
+group_flush_interval_seconds = 10
+timeout_check_interval_seconds = 10
+cleanup_interval_seconds = 60
+enable_group_flush = true
+enable_timeout_processing = true
+enable_recurring_actions = true
+recurring_check_interval_seconds = 30
+max_recurring_actions_per_tenant = 10
+enable_retention_reaper = true
+retention_check_interval_seconds = 60
+namespace = "iot"
+tenant = "smartbuilding-hq"
+
+# ─── Quotas ─────────────────────────────────────────────────────────────────
+# Quota enforcement enabled; policies created via the API in scripts/setup-api.sh.
+[quotas]
+enabled = true

--- a/examples/aws-event-pipeline/rules/processing.yaml
+++ b/examples/aws-event-pipeline/rules/processing.yaml
@@ -1,0 +1,58 @@
+# Processing rules: dedup, throttle, group, and schedule telemetry data.
+
+rules:
+  # ── Deduplicate duplicate sensor readings within 60s ─────────────────────
+  - name: dedup-sensor-readings
+    priority: 2
+    description: "Deduplicate identical sensor readings within a 60-second window"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.action_type
+          eq: "sensor_reading"
+    action:
+      type: deduplicate
+      ttl_seconds: 60
+
+  # ── Throttle rapid telemetry: max 30 per minute ─────────────────────────
+  - name: throttle-telemetry
+    priority: 3
+    description: "Limit telemetry ingestion to 30 readings per minute per tenant"
+    condition:
+      field: action.tenant
+      eq: "smartbuilding-hq"
+    action:
+      type: throttle
+      max_count: 30
+      window_seconds: 60
+
+  # ── Group humidity readings into 30s batches ─────────────────────────────
+  - name: group-humidity-readings
+    priority: 4
+    description: "Batch humidity readings by floor, flush every 30 seconds"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.payload.sensor_type
+          eq: "humidity"
+    action:
+      type: group
+      group_by:
+        - payload.floor
+      group_wait_seconds: 30
+
+  # ── Schedule energy reports with 60s delay ───────────────────────────────
+  - name: schedule-energy-reports
+    priority: 4
+    description: "Delay energy meter reports by 60 seconds for batch aggregation"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.payload.sensor_type
+          eq: "energy"
+    action:
+      type: schedule
+      delay_seconds: 60

--- a/examples/aws-event-pipeline/rules/routing.yaml
+++ b/examples/aws-event-pipeline/rules/routing.yaml
@@ -1,0 +1,99 @@
+# Routing rules: direct telemetry to appropriate AWS services.
+
+rules:
+  # ── Critical temperature → SNS alert fan-out ─────────────────────────────
+  - name: critical-temperature-alert
+    priority: 5
+    description: "Route critical temperature readings (>85°C) to SNS for immediate alerting"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.payload.sensor_type
+          eq: "temperature"
+        - field: action.payload.value
+          gt: 85
+    action:
+      type: reroute
+      target_provider: "alert-fanout"
+
+  # ── Intrusion detection → SNS alert fan-out ──────────────────────────────
+  - name: intrusion-alert
+    priority: 6
+    description: "Route motion intrusion events to SNS for security alerting"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.payload.sensor_type
+          eq: "motion"
+        - field: action.payload.event
+          eq: "intrusion"
+    action:
+      type: reroute
+      target_provider: "alert-fanout"
+
+  # ── Standard sensor readings → telemetry processing chain ────────────────
+  - name: chain-sensor-readings
+    priority: 10
+    description: "Start telemetry processing chain for normal sensor readings"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.action_type
+          eq: "sensor_reading"
+    action:
+      type: chain
+      chain: "telemetry-processing"
+
+  # ── Device lifecycle events → EventBridge ────────────────────────────────
+  - name: lifecycle-to-eventbridge
+    priority: 12
+    description: "Publish device lifecycle events to EventBridge bus"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.action_type
+          eq: "device_lifecycle"
+    action:
+      type: reroute
+      target_provider: "event-bus"
+
+  # ── Firmware updates → SQS for batch processing ─────────────────────────
+  - name: firmware-to-sqs
+    priority: 14
+    description: "Queue firmware update requests for batch processing via SQS"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.action_type
+          eq: "firmware_update"
+    action:
+      type: reroute
+      target_provider: "metrics-queue"
+
+  # ── Enrich all telemetry with pipeline metadata ──────────────────────────
+  - name: enrich-telemetry-metadata
+    priority: 16
+    description: "Add pipeline version and building zone metadata to all actions"
+    condition:
+      field: action.tenant
+      eq: "smartbuilding-hq"
+    action:
+      type: modify
+      changes:
+        pipeline_version: "2.0.0"
+        building_zone: "main-campus"
+
+  # ── Allow remaining actions ──────────────────────────────────────────────
+  - name: allow-remaining
+    priority: 20
+    description: "Allow any smartbuilding-hq action that passed prior rules"
+    condition:
+      field: action.tenant
+      eq: "smartbuilding-hq"
+    action:
+      type: allow

--- a/examples/aws-event-pipeline/rules/safety.yaml
+++ b/examples/aws-event-pipeline/rules/safety.yaml
@@ -1,0 +1,40 @@
+# Safety rules: suppress test devices, deny unsigned firmware, catch-all.
+
+rules:
+  # ── Suppress telemetry from test devices ─────────────────────────────────
+  - name: suppress-test-devices
+    priority: 1
+    description: "Block all telemetry from devices in the test environment"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.payload.environment
+          eq: "test"
+    action:
+      type: suppress
+
+  # ── Deny unsigned firmware updates ───────────────────────────────────────
+  - name: deny-unsigned-firmware
+    priority: 1
+    description: "Block firmware updates that are not cryptographically signed"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "smartbuilding-hq"
+        - field: action.action_type
+          eq: "firmware_update"
+        - field: action.payload.signed
+          eq: false
+    action:
+      type: deny
+
+  # ── Catch-all: suppress anything not explicitly allowed ──────────────────
+  - name: deny-unmatched
+    priority: 100
+    description: "Block any action not matched by a higher-priority rule"
+    condition:
+      field: action.tenant
+      eq: "smartbuilding-hq"
+    action:
+      type: suppress

--- a/examples/aws-event-pipeline/scripts/send-telemetry.sh
+++ b/examples/aws-event-pipeline/scripts/send-telemetry.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+# Fires ~20 sample telemetry events exercising all Acteon features with AWS providers.
+#
+# Categories:
+#   2 critical temp    → rerouted to SNS (>85°C threshold)
+#   2 intrusion        → rerouted to SNS (motion sensor)
+#   3 normal temp      → chain: normalize → detect → archive
+#   3 humidity         → grouped by floor, 30s batch
+#   2 energy           → scheduled with 60s delay
+#   3 rapid-fire       → hits throttle at 30/min
+#   2 duplicates       → same dedup_key, deduplicated
+#   2 test devices     → environment=test, suppressed
+#   1 device lifecycle → rerouted to EventBridge
+#   1 unsigned firmware → denied
+#
+# Usage: bash examples/aws-event-pipeline/scripts/send-telemetry.sh
+# Environment:
+#   ACTEON_URL - Acteon gateway URL (default: http://localhost:8080)
+set -euo pipefail
+
+ACTEON_URL="${ACTEON_URL:-http://localhost:8080}"
+
+dispatch() {
+  local label="$1"
+  shift
+  echo -n "  $label: "
+  RESPONSE=$(curl -sf -X POST "$ACTEON_URL/v1/dispatch" \
+    -H "Content-Type: application/json" \
+    -d "$1" 2>&1) || { echo "FAILED"; return; }
+  # Extract the outcome key from the response
+  OUTCOME=$(echo "$RESPONSE" | jq -r 'keys[0] // "unknown"' 2>/dev/null || echo "unknown")
+  echo "$OUTCOME"
+}
+
+CREATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+echo "=== AWS Event Pipeline: Sending Telemetry ==="
+echo ""
+
+# ── Critical temperature (2) → rerouted to SNS ────────────────────────────
+echo "Critical temperature alerts (SNS fan-out):"
+dispatch "temp-crit-floor3" '{
+  "id": "temp-crit-001",
+  "namespace": "iot",
+  "tenant": "smartbuilding-hq",
+  "provider": "metrics-queue",
+  "action_type": "sensor_reading",
+  "payload": {"device_id": "temp-sensor-301", "sensor_type": "temperature", "value": 92, "unit": "celsius", "floor": "3", "zone": "server-room"},
+  "metadata": {"source": "building-iot"},
+  "created_at": "'"$CREATED_AT"'"
+}'
+
+dispatch "temp-crit-floor5" '{
+  "id": "temp-crit-002",
+  "namespace": "iot",
+  "tenant": "smartbuilding-hq",
+  "provider": "metrics-queue",
+  "action_type": "sensor_reading",
+  "payload": {"device_id": "temp-sensor-501", "sensor_type": "temperature", "value": 88, "unit": "celsius", "floor": "5", "zone": "electrical-room"},
+  "metadata": {"source": "building-iot"},
+  "created_at": "'"$CREATED_AT"'"
+}'
+echo ""
+
+# ── Intrusion events (2) → rerouted to SNS ────────────────────────────────
+echo "Intrusion alerts (SNS fan-out):"
+dispatch "motion-lobby-001" '{
+  "id": "motion-001",
+  "namespace": "iot",
+  "tenant": "smartbuilding-hq",
+  "provider": "alert-fanout",
+  "action_type": "sensor_reading",
+  "payload": {"device_id": "motion-sensor-101", "sensor_type": "motion", "event": "intrusion", "floor": "1", "zone": "lobby"},
+  "metadata": {"source": "security-system"},
+  "created_at": "'"$CREATED_AT"'"
+}'
+
+dispatch "motion-parking-002" '{
+  "id": "motion-002",
+  "namespace": "iot",
+  "tenant": "smartbuilding-hq",
+  "provider": "alert-fanout",
+  "action_type": "sensor_reading",
+  "payload": {"device_id": "motion-sensor-B01", "sensor_type": "motion", "event": "intrusion", "floor": "B1", "zone": "parking"},
+  "metadata": {"source": "security-system"},
+  "created_at": "'"$CREATED_AT"'"
+}'
+echo ""
+
+# ── Normal temperature readings (3) → telemetry processing chain ──────────
+echo "Normal temperature readings (chain):"
+for i in 1 2 3; do
+  dispatch "temp-normal-$i" '{
+    "id": "temp-norm-00'"$i"'",
+    "namespace": "iot",
+    "tenant": "smartbuilding-hq",
+    "provider": "metrics-queue",
+    "action_type": "sensor_reading",
+    "payload": {"device_id": "temp-sensor-20'"$i"'", "sensor_type": "temperature", "value": '"$((20 + i))"', "unit": "celsius", "floor": "2", "zone": "office"},
+    "metadata": {"source": "building-iot"},
+    "created_at": "'"$CREATED_AT"'"
+  }'
+done
+echo ""
+
+# ── Humidity readings (3) → grouped by floor, 30s batch ───────────────────
+echo "Humidity readings (grouped by floor):"
+FLOORS=("2" "3" "2")
+for i in 0 1 2; do
+  FLOOR="${FLOORS[$i]}"
+  dispatch "humidity-floor$FLOOR-$i" '{
+    "id": "humid-00'"$i"'",
+    "namespace": "iot",
+    "tenant": "smartbuilding-hq",
+    "provider": "metrics-queue",
+    "action_type": "sensor_reading",
+    "payload": {"device_id": "humid-sensor-'"$FLOOR"'0'"$i"'", "sensor_type": "humidity", "value": '"$((45 + i * 5))"', "unit": "percent", "floor": "'"$FLOOR"'", "zone": "hvac"},
+    "metadata": {"source": "building-iot"},
+    "created_at": "'"$CREATED_AT"'"
+  }'
+done
+echo ""
+
+# ── Energy readings (2) → scheduled with 60s delay ────────────────────────
+echo "Energy readings (scheduled, 60s delay):"
+for i in 1 2; do
+  dispatch "energy-meter-$i" '{
+    "id": "energy-00'"$i"'",
+    "namespace": "iot",
+    "tenant": "smartbuilding-hq",
+    "provider": "metrics-queue",
+    "action_type": "sensor_reading",
+    "payload": {"device_id": "energy-meter-'"$i"'", "sensor_type": "energy", "value": '"$((250 + i * 50))"', "unit": "kwh", "floor": "'"$i"'", "zone": "main-panel"},
+    "metadata": {"source": "building-iot"},
+    "created_at": "'"$CREATED_AT"'"
+  }'
+done
+echo ""
+
+# ── Rapid-fire readings (3) → hits throttle limit ─────────────────────────
+echo "Rapid-fire readings (throttle test):"
+for i in $(seq 1 3); do
+  dispatch "rapid-$i" '{
+    "id": "rapid-'"$i"'",
+    "namespace": "iot",
+    "tenant": "smartbuilding-hq",
+    "provider": "metrics-queue",
+    "action_type": "sensor_reading",
+    "payload": {"device_id": "temp-sensor-999", "sensor_type": "temperature", "value": 22, "unit": "celsius", "floor": "1", "zone": "corridor"},
+    "metadata": {"source": "rapid-test"},
+    "created_at": "'"$CREATED_AT"'"
+  }'
+done
+echo ""
+
+# ── Duplicate readings (2) → same dedup_key, deduplicated ─────────────────
+echo "Duplicate readings (dedup test):"
+for i in 1 2; do
+  dispatch "dup-$i" '{
+    "id": "dup-temp-00'"$i"'",
+    "namespace": "iot",
+    "tenant": "smartbuilding-hq",
+    "provider": "metrics-queue",
+    "action_type": "sensor_reading",
+    "payload": {"device_id": "temp-sensor-400", "sensor_type": "temperature", "value": 25, "unit": "celsius", "floor": "4", "zone": "lab"},
+    "metadata": {"source": "building-iot"},
+    "dedup_key": "temp-sensor-400-reading",
+    "created_at": "'"$CREATED_AT"'"
+  }'
+done
+echo ""
+
+# ── Test device readings (2) → suppressed ─────────────────────────────────
+echo "Test device readings (suppressed):"
+for i in 1 2; do
+  dispatch "test-dev-$i" '{
+    "id": "test-dev-00'"$i"'",
+    "namespace": "iot",
+    "tenant": "smartbuilding-hq",
+    "provider": "metrics-queue",
+    "action_type": "sensor_reading",
+    "payload": {"device_id": "test-sensor-00'"$i"'", "sensor_type": "temperature", "value": 99, "unit": "celsius", "floor": "0", "zone": "lab", "environment": "test"},
+    "metadata": {"source": "test-harness"},
+    "created_at": "'"$CREATED_AT"'"
+  }'
+done
+echo ""
+
+# ── Device lifecycle event (1) → rerouted to EventBridge ──────────────────
+echo "Device lifecycle event (EventBridge):"
+dispatch "device-online-001" '{
+  "id": "lifecycle-001",
+  "namespace": "iot",
+  "tenant": "smartbuilding-hq",
+  "provider": "event-bus",
+  "action_type": "device_lifecycle",
+  "payload": {"device_id": "temp-sensor-301", "event": "online", "firmware_version": "3.2.1", "uptime_seconds": 0},
+  "metadata": {"source": "device-manager"},
+  "created_at": "'"$CREATED_AT"'"
+}'
+echo ""
+
+# ── Unsigned firmware update (1) → denied ──────────────────────────────────
+echo "Unsigned firmware update (denied):"
+dispatch "firmware-unsigned-001" '{
+  "id": "firmware-001",
+  "namespace": "iot",
+  "tenant": "smartbuilding-hq",
+  "provider": "metrics-queue",
+  "action_type": "firmware_update",
+  "payload": {"device_id": "temp-sensor-301", "version": "3.3.0", "signed": false, "size_bytes": 1048576},
+  "metadata": {"source": "ota-service"},
+  "created_at": "'"$CREATED_AT"'"
+}'
+echo ""
+
+echo "=== Done: ~21 telemetry events dispatched ==="
+echo ""
+echo "Expected outcomes:"
+echo "  - 2 suppressed (test devices)"
+echo "  - 1 denied (unsigned firmware)"
+echo "  - 1 deduplicated (same dedup_key)"
+echo "  - 3 grouped (humidity, batched by floor 30s)"
+echo "  - 2 scheduled (energy, 60s delay)"
+echo "  - Some throttled (if >30/min reached)"
+echo "  - 2 rerouted to SNS (critical temperature)"
+echo "  - 2 rerouted to SNS (intrusion)"
+echo "  - 3+ chain_started (normal sensor readings)"
+echo "  - 1 rerouted to EventBridge (device lifecycle)"
+echo ""
+echo "Run 'bash examples/aws-event-pipeline/scripts/show-report.sh' to see results."

--- a/examples/aws-event-pipeline/scripts/setup-api.sh
+++ b/examples/aws-event-pipeline/scripts/setup-api.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Creates API-managed resources: quota, retention policy, and recurring action.
+#
+# Usage: bash examples/aws-event-pipeline/scripts/setup-api.sh
+# Environment:
+#   ACTEON_URL - Acteon gateway URL (default: http://localhost:8080)
+set -euo pipefail
+
+ACTEON_URL="${ACTEON_URL:-http://localhost:8080}"
+
+echo "=== AWS Event Pipeline: API Setup ==="
+echo ""
+
+# ── Quota: 500 actions/hour for smartbuilding-hq ───────────────────────────
+echo "Creating quota (500 actions/hour)..."
+curl -sf -X POST "$ACTEON_URL/v1/quotas" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "iot",
+    "tenant": "smartbuilding-hq",
+    "max_actions": 500,
+    "window": "hourly",
+    "overage_behavior": "block",
+    "enabled": true,
+    "description": "500 actions per hour for smartbuilding-hq"
+  }' | jq .
+echo ""
+
+# ── Retention: audit 7 days, events 2 days ─────────────────────────────────
+echo "Creating retention policy (audit 7d, events 2d)..."
+curl -sf -X POST "$ACTEON_URL/v1/retention" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "iot",
+    "tenant": "smartbuilding-hq",
+    "enabled": true,
+    "audit_ttl_seconds": 604800,
+    "event_ttl_seconds": 172800,
+    "compliance_hold": false,
+    "description": "7-day audit, 2-day events"
+  }' | jq .
+echo ""
+
+# ── Recurring: device heartbeat check every 5 minutes ─────────────────────
+echo "Creating recurring action (heartbeat every 5 min)..."
+curl -sf -X POST "$ACTEON_URL/v1/recurring" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "iot",
+    "tenant": "smartbuilding-hq",
+    "cron_expr": "*/5 * * * *",
+    "timezone": "UTC",
+    "enabled": true,
+    "action_template": {
+      "provider": "event-bus",
+      "action_type": "device_lifecycle",
+      "payload": {
+        "event": "heartbeat_check",
+        "source": "acteon.scheduler",
+        "check_id": "heartbeat-{{execution_time}}"
+      }
+    },
+    "description": "Device heartbeat check every 5 minutes"
+  }' | jq .
+echo ""
+
+echo "Setup complete. Resources created:"
+echo "  - Quota: 500/hour for iot:smartbuilding-hq"
+echo "  - Retention: audit 7d, events 2d for iot:smartbuilding-hq"
+echo "  - Recurring: heartbeat check every 5 min via event-bus"

--- a/examples/aws-event-pipeline/scripts/setup.sh
+++ b/examples/aws-event-pipeline/scripts/setup.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Creates LocalStack AWS resources: SNS topic, Lambda functions, EventBridge bus, SQS queues.
+#
+# Prerequisites:
+#   - LocalStack running: docker run --rm -d --name localstack -p 4566:4566 localstack/localstack
+#   - awslocal CLI: pip install awscli-local
+#
+# Usage: bash examples/aws-event-pipeline/scripts/setup.sh
+set -euo pipefail
+
+ENDPOINT="http://localhost:4566"
+REGION="us-east-1"
+ACCOUNT="000000000000"
+
+export AWS_DEFAULT_REGION="$REGION"
+export AWS_ACCESS_KEY_ID="test"
+export AWS_SECRET_ACCESS_KEY="test"
+
+echo "=== AWS Event Pipeline: LocalStack Setup ==="
+echo ""
+
+# ── SNS Topic ──────────────────────────────────────────────────────────────
+echo "Creating SNS topic: building-alerts..."
+awslocal sns create-topic --name building-alerts | jq .
+echo ""
+
+# ── SQS Queues ─────────────────────────────────────────────────────────────
+echo "Creating SQS queue: telemetry-metrics..."
+awslocal sqs create-queue --queue-name telemetry-metrics | jq .
+echo ""
+
+echo "Creating SQS dead-letter queue: telemetry-dlq..."
+awslocal sqs create-queue --queue-name telemetry-dlq | jq .
+echo ""
+
+# ── EventBridge Bus ────────────────────────────────────────────────────────
+echo "Creating EventBridge bus: building-events..."
+awslocal events create-event-bus --name building-events | jq .
+echo ""
+
+# ── Lambda Functions ───────────────────────────────────────────────────────
+# Create a temporary directory for the mock Lambda code
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Mock anomaly detector: returns anomaly=true for values > 85
+cat > "$TMPDIR/anomaly_detector.py" << 'PYEOF'
+import json
+
+def handler(event, context):
+    value = float(event.get("value", 0))
+    sensor_type = event.get("sensor_type", "unknown")
+    anomaly = False
+    reason = "normal"
+
+    if sensor_type == "temperature" and value > 85:
+        anomaly = True
+        reason = "temperature_critical"
+    elif sensor_type == "humidity" and (value < 20 or value > 80):
+        anomaly = True
+        reason = "humidity_out_of_range"
+    elif sensor_type == "energy" and value > 1000:
+        anomaly = True
+        reason = "energy_spike"
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "anomaly": anomaly,
+            "reason": reason,
+            "device_id": event.get("device_id"),
+            "sensor_type": sensor_type,
+            "value": value
+        })
+    }
+PYEOF
+
+# Mock telemetry normalizer: adds timestamp and standardizes units
+cat > "$TMPDIR/normalizer.py" << 'PYEOF'
+import json
+from datetime import datetime, timezone
+
+UNIT_MAP = {
+    "temperature": "celsius",
+    "humidity": "percent",
+    "energy": "kwh",
+    "motion": "binary"
+}
+
+def handler(event, context):
+    sensor_type = event.get("sensor_type", "unknown")
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "device_id": event.get("device_id"),
+            "sensor_type": sensor_type,
+            "value": event.get("value"),
+            "unit": UNIT_MAP.get(sensor_type, event.get("unit", "unknown")),
+            "normalized_at": datetime.now(timezone.utc).isoformat(),
+            "schema_version": "2.0"
+        })
+    }
+PYEOF
+
+echo "Creating Lambda function: anomaly-detector..."
+cd "$TMPDIR" && zip -q anomaly_detector.zip anomaly_detector.py && cd -
+awslocal lambda create-function \
+  --function-name anomaly-detector \
+  --runtime python3.12 \
+  --handler anomaly_detector.handler \
+  --role "arn:aws:iam::${ACCOUNT}:role/lambda-role" \
+  --zip-file "fileb://${TMPDIR}/anomaly_detector.zip" \
+  --timeout 30 | jq '{FunctionName, Runtime, State}'
+echo ""
+
+echo "Creating Lambda function: telemetry-normalizer..."
+cd "$TMPDIR" && zip -q normalizer.zip normalizer.py && cd -
+awslocal lambda create-function \
+  --function-name telemetry-normalizer \
+  --runtime python3.12 \
+  --handler normalizer.handler \
+  --role "arn:aws:iam::${ACCOUNT}:role/lambda-role" \
+  --zip-file "fileb://${TMPDIR}/normalizer.zip" \
+  --timeout 30 | jq '{FunctionName, Runtime, State}'
+echo ""
+
+# ── DynamoDB Tables ────────────────────────────────────────────────────────
+echo "Creating DynamoDB table: acteon_state..."
+awslocal dynamodb create-table \
+  --table-name acteon_state \
+  --attribute-definitions AttributeName=pk,AttributeType=S AttributeName=sk,AttributeType=S \
+  --key-schema AttributeName=pk,KeyType=HASH AttributeName=sk,KeyType=RANGE \
+  --billing-mode PAY_PER_REQUEST 2>/dev/null | jq '{TableName: .TableDescription.TableName, Status: .TableDescription.TableStatus}' || echo "  (table may already exist)"
+echo ""
+
+echo "Creating DynamoDB table: acteon_audit..."
+awslocal dynamodb create-table \
+  --table-name acteon_audit \
+  --attribute-definitions AttributeName=pk,AttributeType=S AttributeName=sk,AttributeType=S \
+  --key-schema AttributeName=pk,KeyType=HASH AttributeName=sk,KeyType=RANGE \
+  --billing-mode PAY_PER_REQUEST 2>/dev/null | jq '{TableName: .TableDescription.TableName, Status: .TableDescription.TableStatus}' || echo "  (table may already exist)"
+echo ""
+
+echo "=== LocalStack setup complete ==="
+echo ""
+echo "Resources created:"
+echo "  - SNS topic: building-alerts"
+echo "  - Lambda: anomaly-detector (Python 3.12)"
+echo "  - Lambda: telemetry-normalizer (Python 3.12)"
+echo "  - EventBridge bus: building-events"
+echo "  - SQS queue: telemetry-metrics"
+echo "  - SQS queue: telemetry-dlq (dead-letter)"
+echo "  - DynamoDB table: acteon_state"
+echo "  - DynamoDB table: acteon_audit"

--- a/examples/aws-event-pipeline/scripts/show-report.sh
+++ b/examples/aws-event-pipeline/scripts/show-report.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Queries 8 API endpoints and displays a comprehensive pipeline report.
+#
+# Usage: bash examples/aws-event-pipeline/scripts/show-report.sh
+# Environment:
+#   ACTEON_URL - Acteon gateway URL (default: http://localhost:8080)
+set -euo pipefail
+
+ACTEON_URL="${ACTEON_URL:-http://localhost:8080}"
+NAMESPACE="iot"
+TENANT="smartbuilding-hq"
+
+echo "╔══════════════════════════════════════════════════════════════════╗"
+echo "║          AWS Event Pipeline — Report                           ║"
+echo "╚══════════════════════════════════════════════════════════════════╝"
+echo ""
+
+# ── 1. Audit trail ──────────────────────────────────────────────────────────
+echo "━━━ 1. Audit Trail ━━━"
+AUDIT=$(curl -sf "$ACTEON_URL/v1/audit?namespace=$NAMESPACE&tenant=$TENANT&limit=200" 2>/dev/null) || AUDIT='{"records":[]}'
+RECORDS=$(echo "$AUDIT" | jq '.records // []')
+TOTAL=$(echo "$RECORDS" | jq 'length')
+
+echo "Total dispatches: $TOTAL"
+echo ""
+echo "Outcome breakdown:"
+echo "$RECORDS" | jq -r '
+  group_by(.outcome) |
+  map({outcome: .[0].outcome, count: length}) |
+  sort_by(-.count) |
+  .[] |
+  "  \(.outcome): \(.count)"
+'
+echo ""
+
+# Show redaction in action (if any payloads stored)
+REDACTED=$(echo "$RECORDS" | jq '[.[] | select(.payload != null) | .payload | to_entries[] | select(.value == "[REDACTED]") | .key] | unique')
+if [ "$REDACTED" != "[]" ] && [ "$REDACTED" != "null" ]; then
+  echo "Redacted fields found in payloads: $REDACTED"
+  echo ""
+fi
+
+# ── 2. Chains ───────────────────────────────────────────────────────────────
+echo "━━━ 2. Chains ━━━"
+CHAINS=$(curl -sf "$ACTEON_URL/v1/chains?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || CHAINS='[]'
+CHAIN_COUNT=$(echo "$CHAINS" | jq 'if type == "array" then length else 0 end')
+echo "Active/completed chains: $CHAIN_COUNT"
+if [ "$CHAIN_COUNT" -gt 0 ]; then
+  echo "$CHAINS" | jq -r '
+    if type == "array" then
+      .[] |
+      "  [\(.status // "?")] \(.chain_name // "?") — started: \(.started_at // "?") step: \(.current_step_index // 0)"
+    else
+      empty
+    end
+  ' 2>/dev/null || true
+fi
+echo ""
+
+# ── 3. Events ───────────────────────────────────────────────────────────────
+echo "━━━ 3. Events ━━━"
+EVENTS=$(curl -sf "$ACTEON_URL/v1/events?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || EVENTS='[]'
+EVENT_COUNT=$(echo "$EVENTS" | jq 'if type == "array" then length else 0 end')
+echo "Tracked events: $EVENT_COUNT"
+if [ "$EVENT_COUNT" -gt 0 ]; then
+  echo "$EVENTS" | jq -r '
+    if type == "array" then
+      .[] |
+      "  [\(.state // "?")] fingerprint=\(.fingerprint // "?") updated=\(.updated_at // "?")"
+    else
+      empty
+    end
+  ' 2>/dev/null || true
+fi
+echo ""
+
+# ── 4. Provider Health ────────────────────────────────────────────────────
+echo "━━━ 4. Provider Health ━━━"
+HEALTH=$(curl -sf "$ACTEON_URL/v1/providers/health" 2>/dev/null) || HEALTH='{}'
+echo "$HEALTH" | jq -r '
+  to_entries[] |
+  "  \(.key): status=\(.value.status // "?") circuit=\(.value.circuit_breaker // "?")"
+' 2>/dev/null || echo "  (no health data)"
+echo ""
+
+# ── 5. Quotas ─────────────────────────────────────────────────────────────
+echo "━━━ 5. Quotas ━━━"
+QUOTAS=$(curl -sf "$ACTEON_URL/v1/quotas?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || QUOTAS='[]'
+QUOTA_COUNT=$(echo "$QUOTAS" | jq 'if type == "array" then length else 0 end')
+echo "Quota policies: $QUOTA_COUNT"
+if [ "$QUOTA_COUNT" -gt 0 ]; then
+  echo "$QUOTAS" | jq -r '
+    if type == "array" then
+      .[] |
+      "  \(.description // "unnamed"): \(.max_actions // "?")/\(.window // "?") [\(if .enabled then "enabled" else "disabled" end)]"
+    else
+      empty
+    end
+  ' 2>/dev/null || true
+fi
+echo ""
+
+# ── 6. Groups ─────────────────────────────────────────────────────────────
+echo "━━━ 6. Event Groups ━━━"
+GROUPS=$(curl -sf "$ACTEON_URL/v1/groups" 2>/dev/null) || GROUPS='[]'
+GROUP_COUNT=$(echo "$GROUPS" | jq 'if type == "array" then length else 0 end')
+echo "Active groups: $GROUP_COUNT"
+if [ "$GROUP_COUNT" -gt 0 ]; then
+  echo "$GROUPS" | jq -r '
+    if type == "array" then
+      .[] |
+      "  group=\(.group_key // "?") count=\(.count // 0) created=\(.created_at // "?")"
+    else
+      empty
+    end
+  ' 2>/dev/null || true
+fi
+echo ""
+
+# ── 7. Recurring Actions ──────────────────────────────────────────────────
+echo "━━━ 7. Recurring Actions ━━━"
+RECURRING=$(curl -sf "$ACTEON_URL/v1/recurring?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || RECURRING='[]'
+REC_COUNT=$(echo "$RECURRING" | jq 'if type == "array" then length else 0 end')
+echo "Recurring actions: $REC_COUNT"
+if [ "$REC_COUNT" -gt 0 ]; then
+  echo "$RECURRING" | jq -r '
+    if type == "array" then
+      .[] |
+      "  \(.description // "unnamed"): cron=\(.cron_expr // "?") executions=\(.execution_count // 0) [\(if .enabled then "active" else "paused" end)]"
+    else
+      empty
+    end
+  ' 2>/dev/null || true
+fi
+echo ""
+
+# ── 8. Retention Policies ─────────────────────────────────────────────────
+echo "━━━ 8. Retention Policies ━━━"
+RETENTION=$(curl -sf "$ACTEON_URL/v1/retention?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || RETENTION='[]'
+RET_COUNT=$(echo "$RETENTION" | jq 'if type == "array" then length else 0 end')
+echo "Retention policies: $RET_COUNT"
+if [ "$RET_COUNT" -gt 0 ]; then
+  echo "$RETENTION" | jq -r '
+    if type == "array" then
+      .[] |
+      "  \(.description // "unnamed"): audit=\(.audit_ttl_seconds // "?")s events=\(.event_ttl_seconds // "?")s [\(if .enabled then "enabled" else "disabled" end)]"
+    else
+      empty
+    end
+  ' 2>/dev/null || true
+fi
+echo ""
+
+echo "═══════════════════════════════════════════════════════════════════"
+echo "Report complete."

--- a/examples/aws-event-pipeline/scripts/teardown.sh
+++ b/examples/aws-event-pipeline/scripts/teardown.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Cleans up API-created resources (quotas, retention policies, recurring actions).
+#
+# Usage: bash examples/aws-event-pipeline/scripts/teardown.sh
+# Environment:
+#   ACTEON_URL - Acteon gateway URL (default: http://localhost:8080)
+set -euo pipefail
+
+ACTEON_URL="${ACTEON_URL:-http://localhost:8080}"
+NAMESPACE="iot"
+TENANT="smartbuilding-hq"
+
+echo "=== AWS Event Pipeline: Teardown ==="
+echo ""
+
+# ── Delete quotas ──────────────────────────────────────────────────────────
+echo "Deleting quotas..."
+QUOTAS=$(curl -sf "$ACTEON_URL/v1/quotas?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || QUOTAS='[]'
+echo "$QUOTAS" | jq -r 'if type == "array" then .[].id else empty end' 2>/dev/null | while read -r ID; do
+  echo "  Deleting quota $ID..."
+  curl -sf -X DELETE "$ACTEON_URL/v1/quotas/$ID" > /dev/null 2>&1 && echo "    done" || echo "    failed"
+done
+echo ""
+
+# ── Delete retention policies ──────────────────────────────────────────────
+echo "Deleting retention policies..."
+RETENTION=$(curl -sf "$ACTEON_URL/v1/retention?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || RETENTION='[]'
+echo "$RETENTION" | jq -r 'if type == "array" then .[].id else empty end' 2>/dev/null | while read -r ID; do
+  echo "  Deleting retention policy $ID..."
+  curl -sf -X DELETE "$ACTEON_URL/v1/retention/$ID" > /dev/null 2>&1 && echo "    done" || echo "    failed"
+done
+echo ""
+
+# ── Delete recurring actions ───────────────────────────────────────────────
+echo "Deleting recurring actions..."
+RECURRING=$(curl -sf "$ACTEON_URL/v1/recurring?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || RECURRING='[]'
+echo "$RECURRING" | jq -r 'if type == "array" then .[].id else empty end' 2>/dev/null | while read -r ID; do
+  echo "  Deleting recurring action $ID..."
+  curl -sf -X DELETE "$ACTEON_URL/v1/recurring/$ID" > /dev/null 2>&1 && echo "    done" || echo "    failed"
+done
+echo ""
+
+echo "=== Teardown complete ==="
+echo ""
+echo "To also remove LocalStack resources, stop the container:"
+echo "  docker stop localstack"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,6 +135,8 @@ nav:
     - Provider Health: features/provider-health.md
     - Grafana Dashboards: features/grafana-dashboards.md
     - WASM Plugins: features/wasm-plugins.md
+    - AWS Providers: features/aws-providers.md
+    - Native Providers: features/native-providers.md
   - Backends:
     - backends/index.md
     - State Backends: backends/state-backends.md
@@ -169,6 +171,7 @@ nav:
   - Guides:
     - guides/index.md
     - AI Agent Swarm Coordination: guides/agent-swarm-coordination.md
+    - AWS Event-Driven Pipeline: guides/aws-event-pipeline.md
   - Reference:
     - reference/index.md
     - Type Reference: reference/types.md


### PR DESCRIPTION
## Summary
- Add `acteon-aws` crate with feature-gated AWS service providers (SNS, Lambda, EventBridge, SQS, SES) and shared auth/error modules
- Refactor email provider to pluggable `EmailBackend` trait with SMTP and SES implementations
- Wire all new providers into server config and provider factory

## Details

### `acteon-aws` crate (`crates/aws/`)
- Shared AWS credential resolution with STS assume-role support
- Feature-gated providers: `sns`, `lambda`, `eventbridge`, `sqs`, `ses`
- SDK error classification for retryable vs non-retryable failures
- Manual `Debug` impls that redact credentials with `[REDACTED]`
- 51 unit tests

### Email backend refactor (`crates/integrations/email/`)
- New `EmailBackend` trait with `SmtpBackend` and `SesBackend` implementations
- `EmailProvider` wraps `Box<dyn EmailBackend>` — fully pluggable
- Backward compatible: existing SMTP configs work without changes

### Server integration (`crates/server/`)
- New provider types in config: `email` (smtp/ses), `aws-sns`, `aws-lambda`, `aws-eventbridge`, `aws-sqs`
- TOML config fields for email backend selection and AWS service settings

## Test plan
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --no-deps -- -D warnings` — clean
- [x] `cargo test --workspace --lib --bins --tests` — all pass (0 failures)
- [x] `npm run lint && npm run build` — clean
- [ ] Integration test with real AWS credentials (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)