### PR TITLE
feat: add AWS EC2 and Auto Scaling providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,8 @@ dependencies = [
  "acteon-core",
  "acteon-provider",
  "aws-config",
+ "aws-sdk-autoscaling",
+ "aws-sdk-ec2",
  "aws-sdk-eventbridge",
  "aws-sdk-lambda",
  "aws-sdk-s3",
@@ -1021,6 +1023,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-autoscaling"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffcd0bb3d8c777e815202fceee7c4c339e2bfef9cdc1700a93abd81ad25df1eb"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-dynamodb"
 version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1063,30 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ec2"
+version = "1.206.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45900e23181a7783ee0a247ccf255070b07d112968d2dc0dfc6b1facd6871c11"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
  "fastrand",
  "http 0.2.12",
  "regex-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ version = "0.1.0"
 dependencies = [
  "acteon-core",
  "acteon-provider",
+ "async-trait",
  "aws-config",
  "aws-sdk-autoscaling",
  "aws-sdk-ec2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,8 @@ aws-sdk-eventbridge = "1"
 aws-sdk-sqs = "1"
 aws-sdk-sesv2 = "1"
 aws-sdk-s3 = "1"
+aws-sdk-ec2 = "1"
+aws-sdk-autoscaling = "1"
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 
 # PostgreSQL

--- a/clients/go/acteon/models.go
+++ b/clients/go/acteon/models.go
@@ -1335,3 +1335,193 @@ func NewS3DeleteObjectPayloadWithBucket(key, bucket string) map[string]any {
 	}
 	return p
 }
+
+// =============================================================================
+// AWS EC2 Provider Payload Helpers
+// =============================================================================
+
+// NewEc2StartInstancesPayload creates a payload for the AWS EC2 start-instances action.
+func NewEc2StartInstancesPayload(instanceIDs []string) map[string]any {
+	return map[string]any{
+		"instance_ids": instanceIDs,
+	}
+}
+
+// NewEc2StopInstancesPayload creates a payload for the AWS EC2 stop-instances action.
+func NewEc2StopInstancesPayload(instanceIDs []string) map[string]any {
+	return map[string]any{
+		"instance_ids": instanceIDs,
+	}
+}
+
+// NewEc2StopInstancesPayloadWithOptions creates an EC2 stop-instances payload with optional fields.
+func NewEc2StopInstancesPayloadWithOptions(instanceIDs []string, hibernate, force bool) map[string]any {
+	p := NewEc2StopInstancesPayload(instanceIDs)
+	if hibernate {
+		p["hibernate"] = hibernate
+	}
+	if force {
+		p["force"] = force
+	}
+	return p
+}
+
+// NewEc2RebootInstancesPayload creates a payload for the AWS EC2 reboot-instances action.
+func NewEc2RebootInstancesPayload(instanceIDs []string) map[string]any {
+	return map[string]any{
+		"instance_ids": instanceIDs,
+	}
+}
+
+// NewEc2TerminateInstancesPayload creates a payload for the AWS EC2 terminate-instances action.
+func NewEc2TerminateInstancesPayload(instanceIDs []string) map[string]any {
+	return map[string]any{
+		"instance_ids": instanceIDs,
+	}
+}
+
+// NewEc2HibernateInstancesPayload creates a payload for the AWS EC2 hibernate-instances action.
+func NewEc2HibernateInstancesPayload(instanceIDs []string) map[string]any {
+	return map[string]any{
+		"instance_ids": instanceIDs,
+	}
+}
+
+// NewEc2RunInstancesPayload creates a payload for the AWS EC2 run-instances action.
+func NewEc2RunInstancesPayload(imageID, instanceType string) map[string]any {
+	return map[string]any{
+		"image_id":      imageID,
+		"instance_type": instanceType,
+	}
+}
+
+// NewEc2RunInstancesPayloadWithOptions creates an EC2 run-instances payload with optional fields.
+func NewEc2RunInstancesPayloadWithOptions(imageID, instanceType string, minCount, maxCount int, keyName, subnetID, userData, iamProfile string, sgIDs []string, tags map[string]string) map[string]any {
+	p := NewEc2RunInstancesPayload(imageID, instanceType)
+	if minCount > 0 {
+		p["min_count"] = minCount
+	}
+	if maxCount > 0 {
+		p["max_count"] = maxCount
+	}
+	if keyName != "" {
+		p["key_name"] = keyName
+	}
+	if subnetID != "" {
+		p["subnet_id"] = subnetID
+	}
+	if userData != "" {
+		p["user_data"] = userData
+	}
+	if iamProfile != "" {
+		p["iam_instance_profile"] = iamProfile
+	}
+	if len(sgIDs) > 0 {
+		p["security_group_ids"] = sgIDs
+	}
+	if len(tags) > 0 {
+		p["tags"] = tags
+	}
+	return p
+}
+
+// NewEc2AttachVolumePayload creates a payload for the AWS EC2 attach-volume action.
+func NewEc2AttachVolumePayload(volumeID, instanceID, device string) map[string]any {
+	return map[string]any{
+		"volume_id":   volumeID,
+		"instance_id": instanceID,
+		"device":      device,
+	}
+}
+
+// NewEc2DetachVolumePayload creates a payload for the AWS EC2 detach-volume action.
+func NewEc2DetachVolumePayload(volumeID string) map[string]any {
+	return map[string]any{
+		"volume_id": volumeID,
+	}
+}
+
+// NewEc2DetachVolumePayloadWithOptions creates an EC2 detach-volume payload with optional fields.
+func NewEc2DetachVolumePayloadWithOptions(volumeID, instanceID, device string, force bool) map[string]any {
+	p := NewEc2DetachVolumePayload(volumeID)
+	if instanceID != "" {
+		p["instance_id"] = instanceID
+	}
+	if device != "" {
+		p["device"] = device
+	}
+	if force {
+		p["force"] = force
+	}
+	return p
+}
+
+// NewEc2DescribeInstancesPayload creates a payload for the AWS EC2 describe-instances action.
+func NewEc2DescribeInstancesPayload(instanceIDs []string) map[string]any {
+	p := map[string]any{}
+	if len(instanceIDs) > 0 {
+		p["instance_ids"] = instanceIDs
+	}
+	return p
+}
+
+// =============================================================================
+// AWS Auto Scaling Provider Payload Helpers
+// =============================================================================
+
+// NewAsgDescribeGroupsPayload creates a payload for the AWS Auto Scaling describe-groups action.
+func NewAsgDescribeGroupsPayload(groupNames []string) map[string]any {
+	p := map[string]any{}
+	if len(groupNames) > 0 {
+		p["auto_scaling_group_names"] = groupNames
+	}
+	return p
+}
+
+// NewAsgSetDesiredCapacityPayload creates a payload for the AWS Auto Scaling set-desired-capacity action.
+func NewAsgSetDesiredCapacityPayload(groupName string, desiredCapacity int) map[string]any {
+	return map[string]any{
+		"auto_scaling_group_name": groupName,
+		"desired_capacity":       desiredCapacity,
+	}
+}
+
+// NewAsgSetDesiredCapacityPayloadWithOptions creates an Auto Scaling set-desired-capacity payload with optional fields.
+func NewAsgSetDesiredCapacityPayloadWithOptions(groupName string, desiredCapacity int, honorCooldown bool) map[string]any {
+	p := NewAsgSetDesiredCapacityPayload(groupName, desiredCapacity)
+	if honorCooldown {
+		p["honor_cooldown"] = honorCooldown
+	}
+	return p
+}
+
+// NewAsgUpdateGroupPayload creates a payload for the AWS Auto Scaling update-group action.
+func NewAsgUpdateGroupPayload(groupName string) map[string]any {
+	return map[string]any{
+		"auto_scaling_group_name": groupName,
+	}
+}
+
+// NewAsgUpdateGroupPayloadWithOptions creates an Auto Scaling update-group payload with optional fields.
+func NewAsgUpdateGroupPayloadWithOptions(groupName string, minSize, maxSize, desiredCapacity, defaultCooldown *int, healthCheckType string, healthCheckGracePeriod *int) map[string]any {
+	p := NewAsgUpdateGroupPayload(groupName)
+	if minSize != nil {
+		p["min_size"] = *minSize
+	}
+	if maxSize != nil {
+		p["max_size"] = *maxSize
+	}
+	if desiredCapacity != nil {
+		p["desired_capacity"] = *desiredCapacity
+	}
+	if defaultCooldown != nil {
+		p["default_cooldown"] = *defaultCooldown
+	}
+	if healthCheckType != "" {
+		p["health_check_type"] = healthCheckType
+	}
+	if healthCheckGracePeriod != nil {
+		p["health_check_grace_period"] = *healthCheckGracePeriod
+	}
+	return p
+}

--- a/clients/go/acteon/models_test.go
+++ b/clients/go/acteon/models_test.go
@@ -401,3 +401,251 @@ func TestPluginInvocationResponseMinimal(t *testing.T) {
 		t.Error("expected nil duration_ms")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// AWS EC2 Provider Payload Helpers
+// ---------------------------------------------------------------------------
+
+func TestNewEc2StartInstancesPayload(t *testing.T) {
+	p := NewEc2StartInstancesPayload([]string{"i-abc123", "i-def456"})
+	ids := p["instance_ids"].([]string)
+	if len(ids) != 2 || ids[0] != "i-abc123" || ids[1] != "i-def456" {
+		t.Errorf("unexpected instance_ids: %v", ids)
+	}
+}
+
+func TestNewEc2StopInstancesPayload(t *testing.T) {
+	p := NewEc2StopInstancesPayload([]string{"i-abc123"})
+	ids := p["instance_ids"].([]string)
+	if len(ids) != 1 || ids[0] != "i-abc123" {
+		t.Errorf("unexpected instance_ids: %v", ids)
+	}
+	if _, ok := p["hibernate"]; ok {
+		t.Error("expected no hibernate key in basic payload")
+	}
+	if _, ok := p["force"]; ok {
+		t.Error("expected no force key in basic payload")
+	}
+}
+
+func TestNewEc2StopInstancesPayloadWithOptions(t *testing.T) {
+	p := NewEc2StopInstancesPayloadWithOptions([]string{"i-abc123"}, true, true)
+	if p["hibernate"] != true {
+		t.Errorf("expected hibernate=true, got %v", p["hibernate"])
+	}
+	if p["force"] != true {
+		t.Errorf("expected force=true, got %v", p["force"])
+	}
+}
+
+func TestNewEc2RebootInstancesPayload(t *testing.T) {
+	p := NewEc2RebootInstancesPayload([]string{"i-abc123"})
+	ids := p["instance_ids"].([]string)
+	if len(ids) != 1 || ids[0] != "i-abc123" {
+		t.Errorf("unexpected instance_ids: %v", ids)
+	}
+}
+
+func TestNewEc2TerminateInstancesPayload(t *testing.T) {
+	p := NewEc2TerminateInstancesPayload([]string{"i-abc123", "i-def456"})
+	ids := p["instance_ids"].([]string)
+	if len(ids) != 2 {
+		t.Errorf("expected 2 instance IDs, got %d", len(ids))
+	}
+}
+
+func TestNewEc2HibernateInstancesPayload(t *testing.T) {
+	p := NewEc2HibernateInstancesPayload([]string{"i-abc123"})
+	ids := p["instance_ids"].([]string)
+	if len(ids) != 1 || ids[0] != "i-abc123" {
+		t.Errorf("unexpected instance_ids: %v", ids)
+	}
+}
+
+func TestNewEc2RunInstancesPayload(t *testing.T) {
+	p := NewEc2RunInstancesPayload("ami-12345678", "t3.micro")
+	if p["image_id"] != "ami-12345678" {
+		t.Errorf("expected image_id ami-12345678, got %v", p["image_id"])
+	}
+	if p["instance_type"] != "t3.micro" {
+		t.Errorf("expected instance_type t3.micro, got %v", p["instance_type"])
+	}
+	if _, ok := p["min_count"]; ok {
+		t.Error("expected no min_count in basic payload")
+	}
+}
+
+func TestNewEc2RunInstancesPayloadWithOptions(t *testing.T) {
+	p := NewEc2RunInstancesPayloadWithOptions(
+		"ami-12345678", "t3.large",
+		2, 5,
+		"my-keypair", "subnet-abc", "IyEvYmluL2Jhc2g=", "my-profile",
+		[]string{"sg-111", "sg-222"},
+		map[string]string{"Name": "web-server"},
+	)
+	if p["image_id"] != "ami-12345678" {
+		t.Errorf("expected image_id ami-12345678, got %v", p["image_id"])
+	}
+	if p["min_count"] != 2 {
+		t.Errorf("expected min_count 2, got %v", p["min_count"])
+	}
+	if p["max_count"] != 5 {
+		t.Errorf("expected max_count 5, got %v", p["max_count"])
+	}
+	if p["key_name"] != "my-keypair" {
+		t.Errorf("expected key_name my-keypair, got %v", p["key_name"])
+	}
+	if p["subnet_id"] != "subnet-abc" {
+		t.Errorf("expected subnet_id subnet-abc, got %v", p["subnet_id"])
+	}
+	sgIDs := p["security_group_ids"].([]string)
+	if len(sgIDs) != 2 {
+		t.Errorf("expected 2 security group IDs, got %d", len(sgIDs))
+	}
+	tags := p["tags"].(map[string]string)
+	if tags["Name"] != "web-server" {
+		t.Errorf("expected tag Name=web-server, got %v", tags["Name"])
+	}
+	if p["iam_instance_profile"] != "my-profile" {
+		t.Errorf("expected iam_instance_profile my-profile, got %v", p["iam_instance_profile"])
+	}
+}
+
+func TestNewEc2AttachVolumePayload(t *testing.T) {
+	p := NewEc2AttachVolumePayload("vol-abc123", "i-def456", "/dev/sdf")
+	if p["volume_id"] != "vol-abc123" {
+		t.Errorf("expected volume_id vol-abc123, got %v", p["volume_id"])
+	}
+	if p["instance_id"] != "i-def456" {
+		t.Errorf("expected instance_id i-def456, got %v", p["instance_id"])
+	}
+	if p["device"] != "/dev/sdf" {
+		t.Errorf("expected device /dev/sdf, got %v", p["device"])
+	}
+}
+
+func TestNewEc2DetachVolumePayload(t *testing.T) {
+	p := NewEc2DetachVolumePayload("vol-abc123")
+	if p["volume_id"] != "vol-abc123" {
+		t.Errorf("expected volume_id vol-abc123, got %v", p["volume_id"])
+	}
+	if _, ok := p["instance_id"]; ok {
+		t.Error("expected no instance_id in basic payload")
+	}
+}
+
+func TestNewEc2DetachVolumePayloadWithOptions(t *testing.T) {
+	p := NewEc2DetachVolumePayloadWithOptions("vol-abc123", "i-def456", "/dev/sdf", true)
+	if p["volume_id"] != "vol-abc123" {
+		t.Errorf("expected volume_id vol-abc123, got %v", p["volume_id"])
+	}
+	if p["instance_id"] != "i-def456" {
+		t.Errorf("expected instance_id i-def456, got %v", p["instance_id"])
+	}
+	if p["device"] != "/dev/sdf" {
+		t.Errorf("expected device /dev/sdf, got %v", p["device"])
+	}
+	if p["force"] != true {
+		t.Errorf("expected force=true, got %v", p["force"])
+	}
+}
+
+func TestNewEc2DescribeInstancesPayload(t *testing.T) {
+	p := NewEc2DescribeInstancesPayload(nil)
+	if _, ok := p["instance_ids"]; ok {
+		t.Error("expected no instance_ids when nil")
+	}
+
+	p = NewEc2DescribeInstancesPayload([]string{"i-abc123"})
+	ids := p["instance_ids"].([]string)
+	if len(ids) != 1 || ids[0] != "i-abc123" {
+		t.Errorf("unexpected instance_ids: %v", ids)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AWS Auto Scaling Provider Payload Helpers
+// ---------------------------------------------------------------------------
+
+func TestNewAsgDescribeGroupsPayload(t *testing.T) {
+	p := NewAsgDescribeGroupsPayload(nil)
+	if _, ok := p["auto_scaling_group_names"]; ok {
+		t.Error("expected no group names when nil")
+	}
+
+	p = NewAsgDescribeGroupsPayload([]string{"my-asg-1", "my-asg-2"})
+	names := p["auto_scaling_group_names"].([]string)
+	if len(names) != 2 {
+		t.Errorf("expected 2 group names, got %d", len(names))
+	}
+}
+
+func TestNewAsgSetDesiredCapacityPayload(t *testing.T) {
+	p := NewAsgSetDesiredCapacityPayload("my-asg", 5)
+	if p["auto_scaling_group_name"] != "my-asg" {
+		t.Errorf("expected group name my-asg, got %v", p["auto_scaling_group_name"])
+	}
+	if p["desired_capacity"] != 5 {
+		t.Errorf("expected desired_capacity 5, got %v", p["desired_capacity"])
+	}
+	if _, ok := p["honor_cooldown"]; ok {
+		t.Error("expected no honor_cooldown in basic payload")
+	}
+}
+
+func TestNewAsgSetDesiredCapacityPayloadWithOptions(t *testing.T) {
+	p := NewAsgSetDesiredCapacityPayloadWithOptions("my-asg", 10, true)
+	if p["auto_scaling_group_name"] != "my-asg" {
+		t.Errorf("expected group name my-asg, got %v", p["auto_scaling_group_name"])
+	}
+	if p["desired_capacity"] != 10 {
+		t.Errorf("expected desired_capacity 10, got %v", p["desired_capacity"])
+	}
+	if p["honor_cooldown"] != true {
+		t.Errorf("expected honor_cooldown=true, got %v", p["honor_cooldown"])
+	}
+}
+
+func TestNewAsgUpdateGroupPayload(t *testing.T) {
+	p := NewAsgUpdateGroupPayload("my-asg")
+	if p["auto_scaling_group_name"] != "my-asg" {
+		t.Errorf("expected group name my-asg, got %v", p["auto_scaling_group_name"])
+	}
+	if _, ok := p["min_size"]; ok {
+		t.Error("expected no min_size in basic payload")
+	}
+}
+
+func TestNewAsgUpdateGroupPayloadWithOptions(t *testing.T) {
+	minSize := 1
+	maxSize := 10
+	desiredCapacity := 5
+	defaultCooldown := 300
+	healthCheckGracePeriod := 120
+	p := NewAsgUpdateGroupPayloadWithOptions(
+		"my-asg",
+		&minSize, &maxSize, &desiredCapacity, &defaultCooldown,
+		"ELB", &healthCheckGracePeriod,
+	)
+	if p["auto_scaling_group_name"] != "my-asg" {
+		t.Errorf("expected group name my-asg, got %v", p["auto_scaling_group_name"])
+	}
+	if p["min_size"] != 1 {
+		t.Errorf("expected min_size 1, got %v", p["min_size"])
+	}
+	if p["max_size"] != 10 {
+		t.Errorf("expected max_size 10, got %v", p["max_size"])
+	}
+	if p["desired_capacity"] != 5 {
+		t.Errorf("expected desired_capacity 5, got %v", p["desired_capacity"])
+	}
+	if p["default_cooldown"] != 300 {
+		t.Errorf("expected default_cooldown 300, got %v", p["default_cooldown"])
+	}
+	if p["health_check_type"] != "ELB" {
+		t.Errorf("expected health_check_type ELB, got %v", p["health_check_type"])
+	}
+	if p["health_check_grace_period"] != 120 {
+		t.Errorf("expected health_check_grace_period 120, got %v", p["health_check_grace_period"])
+	}
+}

--- a/clients/java/src/main/java/com/acteon/client/models/AsgDescribeGroupsPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/AsgDescribeGroupsPayload.java
@@ -1,0 +1,27 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS Auto Scaling describe-groups action
+ * ({@code aws-autoscaling}, action type {@code describe_auto_scaling_groups}).
+ */
+public class AsgDescribeGroupsPayload {
+    private List<String> groupNames;
+
+    public AsgDescribeGroupsPayload() {
+    }
+
+    public AsgDescribeGroupsPayload withGroupNames(List<String> groupNames) {
+        this.groupNames = groupNames;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        if (groupNames != null) payload.put("auto_scaling_group_names", groupNames);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/AsgSetCapacityPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/AsgSetCapacityPayload.java
@@ -1,0 +1,32 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS Auto Scaling set-desired-capacity action
+ * ({@code aws-autoscaling}, action type {@code set_desired_capacity}).
+ */
+public class AsgSetCapacityPayload {
+    private final String groupName;
+    private final int desiredCapacity;
+    private Boolean honorCooldown;
+
+    public AsgSetCapacityPayload(String groupName, int desiredCapacity) {
+        this.groupName = groupName;
+        this.desiredCapacity = desiredCapacity;
+    }
+
+    public AsgSetCapacityPayload withHonorCooldown(boolean honorCooldown) {
+        this.honorCooldown = honorCooldown;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("auto_scaling_group_name", groupName);
+        payload.put("desired_capacity", desiredCapacity);
+        if (honorCooldown != null) payload.put("honor_cooldown", honorCooldown);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/AsgUpdateGroupPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/AsgUpdateGroupPayload.java
@@ -1,0 +1,64 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS Auto Scaling update-group action
+ * ({@code aws-autoscaling}, action type {@code update_auto_scaling_group}).
+ */
+public class AsgUpdateGroupPayload {
+    private final String groupName;
+    private Integer minSize;
+    private Integer maxSize;
+    private Integer desiredCapacity;
+    private Integer defaultCooldown;
+    private String healthCheckType;
+    private Integer healthCheckGracePeriod;
+
+    public AsgUpdateGroupPayload(String groupName) {
+        this.groupName = groupName;
+    }
+
+    public AsgUpdateGroupPayload withMinSize(Integer minSize) {
+        this.minSize = minSize;
+        return this;
+    }
+
+    public AsgUpdateGroupPayload withMaxSize(Integer maxSize) {
+        this.maxSize = maxSize;
+        return this;
+    }
+
+    public AsgUpdateGroupPayload withDesiredCapacity(Integer desiredCapacity) {
+        this.desiredCapacity = desiredCapacity;
+        return this;
+    }
+
+    public AsgUpdateGroupPayload withDefaultCooldown(Integer defaultCooldown) {
+        this.defaultCooldown = defaultCooldown;
+        return this;
+    }
+
+    public AsgUpdateGroupPayload withHealthCheckType(String healthCheckType) {
+        this.healthCheckType = healthCheckType;
+        return this;
+    }
+
+    public AsgUpdateGroupPayload withHealthCheckGracePeriod(Integer healthCheckGracePeriod) {
+        this.healthCheckGracePeriod = healthCheckGracePeriod;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("auto_scaling_group_name", groupName);
+        if (minSize != null) payload.put("min_size", minSize);
+        if (maxSize != null) payload.put("max_size", maxSize);
+        if (desiredCapacity != null) payload.put("desired_capacity", desiredCapacity);
+        if (defaultCooldown != null) payload.put("default_cooldown", defaultCooldown);
+        if (healthCheckType != null) payload.put("health_check_type", healthCheckType);
+        if (healthCheckGracePeriod != null) payload.put("health_check_grace_period", healthCheckGracePeriod);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/Ec2AttachVolumePayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/Ec2AttachVolumePayload.java
@@ -1,0 +1,27 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS EC2 attach-volume action ({@code aws-ec2}, action type {@code attach_volume}).
+ */
+public class Ec2AttachVolumePayload {
+    private final String volumeId;
+    private final String instanceId;
+    private final String device;
+
+    public Ec2AttachVolumePayload(String volumeId, String instanceId, String device) {
+        this.volumeId = volumeId;
+        this.instanceId = instanceId;
+        this.device = device;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("volume_id", volumeId);
+        payload.put("instance_id", instanceId);
+        payload.put("device", device);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/Ec2DescribeInstancesPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/Ec2DescribeInstancesPayload.java
@@ -1,0 +1,26 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS EC2 describe-instances action ({@code aws-ec2}, action type {@code describe_instances}).
+ */
+public class Ec2DescribeInstancesPayload {
+    private List<String> instanceIds;
+
+    public Ec2DescribeInstancesPayload() {
+    }
+
+    public Ec2DescribeInstancesPayload withInstanceIds(List<String> instanceIds) {
+        this.instanceIds = instanceIds;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        if (instanceIds != null) payload.put("instance_ids", instanceIds);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/Ec2DetachVolumePayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/Ec2DetachVolumePayload.java
@@ -1,0 +1,42 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS EC2 detach-volume action ({@code aws-ec2}, action type {@code detach_volume}).
+ */
+public class Ec2DetachVolumePayload {
+    private final String volumeId;
+    private String instanceId;
+    private String device;
+    private Boolean force;
+
+    public Ec2DetachVolumePayload(String volumeId) {
+        this.volumeId = volumeId;
+    }
+
+    public Ec2DetachVolumePayload withInstanceId(String instanceId) {
+        this.instanceId = instanceId;
+        return this;
+    }
+
+    public Ec2DetachVolumePayload withDevice(String device) {
+        this.device = device;
+        return this;
+    }
+
+    public Ec2DetachVolumePayload withForce(boolean force) {
+        this.force = force;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("volume_id", volumeId);
+        if (instanceId != null) payload.put("instance_id", instanceId);
+        if (device != null) payload.put("device", device);
+        if (force != null) payload.put("force", force);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/Ec2RunInstancesPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/Ec2RunInstancesPayload.java
@@ -1,0 +1,81 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS EC2 run-instances action ({@code aws-ec2}, action type {@code run_instances}).
+ */
+public class Ec2RunInstancesPayload {
+    private final String imageId;
+    private final String instanceType;
+    private Integer minCount;
+    private Integer maxCount;
+    private String keyName;
+    private List<String> securityGroupIds;
+    private String subnetId;
+    private String userData;
+    private Map<String, String> tags;
+    private String iamInstanceProfile;
+
+    public Ec2RunInstancesPayload(String imageId, String instanceType) {
+        this.imageId = imageId;
+        this.instanceType = instanceType;
+    }
+
+    public Ec2RunInstancesPayload withMinCount(int minCount) {
+        this.minCount = minCount;
+        return this;
+    }
+
+    public Ec2RunInstancesPayload withMaxCount(int maxCount) {
+        this.maxCount = maxCount;
+        return this;
+    }
+
+    public Ec2RunInstancesPayload withKeyName(String keyName) {
+        this.keyName = keyName;
+        return this;
+    }
+
+    public Ec2RunInstancesPayload withSecurityGroupIds(List<String> securityGroupIds) {
+        this.securityGroupIds = securityGroupIds;
+        return this;
+    }
+
+    public Ec2RunInstancesPayload withSubnetId(String subnetId) {
+        this.subnetId = subnetId;
+        return this;
+    }
+
+    public Ec2RunInstancesPayload withUserData(String userData) {
+        this.userData = userData;
+        return this;
+    }
+
+    public Ec2RunInstancesPayload withTags(Map<String, String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
+    public Ec2RunInstancesPayload withIamInstanceProfile(String iamInstanceProfile) {
+        this.iamInstanceProfile = iamInstanceProfile;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("image_id", imageId);
+        payload.put("instance_type", instanceType);
+        if (minCount != null) payload.put("min_count", minCount);
+        if (maxCount != null) payload.put("max_count", maxCount);
+        if (keyName != null) payload.put("key_name", keyName);
+        if (securityGroupIds != null) payload.put("security_group_ids", securityGroupIds);
+        if (subnetId != null) payload.put("subnet_id", subnetId);
+        if (userData != null) payload.put("user_data", userData);
+        if (tags != null) payload.put("tags", tags);
+        if (iamInstanceProfile != null) payload.put("iam_instance_profile", iamInstanceProfile);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/Ec2StartInstancesPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/Ec2StartInstancesPayload.java
@@ -1,0 +1,22 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS EC2 start-instances action ({@code aws-ec2}, action type {@code start_instances}).
+ */
+public class Ec2StartInstancesPayload {
+    private final List<String> instanceIds;
+
+    public Ec2StartInstancesPayload(List<String> instanceIds) {
+        this.instanceIds = instanceIds;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("instance_ids", instanceIds);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/Ec2StopInstancesPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/Ec2StopInstancesPayload.java
@@ -1,0 +1,36 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Payload builder for the AWS EC2 stop-instances action ({@code aws-ec2}, action type {@code stop_instances}).
+ */
+public class Ec2StopInstancesPayload {
+    private final List<String> instanceIds;
+    private Boolean hibernate;
+    private Boolean force;
+
+    public Ec2StopInstancesPayload(List<String> instanceIds) {
+        this.instanceIds = instanceIds;
+    }
+
+    public Ec2StopInstancesPayload withHibernate(boolean hibernate) {
+        this.hibernate = hibernate;
+        return this;
+    }
+
+    public Ec2StopInstancesPayload withForce(boolean force) {
+        this.force = force;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("instance_ids", instanceIds);
+        if (hibernate != null) payload.put("hibernate", hibernate);
+        if (force != null) payload.put("force", force);
+        return payload;
+    }
+}

--- a/clients/java/src/test/java/com/acteon/client/models/Ec2AutoScalingPayloadTest.java
+++ b/clients/java/src/test/java/com/acteon/client/models/Ec2AutoScalingPayloadTest.java
@@ -1,0 +1,234 @@
+package com.acteon.client.models;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class Ec2AutoScalingPayloadTest {
+
+    // =========================================================================
+    // EC2 Start Instances
+    // =========================================================================
+
+    @Test
+    void ec2StartInstancesBasic() {
+        Map<String, Object> payload = new Ec2StartInstancesPayload(
+                List.of("i-abc123", "i-def456")
+        ).toPayload();
+
+        assertEquals(List.of("i-abc123", "i-def456"), payload.get("instance_ids"));
+    }
+
+    // =========================================================================
+    // EC2 Stop Instances
+    // =========================================================================
+
+    @Test
+    void ec2StopInstancesBasic() {
+        Map<String, Object> payload = new Ec2StopInstancesPayload(
+                List.of("i-abc123")
+        ).toPayload();
+
+        assertEquals(List.of("i-abc123"), payload.get("instance_ids"));
+        assertFalse(payload.containsKey("hibernate"));
+        assertFalse(payload.containsKey("force"));
+    }
+
+    @Test
+    void ec2StopInstancesWithOptions() {
+        Map<String, Object> payload = new Ec2StopInstancesPayload(
+                List.of("i-abc123", "i-def456")
+        ).withHibernate(true).withForce(true).toPayload();
+
+        assertEquals(List.of("i-abc123", "i-def456"), payload.get("instance_ids"));
+        assertEquals(true, payload.get("hibernate"));
+        assertEquals(true, payload.get("force"));
+    }
+
+    // =========================================================================
+    // EC2 Run Instances
+    // =========================================================================
+
+    @Test
+    void ec2RunInstancesBasic() {
+        Map<String, Object> payload = new Ec2RunInstancesPayload(
+                "ami-12345678", "t3.micro"
+        ).toPayload();
+
+        assertEquals("ami-12345678", payload.get("image_id"));
+        assertEquals("t3.micro", payload.get("instance_type"));
+        assertFalse(payload.containsKey("min_count"));
+        assertFalse(payload.containsKey("key_name"));
+        assertFalse(payload.containsKey("tags"));
+    }
+
+    @Test
+    void ec2RunInstancesWithAllOptions() {
+        Map<String, Object> payload = new Ec2RunInstancesPayload("ami-12345678", "t3.large")
+                .withMinCount(2)
+                .withMaxCount(5)
+                .withKeyName("my-keypair")
+                .withSecurityGroupIds(List.of("sg-111", "sg-222"))
+                .withSubnetId("subnet-abc")
+                .withUserData("IyEvYmluL2Jhc2g=")
+                .withTags(Map.of("Name", "web-server", "env", "staging"))
+                .withIamInstanceProfile("arn:aws:iam::123456789012:instance-profile/role")
+                .toPayload();
+
+        assertEquals("ami-12345678", payload.get("image_id"));
+        assertEquals("t3.large", payload.get("instance_type"));
+        assertEquals(2, payload.get("min_count"));
+        assertEquals(5, payload.get("max_count"));
+        assertEquals("my-keypair", payload.get("key_name"));
+        assertEquals(List.of("sg-111", "sg-222"), payload.get("security_group_ids"));
+        assertEquals("subnet-abc", payload.get("subnet_id"));
+        assertEquals("IyEvYmluL2Jhc2g=", payload.get("user_data"));
+        assertEquals("arn:aws:iam::123456789012:instance-profile/role", payload.get("iam_instance_profile"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> tags = (Map<String, String>) payload.get("tags");
+        assertEquals("web-server", tags.get("Name"));
+        assertEquals("staging", tags.get("env"));
+    }
+
+    // =========================================================================
+    // EC2 Attach Volume
+    // =========================================================================
+
+    @Test
+    void ec2AttachVolumeBasic() {
+        Map<String, Object> payload = new Ec2AttachVolumePayload(
+                "vol-abc123", "i-def456", "/dev/sdf"
+        ).toPayload();
+
+        assertEquals("vol-abc123", payload.get("volume_id"));
+        assertEquals("i-def456", payload.get("instance_id"));
+        assertEquals("/dev/sdf", payload.get("device"));
+    }
+
+    // =========================================================================
+    // EC2 Detach Volume
+    // =========================================================================
+
+    @Test
+    void ec2DetachVolumeBasic() {
+        Map<String, Object> payload = new Ec2DetachVolumePayload("vol-abc123").toPayload();
+
+        assertEquals("vol-abc123", payload.get("volume_id"));
+        assertFalse(payload.containsKey("instance_id"));
+        assertFalse(payload.containsKey("device"));
+        assertFalse(payload.containsKey("force"));
+    }
+
+    @Test
+    void ec2DetachVolumeWithOptions() {
+        Map<String, Object> payload = new Ec2DetachVolumePayload("vol-abc123")
+                .withInstanceId("i-def456")
+                .withDevice("/dev/sdf")
+                .withForce(true)
+                .toPayload();
+
+        assertEquals("vol-abc123", payload.get("volume_id"));
+        assertEquals("i-def456", payload.get("instance_id"));
+        assertEquals("/dev/sdf", payload.get("device"));
+        assertEquals(true, payload.get("force"));
+    }
+
+    // =========================================================================
+    // EC2 Describe Instances
+    // =========================================================================
+
+    @Test
+    void ec2DescribeInstancesEmpty() {
+        Map<String, Object> payload = new Ec2DescribeInstancesPayload().toPayload();
+        assertFalse(payload.containsKey("instance_ids"));
+    }
+
+    @Test
+    void ec2DescribeInstancesWithIds() {
+        Map<String, Object> payload = new Ec2DescribeInstancesPayload()
+                .withInstanceIds(List.of("i-abc123", "i-def456"))
+                .toPayload();
+
+        assertEquals(List.of("i-abc123", "i-def456"), payload.get("instance_ids"));
+    }
+
+    // =========================================================================
+    // Auto Scaling Describe Groups
+    // =========================================================================
+
+    @Test
+    void asgDescribeGroupsEmpty() {
+        Map<String, Object> payload = new AsgDescribeGroupsPayload().toPayload();
+        assertFalse(payload.containsKey("auto_scaling_group_names"));
+    }
+
+    @Test
+    void asgDescribeGroupsWithNames() {
+        Map<String, Object> payload = new AsgDescribeGroupsPayload()
+                .withGroupNames(List.of("my-asg-1", "my-asg-2"))
+                .toPayload();
+
+        assertEquals(List.of("my-asg-1", "my-asg-2"), payload.get("auto_scaling_group_names"));
+    }
+
+    // =========================================================================
+    // Auto Scaling Set Desired Capacity
+    // =========================================================================
+
+    @Test
+    void asgSetCapacityBasic() {
+        Map<String, Object> payload = new AsgSetCapacityPayload("my-asg", 5).toPayload();
+
+        assertEquals("my-asg", payload.get("auto_scaling_group_name"));
+        assertEquals(5, payload.get("desired_capacity"));
+        assertFalse(payload.containsKey("honor_cooldown"));
+    }
+
+    @Test
+    void asgSetCapacityWithHonorCooldown() {
+        Map<String, Object> payload = new AsgSetCapacityPayload("my-asg", 10)
+                .withHonorCooldown(true)
+                .toPayload();
+
+        assertEquals("my-asg", payload.get("auto_scaling_group_name"));
+        assertEquals(10, payload.get("desired_capacity"));
+        assertEquals(true, payload.get("honor_cooldown"));
+    }
+
+    // =========================================================================
+    // Auto Scaling Update Group
+    // =========================================================================
+
+    @Test
+    void asgUpdateGroupBasic() {
+        Map<String, Object> payload = new AsgUpdateGroupPayload("my-asg").toPayload();
+
+        assertEquals("my-asg", payload.get("auto_scaling_group_name"));
+        assertFalse(payload.containsKey("min_size"));
+        assertFalse(payload.containsKey("max_size"));
+    }
+
+    @Test
+    void asgUpdateGroupWithAllOptions() {
+        Map<String, Object> payload = new AsgUpdateGroupPayload("my-asg")
+                .withMinSize(1)
+                .withMaxSize(10)
+                .withDesiredCapacity(5)
+                .withDefaultCooldown(300)
+                .withHealthCheckType("ELB")
+                .withHealthCheckGracePeriod(120)
+                .toPayload();
+
+        assertEquals("my-asg", payload.get("auto_scaling_group_name"));
+        assertEquals(1, payload.get("min_size"));
+        assertEquals(10, payload.get("max_size"));
+        assertEquals(5, payload.get("desired_capacity"));
+        assertEquals(300, payload.get("default_cooldown"));
+        assertEquals("ELB", payload.get("health_check_type"));
+        assertEquals(120, payload.get("health_check_grace_period"));
+    }
+}

--- a/clients/nodejs/src/models.ts
+++ b/clients/nodejs/src/models.ts
@@ -2140,3 +2140,250 @@ export function createS3DeleteObjectPayload(
   if (options?.bucket) payload.bucket = options.bucket;
   return payload;
 }
+
+// =============================================================================
+// AWS EC2 Provider Payload Helpers
+// =============================================================================
+
+/** Payload for the AWS EC2 start-instances action. */
+export interface Ec2StartInstancesPayload {
+  instance_ids: string[];
+}
+
+/** Create a payload for the AWS EC2 start-instances action. */
+export function createEc2StartInstancesPayload(
+  instanceIds: string[]
+): Record<string, unknown> {
+  return { instance_ids: instanceIds };
+}
+
+/** Payload for the AWS EC2 stop-instances action. */
+export interface Ec2StopInstancesPayload {
+  instance_ids: string[];
+  hibernate?: boolean;
+  force?: boolean;
+}
+
+/** Create a payload for the AWS EC2 stop-instances action. */
+export function createEc2StopInstancesPayload(
+  instanceIds: string[],
+  options?: { hibernate?: boolean; force?: boolean }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { instance_ids: instanceIds };
+  if (options?.hibernate !== undefined) payload.hibernate = options.hibernate;
+  if (options?.force !== undefined) payload.force = options.force;
+  return payload;
+}
+
+/** Payload for the AWS EC2 reboot-instances action. */
+export interface Ec2RebootInstancesPayload {
+  instance_ids: string[];
+}
+
+/** Create a payload for the AWS EC2 reboot-instances action. */
+export function createEc2RebootInstancesPayload(
+  instanceIds: string[]
+): Record<string, unknown> {
+  return { instance_ids: instanceIds };
+}
+
+/** Payload for the AWS EC2 terminate-instances action. */
+export interface Ec2TerminateInstancesPayload {
+  instance_ids: string[];
+}
+
+/** Create a payload for the AWS EC2 terminate-instances action. */
+export function createEc2TerminateInstancesPayload(
+  instanceIds: string[]
+): Record<string, unknown> {
+  return { instance_ids: instanceIds };
+}
+
+/** Create a payload for the AWS EC2 hibernate-instances action. */
+export function createEc2HibernateInstancesPayload(
+  instanceIds: string[]
+): Record<string, unknown> {
+  return { instance_ids: instanceIds };
+}
+
+/** Payload for the AWS EC2 run-instances action. */
+export interface Ec2RunInstancesPayload {
+  image_id: string;
+  instance_type: string;
+  min_count?: number;
+  max_count?: number;
+  key_name?: string;
+  security_group_ids?: string[];
+  subnet_id?: string;
+  user_data?: string;
+  tags?: Record<string, string>;
+  iam_instance_profile?: string;
+}
+
+/** Create a payload for the AWS EC2 run-instances action. */
+export function createEc2RunInstancesPayload(
+  imageId: string,
+  instanceType: string,
+  options?: {
+    minCount?: number;
+    maxCount?: number;
+    keyName?: string;
+    securityGroupIds?: string[];
+    subnetId?: string;
+    userData?: string;
+    tags?: Record<string, string>;
+    iamInstanceProfile?: string;
+  }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    image_id: imageId,
+    instance_type: instanceType,
+  };
+  if (options?.minCount !== undefined) payload.min_count = options.minCount;
+  if (options?.maxCount !== undefined) payload.max_count = options.maxCount;
+  if (options?.keyName !== undefined) payload.key_name = options.keyName;
+  if (options?.securityGroupIds !== undefined)
+    payload.security_group_ids = options.securityGroupIds;
+  if (options?.subnetId !== undefined) payload.subnet_id = options.subnetId;
+  if (options?.userData !== undefined) payload.user_data = options.userData;
+  if (options?.tags !== undefined) payload.tags = options.tags;
+  if (options?.iamInstanceProfile !== undefined)
+    payload.iam_instance_profile = options.iamInstanceProfile;
+  return payload;
+}
+
+/** Payload for the AWS EC2 attach-volume action. */
+export interface Ec2AttachVolumePayload {
+  volume_id: string;
+  instance_id: string;
+  device: string;
+}
+
+/** Create a payload for the AWS EC2 attach-volume action. */
+export function createEc2AttachVolumePayload(
+  volumeId: string,
+  instanceId: string,
+  device: string
+): Record<string, unknown> {
+  return {
+    volume_id: volumeId,
+    instance_id: instanceId,
+    device,
+  };
+}
+
+/** Payload for the AWS EC2 detach-volume action. */
+export interface Ec2DetachVolumePayload {
+  volume_id: string;
+  instance_id?: string;
+  device?: string;
+  force?: boolean;
+}
+
+/** Create a payload for the AWS EC2 detach-volume action. */
+export function createEc2DetachVolumePayload(
+  volumeId: string,
+  options?: { instanceId?: string; device?: string; force?: boolean }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { volume_id: volumeId };
+  if (options?.instanceId !== undefined)
+    payload.instance_id = options.instanceId;
+  if (options?.device !== undefined) payload.device = options.device;
+  if (options?.force !== undefined) payload.force = options.force;
+  return payload;
+}
+
+/** Payload for the AWS EC2 describe-instances action. */
+export interface Ec2DescribeInstancesPayload {
+  instance_ids?: string[];
+}
+
+/** Create a payload for the AWS EC2 describe-instances action. */
+export function createEc2DescribeInstancesPayload(
+  options?: { instanceIds?: string[] }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  if (options?.instanceIds !== undefined)
+    payload.instance_ids = options.instanceIds;
+  return payload;
+}
+
+// =============================================================================
+// AWS Auto Scaling Provider Payload Helpers
+// =============================================================================
+
+/** Payload for the AWS Auto Scaling describe-groups action. */
+export interface AsgDescribeGroupsPayload {
+  auto_scaling_group_names?: string[];
+}
+
+/** Create a payload for the AWS Auto Scaling describe-groups action. */
+export function createAsgDescribeGroupsPayload(
+  options?: { groupNames?: string[] }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  if (options?.groupNames !== undefined)
+    payload.auto_scaling_group_names = options.groupNames;
+  return payload;
+}
+
+/** Payload for the AWS Auto Scaling set-desired-capacity action. */
+export interface AsgSetDesiredCapacityPayload {
+  auto_scaling_group_name: string;
+  desired_capacity: number;
+  honor_cooldown?: boolean;
+}
+
+/** Create a payload for the AWS Auto Scaling set-desired-capacity action. */
+export function createAsgSetDesiredCapacityPayload(
+  groupName: string,
+  desiredCapacity: number,
+  options?: { honorCooldown?: boolean }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    auto_scaling_group_name: groupName,
+    desired_capacity: desiredCapacity,
+  };
+  if (options?.honorCooldown !== undefined)
+    payload.honor_cooldown = options.honorCooldown;
+  return payload;
+}
+
+/** Payload for the AWS Auto Scaling update-group action. */
+export interface AsgUpdateGroupPayload {
+  auto_scaling_group_name: string;
+  min_size?: number;
+  max_size?: number;
+  desired_capacity?: number;
+  default_cooldown?: number;
+  health_check_type?: string;
+  health_check_grace_period?: number;
+}
+
+/** Create a payload for the AWS Auto Scaling update-group action. */
+export function createAsgUpdateGroupPayload(
+  groupName: string,
+  options?: {
+    minSize?: number;
+    maxSize?: number;
+    desiredCapacity?: number;
+    defaultCooldown?: number;
+    healthCheckType?: string;
+    healthCheckGracePeriod?: number;
+  }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    auto_scaling_group_name: groupName,
+  };
+  if (options?.minSize !== undefined) payload.min_size = options.minSize;
+  if (options?.maxSize !== undefined) payload.max_size = options.maxSize;
+  if (options?.desiredCapacity !== undefined)
+    payload.desired_capacity = options.desiredCapacity;
+  if (options?.defaultCooldown !== undefined)
+    payload.default_cooldown = options.defaultCooldown;
+  if (options?.healthCheckType !== undefined)
+    payload.health_check_type = options.healthCheckType;
+  if (options?.healthCheckGracePeriod !== undefined)
+    payload.health_check_grace_period = options.healthCheckGracePeriod;
+  return payload;
+}

--- a/clients/python/acteon_client/models.py
+++ b/clients/python/acteon_client/models.py
@@ -2403,3 +2403,311 @@ def s3_delete_object_payload(
     if bucket is not None:
         payload["bucket"] = bucket
     return payload
+
+
+# =============================================================================
+# AWS EC2 Provider Payload Helpers
+# =============================================================================
+
+
+def ec2_start_instances_payload(
+    instance_ids: List[str],
+) -> dict[str, Any]:
+    """Build a payload for the AWS EC2 start-instances action.
+
+    Args:
+        instance_ids: List of EC2 instance IDs to start.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-ec2`` provider
+        with action type ``start_instances``.
+    """
+    return {"instance_ids": instance_ids}
+
+
+def ec2_stop_instances_payload(
+    instance_ids: List[str],
+    *,
+    hibernate: Optional[bool] = None,
+    force: Optional[bool] = None,
+) -> dict[str, Any]:
+    """Build a payload for the AWS EC2 stop-instances action.
+
+    Args:
+        instance_ids: List of EC2 instance IDs to stop.
+        hibernate: Whether to hibernate the instances instead of stopping.
+        force: Whether to force stop the instances.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-ec2`` provider
+        with action type ``stop_instances``.
+    """
+    payload: dict[str, Any] = {"instance_ids": instance_ids}
+    if hibernate is not None:
+        payload["hibernate"] = hibernate
+    if force is not None:
+        payload["force"] = force
+    return payload
+
+
+def ec2_reboot_instances_payload(
+    instance_ids: List[str],
+) -> dict[str, Any]:
+    """Build a payload for the AWS EC2 reboot-instances action.
+
+    Args:
+        instance_ids: List of EC2 instance IDs to reboot.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-ec2`` provider
+        with action type ``reboot_instances``.
+    """
+    return {"instance_ids": instance_ids}
+
+
+def ec2_terminate_instances_payload(
+    instance_ids: List[str],
+) -> dict[str, Any]:
+    """Build a payload for the AWS EC2 terminate-instances action.
+
+    Args:
+        instance_ids: List of EC2 instance IDs to terminate.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-ec2`` provider
+        with action type ``terminate_instances``.
+    """
+    return {"instance_ids": instance_ids}
+
+
+def ec2_hibernate_instances_payload(
+    instance_ids: List[str],
+) -> dict[str, Any]:
+    """Build a payload for the AWS EC2 hibernate-instances action.
+
+    Args:
+        instance_ids: List of EC2 instance IDs to hibernate.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-ec2`` provider
+        with action type ``hibernate_instances``.
+    """
+    return {"instance_ids": instance_ids}
+
+
+def ec2_run_instances_payload(
+    image_id: str,
+    instance_type: str,
+    *,
+    min_count: Optional[int] = None,
+    max_count: Optional[int] = None,
+    key_name: Optional[str] = None,
+    security_group_ids: Optional[List[str]] = None,
+    subnet_id: Optional[str] = None,
+    user_data: Optional[str] = None,
+    tags: Optional[dict[str, str]] = None,
+    iam_instance_profile: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a payload for the AWS EC2 run-instances action.
+
+    Args:
+        image_id: AMI ID to launch.
+        instance_type: EC2 instance type (e.g., ``"t3.micro"``).
+        min_count: Minimum number of instances to launch.
+        max_count: Maximum number of instances to launch.
+        key_name: Name of the key pair for SSH access.
+        security_group_ids: List of security group IDs.
+        subnet_id: VPC subnet ID to launch into.
+        user_data: Base64-encoded user data script.
+        tags: Tags to apply to the launched instances.
+        iam_instance_profile: IAM instance profile name or ARN.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-ec2`` provider
+        with action type ``run_instances``.
+    """
+    payload: dict[str, Any] = {
+        "image_id": image_id,
+        "instance_type": instance_type,
+    }
+    if min_count is not None:
+        payload["min_count"] = min_count
+    if max_count is not None:
+        payload["max_count"] = max_count
+    if key_name is not None:
+        payload["key_name"] = key_name
+    if security_group_ids is not None:
+        payload["security_group_ids"] = security_group_ids
+    if subnet_id is not None:
+        payload["subnet_id"] = subnet_id
+    if user_data is not None:
+        payload["user_data"] = user_data
+    if tags is not None:
+        payload["tags"] = tags
+    if iam_instance_profile is not None:
+        payload["iam_instance_profile"] = iam_instance_profile
+    return payload
+
+
+def ec2_attach_volume_payload(
+    volume_id: str,
+    instance_id: str,
+    device: str,
+) -> dict[str, Any]:
+    """Build a payload for the AWS EC2 attach-volume action.
+
+    Args:
+        volume_id: EBS volume ID to attach.
+        instance_id: EC2 instance ID to attach the volume to.
+        device: Device name (e.g., ``"/dev/sdf"``).
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-ec2`` provider
+        with action type ``attach_volume``.
+    """
+    return {
+        "volume_id": volume_id,
+        "instance_id": instance_id,
+        "device": device,
+    }
+
+
+def ec2_detach_volume_payload(
+    volume_id: str,
+    *,
+    instance_id: Optional[str] = None,
+    device: Optional[str] = None,
+    force: Optional[bool] = None,
+) -> dict[str, Any]:
+    """Build a payload for the AWS EC2 detach-volume action.
+
+    Args:
+        volume_id: EBS volume ID to detach.
+        instance_id: EC2 instance ID to detach the volume from.
+        device: Device name.
+        force: Whether to force detach the volume.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-ec2`` provider
+        with action type ``detach_volume``.
+    """
+    payload: dict[str, Any] = {"volume_id": volume_id}
+    if instance_id is not None:
+        payload["instance_id"] = instance_id
+    if device is not None:
+        payload["device"] = device
+    if force is not None:
+        payload["force"] = force
+    return payload
+
+
+def ec2_describe_instances_payload(
+    *,
+    instance_ids: Optional[List[str]] = None,
+) -> dict[str, Any]:
+    """Build a payload for the AWS EC2 describe-instances action.
+
+    Args:
+        instance_ids: Optional list of EC2 instance IDs to describe.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-ec2`` provider
+        with action type ``describe_instances``.
+    """
+    payload: dict[str, Any] = {}
+    if instance_ids is not None:
+        payload["instance_ids"] = instance_ids
+    return payload
+
+
+# =============================================================================
+# AWS Auto Scaling Provider Payload Helpers
+# =============================================================================
+
+
+def autoscaling_describe_groups_payload(
+    *,
+    group_names: Optional[List[str]] = None,
+) -> dict[str, Any]:
+    """Build a payload for the AWS Auto Scaling describe-groups action.
+
+    Args:
+        group_names: Optional list of Auto Scaling group names to describe.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-autoscaling``
+        provider with action type ``describe_auto_scaling_groups``.
+    """
+    payload: dict[str, Any] = {}
+    if group_names is not None:
+        payload["auto_scaling_group_names"] = group_names
+    return payload
+
+
+def autoscaling_set_desired_capacity_payload(
+    group_name: str,
+    desired_capacity: int,
+    *,
+    honor_cooldown: Optional[bool] = None,
+) -> dict[str, Any]:
+    """Build a payload for the AWS Auto Scaling set-desired-capacity action.
+
+    Args:
+        group_name: Auto Scaling group name.
+        desired_capacity: Desired number of instances.
+        honor_cooldown: Whether to honor the cooldown period.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-autoscaling``
+        provider with action type ``set_desired_capacity``.
+    """
+    payload: dict[str, Any] = {
+        "auto_scaling_group_name": group_name,
+        "desired_capacity": desired_capacity,
+    }
+    if honor_cooldown is not None:
+        payload["honor_cooldown"] = honor_cooldown
+    return payload
+
+
+def autoscaling_update_group_payload(
+    group_name: str,
+    *,
+    min_size: Optional[int] = None,
+    max_size: Optional[int] = None,
+    desired_capacity: Optional[int] = None,
+    default_cooldown: Optional[int] = None,
+    health_check_type: Optional[str] = None,
+    health_check_grace_period: Optional[int] = None,
+) -> dict[str, Any]:
+    """Build a payload for the AWS Auto Scaling update-group action.
+
+    Args:
+        group_name: Auto Scaling group name.
+        min_size: Minimum group size.
+        max_size: Maximum group size.
+        desired_capacity: Desired number of instances.
+        default_cooldown: Default cooldown period in seconds.
+        health_check_type: Health check type (e.g., ``"EC2"``, ``"ELB"``).
+        health_check_grace_period: Health check grace period in seconds.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``aws-autoscaling``
+        provider with action type ``update_auto_scaling_group``.
+    """
+    payload: dict[str, Any] = {
+        "auto_scaling_group_name": group_name,
+    }
+    if min_size is not None:
+        payload["min_size"] = min_size
+    if max_size is not None:
+        payload["max_size"] = max_size
+    if desired_capacity is not None:
+        payload["desired_capacity"] = desired_capacity
+    if default_cooldown is not None:
+        payload["default_cooldown"] = default_cooldown
+    if health_check_type is not None:
+        payload["health_check_type"] = health_check_type
+    if health_check_grace_period is not None:
+        payload["health_check_grace_period"] = health_check_grace_period
+    return payload

--- a/clients/python/tests/test_aws_ec2_autoscaling.py
+++ b/clients/python/tests/test_aws_ec2_autoscaling.py
@@ -1,0 +1,254 @@
+"""Tests for AWS EC2 and Auto Scaling payload helpers in acteon_client.models."""
+
+import unittest
+from acteon_client.models import (
+    ec2_start_instances_payload,
+    ec2_stop_instances_payload,
+    ec2_reboot_instances_payload,
+    ec2_terminate_instances_payload,
+    ec2_hibernate_instances_payload,
+    ec2_run_instances_payload,
+    ec2_attach_volume_payload,
+    ec2_detach_volume_payload,
+    ec2_describe_instances_payload,
+    autoscaling_describe_groups_payload,
+    autoscaling_set_desired_capacity_payload,
+    autoscaling_update_group_payload,
+)
+
+
+class TestEc2StartInstancesPayload(unittest.TestCase):
+    """Tests for ec2_start_instances_payload."""
+
+    def test_basic(self):
+        result = ec2_start_instances_payload(["i-abc123", "i-def456"])
+        self.assertEqual(result, {"instance_ids": ["i-abc123", "i-def456"]})
+
+    def test_single_instance(self):
+        result = ec2_start_instances_payload(["i-abc123"])
+        self.assertEqual(result, {"instance_ids": ["i-abc123"]})
+
+
+class TestEc2StopInstancesPayload(unittest.TestCase):
+    """Tests for ec2_stop_instances_payload."""
+
+    def test_basic(self):
+        result = ec2_stop_instances_payload(["i-abc123"])
+        self.assertEqual(result, {"instance_ids": ["i-abc123"]})
+        self.assertNotIn("hibernate", result)
+        self.assertNotIn("force", result)
+
+    def test_with_hibernate(self):
+        result = ec2_stop_instances_payload(["i-abc123"], hibernate=True)
+        self.assertEqual(result["instance_ids"], ["i-abc123"])
+        self.assertTrue(result["hibernate"])
+
+    def test_with_force(self):
+        result = ec2_stop_instances_payload(["i-abc123"], force=True)
+        self.assertTrue(result["force"])
+
+    def test_with_all_options(self):
+        result = ec2_stop_instances_payload(
+            ["i-abc123", "i-def456"],
+            hibernate=True,
+            force=True,
+        )
+        self.assertEqual(result["instance_ids"], ["i-abc123", "i-def456"])
+        self.assertTrue(result["hibernate"])
+        self.assertTrue(result["force"])
+
+
+class TestEc2RebootInstancesPayload(unittest.TestCase):
+    """Tests for ec2_reboot_instances_payload."""
+
+    def test_basic(self):
+        result = ec2_reboot_instances_payload(["i-abc123"])
+        self.assertEqual(result, {"instance_ids": ["i-abc123"]})
+
+
+class TestEc2TerminateInstancesPayload(unittest.TestCase):
+    """Tests for ec2_terminate_instances_payload."""
+
+    def test_basic(self):
+        result = ec2_terminate_instances_payload(["i-abc123", "i-def456"])
+        self.assertEqual(result, {"instance_ids": ["i-abc123", "i-def456"]})
+
+
+class TestEc2HibernateInstancesPayload(unittest.TestCase):
+    """Tests for ec2_hibernate_instances_payload."""
+
+    def test_basic(self):
+        result = ec2_hibernate_instances_payload(["i-abc123"])
+        self.assertEqual(result, {"instance_ids": ["i-abc123"]})
+
+
+class TestEc2RunInstancesPayload(unittest.TestCase):
+    """Tests for ec2_run_instances_payload."""
+
+    def test_basic(self):
+        result = ec2_run_instances_payload("ami-12345678", "t3.micro")
+        self.assertEqual(result, {
+            "image_id": "ami-12345678",
+            "instance_type": "t3.micro",
+        })
+
+    def test_with_all_options(self):
+        result = ec2_run_instances_payload(
+            "ami-12345678",
+            "t3.large",
+            min_count=2,
+            max_count=5,
+            key_name="my-keypair",
+            security_group_ids=["sg-111", "sg-222"],
+            subnet_id="subnet-abc",
+            user_data="IyEvYmluL2Jhc2g=",
+            tags={"Name": "web-server", "env": "staging"},
+            iam_instance_profile="arn:aws:iam::123456789012:instance-profile/role",
+        )
+        self.assertEqual(result["image_id"], "ami-12345678")
+        self.assertEqual(result["instance_type"], "t3.large")
+        self.assertEqual(result["min_count"], 2)
+        self.assertEqual(result["max_count"], 5)
+        self.assertEqual(result["key_name"], "my-keypair")
+        self.assertEqual(result["security_group_ids"], ["sg-111", "sg-222"])
+        self.assertEqual(result["subnet_id"], "subnet-abc")
+        self.assertEqual(result["user_data"], "IyEvYmluL2Jhc2g=")
+        self.assertEqual(result["tags"], {"Name": "web-server", "env": "staging"})
+        self.assertEqual(
+            result["iam_instance_profile"],
+            "arn:aws:iam::123456789012:instance-profile/role",
+        )
+
+    def test_optional_fields_omitted(self):
+        result = ec2_run_instances_payload("ami-12345678", "t3.micro")
+        self.assertNotIn("min_count", result)
+        self.assertNotIn("max_count", result)
+        self.assertNotIn("key_name", result)
+        self.assertNotIn("security_group_ids", result)
+        self.assertNotIn("subnet_id", result)
+        self.assertNotIn("user_data", result)
+        self.assertNotIn("tags", result)
+        self.assertNotIn("iam_instance_profile", result)
+
+
+class TestEc2AttachVolumePayload(unittest.TestCase):
+    """Tests for ec2_attach_volume_payload."""
+
+    def test_basic(self):
+        result = ec2_attach_volume_payload("vol-abc123", "i-def456", "/dev/sdf")
+        self.assertEqual(result, {
+            "volume_id": "vol-abc123",
+            "instance_id": "i-def456",
+            "device": "/dev/sdf",
+        })
+
+
+class TestEc2DetachVolumePayload(unittest.TestCase):
+    """Tests for ec2_detach_volume_payload."""
+
+    def test_basic(self):
+        result = ec2_detach_volume_payload("vol-abc123")
+        self.assertEqual(result, {"volume_id": "vol-abc123"})
+        self.assertNotIn("instance_id", result)
+        self.assertNotIn("device", result)
+        self.assertNotIn("force", result)
+
+    def test_with_all_options(self):
+        result = ec2_detach_volume_payload(
+            "vol-abc123",
+            instance_id="i-def456",
+            device="/dev/sdf",
+            force=True,
+        )
+        self.assertEqual(result["volume_id"], "vol-abc123")
+        self.assertEqual(result["instance_id"], "i-def456")
+        self.assertEqual(result["device"], "/dev/sdf")
+        self.assertTrue(result["force"])
+
+
+class TestEc2DescribeInstancesPayload(unittest.TestCase):
+    """Tests for ec2_describe_instances_payload."""
+
+    def test_empty(self):
+        result = ec2_describe_instances_payload()
+        self.assertEqual(result, {})
+
+    def test_with_instance_ids(self):
+        result = ec2_describe_instances_payload(instance_ids=["i-abc123", "i-def456"])
+        self.assertEqual(result, {"instance_ids": ["i-abc123", "i-def456"]})
+
+
+class TestAutoscalingDescribeGroupsPayload(unittest.TestCase):
+    """Tests for autoscaling_describe_groups_payload."""
+
+    def test_empty(self):
+        result = autoscaling_describe_groups_payload()
+        self.assertEqual(result, {})
+
+    def test_with_group_names(self):
+        result = autoscaling_describe_groups_payload(
+            group_names=["my-asg-1", "my-asg-2"]
+        )
+        self.assertEqual(
+            result,
+            {"auto_scaling_group_names": ["my-asg-1", "my-asg-2"]},
+        )
+
+
+class TestAutoscalingSetDesiredCapacityPayload(unittest.TestCase):
+    """Tests for autoscaling_set_desired_capacity_payload."""
+
+    def test_basic(self):
+        result = autoscaling_set_desired_capacity_payload("my-asg", 5)
+        self.assertEqual(result, {
+            "auto_scaling_group_name": "my-asg",
+            "desired_capacity": 5,
+        })
+        self.assertNotIn("honor_cooldown", result)
+
+    def test_with_honor_cooldown(self):
+        result = autoscaling_set_desired_capacity_payload(
+            "my-asg", 10, honor_cooldown=True
+        )
+        self.assertEqual(result["auto_scaling_group_name"], "my-asg")
+        self.assertEqual(result["desired_capacity"], 10)
+        self.assertTrue(result["honor_cooldown"])
+
+
+class TestAutoscalingUpdateGroupPayload(unittest.TestCase):
+    """Tests for autoscaling_update_group_payload."""
+
+    def test_basic(self):
+        result = autoscaling_update_group_payload("my-asg")
+        self.assertEqual(result, {"auto_scaling_group_name": "my-asg"})
+
+    def test_with_all_options(self):
+        result = autoscaling_update_group_payload(
+            "my-asg",
+            min_size=1,
+            max_size=10,
+            desired_capacity=5,
+            default_cooldown=300,
+            health_check_type="ELB",
+            health_check_grace_period=120,
+        )
+        self.assertEqual(result["auto_scaling_group_name"], "my-asg")
+        self.assertEqual(result["min_size"], 1)
+        self.assertEqual(result["max_size"], 10)
+        self.assertEqual(result["desired_capacity"], 5)
+        self.assertEqual(result["default_cooldown"], 300)
+        self.assertEqual(result["health_check_type"], "ELB")
+        self.assertEqual(result["health_check_grace_period"], 120)
+
+    def test_optional_fields_omitted(self):
+        result = autoscaling_update_group_payload("my-asg")
+        self.assertNotIn("min_size", result)
+        self.assertNotIn("max_size", result)
+        self.assertNotIn("desired_capacity", result)
+        self.assertNotIn("default_cooldown", result)
+        self.assertNotIn("health_check_type", result)
+        self.assertNotIn("health_check_grace_period", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/aws/Cargo.toml
+++ b/crates/aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acteon-aws"
-description = "AWS service providers for Acteon (SNS, Lambda, EventBridge, SQS, SES)"
+description = "AWS service providers for Acteon (SNS, Lambda, EventBridge, SQS, SES, S3, EC2, Auto Scaling)"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -15,7 +15,9 @@ eventbridge = ["dep:aws-sdk-eventbridge"]
 sqs = ["dep:aws-sdk-sqs"]
 ses = ["dep:aws-sdk-sesv2"]
 s3 = ["dep:aws-sdk-s3"]
-full = ["sns", "lambda", "eventbridge", "sqs", "ses", "s3"]
+ec2 = ["dep:aws-sdk-ec2"]
+autoscaling = ["dep:aws-sdk-autoscaling"]
+full = ["sns", "lambda", "eventbridge", "sqs", "ses", "s3", "ec2", "autoscaling"]
 
 [dependencies]
 acteon-core = { workspace = true }
@@ -27,6 +29,8 @@ aws-sdk-eventbridge = { workspace = true, optional = true }
 aws-sdk-sqs = { workspace = true, optional = true }
 aws-sdk-sesv2 = { workspace = true, optional = true }
 aws-sdk-s3 = { workspace = true, optional = true }
+aws-sdk-ec2 = { workspace = true, optional = true }
+aws-sdk-autoscaling = { workspace = true, optional = true }
 base64 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aws/Cargo.toml
+++ b/crates/aws/Cargo.toml
@@ -31,6 +31,7 @@ aws-sdk-sesv2 = { workspace = true, optional = true }
 aws-sdk-s3 = { workspace = true, optional = true }
 aws-sdk-ec2 = { workspace = true, optional = true }
 aws-sdk-autoscaling = { workspace = true, optional = true }
+async-trait = { workspace = true }
 base64 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aws/src/autoscaling.rs
+++ b/crates/aws/src/autoscaling.rs
@@ -1,0 +1,451 @@
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::ProviderError;
+use acteon_provider::provider::Provider;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, instrument};
+
+use crate::auth::build_sdk_config;
+use crate::config::AwsBaseConfig;
+use crate::error::classify_sdk_error;
+
+/// Configuration for the AWS Auto Scaling provider.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AutoScalingConfig {
+    /// Shared AWS configuration (region, role ARN, endpoint URL).
+    #[serde(flatten)]
+    pub aws: AwsBaseConfig,
+}
+
+impl std::fmt::Debug for AutoScalingConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AutoScalingConfig")
+            .field("aws", &self.aws)
+            .finish()
+    }
+}
+
+impl AutoScalingConfig {
+    /// Create a new `AutoScalingConfig` with the given AWS region.
+    pub fn new(region: impl Into<String>) -> Self {
+        Self {
+            aws: AwsBaseConfig::new(region),
+        }
+    }
+
+    /// Set the endpoint URL override (for `LocalStack`).
+    #[must_use]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.aws.endpoint_url = Some(endpoint_url.into());
+        self
+    }
+
+    /// Set the IAM role ARN to assume.
+    #[must_use]
+    pub fn with_role_arn(mut self, role_arn: impl Into<String>) -> Self {
+        self.aws.role_arn = Some(role_arn.into());
+        self
+    }
+
+    /// Set the STS session name for assume-role.
+    #[must_use]
+    pub fn with_session_name(mut self, session_name: impl Into<String>) -> Self {
+        self.aws.session_name = Some(session_name.into());
+        self
+    }
+
+    /// Set the external ID for cross-account trust policies.
+    #[must_use]
+    pub fn with_external_id(mut self, external_id: impl Into<String>) -> Self {
+        self.aws.external_id = Some(external_id.into());
+        self
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Payload types
+// ---------------------------------------------------------------------------
+
+/// Payload for the `describe_auto_scaling_groups` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AsgDescribePayload {
+    /// Auto Scaling Group names to describe. If empty, describes all groups.
+    #[serde(default)]
+    pub auto_scaling_group_names: Vec<String>,
+}
+
+/// Payload for the `set_desired_capacity` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AsgSetCapacityPayload {
+    /// Auto Scaling Group name.
+    pub auto_scaling_group_name: String,
+
+    /// Desired capacity to set.
+    pub desired_capacity: i32,
+
+    /// Whether to honor the group's cooldown period.
+    #[serde(default)]
+    pub honor_cooldown: bool,
+}
+
+/// Payload for the `update_auto_scaling_group` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AsgUpdatePayload {
+    /// Auto Scaling Group name.
+    pub auto_scaling_group_name: String,
+
+    /// New minimum size.
+    #[serde(default)]
+    pub min_size: Option<i32>,
+
+    /// New maximum size.
+    #[serde(default)]
+    pub max_size: Option<i32>,
+
+    /// New desired capacity.
+    #[serde(default)]
+    pub desired_capacity: Option<i32>,
+
+    /// New default cooldown period in seconds.
+    #[serde(default)]
+    pub default_cooldown: Option<i32>,
+
+    /// New health check type (`"EC2"` or `"ELB"`).
+    #[serde(default)]
+    pub health_check_type: Option<String>,
+
+    /// New health check grace period in seconds.
+    #[serde(default)]
+    pub health_check_grace_period: Option<i32>,
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+/// AWS Auto Scaling provider for managing Auto Scaling Groups.
+pub struct AutoScalingProvider {
+    config: AutoScalingConfig,
+    client: aws_sdk_autoscaling::Client,
+}
+
+impl std::fmt::Debug for AutoScalingProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AutoScalingProvider")
+            .field("config", &self.config)
+            .field("client", &"<AutoScalingClient>")
+            .finish()
+    }
+}
+
+impl AutoScalingProvider {
+    /// Create a new `AutoScalingProvider` by building an AWS SDK client.
+    pub async fn new(config: AutoScalingConfig) -> Self {
+        let sdk_config = build_sdk_config(&config.aws).await;
+        let client = aws_sdk_autoscaling::Client::new(&sdk_config);
+        Self { config, client }
+    }
+
+    /// Create an `AutoScalingProvider` with a pre-built client (for testing).
+    pub fn with_client(config: AutoScalingConfig, client: aws_sdk_autoscaling::Client) -> Self {
+        Self { config, client }
+    }
+}
+
+impl Provider for AutoScalingProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "aws-autoscaling"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "aws-autoscaling"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        match action.action_type.as_str() {
+            "describe_auto_scaling_groups" => self.describe_groups(action).await,
+            "set_desired_capacity" => self.set_desired_capacity(action).await,
+            "update_auto_scaling_group" => self.update_group(action).await,
+            other => Err(ProviderError::Configuration(format!(
+                "unknown Auto Scaling action type '{other}' (expected \
+                 'describe_auto_scaling_groups', 'set_desired_capacity', \
+                 or 'update_auto_scaling_group')"
+            ))),
+        }
+    }
+
+    #[instrument(skip(self), fields(provider = "aws-autoscaling"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        debug!("performing Auto Scaling health check");
+        self.client
+            .describe_auto_scaling_groups()
+            .max_records(1)
+            .send()
+            .await
+            .map_err(|e| {
+                error!(error = %e, "Auto Scaling health check failed");
+                ProviderError::Connection(format!("Auto Scaling health check failed: {e}"))
+            })?;
+        info!("Auto Scaling health check passed");
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Action implementations
+// ---------------------------------------------------------------------------
+
+impl AutoScalingProvider {
+    async fn describe_groups(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing Auto Scaling describe_auto_scaling_groups payload");
+        let payload: AsgDescribePayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        debug!(group_names = ?payload.auto_scaling_group_names, "describing Auto Scaling Groups");
+
+        let mut request = self.client.describe_auto_scaling_groups();
+        if !payload.auto_scaling_group_names.is_empty() {
+            request = request
+                .set_auto_scaling_group_names(Some(payload.auto_scaling_group_names.clone()));
+        }
+
+        let result = request.send().await.map_err(|e| {
+            let err_str = e.to_string();
+            error!(error = %err_str, "describe_auto_scaling_groups failed");
+            let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+            aws_err
+        })?;
+
+        let groups: Vec<_> = result
+            .auto_scaling_groups()
+            .iter()
+            .map(|g| {
+                serde_json::json!({
+                    "auto_scaling_group_name": g.auto_scaling_group_name(),
+                    "min_size": g.min_size(),
+                    "max_size": g.max_size(),
+                    "desired_capacity": g.desired_capacity(),
+                    "instance_count": g.instances().len(),
+                    "health_check_type": g.health_check_type().unwrap_or_default(),
+                })
+            })
+            .collect();
+
+        info!(count = groups.len(), "Auto Scaling Groups described");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "action": "describe_auto_scaling_groups",
+            "auto_scaling_groups": groups,
+        })))
+    }
+
+    async fn set_desired_capacity(
+        &self,
+        action: &Action,
+    ) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing Auto Scaling set_desired_capacity payload");
+        let payload: AsgSetCapacityPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        debug!(
+            group = %payload.auto_scaling_group_name,
+            desired_capacity = payload.desired_capacity,
+            honor_cooldown = payload.honor_cooldown,
+            "setting desired capacity"
+        );
+
+        self.client
+            .set_desired_capacity()
+            .auto_scaling_group_name(&payload.auto_scaling_group_name)
+            .desired_capacity(payload.desired_capacity)
+            .honor_cooldown(payload.honor_cooldown)
+            .send()
+            .await
+            .map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "set_desired_capacity failed");
+                let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+                aws_err
+            })?;
+
+        info!(
+            group = %payload.auto_scaling_group_name,
+            desired_capacity = payload.desired_capacity,
+            "desired capacity set"
+        );
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "action": "set_desired_capacity",
+            "auto_scaling_group_name": payload.auto_scaling_group_name,
+            "desired_capacity": payload.desired_capacity,
+            "status": "updated",
+        })))
+    }
+
+    async fn update_group(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing Auto Scaling update_auto_scaling_group payload");
+        let payload: AsgUpdatePayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        debug!(group = %payload.auto_scaling_group_name, "updating Auto Scaling Group");
+
+        let mut request = self
+            .client
+            .update_auto_scaling_group()
+            .auto_scaling_group_name(&payload.auto_scaling_group_name);
+
+        if let Some(min) = payload.min_size {
+            request = request.min_size(min);
+        }
+        if let Some(max) = payload.max_size {
+            request = request.max_size(max);
+        }
+        if let Some(desired) = payload.desired_capacity {
+            request = request.desired_capacity(desired);
+        }
+        if let Some(cooldown) = payload.default_cooldown {
+            request = request.default_cooldown(cooldown);
+        }
+        if let Some(ref hct) = payload.health_check_type {
+            request = request.health_check_type(hct);
+        }
+        if let Some(grace) = payload.health_check_grace_period {
+            request = request.health_check_grace_period(grace);
+        }
+
+        request.send().await.map_err(|e| {
+            let err_str = e.to_string();
+            error!(error = %err_str, "update_auto_scaling_group failed");
+            let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+            aws_err
+        })?;
+
+        info!(group = %payload.auto_scaling_group_name, "Auto Scaling Group updated");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "action": "update_auto_scaling_group",
+            "auto_scaling_group_name": payload.auto_scaling_group_name,
+            "status": "updated",
+        })))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_new_sets_region() {
+        let config = AutoScalingConfig::new("us-west-2");
+        assert_eq!(config.aws.region, "us-west-2");
+    }
+
+    #[test]
+    fn config_builder_chain() {
+        let config = AutoScalingConfig::new("eu-west-1")
+            .with_endpoint_url("http://localhost:4566")
+            .with_role_arn("arn:aws:iam::123:role/asg-access")
+            .with_session_name("test-session")
+            .with_external_id("ext-789");
+
+        assert_eq!(
+            config.aws.endpoint_url.as_deref(),
+            Some("http://localhost:4566")
+        );
+        assert!(config.aws.role_arn.is_some());
+        assert_eq!(config.aws.session_name.as_deref(), Some("test-session"));
+        assert_eq!(config.aws.external_id.as_deref(), Some("ext-789"));
+    }
+
+    #[test]
+    fn config_debug_format() {
+        let config =
+            AutoScalingConfig::new("us-east-1").with_role_arn("arn:aws:iam::123:role/test");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("AutoScalingConfig"));
+        assert!(debug.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config =
+            AutoScalingConfig::new("ap-southeast-1").with_endpoint_url("http://localhost:4566");
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: AutoScalingConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.aws.region, "ap-southeast-1");
+        assert_eq!(
+            deserialized.aws.endpoint_url.as_deref(),
+            Some("http://localhost:4566")
+        );
+    }
+
+    #[test]
+    fn deserialize_describe_payload() {
+        let json = serde_json::json!({
+            "auto_scaling_group_names": ["my-asg-1", "my-asg-2"]
+        });
+        let payload: AsgDescribePayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.auto_scaling_group_names.len(), 2);
+    }
+
+    #[test]
+    fn deserialize_describe_payload_empty() {
+        let json = serde_json::json!({});
+        let payload: AsgDescribePayload = serde_json::from_value(json).unwrap();
+        assert!(payload.auto_scaling_group_names.is_empty());
+    }
+
+    #[test]
+    fn deserialize_set_capacity_payload() {
+        let json = serde_json::json!({
+            "auto_scaling_group_name": "my-asg",
+            "desired_capacity": 5,
+            "honor_cooldown": true
+        });
+        let payload: AsgSetCapacityPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.auto_scaling_group_name, "my-asg");
+        assert_eq!(payload.desired_capacity, 5);
+        assert!(payload.honor_cooldown);
+    }
+
+    #[test]
+    fn deserialize_set_capacity_defaults() {
+        let json = serde_json::json!({
+            "auto_scaling_group_name": "my-asg",
+            "desired_capacity": 3
+        });
+        let payload: AsgSetCapacityPayload = serde_json::from_value(json).unwrap();
+        assert!(!payload.honor_cooldown);
+    }
+
+    #[test]
+    fn deserialize_update_payload() {
+        let json = serde_json::json!({
+            "auto_scaling_group_name": "my-asg",
+            "min_size": 2,
+            "max_size": 10,
+            "desired_capacity": 5,
+            "default_cooldown": 300,
+            "health_check_type": "ELB",
+            "health_check_grace_period": 120
+        });
+        let payload: AsgUpdatePayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.auto_scaling_group_name, "my-asg");
+        assert_eq!(payload.min_size, Some(2));
+        assert_eq!(payload.max_size, Some(10));
+        assert_eq!(payload.desired_capacity, Some(5));
+        assert_eq!(payload.default_cooldown, Some(300));
+        assert_eq!(payload.health_check_type.as_deref(), Some("ELB"));
+        assert_eq!(payload.health_check_grace_period, Some(120));
+    }
+
+    #[test]
+    fn deserialize_update_payload_minimal() {
+        let json = serde_json::json!({
+            "auto_scaling_group_name": "my-asg"
+        });
+        let payload: AsgUpdatePayload = serde_json::from_value(json).unwrap();
+        assert!(payload.min_size.is_none());
+        assert!(payload.max_size.is_none());
+        assert!(payload.desired_capacity.is_none());
+    }
+}

--- a/crates/aws/src/ec2.rs
+++ b/crates/aws/src/ec2.rs
@@ -1,0 +1,973 @@
+use std::collections::HashMap;
+
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::ProviderError;
+use acteon_provider::provider::Provider;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, instrument};
+
+use crate::auth::build_sdk_config;
+use crate::config::AwsBaseConfig;
+use crate::error::classify_sdk_error;
+
+/// Configuration for the AWS EC2 provider.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Ec2Config {
+    /// Shared AWS configuration (region, role ARN, endpoint URL).
+    #[serde(flatten)]
+    pub aws: AwsBaseConfig,
+
+    /// Default security group IDs applied to `run_instances` when not overridden in the payload.
+    #[serde(default)]
+    pub default_security_group_ids: Option<Vec<String>>,
+
+    /// Default subnet ID applied to `run_instances` when not overridden in the payload.
+    #[serde(default)]
+    pub default_subnet_id: Option<String>,
+
+    /// Default key-pair name applied to `run_instances` when not overridden in the payload.
+    #[serde(default)]
+    pub default_key_name: Option<String>,
+}
+
+impl std::fmt::Debug for Ec2Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Ec2Config")
+            .field("aws", &self.aws)
+            .field(
+                "default_security_group_ids",
+                &self.default_security_group_ids,
+            )
+            .field("default_subnet_id", &self.default_subnet_id)
+            .field("default_key_name", &self.default_key_name)
+            .finish()
+    }
+}
+
+impl Ec2Config {
+    /// Create a new `Ec2Config` with the given AWS region.
+    pub fn new(region: impl Into<String>) -> Self {
+        Self {
+            aws: AwsBaseConfig::new(region),
+            default_security_group_ids: None,
+            default_subnet_id: None,
+            default_key_name: None,
+        }
+    }
+
+    /// Set default security group IDs for `run_instances`.
+    #[must_use]
+    pub fn with_default_security_group_ids(mut self, ids: Vec<String>) -> Self {
+        self.default_security_group_ids = Some(ids);
+        self
+    }
+
+    /// Set the default subnet ID for `run_instances`.
+    #[must_use]
+    pub fn with_default_subnet_id(mut self, subnet_id: impl Into<String>) -> Self {
+        self.default_subnet_id = Some(subnet_id.into());
+        self
+    }
+
+    /// Set the default key-pair name for `run_instances`.
+    #[must_use]
+    pub fn with_default_key_name(mut self, key_name: impl Into<String>) -> Self {
+        self.default_key_name = Some(key_name.into());
+        self
+    }
+
+    /// Set the endpoint URL override (for `LocalStack`).
+    #[must_use]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.aws.endpoint_url = Some(endpoint_url.into());
+        self
+    }
+
+    /// Set the IAM role ARN to assume.
+    #[must_use]
+    pub fn with_role_arn(mut self, role_arn: impl Into<String>) -> Self {
+        self.aws.role_arn = Some(role_arn.into());
+        self
+    }
+
+    /// Set the STS session name for assume-role.
+    #[must_use]
+    pub fn with_session_name(mut self, session_name: impl Into<String>) -> Self {
+        self.aws.session_name = Some(session_name.into());
+        self
+    }
+
+    /// Set the external ID for cross-account trust policies.
+    #[must_use]
+    pub fn with_external_id(mut self, external_id: impl Into<String>) -> Self {
+        self.aws.external_id = Some(external_id.into());
+        self
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Payload types
+// ---------------------------------------------------------------------------
+
+/// Payload for the `start_instances` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ec2StartPayload {
+    /// EC2 instance IDs to start.
+    pub instance_ids: Vec<String>,
+}
+
+/// Payload for the `stop_instances` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ec2StopPayload {
+    /// EC2 instance IDs to stop.
+    pub instance_ids: Vec<String>,
+
+    /// If `true`, hibernate the instances instead of stopping them.
+    #[serde(default)]
+    pub hibernate: bool,
+
+    /// If `true`, force the instances to stop without a graceful shutdown.
+    #[serde(default)]
+    pub force: bool,
+}
+
+/// Payload for the `reboot_instances` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ec2RebootPayload {
+    /// EC2 instance IDs to reboot.
+    pub instance_ids: Vec<String>,
+}
+
+/// Payload for the `terminate_instances` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ec2TerminatePayload {
+    /// EC2 instance IDs to terminate.
+    pub instance_ids: Vec<String>,
+}
+
+/// Payload for the `run_instances` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ec2RunInstancesPayload {
+    /// AMI ID to launch.
+    pub image_id: String,
+
+    /// Instance type (e.g. `"t3.micro"`).
+    pub instance_type: String,
+
+    /// Minimum number of instances to launch (defaults to 1).
+    #[serde(default = "default_one")]
+    pub min_count: i32,
+
+    /// Maximum number of instances to launch (defaults to 1).
+    #[serde(default = "default_one")]
+    pub max_count: i32,
+
+    /// Key-pair name. Overrides config `default_key_name`.
+    #[serde(default)]
+    pub key_name: Option<String>,
+
+    /// Security group IDs. Overrides config `default_security_group_ids`.
+    #[serde(default)]
+    pub security_group_ids: Option<Vec<String>>,
+
+    /// Subnet ID. Overrides config `default_subnet_id`.
+    #[serde(default)]
+    pub subnet_id: Option<String>,
+
+    /// Base64-encoded user data script.
+    #[serde(default)]
+    pub user_data: Option<String>,
+
+    /// Tags to apply to the launched instances.
+    #[serde(default)]
+    pub tags: HashMap<String, String>,
+
+    /// IAM instance profile name or ARN.
+    #[serde(default)]
+    pub iam_instance_profile: Option<String>,
+}
+
+fn default_one() -> i32 {
+    1
+}
+
+/// Payload for the `attach_volume` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ec2AttachVolumePayload {
+    /// EBS volume ID.
+    pub volume_id: String,
+
+    /// EC2 instance ID.
+    pub instance_id: String,
+
+    /// Device name (e.g. `"/dev/sdf"`).
+    pub device: String,
+}
+
+/// Payload for the `detach_volume` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ec2DetachVolumePayload {
+    /// EBS volume ID.
+    pub volume_id: String,
+
+    /// Optional instance ID to detach from.
+    #[serde(default)]
+    pub instance_id: Option<String>,
+
+    /// Device name (optional).
+    #[serde(default)]
+    pub device: Option<String>,
+
+    /// Force detachment.
+    #[serde(default)]
+    pub force: bool,
+}
+
+/// Payload for the `describe_instances` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ec2DescribePayload {
+    /// Optional instance IDs to describe. If empty, describes all instances.
+    #[serde(default)]
+    pub instance_ids: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+/// AWS EC2 provider for instance lifecycle management.
+pub struct Ec2Provider {
+    config: Ec2Config,
+    client: aws_sdk_ec2::Client,
+}
+
+impl std::fmt::Debug for Ec2Provider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Ec2Provider")
+            .field("config", &self.config)
+            .field("client", &"<Ec2Client>")
+            .finish()
+    }
+}
+
+impl Ec2Provider {
+    /// Create a new `Ec2Provider` by building an AWS SDK client.
+    pub async fn new(config: Ec2Config) -> Self {
+        let sdk_config = build_sdk_config(&config.aws).await;
+        let client = aws_sdk_ec2::Client::new(&sdk_config);
+        Self { config, client }
+    }
+
+    /// Create an `Ec2Provider` with a pre-built client (for testing).
+    pub fn with_client(config: Ec2Config, client: aws_sdk_ec2::Client) -> Self {
+        Self { config, client }
+    }
+
+    /// Resolve key name from payload or config default.
+    fn resolve_key_name<'a>(&'a self, payload_key_name: Option<&'a str>) -> Option<&'a str> {
+        payload_key_name.or(self.config.default_key_name.as_deref())
+    }
+
+    /// Resolve subnet ID from payload or config default.
+    fn resolve_subnet_id<'a>(&'a self, payload_subnet_id: Option<&'a str>) -> Option<&'a str> {
+        payload_subnet_id.or(self.config.default_subnet_id.as_deref())
+    }
+
+    /// Resolve security group IDs from payload or config default.
+    fn resolve_security_group_ids<'a>(
+        &'a self,
+        payload_sg_ids: Option<&'a [String]>,
+    ) -> Option<&'a [String]> {
+        payload_sg_ids.or(self.config.default_security_group_ids.as_deref())
+    }
+}
+
+impl Provider for Ec2Provider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "aws-ec2"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "aws-ec2"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        match action.action_type.as_str() {
+            "start_instances" => self.start_instances(action).await,
+            "stop_instances" => self.stop_instances(action).await,
+            "reboot_instances" => self.reboot_instances(action).await,
+            "terminate_instances" => self.terminate_instances(action).await,
+            "hibernate_instances" => self.hibernate_instances(action).await,
+            "run_instances" => self.run_instances(action).await,
+            "attach_volume" => self.attach_volume(action).await,
+            "detach_volume" => self.detach_volume(action).await,
+            "describe_instances" => self.describe_instances(action).await,
+            other => Err(ProviderError::Configuration(format!(
+                "unknown EC2 action type '{other}' (expected 'start_instances', 'stop_instances', \
+                 'reboot_instances', 'terminate_instances', 'hibernate_instances', 'run_instances', \
+                 'attach_volume', 'detach_volume', or 'describe_instances')"
+            ))),
+        }
+    }
+
+    #[instrument(skip(self), fields(provider = "aws-ec2"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        debug!("performing EC2 health check via dry-run describe_instances");
+        let result = self.client.describe_instances().dry_run(true).send().await;
+
+        match result {
+            // A successful response means the API is reachable.
+            Ok(_) => {
+                info!("EC2 health check passed");
+                Ok(())
+            }
+            Err(e) => {
+                let err_str = e.to_string();
+                // DryRunOperation means the API call would have succeeded — healthy.
+                if err_str.contains("DryRunOperation") {
+                    info!("EC2 health check passed (dry-run)");
+                    Ok(())
+                } else {
+                    error!(error = %err_str, "EC2 health check failed");
+                    Err(ProviderError::Connection(format!(
+                        "EC2 health check failed: {err_str}"
+                    )))
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Action implementations
+// ---------------------------------------------------------------------------
+
+impl Ec2Provider {
+    async fn start_instances(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing EC2 start_instances payload");
+        let payload: Ec2StartPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        if payload.instance_ids.is_empty() {
+            return Err(ProviderError::Configuration(
+                "instance_ids must not be empty".to_owned(),
+            ));
+        }
+
+        debug!(instance_ids = ?payload.instance_ids, "starting EC2 instances");
+
+        let result = self
+            .client
+            .start_instances()
+            .set_instance_ids(Some(payload.instance_ids.clone()))
+            .send()
+            .await
+            .map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "EC2 start_instances failed");
+                let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+                aws_err
+            })?;
+
+        let states: Vec<_> = result
+            .starting_instances()
+            .iter()
+            .map(|s| {
+                serde_json::json!({
+                    "instance_id": s.instance_id().unwrap_or_default(),
+                    "previous_state": s.previous_state().and_then(|st| st.name()).map_or("unknown", aws_sdk_ec2::types::InstanceStateName::as_str),
+                    "current_state": s.current_state().and_then(|st| st.name()).map_or("unknown", aws_sdk_ec2::types::InstanceStateName::as_str),
+                })
+            })
+            .collect();
+
+        info!(count = states.len(), "EC2 instances starting");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "action": "start_instances",
+            "instance_state_changes": states,
+        })))
+    }
+
+    async fn stop_instances(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing EC2 stop_instances payload");
+        let payload: Ec2StopPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        if payload.instance_ids.is_empty() {
+            return Err(ProviderError::Configuration(
+                "instance_ids must not be empty".to_owned(),
+            ));
+        }
+
+        debug!(instance_ids = ?payload.instance_ids, hibernate = payload.hibernate, force = payload.force, "stopping EC2 instances");
+
+        let result = self
+            .client
+            .stop_instances()
+            .set_instance_ids(Some(payload.instance_ids.clone()))
+            .hibernate(payload.hibernate)
+            .force(payload.force)
+            .send()
+            .await
+            .map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "EC2 stop_instances failed");
+                let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+                aws_err
+            })?;
+
+        let states: Vec<_> = result
+            .stopping_instances()
+            .iter()
+            .map(|s| {
+                serde_json::json!({
+                    "instance_id": s.instance_id().unwrap_or_default(),
+                    "previous_state": s.previous_state().and_then(|st| st.name()).map_or("unknown", aws_sdk_ec2::types::InstanceStateName::as_str),
+                    "current_state": s.current_state().and_then(|st| st.name()).map_or("unknown", aws_sdk_ec2::types::InstanceStateName::as_str),
+                })
+            })
+            .collect();
+
+        info!(
+            count = states.len(),
+            hibernate = payload.hibernate,
+            "EC2 instances stopping"
+        );
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "action": "stop_instances",
+            "hibernate": payload.hibernate,
+            "instance_state_changes": states,
+        })))
+    }
+
+    async fn hibernate_instances(
+        &self,
+        action: &Action,
+    ) -> Result<ProviderResponse, ProviderError> {
+        debug!("hibernate_instances is sugar for stop_instances with hibernate=true");
+        // Parse just the instance_ids and re-dispatch as stop with hibernate=true.
+        let payload: Ec2StartPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let stop_payload = serde_json::json!({
+            "instance_ids": payload.instance_ids,
+            "hibernate": true,
+        });
+
+        let mut stop_action = action.clone();
+        stop_action.payload = stop_payload;
+        "stop_instances".clone_into(&mut stop_action.action_type);
+
+        self.stop_instances(&stop_action).await
+    }
+
+    async fn reboot_instances(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing EC2 reboot_instances payload");
+        let payload: Ec2RebootPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        if payload.instance_ids.is_empty() {
+            return Err(ProviderError::Configuration(
+                "instance_ids must not be empty".to_owned(),
+            ));
+        }
+
+        debug!(instance_ids = ?payload.instance_ids, "rebooting EC2 instances");
+
+        self.client
+            .reboot_instances()
+            .set_instance_ids(Some(payload.instance_ids.clone()))
+            .send()
+            .await
+            .map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "EC2 reboot_instances failed");
+                let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+                aws_err
+            })?;
+
+        info!(
+            count = payload.instance_ids.len(),
+            "EC2 instances rebooting"
+        );
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "action": "reboot_instances",
+            "instance_ids": payload.instance_ids,
+            "status": "rebooting",
+        })))
+    }
+
+    async fn terminate_instances(
+        &self,
+        action: &Action,
+    ) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing EC2 terminate_instances payload");
+        let payload: Ec2TerminatePayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        if payload.instance_ids.is_empty() {
+            return Err(ProviderError::Configuration(
+                "instance_ids must not be empty".to_owned(),
+            ));
+        }
+
+        debug!(instance_ids = ?payload.instance_ids, "terminating EC2 instances");
+
+        let result = self
+            .client
+            .terminate_instances()
+            .set_instance_ids(Some(payload.instance_ids.clone()))
+            .send()
+            .await
+            .map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "EC2 terminate_instances failed");
+                let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+                aws_err
+            })?;
+
+        let states: Vec<_> = result
+            .terminating_instances()
+            .iter()
+            .map(|s| {
+                serde_json::json!({
+                    "instance_id": s.instance_id().unwrap_or_default(),
+                    "previous_state": s.previous_state().and_then(|st| st.name()).map_or("unknown", aws_sdk_ec2::types::InstanceStateName::as_str),
+                    "current_state": s.current_state().and_then(|st| st.name()).map_or("unknown", aws_sdk_ec2::types::InstanceStateName::as_str),
+                })
+            })
+            .collect();
+
+        info!(count = states.len(), "EC2 instances terminating");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "action": "terminate_instances",
+            "instance_state_changes": states,
+        })))
+    }
+
+    async fn run_instances(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing EC2 run_instances payload");
+        let payload: Ec2RunInstancesPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let key_name = self.resolve_key_name(payload.key_name.as_deref());
+        let subnet_id = self.resolve_subnet_id(payload.subnet_id.as_deref());
+        let sg_ids = self.resolve_security_group_ids(payload.security_group_ids.as_deref());
+
+        debug!(
+            image_id = %payload.image_id,
+            instance_type = %payload.instance_type,
+            min_count = payload.min_count,
+            max_count = payload.max_count,
+            "launching EC2 instances"
+        );
+
+        let mut request = self
+            .client
+            .run_instances()
+            .image_id(&payload.image_id)
+            .instance_type(
+                payload
+                    .instance_type
+                    .parse::<aws_sdk_ec2::types::InstanceType>()
+                    .map_err(|_| {
+                        ProviderError::Configuration(format!(
+                            "invalid instance type '{}'",
+                            payload.instance_type
+                        ))
+                    })?,
+            )
+            .min_count(payload.min_count)
+            .max_count(payload.max_count);
+
+        if let Some(kn) = key_name {
+            request = request.key_name(kn);
+        }
+
+        if let Some(sid) = subnet_id {
+            request = request.subnet_id(sid);
+        }
+
+        if let Some(ids) = sg_ids {
+            for id in ids {
+                request = request.security_group_ids(id);
+            }
+        }
+
+        if let Some(ref ud) = payload.user_data {
+            request = request.user_data(ud);
+        }
+
+        if let Some(ref profile) = payload.iam_instance_profile {
+            let iam_spec = if profile.starts_with("arn:") {
+                aws_sdk_ec2::types::IamInstanceProfileSpecification::builder()
+                    .arn(profile)
+                    .build()
+            } else {
+                aws_sdk_ec2::types::IamInstanceProfileSpecification::builder()
+                    .name(profile)
+                    .build()
+            };
+            request = request.iam_instance_profile(iam_spec);
+        }
+
+        if !payload.tags.is_empty() {
+            let tags: Vec<aws_sdk_ec2::types::Tag> = payload
+                .tags
+                .iter()
+                .map(|(k, v)| aws_sdk_ec2::types::Tag::builder().key(k).value(v).build())
+                .collect();
+            let tag_spec = aws_sdk_ec2::types::TagSpecification::builder()
+                .resource_type(aws_sdk_ec2::types::ResourceType::Instance)
+                .set_tags(Some(tags))
+                .build();
+            request = request.tag_specifications(tag_spec);
+        }
+
+        let result = request.send().await.map_err(|e| {
+            let err_str = e.to_string();
+            error!(error = %err_str, "EC2 run_instances failed");
+            let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+            aws_err
+        })?;
+
+        let instances: Vec<_> = result
+            .instances()
+            .iter()
+            .map(|i| {
+                serde_json::json!({
+                    "instance_id": i.instance_id().unwrap_or_default(),
+                    "instance_type": i.instance_type().map_or("unknown", aws_sdk_ec2::types::InstanceType::as_str),
+                    "state": i.state().and_then(|s| s.name()).map_or("unknown", aws_sdk_ec2::types::InstanceStateName::as_str),
+                })
+            })
+            .collect();
+
+        info!(count = instances.len(), "EC2 instances launched");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "action": "run_instances",
+            "reservation_id": result.reservation_id().unwrap_or_default(),
+            "instances": instances,
+        })))
+    }
+
+    async fn attach_volume(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing EC2 attach_volume payload");
+        let payload: Ec2AttachVolumePayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        debug!(
+            volume_id = %payload.volume_id,
+            instance_id = %payload.instance_id,
+            device = %payload.device,
+            "attaching EBS volume"
+        );
+
+        let result = self
+            .client
+            .attach_volume()
+            .volume_id(&payload.volume_id)
+            .instance_id(&payload.instance_id)
+            .device(&payload.device)
+            .send()
+            .await
+            .map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "EC2 attach_volume failed");
+                let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+                aws_err
+            })?;
+
+        info!(
+            volume_id = %payload.volume_id,
+            instance_id = %payload.instance_id,
+            "EBS volume attached"
+        );
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "action": "attach_volume",
+            "volume_id": result.volume_id().unwrap_or_default(),
+            "instance_id": result.instance_id().unwrap_or_default(),
+            "device": result.device().unwrap_or_default(),
+            "state": result.state().map_or("unknown", aws_sdk_ec2::types::VolumeAttachmentState::as_str),
+        })))
+    }
+
+    async fn detach_volume(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing EC2 detach_volume payload");
+        let payload: Ec2DetachVolumePayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        debug!(volume_id = %payload.volume_id, force = payload.force, "detaching EBS volume");
+
+        let mut request = self.client.detach_volume().volume_id(&payload.volume_id);
+
+        if let Some(ref iid) = payload.instance_id {
+            request = request.instance_id(iid);
+        }
+        if let Some(ref dev) = payload.device {
+            request = request.device(dev);
+        }
+        if payload.force {
+            request = request.force(true);
+        }
+
+        let result = request.send().await.map_err(|e| {
+            let err_str = e.to_string();
+            error!(error = %err_str, "EC2 detach_volume failed");
+            let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+            aws_err
+        })?;
+
+        info!(volume_id = %payload.volume_id, "EBS volume detached");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "action": "detach_volume",
+            "volume_id": result.volume_id().unwrap_or_default(),
+            "instance_id": result.instance_id().unwrap_or_default(),
+            "state": result.state().map_or("unknown", aws_sdk_ec2::types::VolumeAttachmentState::as_str),
+        })))
+    }
+
+    async fn describe_instances(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing EC2 describe_instances payload");
+        let payload: Ec2DescribePayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        debug!(instance_ids = ?payload.instance_ids, "describing EC2 instances");
+
+        let mut request = self.client.describe_instances();
+        if !payload.instance_ids.is_empty() {
+            request = request.set_instance_ids(Some(payload.instance_ids.clone()));
+        }
+
+        let result = request.send().await.map_err(|e| {
+            let err_str = e.to_string();
+            error!(error = %err_str, "EC2 describe_instances failed");
+            let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+            aws_err
+        })?;
+
+        let instances: Vec<_> = result
+            .reservations()
+            .iter()
+            .flat_map(aws_sdk_ec2::types::Reservation::instances)
+            .map(|i| {
+                serde_json::json!({
+                    "instance_id": i.instance_id().unwrap_or_default(),
+                    "instance_type": i.instance_type().map_or("unknown", aws_sdk_ec2::types::InstanceType::as_str),
+                    "state": i.state().and_then(|s| s.name()).map_or("unknown", aws_sdk_ec2::types::InstanceStateName::as_str),
+                    "public_ip": i.public_ip_address().unwrap_or_default(),
+                    "private_ip": i.private_ip_address().unwrap_or_default(),
+                })
+            })
+            .collect();
+
+        info!(count = instances.len(), "EC2 instances described");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "action": "describe_instances",
+            "instances": instances,
+        })))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_new_sets_region() {
+        let config = Ec2Config::new("us-west-2");
+        assert_eq!(config.aws.region, "us-west-2");
+        assert!(config.default_security_group_ids.is_none());
+        assert!(config.default_subnet_id.is_none());
+        assert!(config.default_key_name.is_none());
+    }
+
+    #[test]
+    fn config_builder_chain() {
+        let config = Ec2Config::new("eu-west-1")
+            .with_default_security_group_ids(vec!["sg-123".to_owned()])
+            .with_default_subnet_id("subnet-abc")
+            .with_default_key_name("my-key")
+            .with_endpoint_url("http://localhost:4566")
+            .with_role_arn("arn:aws:iam::123:role/ec2-access")
+            .with_session_name("test-session")
+            .with_external_id("ext-456");
+
+        assert_eq!(
+            config.default_security_group_ids.as_deref(),
+            Some(vec!["sg-123".to_owned()].as_slice())
+        );
+        assert_eq!(config.default_subnet_id.as_deref(), Some("subnet-abc"));
+        assert_eq!(config.default_key_name.as_deref(), Some("my-key"));
+        assert_eq!(
+            config.aws.endpoint_url.as_deref(),
+            Some("http://localhost:4566")
+        );
+        assert!(config.aws.role_arn.is_some());
+        assert_eq!(config.aws.session_name.as_deref(), Some("test-session"));
+        assert_eq!(config.aws.external_id.as_deref(), Some("ext-456"));
+    }
+
+    #[test]
+    fn config_debug_format() {
+        let config = Ec2Config::new("us-east-1").with_role_arn("arn:aws:iam::123:role/test");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("Ec2Config"));
+        assert!(debug.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config = Ec2Config::new("ap-southeast-1")
+            .with_default_key_name("prod-key")
+            .with_default_subnet_id("subnet-xyz");
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: Ec2Config = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.aws.region, "ap-southeast-1");
+        assert_eq!(deserialized.default_key_name.as_deref(), Some("prod-key"));
+        assert_eq!(
+            deserialized.default_subnet_id.as_deref(),
+            Some("subnet-xyz")
+        );
+    }
+
+    #[test]
+    fn deserialize_start_payload() {
+        let json = serde_json::json!({
+            "instance_ids": ["i-abc123", "i-def456"]
+        });
+        let payload: Ec2StartPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.instance_ids.len(), 2);
+        assert_eq!(payload.instance_ids[0], "i-abc123");
+    }
+
+    #[test]
+    fn deserialize_stop_payload() {
+        let json = serde_json::json!({
+            "instance_ids": ["i-abc123"],
+            "hibernate": true,
+            "force": false
+        });
+        let payload: Ec2StopPayload = serde_json::from_value(json).unwrap();
+        assert!(payload.hibernate);
+        assert!(!payload.force);
+    }
+
+    #[test]
+    fn deserialize_stop_payload_defaults() {
+        let json = serde_json::json!({
+            "instance_ids": ["i-abc123"]
+        });
+        let payload: Ec2StopPayload = serde_json::from_value(json).unwrap();
+        assert!(!payload.hibernate);
+        assert!(!payload.force);
+    }
+
+    #[test]
+    fn deserialize_reboot_payload() {
+        let json = serde_json::json!({
+            "instance_ids": ["i-abc123"]
+        });
+        let payload: Ec2RebootPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.instance_ids, vec!["i-abc123"]);
+    }
+
+    #[test]
+    fn deserialize_terminate_payload() {
+        let json = serde_json::json!({
+            "instance_ids": ["i-abc123", "i-def456"]
+        });
+        let payload: Ec2TerminatePayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.instance_ids.len(), 2);
+    }
+
+    #[test]
+    fn deserialize_run_instances_payload() {
+        let json = serde_json::json!({
+            "image_id": "ami-12345678",
+            "instance_type": "t3.micro",
+            "min_count": 2,
+            "max_count": 5,
+            "key_name": "my-key",
+            "security_group_ids": ["sg-111", "sg-222"],
+            "subnet_id": "subnet-aaa",
+            "user_data": "IyEvYmluL2Jhc2g=",
+            "tags": {"env": "staging", "team": "platform"},
+            "iam_instance_profile": "arn:aws:iam::123:instance-profile/app"
+        });
+        let payload: Ec2RunInstancesPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.image_id, "ami-12345678");
+        assert_eq!(payload.instance_type, "t3.micro");
+        assert_eq!(payload.min_count, 2);
+        assert_eq!(payload.max_count, 5);
+        assert_eq!(payload.key_name.as_deref(), Some("my-key"));
+        assert_eq!(payload.security_group_ids.as_ref().unwrap().len(), 2);
+        assert_eq!(payload.subnet_id.as_deref(), Some("subnet-aaa"));
+        assert!(payload.user_data.is_some());
+        assert_eq!(payload.tags.len(), 2);
+        assert!(payload.iam_instance_profile.is_some());
+    }
+
+    #[test]
+    fn deserialize_run_instances_minimal() {
+        let json = serde_json::json!({
+            "image_id": "ami-12345678",
+            "instance_type": "t3.nano"
+        });
+        let payload: Ec2RunInstancesPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.min_count, 1);
+        assert_eq!(payload.max_count, 1);
+        assert!(payload.key_name.is_none());
+        assert!(payload.security_group_ids.is_none());
+        assert!(payload.tags.is_empty());
+    }
+
+    #[test]
+    fn deserialize_attach_volume_payload() {
+        let json = serde_json::json!({
+            "volume_id": "vol-abc123",
+            "instance_id": "i-def456",
+            "device": "/dev/sdf"
+        });
+        let payload: Ec2AttachVolumePayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.volume_id, "vol-abc123");
+        assert_eq!(payload.instance_id, "i-def456");
+        assert_eq!(payload.device, "/dev/sdf");
+    }
+
+    #[test]
+    fn deserialize_detach_volume_payload() {
+        let json = serde_json::json!({
+            "volume_id": "vol-abc123",
+            "force": true
+        });
+        let payload: Ec2DetachVolumePayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.volume_id, "vol-abc123");
+        assert!(payload.instance_id.is_none());
+        assert!(payload.force);
+    }
+
+    #[test]
+    fn deserialize_describe_payload() {
+        let json = serde_json::json!({
+            "instance_ids": ["i-abc123"]
+        });
+        let payload: Ec2DescribePayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.instance_ids, vec!["i-abc123"]);
+    }
+
+    #[test]
+    fn deserialize_describe_payload_empty() {
+        let json = serde_json::json!({});
+        let payload: Ec2DescribePayload = serde_json::from_value(json).unwrap();
+        assert!(payload.instance_ids.is_empty());
+    }
+}

--- a/crates/aws/src/lib.rs
+++ b/crates/aws/src/lib.rs
@@ -8,6 +8,8 @@
 //! - **SQS** (`sqs` feature) — Send messages to SQS queues
 //! - **SES** (`ses` feature) — Send emails via SES v2
 //! - **S3** (`s3` feature) — Put/get/delete objects in S3 buckets
+//! - **EC2** (`ec2` feature) — Manage EC2 instance lifecycle
+//! - **Auto Scaling** (`autoscaling` feature) — Manage Auto Scaling Groups
 //!
 //! All providers share a common [`AwsBaseConfig`] for
 //! region, endpoint override, and optional STS assume-role credentials.
@@ -34,6 +36,12 @@ pub mod ses;
 #[cfg(feature = "s3")]
 pub mod s3;
 
+#[cfg(feature = "ec2")]
+pub mod ec2;
+
+#[cfg(feature = "autoscaling")]
+pub mod autoscaling;
+
 // Re-exports for convenience.
 pub use config::AwsBaseConfig;
 pub use error::AwsProviderError;
@@ -55,3 +63,9 @@ pub use ses::{SesClient, SesConfig};
 
 #[cfg(feature = "s3")]
 pub use s3::{S3Config, S3Provider};
+
+#[cfg(feature = "ec2")]
+pub use ec2::{Ec2Config, Ec2Provider};
+
+#[cfg(feature = "autoscaling")]
+pub use autoscaling::{AutoScalingConfig, AutoScalingProvider};

--- a/crates/client/src/aws.rs
+++ b/crates/client/src/aws.rs
@@ -1,7 +1,7 @@
 //! Convenience helpers for creating AWS-targeted actions.
 //!
 //! Provides builder types for each supported AWS provider:
-//! [`sns`], [`lambda`], [`eventbridge`], [`sqs`], and [`s3`].
+//! [`sns`], [`lambda`], [`eventbridge`], [`sqs`], [`s3`], [`ec2`], and [`autoscaling`].
 //!
 //! # Example
 //!
@@ -805,9 +805,1186 @@ pub mod s3 {
     }
 }
 
+// =============================================================================
+// EC2
+// =============================================================================
+
+/// Helpers for creating EC2 instance lifecycle actions.
+pub mod ec2 {
+    use acteon_core::Action;
+    use std::collections::HashMap;
+
+    /// Create a builder for an EC2 `start_instances` action.
+    pub fn start_instances(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> Ec2StartBuilder {
+        Ec2StartBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            instance_ids: Vec::new(),
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an EC2 `start_instances` action.
+    #[derive(Debug)]
+    pub struct Ec2StartBuilder {
+        namespace: String,
+        tenant: String,
+        instance_ids: Vec<String>,
+        dedup_key: Option<String>,
+    }
+
+    impl Ec2StartBuilder {
+        /// Set the instance IDs to start.
+        #[must_use]
+        pub fn instance_ids(mut self, ids: Vec<String>) -> Self {
+            self.instance_ids = ids;
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the EC2 `start_instances` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `instance_ids` is empty.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.instance_ids.is_empty(),
+                "EC2 instance_ids must not be empty"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "instance_ids".to_string(),
+                serde_json::to_value(&self.instance_ids)
+                    .expect("Vec<String> serialization cannot fail"),
+            );
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-ec2",
+                "start_instances",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Create a builder for an EC2 `stop_instances` action.
+    pub fn stop_instances(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> Ec2StopBuilder {
+        Ec2StopBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            instance_ids: Vec::new(),
+            hibernate: None,
+            force: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an EC2 `stop_instances` action.
+    #[derive(Debug)]
+    pub struct Ec2StopBuilder {
+        namespace: String,
+        tenant: String,
+        instance_ids: Vec<String>,
+        hibernate: Option<bool>,
+        force: Option<bool>,
+        dedup_key: Option<String>,
+    }
+
+    impl Ec2StopBuilder {
+        /// Set the instance IDs to stop.
+        #[must_use]
+        pub fn instance_ids(mut self, ids: Vec<String>) -> Self {
+            self.instance_ids = ids;
+            self
+        }
+
+        /// Whether to hibernate the instances instead of stopping them.
+        #[must_use]
+        pub fn hibernate(mut self, hibernate: bool) -> Self {
+            self.hibernate = Some(hibernate);
+            self
+        }
+
+        /// Whether to force the instances to stop without a graceful shutdown.
+        #[must_use]
+        pub fn force(mut self, force: bool) -> Self {
+            self.force = Some(force);
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the EC2 `stop_instances` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `instance_ids` is empty.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.instance_ids.is_empty(),
+                "EC2 instance_ids must not be empty"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "instance_ids".to_string(),
+                serde_json::to_value(&self.instance_ids)
+                    .expect("Vec<String> serialization cannot fail"),
+            );
+
+            if let Some(v) = self.hibernate {
+                payload.insert("hibernate".to_string(), serde_json::Value::Bool(v));
+            }
+            if let Some(v) = self.force {
+                payload.insert("force".to_string(), serde_json::Value::Bool(v));
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-ec2",
+                "stop_instances",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Create a builder for an EC2 `reboot_instances` action.
+    pub fn reboot_instances(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> Ec2RebootBuilder {
+        Ec2RebootBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            instance_ids: Vec::new(),
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an EC2 `reboot_instances` action.
+    #[derive(Debug)]
+    pub struct Ec2RebootBuilder {
+        namespace: String,
+        tenant: String,
+        instance_ids: Vec<String>,
+        dedup_key: Option<String>,
+    }
+
+    impl Ec2RebootBuilder {
+        /// Set the instance IDs to reboot.
+        #[must_use]
+        pub fn instance_ids(mut self, ids: Vec<String>) -> Self {
+            self.instance_ids = ids;
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the EC2 `reboot_instances` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `instance_ids` is empty.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.instance_ids.is_empty(),
+                "EC2 instance_ids must not be empty"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "instance_ids".to_string(),
+                serde_json::to_value(&self.instance_ids)
+                    .expect("Vec<String> serialization cannot fail"),
+            );
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-ec2",
+                "reboot_instances",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Create a builder for an EC2 `terminate_instances` action.
+    pub fn terminate_instances(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> Ec2TerminateBuilder {
+        Ec2TerminateBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            instance_ids: Vec::new(),
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an EC2 `terminate_instances` action.
+    #[derive(Debug)]
+    pub struct Ec2TerminateBuilder {
+        namespace: String,
+        tenant: String,
+        instance_ids: Vec<String>,
+        dedup_key: Option<String>,
+    }
+
+    impl Ec2TerminateBuilder {
+        /// Set the instance IDs to terminate.
+        #[must_use]
+        pub fn instance_ids(mut self, ids: Vec<String>) -> Self {
+            self.instance_ids = ids;
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the EC2 `terminate_instances` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `instance_ids` is empty.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.instance_ids.is_empty(),
+                "EC2 instance_ids must not be empty"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "instance_ids".to_string(),
+                serde_json::to_value(&self.instance_ids)
+                    .expect("Vec<String> serialization cannot fail"),
+            );
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-ec2",
+                "terminate_instances",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Create a builder for an EC2 `hibernate_instances` action.
+    pub fn hibernate_instances(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> Ec2HibernateBuilder {
+        Ec2HibernateBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            instance_ids: Vec::new(),
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an EC2 `hibernate_instances` action.
+    #[derive(Debug)]
+    pub struct Ec2HibernateBuilder {
+        namespace: String,
+        tenant: String,
+        instance_ids: Vec<String>,
+        dedup_key: Option<String>,
+    }
+
+    impl Ec2HibernateBuilder {
+        /// Set the instance IDs to hibernate.
+        #[must_use]
+        pub fn instance_ids(mut self, ids: Vec<String>) -> Self {
+            self.instance_ids = ids;
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the EC2 `hibernate_instances` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `instance_ids` is empty.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.instance_ids.is_empty(),
+                "EC2 instance_ids must not be empty"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "instance_ids".to_string(),
+                serde_json::to_value(&self.instance_ids)
+                    .expect("Vec<String> serialization cannot fail"),
+            );
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-ec2",
+                "hibernate_instances",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Create a builder for an EC2 `run_instances` action.
+    pub fn run_instances(namespace: impl Into<String>, tenant: impl Into<String>) -> Ec2RunBuilder {
+        Ec2RunBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            image_id: String::new(),
+            instance_type: String::new(),
+            min_count: None,
+            max_count: None,
+            key_name: None,
+            security_group_ids: None,
+            subnet_id: None,
+            user_data: None,
+            tags: None,
+            iam_instance_profile: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an EC2 `run_instances` action.
+    #[derive(Debug)]
+    pub struct Ec2RunBuilder {
+        namespace: String,
+        tenant: String,
+        image_id: String,
+        instance_type: String,
+        min_count: Option<i32>,
+        max_count: Option<i32>,
+        key_name: Option<String>,
+        security_group_ids: Option<Vec<String>>,
+        subnet_id: Option<String>,
+        user_data: Option<String>,
+        tags: Option<HashMap<String, String>>,
+        iam_instance_profile: Option<String>,
+        dedup_key: Option<String>,
+    }
+
+    impl Ec2RunBuilder {
+        /// Set the AMI ID.
+        #[must_use]
+        pub fn image_id(mut self, image_id: impl Into<String>) -> Self {
+            self.image_id = image_id.into();
+            self
+        }
+
+        /// Set the instance type (e.g., `"t3.micro"`).
+        #[must_use]
+        pub fn instance_type(mut self, instance_type: impl Into<String>) -> Self {
+            self.instance_type = instance_type.into();
+            self
+        }
+
+        /// Set the minimum number of instances to launch.
+        #[must_use]
+        pub fn min_count(mut self, count: i32) -> Self {
+            self.min_count = Some(count);
+            self
+        }
+
+        /// Set the maximum number of instances to launch.
+        #[must_use]
+        pub fn max_count(mut self, count: i32) -> Self {
+            self.max_count = Some(count);
+            self
+        }
+
+        /// Set the key-pair name.
+        #[must_use]
+        pub fn key_name(mut self, key_name: impl Into<String>) -> Self {
+            self.key_name = Some(key_name.into());
+            self
+        }
+
+        /// Set the security group IDs.
+        #[must_use]
+        pub fn security_group_ids(mut self, ids: Vec<String>) -> Self {
+            self.security_group_ids = Some(ids);
+            self
+        }
+
+        /// Set the subnet ID.
+        #[must_use]
+        pub fn subnet_id(mut self, subnet_id: impl Into<String>) -> Self {
+            self.subnet_id = Some(subnet_id.into());
+            self
+        }
+
+        /// Set the base64-encoded user data script.
+        #[must_use]
+        pub fn user_data(mut self, user_data: impl Into<String>) -> Self {
+            self.user_data = Some(user_data.into());
+            self
+        }
+
+        /// Set tags to apply to the launched instances.
+        #[must_use]
+        pub fn tags(mut self, tags: HashMap<String, String>) -> Self {
+            self.tags = Some(tags);
+            self
+        }
+
+        /// Set the IAM instance profile name or ARN.
+        #[must_use]
+        pub fn iam_instance_profile(mut self, profile: impl Into<String>) -> Self {
+            self.iam_instance_profile = Some(profile.into());
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the EC2 `run_instances` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `image_id` or `instance_type` have not been set.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.image_id.is_empty(),
+                "EC2 image_id must be set for run_instances"
+            );
+            assert!(
+                !self.instance_type.is_empty(),
+                "EC2 instance_type must be set for run_instances"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "image_id".to_string(),
+                serde_json::Value::String(self.image_id),
+            );
+            payload.insert(
+                "instance_type".to_string(),
+                serde_json::Value::String(self.instance_type),
+            );
+
+            if let Some(v) = self.min_count {
+                payload.insert("min_count".to_string(), serde_json::Value::Number(v.into()));
+            }
+            if let Some(v) = self.max_count {
+                payload.insert("max_count".to_string(), serde_json::Value::Number(v.into()));
+            }
+            if let Some(v) = self.key_name {
+                payload.insert("key_name".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.security_group_ids {
+                payload.insert(
+                    "security_group_ids".to_string(),
+                    serde_json::to_value(v).expect("Vec<String> serialization cannot fail"),
+                );
+            }
+            if let Some(v) = self.subnet_id {
+                payload.insert("subnet_id".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.user_data {
+                payload.insert("user_data".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.tags {
+                payload.insert(
+                    "tags".to_string(),
+                    serde_json::to_value(v)
+                        .expect("HashMap<String, String> serialization cannot fail"),
+                );
+            }
+            if let Some(v) = self.iam_instance_profile {
+                payload.insert(
+                    "iam_instance_profile".to_string(),
+                    serde_json::Value::String(v),
+                );
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-ec2",
+                "run_instances",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Create a builder for an EC2 `attach_volume` action.
+    pub fn attach_volume(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> Ec2AttachVolumeBuilder {
+        Ec2AttachVolumeBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            volume_id: String::new(),
+            instance_id: String::new(),
+            device: String::new(),
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an EC2 `attach_volume` action.
+    #[derive(Debug)]
+    pub struct Ec2AttachVolumeBuilder {
+        namespace: String,
+        tenant: String,
+        volume_id: String,
+        instance_id: String,
+        device: String,
+        dedup_key: Option<String>,
+    }
+
+    impl Ec2AttachVolumeBuilder {
+        /// Set the EBS volume ID.
+        #[must_use]
+        pub fn volume_id(mut self, volume_id: impl Into<String>) -> Self {
+            self.volume_id = volume_id.into();
+            self
+        }
+
+        /// Set the EC2 instance ID to attach to.
+        #[must_use]
+        pub fn instance_id(mut self, instance_id: impl Into<String>) -> Self {
+            self.instance_id = instance_id.into();
+            self
+        }
+
+        /// Set the device name (e.g., `"/dev/sdf"`).
+        #[must_use]
+        pub fn device(mut self, device: impl Into<String>) -> Self {
+            self.device = device.into();
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the EC2 `attach_volume` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `volume_id`, `instance_id`, or `device` have not been set.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.volume_id.is_empty(),
+                "EC2 volume_id must be set for attach_volume"
+            );
+            assert!(
+                !self.instance_id.is_empty(),
+                "EC2 instance_id must be set for attach_volume"
+            );
+            assert!(
+                !self.device.is_empty(),
+                "EC2 device must be set for attach_volume"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "volume_id".to_string(),
+                serde_json::Value::String(self.volume_id),
+            );
+            payload.insert(
+                "instance_id".to_string(),
+                serde_json::Value::String(self.instance_id),
+            );
+            payload.insert("device".to_string(), serde_json::Value::String(self.device));
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-ec2",
+                "attach_volume",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Create a builder for an EC2 `detach_volume` action.
+    pub fn detach_volume(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> Ec2DetachVolumeBuilder {
+        Ec2DetachVolumeBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            volume_id: String::new(),
+            instance_id: None,
+            device: None,
+            force: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an EC2 `detach_volume` action.
+    #[derive(Debug)]
+    pub struct Ec2DetachVolumeBuilder {
+        namespace: String,
+        tenant: String,
+        volume_id: String,
+        instance_id: Option<String>,
+        device: Option<String>,
+        force: Option<bool>,
+        dedup_key: Option<String>,
+    }
+
+    impl Ec2DetachVolumeBuilder {
+        /// Set the EBS volume ID.
+        #[must_use]
+        pub fn volume_id(mut self, volume_id: impl Into<String>) -> Self {
+            self.volume_id = volume_id.into();
+            self
+        }
+
+        /// Set the EC2 instance ID to detach from.
+        #[must_use]
+        pub fn instance_id(mut self, instance_id: impl Into<String>) -> Self {
+            self.instance_id = Some(instance_id.into());
+            self
+        }
+
+        /// Set the device name.
+        #[must_use]
+        pub fn device(mut self, device: impl Into<String>) -> Self {
+            self.device = Some(device.into());
+            self
+        }
+
+        /// Whether to force the detachment.
+        #[must_use]
+        pub fn force(mut self, force: bool) -> Self {
+            self.force = Some(force);
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the EC2 `detach_volume` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `volume_id` has not been set.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.volume_id.is_empty(),
+                "EC2 volume_id must be set for detach_volume"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "volume_id".to_string(),
+                serde_json::Value::String(self.volume_id),
+            );
+
+            if let Some(v) = self.instance_id {
+                payload.insert("instance_id".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.device {
+                payload.insert("device".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.force {
+                payload.insert("force".to_string(), serde_json::Value::Bool(v));
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-ec2",
+                "detach_volume",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Create a builder for an EC2 `describe_instances` action.
+    pub fn describe_instances(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> Ec2DescribeBuilder {
+        Ec2DescribeBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            instance_ids: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an EC2 `describe_instances` action.
+    #[derive(Debug)]
+    pub struct Ec2DescribeBuilder {
+        namespace: String,
+        tenant: String,
+        instance_ids: Option<Vec<String>>,
+        dedup_key: Option<String>,
+    }
+
+    impl Ec2DescribeBuilder {
+        /// Set the instance IDs to describe. If not set, describes all instances.
+        #[must_use]
+        pub fn instance_ids(mut self, ids: Vec<String>) -> Self {
+            self.instance_ids = Some(ids);
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the EC2 `describe_instances` Action.
+        pub fn build(self) -> Action {
+            let mut payload = serde_json::Map::new();
+
+            if let Some(ids) = self.instance_ids {
+                payload.insert(
+                    "instance_ids".to_string(),
+                    serde_json::to_value(ids).expect("Vec<String> serialization cannot fail"),
+                );
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-ec2",
+                "describe_instances",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+}
+
+// =============================================================================
+// Auto Scaling
+// =============================================================================
+
+/// Helpers for creating Auto Scaling Group actions.
+pub mod autoscaling {
+    use acteon_core::Action;
+
+    /// Create a builder for an Auto Scaling `describe_auto_scaling_groups` action.
+    pub fn describe_groups(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> AsgDescribeBuilder {
+        AsgDescribeBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            group_names: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an Auto Scaling `describe_auto_scaling_groups` action.
+    #[derive(Debug)]
+    pub struct AsgDescribeBuilder {
+        namespace: String,
+        tenant: String,
+        group_names: Option<Vec<String>>,
+        dedup_key: Option<String>,
+    }
+
+    impl AsgDescribeBuilder {
+        /// Set the Auto Scaling Group names to describe.
+        #[must_use]
+        pub fn group_names(mut self, names: Vec<String>) -> Self {
+            self.group_names = Some(names);
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the Auto Scaling `describe_auto_scaling_groups` Action.
+        pub fn build(self) -> Action {
+            let mut payload = serde_json::Map::new();
+
+            if let Some(names) = self.group_names {
+                payload.insert(
+                    "auto_scaling_group_names".to_string(),
+                    serde_json::to_value(names).expect("Vec<String> serialization cannot fail"),
+                );
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-autoscaling",
+                "describe_auto_scaling_groups",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Create a builder for an Auto Scaling `set_desired_capacity` action.
+    pub fn set_desired_capacity(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> AsgSetCapacityBuilder {
+        AsgSetCapacityBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            group_name: String::new(),
+            desired_capacity: 0,
+            honor_cooldown: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an Auto Scaling `set_desired_capacity` action.
+    #[derive(Debug)]
+    pub struct AsgSetCapacityBuilder {
+        namespace: String,
+        tenant: String,
+        group_name: String,
+        desired_capacity: i32,
+        honor_cooldown: Option<bool>,
+        dedup_key: Option<String>,
+    }
+
+    impl AsgSetCapacityBuilder {
+        /// Set the Auto Scaling Group name.
+        #[must_use]
+        pub fn group_name(mut self, name: impl Into<String>) -> Self {
+            self.group_name = name.into();
+            self
+        }
+
+        /// Set the desired capacity.
+        #[must_use]
+        pub fn desired_capacity(mut self, capacity: i32) -> Self {
+            self.desired_capacity = capacity;
+            self
+        }
+
+        /// Whether to honor the group's cooldown period.
+        #[must_use]
+        pub fn honor_cooldown(mut self, honor: bool) -> Self {
+            self.honor_cooldown = Some(honor);
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the Auto Scaling `set_desired_capacity` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `group_name` has not been set.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.group_name.is_empty(),
+                "Auto Scaling group_name must be set"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "auto_scaling_group_name".to_string(),
+                serde_json::Value::String(self.group_name),
+            );
+            payload.insert(
+                "desired_capacity".to_string(),
+                serde_json::Value::Number(self.desired_capacity.into()),
+            );
+
+            if let Some(v) = self.honor_cooldown {
+                payload.insert("honor_cooldown".to_string(), serde_json::Value::Bool(v));
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-autoscaling",
+                "set_desired_capacity",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Create a builder for an Auto Scaling `update_auto_scaling_group` action.
+    pub fn update_group(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> AsgUpdateBuilder {
+        AsgUpdateBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            group_name: String::new(),
+            min_size: None,
+            max_size: None,
+            desired_capacity: None,
+            default_cooldown: None,
+            health_check_type: None,
+            health_check_grace_period: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an Auto Scaling `update_auto_scaling_group` action.
+    #[derive(Debug)]
+    pub struct AsgUpdateBuilder {
+        namespace: String,
+        tenant: String,
+        group_name: String,
+        min_size: Option<i32>,
+        max_size: Option<i32>,
+        desired_capacity: Option<i32>,
+        default_cooldown: Option<i32>,
+        health_check_type: Option<String>,
+        health_check_grace_period: Option<i32>,
+        dedup_key: Option<String>,
+    }
+
+    impl AsgUpdateBuilder {
+        /// Set the Auto Scaling Group name.
+        #[must_use]
+        pub fn group_name(mut self, name: impl Into<String>) -> Self {
+            self.group_name = name.into();
+            self
+        }
+
+        /// Set the new minimum size.
+        #[must_use]
+        pub fn min_size(mut self, size: i32) -> Self {
+            self.min_size = Some(size);
+            self
+        }
+
+        /// Set the new maximum size.
+        #[must_use]
+        pub fn max_size(mut self, size: i32) -> Self {
+            self.max_size = Some(size);
+            self
+        }
+
+        /// Set the new desired capacity.
+        #[must_use]
+        pub fn desired_capacity(mut self, capacity: i32) -> Self {
+            self.desired_capacity = Some(capacity);
+            self
+        }
+
+        /// Set the new default cooldown period in seconds.
+        #[must_use]
+        pub fn default_cooldown(mut self, cooldown: i32) -> Self {
+            self.default_cooldown = Some(cooldown);
+            self
+        }
+
+        /// Set the new health check type (`"EC2"` or `"ELB"`).
+        #[must_use]
+        pub fn health_check_type(mut self, hct: impl Into<String>) -> Self {
+            self.health_check_type = Some(hct.into());
+            self
+        }
+
+        /// Set the new health check grace period in seconds.
+        #[must_use]
+        pub fn health_check_grace_period(mut self, grace: i32) -> Self {
+            self.health_check_grace_period = Some(grace);
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the Auto Scaling `update_auto_scaling_group` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `group_name` has not been set.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.group_name.is_empty(),
+                "Auto Scaling group_name must be set"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "auto_scaling_group_name".to_string(),
+                serde_json::Value::String(self.group_name),
+            );
+
+            if let Some(v) = self.min_size {
+                payload.insert("min_size".to_string(), serde_json::Value::Number(v.into()));
+            }
+            if let Some(v) = self.max_size {
+                payload.insert("max_size".to_string(), serde_json::Value::Number(v.into()));
+            }
+            if let Some(v) = self.desired_capacity {
+                payload.insert(
+                    "desired_capacity".to_string(),
+                    serde_json::Value::Number(v.into()),
+                );
+            }
+            if let Some(v) = self.default_cooldown {
+                payload.insert(
+                    "default_cooldown".to_string(),
+                    serde_json::Value::Number(v.into()),
+                );
+            }
+            if let Some(v) = self.health_check_type {
+                payload.insert(
+                    "health_check_type".to_string(),
+                    serde_json::Value::String(v),
+                );
+            }
+            if let Some(v) = self.health_check_grace_period {
+                payload.insert(
+                    "health_check_grace_period".to_string(),
+                    serde_json::Value::Number(v.into()),
+                );
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "aws-autoscaling",
+                "update_auto_scaling_group",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{eventbridge, lambda, s3, sns, sqs};
+    use super::{autoscaling, ec2, eventbridge, lambda, s3, sns, sqs};
     use std::collections::HashMap;
 
     #[test]
@@ -989,5 +2166,234 @@ mod tests {
     #[should_panic(expected = "S3 object key must be set")]
     fn s3_panics_without_key() {
         s3::put_object("ns", "t1").build();
+    }
+
+    // =========================================================================
+    // EC2 tests
+    // =========================================================================
+
+    #[test]
+    fn ec2_start_instances_basic() {
+        let a = ec2::start_instances("ns", "t1")
+            .instance_ids(vec!["i-abc123".to_string(), "i-def456".to_string()])
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-ec2");
+        assert_eq!(a.action_type, "start_instances");
+        assert_eq!(a.payload["instance_ids"][0], "i-abc123");
+        assert_eq!(a.payload["instance_ids"][1], "i-def456");
+    }
+
+    #[test]
+    fn ec2_stop_instances_with_options() {
+        let a = ec2::stop_instances("ns", "t1")
+            .instance_ids(vec!["i-abc123".to_string()])
+            .hibernate(true)
+            .force(true)
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-ec2");
+        assert_eq!(a.action_type, "stop_instances");
+        assert_eq!(a.payload["instance_ids"][0], "i-abc123");
+        assert_eq!(a.payload["hibernate"], true);
+        assert_eq!(a.payload["force"], true);
+    }
+
+    #[test]
+    fn ec2_run_instances_basic() {
+        let a = ec2::run_instances("ns", "t1")
+            .image_id("ami-12345678")
+            .instance_type("t3.micro")
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-ec2");
+        assert_eq!(a.action_type, "run_instances");
+        assert_eq!(a.payload["image_id"], "ami-12345678");
+        assert_eq!(a.payload["instance_type"], "t3.micro");
+    }
+
+    #[test]
+    fn ec2_run_instances_with_all_options() {
+        let mut tags = HashMap::new();
+        tags.insert("env".to_string(), "staging".to_string());
+
+        let a = ec2::run_instances("ns", "t1")
+            .image_id("ami-12345678")
+            .instance_type("t3.micro")
+            .min_count(2)
+            .max_count(5)
+            .key_name("my-key")
+            .security_group_ids(vec!["sg-111".to_string(), "sg-222".to_string()])
+            .subnet_id("subnet-aaa")
+            .user_data("IyEvYmluL2Jhc2g=")
+            .tags(tags)
+            .iam_instance_profile("arn:aws:iam::123:instance-profile/app")
+            .dedup_key("run-dedup")
+            .build();
+
+        assert_eq!(a.payload["min_count"], 2);
+        assert_eq!(a.payload["max_count"], 5);
+        assert_eq!(a.payload["key_name"], "my-key");
+        assert_eq!(a.payload["security_group_ids"][0], "sg-111");
+        assert_eq!(a.payload["security_group_ids"][1], "sg-222");
+        assert_eq!(a.payload["subnet_id"], "subnet-aaa");
+        assert_eq!(a.payload["user_data"], "IyEvYmluL2Jhc2g=");
+        assert_eq!(a.payload["tags"]["env"], "staging");
+        assert_eq!(
+            a.payload["iam_instance_profile"],
+            "arn:aws:iam::123:instance-profile/app"
+        );
+        assert_eq!(a.dedup_key.as_deref(), Some("run-dedup"));
+    }
+
+    #[test]
+    fn ec2_attach_volume() {
+        let a = ec2::attach_volume("ns", "t1")
+            .volume_id("vol-abc123")
+            .instance_id("i-def456")
+            .device("/dev/sdf")
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-ec2");
+        assert_eq!(a.action_type, "attach_volume");
+        assert_eq!(a.payload["volume_id"], "vol-abc123");
+        assert_eq!(a.payload["instance_id"], "i-def456");
+        assert_eq!(a.payload["device"], "/dev/sdf");
+    }
+
+    #[test]
+    fn ec2_detach_volume() {
+        let a = ec2::detach_volume("ns", "t1")
+            .volume_id("vol-abc123")
+            .instance_id("i-def456")
+            .device("/dev/sdf")
+            .force(true)
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-ec2");
+        assert_eq!(a.action_type, "detach_volume");
+        assert_eq!(a.payload["volume_id"], "vol-abc123");
+        assert_eq!(a.payload["instance_id"], "i-def456");
+        assert_eq!(a.payload["device"], "/dev/sdf");
+        assert_eq!(a.payload["force"], true);
+    }
+
+    #[test]
+    fn ec2_describe_instances() {
+        let a = ec2::describe_instances("ns", "t1")
+            .instance_ids(vec!["i-abc123".to_string()])
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-ec2");
+        assert_eq!(a.action_type, "describe_instances");
+        assert_eq!(a.payload["instance_ids"][0], "i-abc123");
+    }
+
+    #[test]
+    fn ec2_hibernate_instances() {
+        let a = ec2::hibernate_instances("ns", "t1")
+            .instance_ids(vec!["i-abc123".to_string()])
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-ec2");
+        assert_eq!(a.action_type, "hibernate_instances");
+        assert_eq!(a.payload["instance_ids"][0], "i-abc123");
+    }
+
+    #[test]
+    fn ec2_reboot_instances() {
+        let a = ec2::reboot_instances("ns", "t1")
+            .instance_ids(vec!["i-abc123".to_string()])
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-ec2");
+        assert_eq!(a.action_type, "reboot_instances");
+        assert_eq!(a.payload["instance_ids"][0], "i-abc123");
+    }
+
+    #[test]
+    fn ec2_terminate_instances() {
+        let a = ec2::terminate_instances("ns", "t1")
+            .instance_ids(vec!["i-abc123".to_string()])
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-ec2");
+        assert_eq!(a.action_type, "terminate_instances");
+        assert_eq!(a.payload["instance_ids"][0], "i-abc123");
+    }
+
+    #[test]
+    #[should_panic(expected = "EC2 instance_ids must not be empty")]
+    fn ec2_panics_without_instance_ids() {
+        ec2::start_instances("ns", "t1").build();
+    }
+
+    #[test]
+    #[should_panic(expected = "EC2 image_id must be set")]
+    fn ec2_run_panics_without_image_id() {
+        ec2::run_instances("ns", "t1")
+            .instance_type("t3.micro")
+            .build();
+    }
+
+    // =========================================================================
+    // Auto Scaling tests
+    // =========================================================================
+
+    #[test]
+    fn asg_describe_groups() {
+        let a = autoscaling::describe_groups("ns", "t1")
+            .group_names(vec!["my-asg".to_string()])
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-autoscaling");
+        assert_eq!(a.action_type, "describe_auto_scaling_groups");
+        assert_eq!(a.payload["auto_scaling_group_names"][0], "my-asg");
+    }
+
+    #[test]
+    fn asg_set_desired_capacity() {
+        let a = autoscaling::set_desired_capacity("ns", "t1")
+            .group_name("my-asg")
+            .desired_capacity(5)
+            .honor_cooldown(true)
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-autoscaling");
+        assert_eq!(a.action_type, "set_desired_capacity");
+        assert_eq!(a.payload["auto_scaling_group_name"], "my-asg");
+        assert_eq!(a.payload["desired_capacity"], 5);
+        assert_eq!(a.payload["honor_cooldown"], true);
+    }
+
+    #[test]
+    fn asg_update_group() {
+        let a = autoscaling::update_group("ns", "t1")
+            .group_name("my-asg")
+            .min_size(2)
+            .max_size(10)
+            .desired_capacity(5)
+            .default_cooldown(300)
+            .health_check_type("ELB")
+            .health_check_grace_period(120)
+            .build();
+
+        assert_eq!(a.provider.as_str(), "aws-autoscaling");
+        assert_eq!(a.action_type, "update_auto_scaling_group");
+        assert_eq!(a.payload["auto_scaling_group_name"], "my-asg");
+        assert_eq!(a.payload["min_size"], 2);
+        assert_eq!(a.payload["max_size"], 10);
+        assert_eq!(a.payload["desired_capacity"], 5);
+        assert_eq!(a.payload["default_cooldown"], 300);
+        assert_eq!(a.payload["health_check_type"], "ELB");
+        assert_eq!(a.payload["health_check_grace_period"], 120);
+    }
+
+    #[test]
+    #[should_panic(expected = "Auto Scaling group_name must be set")]
+    fn asg_panics_without_group_name() {
+        autoscaling::set_desired_capacity("ns", "t1")
+            .desired_capacity(5)
+            .build();
     }
 }

--- a/crates/core/src/enrichment.rs
+++ b/crates/core/src/enrichment.rs
@@ -1,0 +1,172 @@
+use serde::{Deserialize, Serialize};
+
+/// Configuration for a pre-dispatch enrichment step.
+///
+/// Enrichments fetch external resource state and merge it into the action
+/// payload before rule evaluation. This allows rules to check live data
+/// (e.g., current `AutoScaling` group capacity) instead of relying solely
+/// on static payload fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct EnrichmentConfig {
+    /// Human-readable name for this enrichment.
+    pub name: String,
+    /// Only apply to actions matching this namespace (if set).
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// Only apply to actions matching this tenant (if set).
+    #[serde(default)]
+    pub tenant: Option<String>,
+    /// Only apply to actions matching this action type (if set).
+    #[serde(default)]
+    pub action_type: Option<String>,
+    /// Only apply to actions targeting this provider (if set).
+    #[serde(default)]
+    pub provider: Option<String>,
+    /// The name of the resource lookup provider to use.
+    pub lookup_provider: String,
+    /// The resource type to look up (e.g., `"auto_scaling_group"`, `"instance"`).
+    pub resource_type: String,
+    /// Template for lookup parameters. Supports `{{payload.X}}`, `{{namespace}}`,
+    /// `{{tenant}}`, `{{action_type}}` placeholders.
+    pub params: serde_json::Value,
+    /// Key under which to merge the lookup result into the action payload.
+    pub merge_key: String,
+    /// Timeout for the lookup call, in seconds.
+    #[serde(default = "default_enrichment_timeout_seconds")]
+    pub timeout_seconds: u64,
+    /// What to do if the lookup fails.
+    #[serde(default)]
+    pub failure_policy: EnrichmentFailurePolicy,
+}
+
+fn default_enrichment_timeout_seconds() -> u64 {
+    5
+}
+
+/// Policy for handling enrichment lookup failures.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum EnrichmentFailurePolicy {
+    /// Continue dispatch without the enrichment data (default).
+    #[default]
+    FailOpen,
+    /// Reject the dispatch if enrichment fails.
+    FailClosed,
+}
+
+/// Diagnostic outcome of an enrichment step.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct EnrichmentOutcome {
+    /// Name of the enrichment config that produced this outcome.
+    pub name: String,
+    /// The lookup provider used.
+    pub provider: String,
+    /// The resource type looked up.
+    pub resource_type: String,
+    /// Whether the lookup succeeded.
+    pub success: bool,
+    /// Error message if the lookup failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// How long the lookup took in milliseconds.
+    pub duration_ms: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enrichment_config_serde_roundtrip() {
+        let config = EnrichmentConfig {
+            name: "fetch-asg-state".into(),
+            namespace: Some("infra".into()),
+            tenant: Some("tenant-1".into()),
+            action_type: Some("set_desired_capacity".into()),
+            provider: Some("aws-autoscaling".into()),
+            lookup_provider: "aws-autoscaling".into(),
+            resource_type: "auto_scaling_group".into(),
+            params: serde_json::json!({
+                "auto_scaling_group_names": ["{{payload.asg_name}}"]
+            }),
+            merge_key: "current_asg_state".into(),
+            timeout_seconds: 10,
+            failure_policy: EnrichmentFailurePolicy::FailClosed,
+        };
+
+        let json = serde_json::to_string(&config).unwrap();
+        let back: EnrichmentConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.name, "fetch-asg-state");
+        assert_eq!(back.namespace.as_deref(), Some("infra"));
+        assert_eq!(back.timeout_seconds, 10);
+        assert_eq!(back.failure_policy, EnrichmentFailurePolicy::FailClosed);
+    }
+
+    #[test]
+    fn enrichment_config_deserializes_with_defaults() {
+        let json = r#"{
+            "name": "basic",
+            "lookup_provider": "test",
+            "resource_type": "widget",
+            "params": {},
+            "merge_key": "data"
+        }"#;
+
+        let config: EnrichmentConfig = serde_json::from_str(json).unwrap();
+        assert!(config.namespace.is_none());
+        assert!(config.tenant.is_none());
+        assert!(config.action_type.is_none());
+        assert!(config.provider.is_none());
+        assert_eq!(config.timeout_seconds, 5);
+        assert_eq!(config.failure_policy, EnrichmentFailurePolicy::FailOpen);
+    }
+
+    #[test]
+    fn enrichment_failure_policy_serde() {
+        let open: EnrichmentFailurePolicy = serde_json::from_str(r#""fail_open""#).unwrap();
+        assert_eq!(open, EnrichmentFailurePolicy::FailOpen);
+
+        let closed: EnrichmentFailurePolicy = serde_json::from_str(r#""fail_closed""#).unwrap();
+        assert_eq!(closed, EnrichmentFailurePolicy::FailClosed);
+    }
+
+    #[test]
+    fn enrichment_outcome_serde_roundtrip() {
+        let outcome = EnrichmentOutcome {
+            name: "fetch-asg".into(),
+            provider: "aws-autoscaling".into(),
+            resource_type: "auto_scaling_group".into(),
+            success: true,
+            error: None,
+            duration_ms: 42,
+        };
+
+        let json = serde_json::to_string(&outcome).unwrap();
+        assert!(!json.contains("error")); // skip_serializing_if = None
+        let back: EnrichmentOutcome = serde_json::from_str(&json).unwrap();
+        assert!(back.success);
+        assert!(back.error.is_none());
+        assert_eq!(back.duration_ms, 42);
+    }
+
+    #[test]
+    fn enrichment_outcome_with_error() {
+        let outcome = EnrichmentOutcome {
+            name: "fetch-instance".into(),
+            provider: "aws-ec2".into(),
+            resource_type: "instance".into(),
+            success: false,
+            error: Some("connection refused".into()),
+            duration_ms: 5000,
+        };
+
+        let json = serde_json::to_string(&outcome).unwrap();
+        assert!(json.contains("error"));
+        let back: EnrichmentOutcome = serde_json::from_str(&json).unwrap();
+        assert!(!back.success);
+        assert_eq!(back.error.as_deref(), Some("connection refused"));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod chain_dag;
 pub mod circuit_breaker;
 pub mod compliance;
 pub mod context;
+pub mod enrichment;
 pub mod error;
 pub mod fingerprint;
 pub mod group;
@@ -30,6 +31,7 @@ pub use circuit_breaker::{
 };
 pub use compliance::{ComplianceConfig, ComplianceMode, HashChainVerification};
 pub use context::ActionContext;
+pub use enrichment::{EnrichmentConfig, EnrichmentFailurePolicy, EnrichmentOutcome};
 pub use error::ActeonError;
 pub use fingerprint::compute_fingerprint;
 pub use group::{EventGroup, GroupState, GroupedEvent};

--- a/crates/gateway/src/enrichment.rs
+++ b/crates/gateway/src/enrichment.rs
@@ -1,0 +1,658 @@
+use std::collections::HashMap;
+use std::hash::BuildHasher;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use acteon_core::Action;
+use acteon_core::enrichment::{EnrichmentConfig, EnrichmentFailurePolicy, EnrichmentOutcome};
+use acteon_provider::ResourceLookup;
+use tracing::{debug, warn};
+
+use crate::error::GatewayError;
+
+/// Resolve placeholders in an enrichment parameter template against an action.
+///
+/// Supported placeholders:
+/// - `{{payload.field_name}}` — value from the action payload (dot-separated for nested paths)
+/// - `{{namespace}}` — the action namespace
+/// - `{{tenant}}` — the action tenant
+/// - `{{action_type}}` — the action type
+///
+/// When a string value is **exactly** a single placeholder (e.g., `"{{payload.names}}"`),
+/// the original JSON value is preserved (arrays, objects, etc.). When a placeholder
+/// appears among other text, string interpolation is performed. Missing fields
+/// resolve to `null`.
+#[must_use]
+pub fn resolve_enrichment_params(
+    template: &serde_json::Value,
+    action: &Action,
+) -> serde_json::Value {
+    match template {
+        serde_json::Value::String(s) => resolve_string_template(s, action),
+        serde_json::Value::Array(arr) => {
+            let resolved: Vec<serde_json::Value> = arr
+                .iter()
+                .map(|v| resolve_enrichment_params(v, action))
+                .collect();
+            serde_json::Value::Array(resolved)
+        }
+        serde_json::Value::Object(map) => {
+            let resolved: serde_json::Map<String, serde_json::Value> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), resolve_enrichment_params(v, action)))
+                .collect();
+            serde_json::Value::Object(resolved)
+        }
+        // Numbers, bools, null pass through unchanged.
+        other => other.clone(),
+    }
+}
+
+/// Resolve a single string template value.
+fn resolve_string_template(s: &str, action: &Action) -> serde_json::Value {
+    // Fast path: if the entire string is a single placeholder, preserve the original type.
+    if let Some(inner) = extract_sole_placeholder(s) {
+        return resolve_placeholder(&inner, action);
+    }
+
+    // Otherwise, do string interpolation for any embedded placeholders.
+    let mut result = s.to_owned();
+    let mut start = 0;
+    while let Some(open) = result[start..].find("{{") {
+        let abs_open = start + open;
+        if let Some(close) = result[abs_open..].find("}}") {
+            let abs_close = abs_open + close;
+            let placeholder = &result[abs_open + 2..abs_close].trim().to_owned();
+            let value = resolve_placeholder(placeholder, action);
+            let replacement = match &value {
+                serde_json::Value::String(v) => v.clone(),
+                serde_json::Value::Null => "null".to_owned(),
+                other => other.to_string(),
+            };
+            result.replace_range(abs_open..abs_close + 2, &replacement);
+            start = abs_open + replacement.len();
+        } else {
+            break;
+        }
+    }
+
+    serde_json::Value::String(result)
+}
+
+/// If the string is exactly `{{ ... }}` (one placeholder, nothing else), return
+/// the inner key. Trims whitespace inside the braces.
+fn extract_sole_placeholder(s: &str) -> Option<String> {
+    let trimmed = s.trim();
+    if trimmed.starts_with("{{") && trimmed.ends_with("}}") {
+        let inner = &trimmed[2..trimmed.len() - 2];
+        // Make sure there are no other `{{` or `}}` inside.
+        if !inner.contains("{{") && !inner.contains("}}") {
+            return Some(inner.trim().to_owned());
+        }
+    }
+    None
+}
+
+/// Resolve a single placeholder key to a JSON value.
+fn resolve_placeholder(key: &str, action: &Action) -> serde_json::Value {
+    match key {
+        "namespace" => serde_json::Value::String(action.namespace.to_string()),
+        "tenant" => serde_json::Value::String(action.tenant.to_string()),
+        "action_type" => serde_json::Value::String(action.action_type.clone()),
+        k if k.starts_with("payload.") => {
+            let path = &k["payload.".len()..];
+            resolve_payload_path(&action.payload, path)
+        }
+        _ => serde_json::Value::Null,
+    }
+}
+
+/// Walk a dot-separated path into a JSON value.
+fn resolve_payload_path(value: &serde_json::Value, path: &str) -> serde_json::Value {
+    let mut current = value;
+    for segment in path.split('.') {
+        match current {
+            serde_json::Value::Object(map) => {
+                if let Some(v) = map.get(segment) {
+                    current = v;
+                } else {
+                    return serde_json::Value::Null;
+                }
+            }
+            _ => return serde_json::Value::Null,
+        }
+    }
+    current.clone()
+}
+
+/// Apply matching enrichment configs to an action, merging lookup results into
+/// the payload.
+///
+/// Returns the diagnostic outcomes for each enrichment that was attempted
+/// (skipped enrichments are not included).
+pub async fn apply_enrichments<S: BuildHasher>(
+    action: &mut Action,
+    enrichments: &[EnrichmentConfig],
+    resource_lookups: &HashMap<String, Arc<dyn ResourceLookup>, S>,
+) -> Result<Vec<EnrichmentOutcome>, GatewayError> {
+    let mut outcomes = Vec::new();
+
+    for config in enrichments {
+        // Check filter criteria.
+        if !matches_enrichment_filter(action, config) {
+            debug!(
+                enrichment = %config.name,
+                "enrichment skipped: action does not match filter"
+            );
+            continue;
+        }
+
+        // Find the lookup provider.
+        let Some(lookup) = resource_lookups.get(&config.lookup_provider) else {
+            let msg = format!(
+                "enrichment '{}': lookup provider '{}' not found",
+                config.name, config.lookup_provider
+            );
+            match config.failure_policy {
+                EnrichmentFailurePolicy::FailOpen => {
+                    warn!("{msg}");
+                    outcomes.push(EnrichmentOutcome {
+                        name: config.name.clone(),
+                        provider: config.lookup_provider.clone(),
+                        resource_type: config.resource_type.clone(),
+                        success: false,
+                        error: Some(msg),
+                        duration_ms: 0,
+                    });
+                    continue;
+                }
+                EnrichmentFailurePolicy::FailClosed => {
+                    return Err(GatewayError::Enrichment(msg));
+                }
+            }
+        };
+        let lookup = Arc::clone(lookup);
+
+        // Resolve template parameters.
+        let resolved_params = resolve_enrichment_params(&config.params, action);
+
+        // Perform the lookup with a timeout.
+        let timeout = Duration::from_secs(config.timeout_seconds);
+        let start = Instant::now();
+        let lookup_result = tokio::time::timeout(
+            timeout,
+            lookup.lookup(&config.resource_type, &resolved_params),
+        )
+        .await;
+        let elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+
+        match lookup_result {
+            Ok(Ok(data)) => {
+                debug!(
+                    enrichment = %config.name,
+                    merge_key = %config.merge_key,
+                    elapsed_ms,
+                    "enrichment lookup succeeded"
+                );
+                // Merge the result into the payload.
+                if let Some(obj) = action.payload.as_object_mut() {
+                    obj.insert(config.merge_key.clone(), data);
+                }
+                outcomes.push(EnrichmentOutcome {
+                    name: config.name.clone(),
+                    provider: config.lookup_provider.clone(),
+                    resource_type: config.resource_type.clone(),
+                    success: true,
+                    error: None,
+                    duration_ms: elapsed_ms,
+                });
+            }
+            Ok(Err(e)) => {
+                let msg = format!("enrichment '{}': lookup failed: {e}", config.name);
+                handle_enrichment_failure(config, &msg, elapsed_ms, &mut outcomes)?;
+            }
+            Err(_) => {
+                let msg = format!(
+                    "enrichment '{}': lookup timed out after {timeout:?}",
+                    config.name
+                );
+                handle_enrichment_failure(config, &msg, elapsed_ms, &mut outcomes)?;
+            }
+        }
+    }
+
+    Ok(outcomes)
+}
+
+/// Check whether an action matches the filter criteria of an enrichment config.
+fn matches_enrichment_filter(action: &Action, config: &EnrichmentConfig) -> bool {
+    if let Some(ref ns) = config.namespace
+        && action.namespace.as_str() != ns
+    {
+        return false;
+    }
+    if let Some(ref t) = config.tenant
+        && action.tenant.as_str() != t
+    {
+        return false;
+    }
+    if let Some(ref at) = config.action_type
+        && action.action_type != *at
+    {
+        return false;
+    }
+    if let Some(ref p) = config.provider
+        && action.provider.as_str() != p
+    {
+        return false;
+    }
+    true
+}
+
+/// Handle a failed enrichment lookup according to the failure policy.
+fn handle_enrichment_failure(
+    config: &EnrichmentConfig,
+    msg: &str,
+    elapsed_ms: u64,
+    outcomes: &mut Vec<EnrichmentOutcome>,
+) -> Result<(), GatewayError> {
+    match config.failure_policy {
+        EnrichmentFailurePolicy::FailOpen => {
+            warn!("{msg}");
+            outcomes.push(EnrichmentOutcome {
+                name: config.name.clone(),
+                provider: config.lookup_provider.clone(),
+                resource_type: config.resource_type.clone(),
+                success: false,
+                error: Some(msg.to_owned()),
+                duration_ms: elapsed_ms,
+            });
+            Ok(())
+        }
+        EnrichmentFailurePolicy::FailClosed => Err(GatewayError::Enrichment(msg.to_owned())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use acteon_provider::ProviderError;
+    use async_trait::async_trait;
+
+    // -----------------------------------------------------------------------
+    // Mock providers
+    // -----------------------------------------------------------------------
+
+    struct MockResourceLookup {
+        response: serde_json::Value,
+    }
+
+    #[async_trait]
+    impl ResourceLookup for MockResourceLookup {
+        async fn lookup(
+            &self,
+            _resource_type: &str,
+            _params: &serde_json::Value,
+        ) -> Result<serde_json::Value, ProviderError> {
+            Ok(self.response.clone())
+        }
+
+        fn supported_resource_types(&self) -> Vec<String> {
+            vec!["test".to_owned()]
+        }
+    }
+
+    struct FailingResourceLookup;
+
+    #[async_trait]
+    impl ResourceLookup for FailingResourceLookup {
+        async fn lookup(
+            &self,
+            _resource_type: &str,
+            _params: &serde_json::Value,
+        ) -> Result<serde_json::Value, ProviderError> {
+            Err(ProviderError::Connection(
+                "lookup connection refused".into(),
+            ))
+        }
+
+        fn supported_resource_types(&self) -> Vec<String> {
+            vec!["test".to_owned()]
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper
+    // -----------------------------------------------------------------------
+
+    fn test_action() -> Action {
+        Action::new(
+            "infra",
+            "tenant-1",
+            "aws-autoscaling",
+            "set_desired_capacity",
+            serde_json::json!({
+                "asg_name": "my-asg",
+                "desired_capacity": 5,
+                "names": ["asg-a", "asg-b"],
+                "nested": {
+                    "key": "deep-value"
+                }
+            }),
+        )
+    }
+
+    fn base_enrichment_config() -> EnrichmentConfig {
+        EnrichmentConfig {
+            name: "test-enrichment".into(),
+            namespace: None,
+            tenant: None,
+            action_type: None,
+            provider: None,
+            lookup_provider: "mock".into(),
+            resource_type: "test".into(),
+            params: serde_json::json!({}),
+            merge_key: "enriched".into(),
+            timeout_seconds: 5,
+            failure_policy: EnrichmentFailurePolicy::FailOpen,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Template resolution tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_resolve_payload_field() {
+        let action = test_action();
+        let template = serde_json::json!({
+            "name": "{{payload.asg_name}}"
+        });
+        let resolved = resolve_enrichment_params(&template, &action);
+        assert_eq!(resolved["name"], "my-asg");
+    }
+
+    #[test]
+    fn test_resolve_full_value_preserves_type() {
+        let action = test_action();
+        // The entire string is a single placeholder pointing to an array.
+        let template = serde_json::json!({
+            "names": "{{payload.names}}"
+        });
+        let resolved = resolve_enrichment_params(&template, &action);
+        assert!(resolved["names"].is_array());
+        let arr = resolved["names"].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0], "asg-a");
+        assert_eq!(arr[1], "asg-b");
+    }
+
+    #[test]
+    fn test_resolve_missing_field() {
+        let action = test_action();
+        let template = serde_json::json!({
+            "missing": "{{payload.nonexistent}}"
+        });
+        let resolved = resolve_enrichment_params(&template, &action);
+        assert!(resolved["missing"].is_null());
+    }
+
+    #[test]
+    fn test_resolve_namespace_tenant() {
+        let action = test_action();
+        let template = serde_json::json!({
+            "ns": "{{namespace}}",
+            "t": "{{tenant}}",
+            "at": "{{action_type}}"
+        });
+        let resolved = resolve_enrichment_params(&template, &action);
+        assert_eq!(resolved["ns"], "infra");
+        assert_eq!(resolved["t"], "tenant-1");
+        assert_eq!(resolved["at"], "set_desired_capacity");
+    }
+
+    #[test]
+    fn test_resolve_nested_template() {
+        let action = test_action();
+        let template = serde_json::json!({
+            "outer": {
+                "inner_name": "{{payload.asg_name}}",
+                "inner_ns": "{{namespace}}"
+            },
+            "list": ["{{payload.asg_name}}", "static"]
+        });
+        let resolved = resolve_enrichment_params(&template, &action);
+        assert_eq!(resolved["outer"]["inner_name"], "my-asg");
+        assert_eq!(resolved["outer"]["inner_ns"], "infra");
+        assert_eq!(resolved["list"][0], "my-asg");
+        assert_eq!(resolved["list"][1], "static");
+    }
+
+    #[test]
+    fn test_resolve_nested_payload_path() {
+        let action = test_action();
+        let template = serde_json::json!({
+            "deep": "{{payload.nested.key}}"
+        });
+        let resolved = resolve_enrichment_params(&template, &action);
+        assert_eq!(resolved["deep"], "deep-value");
+    }
+
+    #[test]
+    fn test_resolve_interpolation_in_longer_string() {
+        let action = test_action();
+        let template = serde_json::json!({
+            "msg": "ASG {{payload.asg_name}} in {{namespace}}"
+        });
+        let resolved = resolve_enrichment_params(&template, &action);
+        assert_eq!(resolved["msg"], "ASG my-asg in infra");
+    }
+
+    #[test]
+    fn test_resolve_non_string_passthrough() {
+        let action = test_action();
+        let template = serde_json::json!({
+            "count": 42,
+            "flag": true,
+            "nothing": null
+        });
+        let resolved = resolve_enrichment_params(&template, &action);
+        assert_eq!(resolved["count"], 42);
+        assert_eq!(resolved["flag"], true);
+        assert!(resolved["nothing"].is_null());
+    }
+
+    // -----------------------------------------------------------------------
+    // apply_enrichments tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_enrichment_merges_data() {
+        let mut action = test_action();
+        let mock = Arc::new(MockResourceLookup {
+            response: serde_json::json!({
+                "auto_scaling_groups": [{
+                    "auto_scaling_group_name": "my-asg",
+                    "desired_capacity": 3
+                }]
+            }),
+        }) as Arc<dyn ResourceLookup>;
+
+        let mut lookups: HashMap<String, Arc<dyn ResourceLookup>> = HashMap::new();
+        lookups.insert("mock".into(), mock);
+
+        let config = base_enrichment_config();
+
+        let outcomes = apply_enrichments(&mut action, &[config], &lookups)
+            .await
+            .unwrap();
+
+        assert_eq!(outcomes.len(), 1);
+        assert!(outcomes[0].success);
+        assert!(outcomes[0].error.is_none());
+
+        // Verify the data was merged under the merge_key.
+        let enriched = &action.payload["enriched"];
+        assert!(enriched.is_object());
+        assert!(enriched["auto_scaling_groups"].is_array());
+    }
+
+    #[tokio::test]
+    async fn test_enrichment_skips_non_matching() {
+        let mut action = test_action();
+        let mock = Arc::new(MockResourceLookup {
+            response: serde_json::json!({"data": true}),
+        }) as Arc<dyn ResourceLookup>;
+
+        let mut lookups: HashMap<String, Arc<dyn ResourceLookup>> = HashMap::new();
+        lookups.insert("mock".into(), mock);
+
+        let mut config = base_enrichment_config();
+        // Set an action_type filter that won't match.
+        config.action_type = Some("describe_instances".into());
+
+        let outcomes = apply_enrichments(&mut action, &[config], &lookups)
+            .await
+            .unwrap();
+
+        // The enrichment was skipped, not attempted.
+        assert!(outcomes.is_empty());
+        // Payload should not have the merge key.
+        assert!(action.payload.get("enriched").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_enrichment_fail_open() {
+        let mut action = test_action();
+        let failing = Arc::new(FailingResourceLookup) as Arc<dyn ResourceLookup>;
+
+        let mut lookups: HashMap<String, Arc<dyn ResourceLookup>> = HashMap::new();
+        lookups.insert("mock".into(), failing);
+
+        let mut config = base_enrichment_config();
+        config.failure_policy = EnrichmentFailurePolicy::FailOpen;
+
+        let outcomes = apply_enrichments(&mut action, &[config], &lookups)
+            .await
+            .unwrap();
+
+        assert_eq!(outcomes.len(), 1);
+        assert!(!outcomes[0].success);
+        assert!(outcomes[0].error.is_some());
+        // Payload should not have the merge key since lookup failed.
+        assert!(action.payload.get("enriched").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_enrichment_fail_closed() {
+        let mut action = test_action();
+        let failing = Arc::new(FailingResourceLookup) as Arc<dyn ResourceLookup>;
+
+        let mut lookups: HashMap<String, Arc<dyn ResourceLookup>> = HashMap::new();
+        lookups.insert("mock".into(), failing);
+
+        let mut config = base_enrichment_config();
+        config.failure_policy = EnrichmentFailurePolicy::FailClosed;
+
+        let result = apply_enrichments(&mut action, &[config], &lookups).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, GatewayError::Enrichment(_)));
+        assert!(err.to_string().contains("lookup failed"));
+    }
+
+    #[tokio::test]
+    async fn test_enrichment_provider_not_found_fail_open() {
+        let mut action = test_action();
+        let lookups: HashMap<String, Arc<dyn ResourceLookup>> = HashMap::new();
+
+        let mut config = base_enrichment_config();
+        config.lookup_provider = "nonexistent".into();
+        config.failure_policy = EnrichmentFailurePolicy::FailOpen;
+
+        let outcomes = apply_enrichments(&mut action, &[config], &lookups)
+            .await
+            .unwrap();
+
+        assert_eq!(outcomes.len(), 1);
+        assert!(!outcomes[0].success);
+        assert!(outcomes[0].error.as_ref().unwrap().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_enrichment_provider_not_found_fail_closed() {
+        let mut action = test_action();
+        let lookups: HashMap<String, Arc<dyn ResourceLookup>> = HashMap::new();
+
+        let mut config = base_enrichment_config();
+        config.lookup_provider = "nonexistent".into();
+        config.failure_policy = EnrichmentFailurePolicy::FailClosed;
+
+        let result = apply_enrichments(&mut action, &[config], &lookups).await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), GatewayError::Enrichment(_)));
+    }
+
+    #[tokio::test]
+    async fn test_enrichment_multiple_configs() {
+        let mut action = test_action();
+        let mock = Arc::new(MockResourceLookup {
+            response: serde_json::json!({"status": "ok"}),
+        }) as Arc<dyn ResourceLookup>;
+
+        let mut lookups: HashMap<String, Arc<dyn ResourceLookup>> = HashMap::new();
+        lookups.insert("mock".into(), mock);
+
+        let mut config1 = base_enrichment_config();
+        config1.name = "enrichment-1".into();
+        config1.merge_key = "data_1".into();
+
+        let mut config2 = base_enrichment_config();
+        config2.name = "enrichment-2".into();
+        config2.merge_key = "data_2".into();
+
+        let outcomes = apply_enrichments(&mut action, &[config1, config2], &lookups)
+            .await
+            .unwrap();
+
+        assert_eq!(outcomes.len(), 2);
+        assert!(outcomes[0].success);
+        assert!(outcomes[1].success);
+        assert!(action.payload.get("data_1").is_some());
+        assert!(action.payload.get("data_2").is_some());
+    }
+
+    #[test]
+    fn test_matches_enrichment_filter_all_none() {
+        let action = test_action();
+        let config = base_enrichment_config();
+        assert!(matches_enrichment_filter(&action, &config));
+    }
+
+    #[test]
+    fn test_matches_enrichment_filter_namespace_match() {
+        let action = test_action();
+        let mut config = base_enrichment_config();
+        config.namespace = Some("infra".into());
+        assert!(matches_enrichment_filter(&action, &config));
+    }
+
+    #[test]
+    fn test_matches_enrichment_filter_namespace_mismatch() {
+        let action = test_action();
+        let mut config = base_enrichment_config();
+        config.namespace = Some("other".into());
+        assert!(!matches_enrichment_filter(&action, &config));
+    }
+
+    #[test]
+    fn test_matches_enrichment_filter_all_criteria() {
+        let action = test_action();
+        let mut config = base_enrichment_config();
+        config.namespace = Some("infra".into());
+        config.tenant = Some("tenant-1".into());
+        config.action_type = Some("set_desired_capacity".into());
+        config.provider = Some("aws-autoscaling".into());
+        assert!(matches_enrichment_filter(&action, &config));
+    }
+}

--- a/crates/gateway/src/error.rs
+++ b/crates/gateway/src/error.rs
@@ -38,4 +38,8 @@ pub enum GatewayError {
     /// An error occurred during chain execution.
     #[error("chain error: {0}")]
     ChainError(String),
+
+    /// A pre-dispatch enrichment step failed with `FailClosed` policy.
+    #[error("enrichment failed: {0}")]
+    Enrichment(String),
 }

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -408,8 +408,10 @@ impl Gateway {
             return Ok(outcome);
         }
 
-        // 2c. Apply pre-dispatch enrichments (skip in dry-run mode).
-        if !dry_run && !self.enrichments.is_empty() {
+        // 2c. Apply pre-dispatch enrichments.
+        // Lookups are read-only, so we run them even in dry-run mode to ensure
+        // rule evaluation produces the same verdict as an actual dispatch.
+        if !self.enrichments.is_empty() {
             crate::enrichment::apply_enrichments(
                 &mut action,
                 &self.enrichments,

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -3,6 +3,7 @@ pub mod builder;
 pub mod chain;
 pub mod circuit_breaker;
 pub mod encrypting_dlq;
+pub mod enrichment;
 pub mod error;
 pub mod gateway;
 pub mod group_manager;

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -3,6 +3,7 @@ pub mod health;
 pub mod log;
 pub mod provider;
 pub mod registry;
+pub mod resource_lookup;
 
 #[cfg(feature = "webhook")]
 pub mod webhook;
@@ -11,6 +12,7 @@ pub use error::ProviderError;
 pub use log::LogProvider;
 pub use provider::{DynProvider, Provider};
 pub use registry::ProviderRegistry;
+pub use resource_lookup::ResourceLookup;
 
 // Outbound W3C Trace Context injection — requires reqwest.
 #[cfg(feature = "trace-context")]

--- a/crates/provider/src/resource_lookup.rs
+++ b/crates/provider/src/resource_lookup.rs
@@ -1,0 +1,23 @@
+use async_trait::async_trait;
+
+use crate::ProviderError;
+
+/// Trait for providers that can look up external resource state.
+///
+/// Used by pre-dispatch enrichment to fetch live data (e.g., current `AutoScaling` group
+/// state) before rule evaluation.
+#[async_trait]
+pub trait ResourceLookup: Send + Sync {
+    /// Look up a resource by type and parameters.
+    ///
+    /// Returns a JSON value containing the resource state, which will be merged
+    /// into the action payload under the configured merge key.
+    async fn lookup(
+        &self,
+        resource_type: &str,
+        params: &serde_json::Value,
+    ) -> Result<serde_json::Value, ProviderError>;
+
+    /// Returns the list of resource types this provider supports.
+    fn supported_resource_types(&self) -> Vec<String>;
+}

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -88,7 +88,7 @@ pub struct ProviderConfig {
     pub name: String,
     /// Provider type: `"webhook"`, `"log"`, `"twilio"`, `"teams"`, `"discord"`,
     /// `"email"`, `"aws-sns"`, `"aws-lambda"`, `"aws-eventbridge"`, `"aws-sqs"`,
-    /// or `"aws-s3"`.
+    /// `"aws-s3"`, `"aws-ec2"`, or `"aws-autoscaling"`.
     #[serde(rename = "type")]
     pub provider_type: String,
     /// Target URL (required for `"webhook"` type).
@@ -155,6 +155,13 @@ pub struct ProviderConfig {
     pub bucket_name: Option<String>,
     /// S3 object key prefix (used by `"aws-s3"` type).
     pub object_prefix: Option<String>,
+    /// Default security group IDs (used by `"aws-ec2"` type).
+    #[serde(default)]
+    pub default_security_group_ids: Option<Vec<String>>,
+    /// Default subnet ID (used by `"aws-ec2"` type).
+    pub default_subnet_id: Option<String>,
+    /// Default key-pair name (used by `"aws-ec2"` type).
+    pub default_key_name: Option<String>,
 }
 
 /// Configuration for the state store backend.

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -827,12 +827,57 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 std::sync::Arc::new(acteon_aws::S3Provider::new(s3_config).await)
             }
+            "aws-ec2" => {
+                let region = provider_cfg.aws_region.as_deref().unwrap_or("us-east-1");
+                let mut ec2_config = acteon_aws::Ec2Config::new(region);
+                if let Some(ref ids) = provider_cfg.default_security_group_ids {
+                    ec2_config = ec2_config.with_default_security_group_ids(ids.clone());
+                }
+                if let Some(ref sid) = provider_cfg.default_subnet_id {
+                    ec2_config = ec2_config.with_default_subnet_id(sid);
+                }
+                if let Some(ref kn) = provider_cfg.default_key_name {
+                    ec2_config = ec2_config.with_default_key_name(kn);
+                }
+                if let Some(ref url) = provider_cfg.aws_endpoint_url {
+                    ec2_config = ec2_config.with_endpoint_url(url);
+                }
+                if let Some(ref arn) = provider_cfg.aws_role_arn {
+                    ec2_config = ec2_config.with_role_arn(arn);
+                }
+                if let Some(ref name) = provider_cfg.aws_session_name {
+                    ec2_config = ec2_config.with_session_name(name);
+                }
+                if let Some(ref ext_id) = provider_cfg.aws_external_id {
+                    ec2_config = ec2_config.with_external_id(ext_id);
+                }
+                std::sync::Arc::new(acteon_aws::Ec2Provider::new(ec2_config).await)
+            }
+            "aws-autoscaling" => {
+                let region = provider_cfg.aws_region.as_deref().unwrap_or("us-east-1");
+                let mut asg_config = acteon_aws::AutoScalingConfig::new(region);
+                if let Some(ref url) = provider_cfg.aws_endpoint_url {
+                    asg_config = asg_config.with_endpoint_url(url);
+                }
+                if let Some(ref arn) = provider_cfg.aws_role_arn {
+                    asg_config = asg_config.with_role_arn(arn);
+                }
+                if let Some(ref name) = provider_cfg.aws_session_name {
+                    asg_config = asg_config.with_session_name(name);
+                }
+                if let Some(ref ext_id) = provider_cfg.aws_external_id {
+                    asg_config = asg_config.with_external_id(ext_id);
+                }
+                std::sync::Arc::new(acteon_aws::AutoScalingProvider::new(asg_config).await)
+            }
             other => {
                 return Err(format!(
-                        "provider '{}': unknown type '{other}' (expected 'webhook', 'log', 'twilio', 'teams', 'discord', 'email', 'aws-sns', 'aws-lambda', 'aws-eventbridge', 'aws-sqs', or 'aws-s3')",
-                        provider_cfg.name
-                    )
-                    .into());
+                    "provider '{}': unknown type '{other}' (expected 'webhook', 'log', 'twilio', \
+                         'teams', 'discord', 'email', 'aws-sns', 'aws-lambda', 'aws-eventbridge', \
+                         'aws-sqs', 'aws-s3', 'aws-ec2', or 'aws-autoscaling')",
+                    provider_cfg.name
+                )
+                .into());
             }
         };
         builder = builder.provider(provider);

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -164,5 +164,9 @@ name = "wasm_plugin_simulation"
 name = "compliance_simulation"
 # No required-features - uses in-memory backends
 
+[[example]]
+name = "ec2_simulation"
+# No required-features - uses in-memory backends
+
 [lints]
 workspace = true

--- a/crates/simulation/examples/ec2_simulation.rs
+++ b/crates/simulation/examples/ec2_simulation.rs
@@ -1,0 +1,520 @@
+//! Simulation demonstrating AWS EC2 and Auto Scaling provider action types.
+//!
+//! Covers all EC2 instance lifecycle operations (start, stop, reboot, terminate,
+//! hibernate, run, describe) and EBS volume operations (attach, detach), plus
+//! Auto Scaling Group management (describe, set capacity, update).
+//!
+//! Run with:
+//! ```bash
+//! cargo run -p acteon-simulation --example ec2_simulation
+//! ```
+
+use acteon_core::{Action, ActionOutcome};
+use acteon_simulation::prelude::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("==================================================================");
+    println!("       AWS EC2 & AUTO SCALING SIMULATION");
+    println!("==================================================================\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("aws-ec2")
+            .add_recording_provider("aws-autoscaling")
+            .build(),
+    )
+    .await?;
+
+    println!("Started simulation cluster with 1 node");
+    println!("Registered providers: aws-ec2, aws-autoscaling\n");
+
+    let mut results: Vec<(&str, ActionOutcome)> = Vec::new();
+
+    // =========================================================================
+    // 1. EC2 Start Instances
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  1. EC2 START INSTANCES");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "compute",
+        "acme-corp",
+        "aws-ec2",
+        "start_instances",
+        serde_json::json!({
+            "instance_ids": ["i-0abc123def456789a", "i-0def456abc789012b"]
+        }),
+    );
+
+    println!("  Dispatching start_instances for 2 instances...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("ec2/start_instances", outcome));
+    println!();
+
+    // =========================================================================
+    // 2. EC2 Stop Instances (basic)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  2. EC2 STOP INSTANCES (basic)");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "compute",
+        "acme-corp",
+        "aws-ec2",
+        "stop_instances",
+        serde_json::json!({
+            "instance_ids": ["i-0abc123def456789a"]
+        }),
+    );
+
+    println!("  Dispatching stop_instances (basic)...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("ec2/stop_instances(basic)", outcome));
+    println!();
+
+    // =========================================================================
+    // 3. EC2 Stop Instances with hibernate
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  3. EC2 STOP INSTANCES (hibernate)");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "compute",
+        "acme-corp",
+        "aws-ec2",
+        "stop_instances",
+        serde_json::json!({
+            "instance_ids": ["i-0abc123def456789a"],
+            "hibernate": true
+        }),
+    );
+
+    println!("  Dispatching stop_instances with hibernate=true...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("ec2/stop_instances(hibernate)", outcome));
+    println!();
+
+    // =========================================================================
+    // 4. EC2 Stop Instances with force
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  4. EC2 STOP INSTANCES (force)");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "compute",
+        "acme-corp",
+        "aws-ec2",
+        "stop_instances",
+        serde_json::json!({
+            "instance_ids": ["i-0abc123def456789a"],
+            "force": true
+        }),
+    );
+
+    println!("  Dispatching stop_instances with force=true...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("ec2/stop_instances(force)", outcome));
+    println!();
+
+    // =========================================================================
+    // 5. EC2 Reboot Instances
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  5. EC2 REBOOT INSTANCES");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "compute",
+        "acme-corp",
+        "aws-ec2",
+        "reboot_instances",
+        serde_json::json!({
+            "instance_ids": ["i-0abc123def456789a"]
+        }),
+    );
+
+    println!("  Dispatching reboot_instances...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("ec2/reboot_instances", outcome));
+    println!();
+
+    // =========================================================================
+    // 6. EC2 Terminate Instances
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  6. EC2 TERMINATE INSTANCES");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "compute",
+        "acme-corp",
+        "aws-ec2",
+        "terminate_instances",
+        serde_json::json!({
+            "instance_ids": ["i-0abc123def456789a", "i-0def456abc789012b"]
+        }),
+    );
+
+    println!("  Dispatching terminate_instances for 2 instances...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("ec2/terminate_instances", outcome));
+    println!();
+
+    // =========================================================================
+    // 7. EC2 Hibernate Instances (sugar action type)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  7. EC2 HIBERNATE INSTANCES (sugar)");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "compute",
+        "acme-corp",
+        "aws-ec2",
+        "hibernate_instances",
+        serde_json::json!({
+            "instance_ids": ["i-0abc123def456789a"]
+        }),
+    );
+
+    println!("  Dispatching hibernate_instances (sugar for stop+hibernate)...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("ec2/hibernate_instances", outcome));
+    println!();
+
+    // =========================================================================
+    // 8. EC2 Run Instances (minimal)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  8. EC2 RUN INSTANCES (minimal)");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "compute",
+        "acme-corp",
+        "aws-ec2",
+        "run_instances",
+        serde_json::json!({
+            "image_id": "ami-0abcdef1234567890",
+            "instance_type": "t3.nano"
+        }),
+    );
+
+    println!("  Dispatching run_instances (minimal payload)...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("ec2/run_instances(minimal)", outcome));
+    println!();
+
+    // =========================================================================
+    // 9. EC2 Run Instances (full options)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  9. EC2 RUN INSTANCES (full options)");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "compute",
+        "acme-corp",
+        "aws-ec2",
+        "run_instances",
+        serde_json::json!({
+            "image_id": "ami-0abcdef1234567890",
+            "instance_type": "t3.micro",
+            "min_count": 2,
+            "max_count": 5,
+            "key_name": "deploy-key",
+            "security_group_ids": ["sg-0123456789abcdef0", "sg-0abcdef0123456789"],
+            "subnet_id": "subnet-0123456789abcdef0",
+            "user_data": "IyEvYmluL2Jhc2gKZWNobyBIZWxsbw==",
+            "tags": {
+                "env": "staging",
+                "team": "platform",
+                "project": "acteon"
+            },
+            "iam_instance_profile": "arn:aws:iam::123456789012:instance-profile/app-profile"
+        }),
+    );
+
+    println!("  Dispatching run_instances (full options with tags, SGs, user data)...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("ec2/run_instances(full)", outcome));
+    println!();
+
+    // =========================================================================
+    // 10. EC2 Attach Volume
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  10. EC2 ATTACH VOLUME");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "compute",
+        "acme-corp",
+        "aws-ec2",
+        "attach_volume",
+        serde_json::json!({
+            "volume_id": "vol-0abc123def456789a",
+            "instance_id": "i-0abc123def456789a",
+            "device": "/dev/sdf"
+        }),
+    );
+
+    println!("  Dispatching attach_volume...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("ec2/attach_volume", outcome));
+    println!();
+
+    // =========================================================================
+    // 11. EC2 Detach Volume
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  11. EC2 DETACH VOLUME");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "compute",
+        "acme-corp",
+        "aws-ec2",
+        "detach_volume",
+        serde_json::json!({
+            "volume_id": "vol-0abc123def456789a",
+            "instance_id": "i-0abc123def456789a",
+            "device": "/dev/sdf"
+        }),
+    );
+
+    println!("  Dispatching detach_volume...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("ec2/detach_volume", outcome));
+    println!();
+
+    // =========================================================================
+    // 12. EC2 Detach Volume with force
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  12. EC2 DETACH VOLUME (force)");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "compute",
+        "acme-corp",
+        "aws-ec2",
+        "detach_volume",
+        serde_json::json!({
+            "volume_id": "vol-0abc123def456789a",
+            "force": true
+        }),
+    );
+
+    println!("  Dispatching detach_volume with force=true...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("ec2/detach_volume(force)", outcome));
+    println!();
+
+    // =========================================================================
+    // 13. EC2 Describe Instances
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  13. EC2 DESCRIBE INSTANCES");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "compute",
+        "acme-corp",
+        "aws-ec2",
+        "describe_instances",
+        serde_json::json!({
+            "instance_ids": ["i-0abc123def456789a"]
+        }),
+    );
+
+    println!("  Dispatching describe_instances...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("ec2/describe_instances", outcome));
+    println!();
+
+    // =========================================================================
+    // 14. ASG Describe Auto Scaling Groups
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  14. ASG DESCRIBE AUTO SCALING GROUPS");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "scaling",
+        "acme-corp",
+        "aws-autoscaling",
+        "describe_auto_scaling_groups",
+        serde_json::json!({
+            "auto_scaling_group_names": ["web-tier-asg", "api-tier-asg"]
+        }),
+    );
+
+    println!("  Dispatching describe_auto_scaling_groups...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("asg/describe_groups", outcome));
+    println!();
+
+    // =========================================================================
+    // 15. ASG Set Desired Capacity
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  15. ASG SET DESIRED CAPACITY");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "scaling",
+        "acme-corp",
+        "aws-autoscaling",
+        "set_desired_capacity",
+        serde_json::json!({
+            "auto_scaling_group_name": "web-tier-asg",
+            "desired_capacity": 6,
+            "honor_cooldown": true
+        }),
+    );
+
+    println!("  Dispatching set_desired_capacity (desired=6, honor_cooldown)...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("asg/set_desired_capacity", outcome));
+    println!();
+
+    // =========================================================================
+    // 16. ASG Update Auto Scaling Group
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  16. ASG UPDATE AUTO SCALING GROUP");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "scaling",
+        "acme-corp",
+        "aws-autoscaling",
+        "update_auto_scaling_group",
+        serde_json::json!({
+            "auto_scaling_group_name": "web-tier-asg",
+            "min_size": 2,
+            "max_size": 20,
+            "desired_capacity": 8,
+            "default_cooldown": 300,
+            "health_check_type": "ELB",
+            "health_check_grace_period": 120
+        }),
+    );
+
+    println!("  Dispatching update_auto_scaling_group (full update)...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("asg/update_group", outcome));
+    println!();
+
+    // =========================================================================
+    // 17. EC2 Unknown Action Type (routed to recording provider)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  17. EC2 UNKNOWN ACTION TYPE");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "compute",
+        "acme-corp",
+        "aws-ec2",
+        "create_snapshot",
+        serde_json::json!({
+            "volume_id": "vol-0abc123def456789a"
+        }),
+    );
+
+    println!("  Dispatching unknown EC2 action type 'create_snapshot'...");
+    println!(
+        "  (Recording provider accepts all action types; real Ec2Provider rejects unknown types)"
+    );
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("ec2/unknown_action", outcome));
+    println!();
+
+    // =========================================================================
+    // 18. ASG Unknown Action Type (routed to recording provider)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  18. ASG UNKNOWN ACTION TYPE");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "scaling",
+        "acme-corp",
+        "aws-autoscaling",
+        "delete_auto_scaling_group",
+        serde_json::json!({
+            "auto_scaling_group_name": "old-asg"
+        }),
+    );
+
+    println!("  Dispatching unknown ASG action type 'delete_auto_scaling_group'...");
+    println!(
+        "  (Recording provider accepts all action types; real AutoScalingProvider rejects unknown types)"
+    );
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("asg/unknown_action", outcome));
+    println!();
+
+    // =========================================================================
+    // Summary
+    // =========================================================================
+    println!("==================================================================");
+    println!("  SUMMARY");
+    println!("==================================================================\n");
+
+    let mut all_passed = true;
+    for (name, outcome) in &results {
+        let passed = matches!(outcome, ActionOutcome::Executed(_));
+        let status = if passed { "PASS" } else { "FAIL" };
+        println!("  [{status}] {name}: {outcome:?}");
+        if !passed {
+            all_passed = false;
+        }
+    }
+
+    println!();
+    println!(
+        "  Total dispatched: {}  |  EC2 calls: {}  |  ASG calls: {}",
+        results.len(),
+        harness.provider("aws-ec2").unwrap().call_count(),
+        harness.provider("aws-autoscaling").unwrap().call_count(),
+    );
+
+    harness.teardown().await?;
+    println!("\n  Simulation cluster shut down");
+
+    if all_passed {
+        println!("\n  All EC2 and Auto Scaling actions dispatched successfully.");
+    } else {
+        println!("\n  Some actions failed. See details above.");
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/docs/book/features/aws-providers.md
+++ b/docs/book/features/aws-providers.md
@@ -1,6 +1,6 @@
 # AWS Providers
 
-Acteon ships with native AWS provider integrations for **SNS**, **Lambda**, **EventBridge**, **SQS**, **S3**, and **SES** (via the email provider). All six are first-class citizens -- they implement the same `Provider` trait, participate in circuit breaking, health checks, and per-provider metrics, and require no external plugins.
+Acteon ships with native AWS provider integrations for **SNS**, **Lambda**, **EventBridge**, **SQS**, **S3**, **SES** (via the email provider), **EC2**, and **Auto Scaling**. All eight are first-class citizens -- they implement the same `Provider` trait, participate in circuit breaking, health checks, and per-provider metrics, and require no external plugins.
 
 ## Overview
 
@@ -12,6 +12,8 @@ Acteon ships with native AWS provider integrations for **SNS**, **Lambda**, **Ev
 | `aws-sqs` | Simple Queue Service | `send_message` | Queue messages for async processing |
 | `aws-s3` | Simple Storage Service | `put_object`, `get_object`, `delete_object` | Store and retrieve objects (logs, artifacts, archives) |
 | `ses` (email) | Simple Email Service | `send_email` | Send transactional emails via SES |
+| `aws-ec2` | EC2 | `start_instances`, `stop_instances`, `reboot_instances`, `terminate_instances`, `hibernate_instances`, `run_instances`, `attach_volume`, `detach_volume`, `describe_instances` | Instance lifecycle management, EBS volume operations |
+| `aws-autoscaling` | Auto Scaling | `describe_auto_scaling_groups`, `set_desired_capacity`, `update_auto_scaling_group` | Manage Auto Scaling Group capacity and settings |
 
 All AWS providers:
 
@@ -154,6 +156,59 @@ aws_region = "us-east-1"
 ```
 
 See the [Email provider documentation](native-providers.md) for full payload format details.
+
+### AWS EC2
+
+```toml
+[[providers]]
+name = "compute"
+type = "aws-ec2"
+aws_region = "us-east-1"
+# Optional defaults applied to run_instances when not overridden in the payload:
+# default_security_group_ids = ["sg-0123456789abcdef0"]
+# default_subnet_id = "subnet-0123456789abcdef0"
+# default_key_name = "my-keypair"
+# aws_endpoint_url = "http://localhost:4566"   # LocalStack
+# aws_role_arn = "arn:aws:iam::123:role/ec2"   # Cross-account
+# aws_session_name = "acteon-ec2"              # STS session name
+# aws_external_id = "ext-123"                  # Trust policy external ID
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used in action dispatch |
+| `type` | Yes | Must be `"aws-ec2"` |
+| `aws_region` | Yes | AWS region |
+| `default_security_group_ids` | No | Default security group IDs for `run_instances`. Can be overridden per-action |
+| `default_subnet_id` | No | Default subnet ID for `run_instances`. Can be overridden per-action |
+| `default_key_name` | No | Default key-pair name for `run_instances`. Can be overridden per-action |
+| `aws_endpoint_url` | No | Endpoint URL override (for LocalStack) |
+| `aws_role_arn` | No | IAM role ARN to assume via STS |
+| `aws_session_name` | No | STS session name (defaults to `"acteon-aws-provider"`) |
+| `aws_external_id` | No | External ID for cross-account trust policies |
+
+### AWS Auto Scaling
+
+```toml
+[[providers]]
+name = "scaling"
+type = "aws-autoscaling"
+aws_region = "us-east-1"
+# aws_endpoint_url = "http://localhost:4566"   # LocalStack
+# aws_role_arn = "arn:aws:iam::123:role/asg"   # Cross-account
+# aws_session_name = "acteon-asg"              # STS session name
+# aws_external_id = "ext-123"                  # Trust policy external ID
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used in action dispatch |
+| `type` | Yes | Must be `"aws-autoscaling"` |
+| `aws_region` | Yes | AWS region |
+| `aws_endpoint_url` | No | Endpoint URL override (for LocalStack) |
+| `aws_role_arn` | No | IAM role ARN to assume via STS |
+| `aws_session_name` | No | STS session name (defaults to `"acteon-aws-provider"`) |
+| `aws_external_id` | No | External ID for cross-account trust policies |
 
 ## Payload Formats
 
@@ -367,6 +422,356 @@ See the [Email provider documentation](native-providers.md) for full payload for
 }
 ```
 
+### EC2: `start_instances`
+
+```json
+{
+  "instance_ids": ["i-0abc123def456789a", "i-0def456abc789012b"]
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `instance_ids` | Yes | string[] | EC2 instance IDs to start |
+
+**Response:**
+
+```json
+{
+  "action": "start_instances",
+  "instance_state_changes": [
+    {
+      "instance_id": "i-0abc123def456789a",
+      "previous_state": "stopped",
+      "current_state": "pending"
+    }
+  ]
+}
+```
+
+### EC2: `stop_instances`
+
+```json
+{
+  "instance_ids": ["i-0abc123def456789a"],
+  "hibernate": false,
+  "force": false
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `instance_ids` | Yes | string[] | EC2 instance IDs to stop |
+| `hibernate` | No | bool | Hibernate the instances instead of stopping (default `false`) |
+| `force` | No | bool | Force stop without graceful shutdown (default `false`) |
+
+**Response:**
+
+```json
+{
+  "action": "stop_instances",
+  "hibernate": false,
+  "instance_state_changes": [
+    {
+      "instance_id": "i-0abc123def456789a",
+      "previous_state": "running",
+      "current_state": "stopping"
+    }
+  ]
+}
+```
+
+### EC2: `reboot_instances`
+
+```json
+{
+  "instance_ids": ["i-0abc123def456789a"]
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `instance_ids` | Yes | string[] | EC2 instance IDs to reboot |
+
+**Response:**
+
+```json
+{
+  "action": "reboot_instances",
+  "instance_ids": ["i-0abc123def456789a"],
+  "status": "rebooting"
+}
+```
+
+### EC2: `terminate_instances`
+
+```json
+{
+  "instance_ids": ["i-0abc123def456789a"]
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `instance_ids` | Yes | string[] | EC2 instance IDs to terminate |
+
+**Response:**
+
+```json
+{
+  "action": "terminate_instances",
+  "instance_state_changes": [
+    {
+      "instance_id": "i-0abc123def456789a",
+      "previous_state": "running",
+      "current_state": "shutting-down"
+    }
+  ]
+}
+```
+
+### EC2: `hibernate_instances`
+
+Sugar action type that internally dispatches `stop_instances` with `hibernate: true`.
+
+```json
+{
+  "instance_ids": ["i-0abc123def456789a"]
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `instance_ids` | Yes | string[] | EC2 instance IDs to hibernate |
+
+**Response:** Same as `stop_instances` with `"hibernate": true`.
+
+### EC2: `run_instances`
+
+```json
+{
+  "image_id": "ami-0abcdef1234567890",
+  "instance_type": "t3.micro",
+  "min_count": 1,
+  "max_count": 2,
+  "key_name": "my-keypair",
+  "security_group_ids": ["sg-0123456789abcdef0"],
+  "subnet_id": "subnet-0123456789abcdef0",
+  "user_data": "IyEvYmluL2Jhc2gKZWNobyBIZWxsbw==",
+  "tags": {
+    "env": "staging",
+    "team": "platform"
+  },
+  "iam_instance_profile": "arn:aws:iam::123456789012:instance-profile/app-profile"
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `image_id` | Yes | string | AMI ID to launch |
+| `instance_type` | Yes | string | Instance type (e.g. `"t3.micro"`) |
+| `min_count` | No | integer | Minimum instances to launch (default 1) |
+| `max_count` | No | integer | Maximum instances to launch (default 1) |
+| `key_name` | No | string | Key-pair name. Overrides config `default_key_name` |
+| `security_group_ids` | No | string[] | Security group IDs. Overrides config `default_security_group_ids` |
+| `subnet_id` | No | string | Subnet ID. Overrides config `default_subnet_id` |
+| `user_data` | No | string | Base64-encoded user data script |
+| `tags` | No | object | Key-value tags applied to launched instances |
+| `iam_instance_profile` | No | string | IAM instance profile name or ARN |
+
+**Response:**
+
+```json
+{
+  "action": "run_instances",
+  "reservation_id": "r-0abc123def456789a",
+  "instances": [
+    {
+      "instance_id": "i-0abc123def456789a",
+      "instance_type": "t3.micro",
+      "state": "pending"
+    }
+  ]
+}
+```
+
+### EC2: `attach_volume`
+
+```json
+{
+  "volume_id": "vol-0abc123def456789a",
+  "instance_id": "i-0abc123def456789a",
+  "device": "/dev/sdf"
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `volume_id` | Yes | string | EBS volume ID to attach |
+| `instance_id` | Yes | string | Target EC2 instance ID |
+| `device` | Yes | string | Device name (e.g. `"/dev/sdf"`) |
+
+**Response:**
+
+```json
+{
+  "action": "attach_volume",
+  "volume_id": "vol-0abc123def456789a",
+  "instance_id": "i-0abc123def456789a",
+  "device": "/dev/sdf",
+  "state": "attaching"
+}
+```
+
+### EC2: `detach_volume`
+
+```json
+{
+  "volume_id": "vol-0abc123def456789a",
+  "instance_id": "i-0abc123def456789a",
+  "device": "/dev/sdf",
+  "force": false
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `volume_id` | Yes | string | EBS volume ID to detach |
+| `instance_id` | No | string | Instance to detach from |
+| `device` | No | string | Device name |
+| `force` | No | bool | Force detachment (default `false`) |
+
+**Response:**
+
+```json
+{
+  "action": "detach_volume",
+  "volume_id": "vol-0abc123def456789a",
+  "instance_id": "i-0abc123def456789a",
+  "state": "detaching"
+}
+```
+
+### EC2: `describe_instances`
+
+```json
+{
+  "instance_ids": ["i-0abc123def456789a"]
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `instance_ids` | No | string[] | Instance IDs to describe. If empty, describes all instances |
+
+**Response:**
+
+```json
+{
+  "action": "describe_instances",
+  "instances": [
+    {
+      "instance_id": "i-0abc123def456789a",
+      "instance_type": "t3.micro",
+      "state": "running",
+      "public_ip": "54.123.45.67",
+      "private_ip": "10.0.1.42"
+    }
+  ]
+}
+```
+
+### Auto Scaling: `describe_auto_scaling_groups`
+
+```json
+{
+  "auto_scaling_group_names": ["web-tier-asg", "api-tier-asg"]
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `auto_scaling_group_names` | No | string[] | Group names to describe. If empty, describes all groups |
+
+**Response:**
+
+```json
+{
+  "action": "describe_auto_scaling_groups",
+  "auto_scaling_groups": [
+    {
+      "auto_scaling_group_name": "web-tier-asg",
+      "min_size": 2,
+      "max_size": 10,
+      "desired_capacity": 4,
+      "instance_count": 4,
+      "health_check_type": "ELB"
+    }
+  ]
+}
+```
+
+### Auto Scaling: `set_desired_capacity`
+
+```json
+{
+  "auto_scaling_group_name": "web-tier-asg",
+  "desired_capacity": 6,
+  "honor_cooldown": true
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `auto_scaling_group_name` | Yes | string | Auto Scaling Group name |
+| `desired_capacity` | Yes | integer | Target capacity |
+| `honor_cooldown` | No | bool | Whether to honor the group's cooldown period (default `false`) |
+
+**Response:**
+
+```json
+{
+  "action": "set_desired_capacity",
+  "auto_scaling_group_name": "web-tier-asg",
+  "desired_capacity": 6,
+  "status": "updated"
+}
+```
+
+### Auto Scaling: `update_auto_scaling_group`
+
+```json
+{
+  "auto_scaling_group_name": "web-tier-asg",
+  "min_size": 2,
+  "max_size": 20,
+  "desired_capacity": 8,
+  "default_cooldown": 300,
+  "health_check_type": "ELB",
+  "health_check_grace_period": 120
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `auto_scaling_group_name` | Yes | string | Auto Scaling Group name |
+| `min_size` | No | integer | New minimum size |
+| `max_size` | No | integer | New maximum size |
+| `desired_capacity` | No | integer | New desired capacity |
+| `default_cooldown` | No | integer | Default cooldown period in seconds |
+| `health_check_type` | No | string | Health check type (`"EC2"` or `"ELB"`) |
+| `health_check_grace_period` | No | integer | Health check grace period in seconds |
+
+**Response:**
+
+```json
+{
+  "action": "update_auto_scaling_group",
+  "auto_scaling_group_name": "web-tier-asg",
+  "status": "updated"
+}
+```
+
 ## Authentication and Credential Refresh
 
 All AWS providers share a common authentication layer in `acteon-aws`. Credentials are resolved in this order:
@@ -403,6 +808,8 @@ The `aws_external_id` is validated against the trust policy's `Condition` block,
 | `aws-sqs` | `ListQueues` (max 1) | Verifies API connectivity and credentials |
 | `aws-s3` | `ListBuckets` (max 1) | Verifies API connectivity and credentials |
 | SES (email) | `GetAccount` | Verifies SES sending is enabled |
+| `aws-ec2` | `DescribeInstances` (dry-run) | `DryRunOperation` error = healthy; verifies IAM permissions |
+| `aws-autoscaling` | `DescribeAutoScalingGroups` (max 1) | Verifies API connectivity and credentials |
 
 All health checks are lightweight read-only operations that do not modify any resources.
 
@@ -463,6 +870,33 @@ curl -X POST http://localhost:8080/v1/dispatch \
       "content_type": "application/json"
     }
   }'
+
+# Start EC2 instances
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "compute",
+    "tenant": "acme-corp",
+    "provider": "compute",
+    "action_type": "start_instances",
+    "payload": {
+      "instance_ids": ["i-0abc123def456789a"]
+    }
+  }'
+
+# Scale up an Auto Scaling Group
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "scaling",
+    "tenant": "acme-corp",
+    "provider": "scaling",
+    "action_type": "set_desired_capacity",
+    "payload": {
+      "auto_scaling_group_name": "web-tier-asg",
+      "desired_capacity": 6
+    }
+  }'
 ```
 
 ## Example: Rust Client
@@ -501,6 +935,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }),
     ).await?;
 
+    // Start EC2 instances
+    client.dispatch_action(
+        "compute", "acme-corp", "compute", "start_instances",
+        serde_json::json!({
+            "instance_ids": ["i-0abc123def456789a"]
+        }),
+    ).await?;
+
+    // Launch new EC2 instances
+    client.dispatch_action(
+        "compute", "acme-corp", "compute", "run_instances",
+        serde_json::json!({
+            "image_id": "ami-0abcdef1234567890",
+            "instance_type": "t3.micro",
+            "max_count": 2,
+            "tags": {"env": "staging"}
+        }),
+    ).await?;
+
+    // Scale up an Auto Scaling Group
+    client.dispatch_action(
+        "scaling", "acme-corp", "scaling", "set_desired_capacity",
+        serde_json::json!({
+            "auto_scaling_group_name": "web-tier-asg",
+            "desired_capacity": 6
+        }),
+    ).await?;
+
     Ok(())
 }
 ```
@@ -525,4 +987,4 @@ aws_endpoint_url = "http://localhost:4566"
 topic_arn = "arn:aws:sns:us-east-1:000000000000:alerts"
 ```
 
-See the [AWS Event-Driven Pipeline Guide](../guides/aws-event-pipeline.md) for a complete runnable example using LocalStack with all six provider types.
+See the [AWS Event-Driven Pipeline Guide](../guides/aws-event-pipeline.md) for a complete runnable example using LocalStack with all eight provider types.

--- a/examples/aws-cost-optimizer/README.md
+++ b/examples/aws-cost-optimizer/README.md
@@ -64,7 +64,7 @@ The example includes **safety rules** (`rules/safety.yaml`) that block destructi
 
 ### The `capacity_verified` attestation pattern
 
-Acteon rules can't query AWS in real time, so the pattern is:
+Acteon rules can't query AWS in real time (without enrichment), so the simplest pattern is:
 
 1. **Client** calls `describe_auto_scaling_groups` to check current capacity
 2. **Client** verifies `desired_capacity > min_size + N` (enough headroom)
@@ -72,6 +72,10 @@ Acteon rules can't query AWS in real time, so the pattern is:
 4. **Acteon** rules allow the destructive operation because the attestation is present
 
 This keeps the safety check at the caller while Acteon enforces that the check was performed. The `available_capacity` field is recorded in the audit trail for post-incident review.
+
+### Pre-dispatch enrichment (alternative)
+
+For automated pipelines where client-side orchestration is impractical, you can configure **pre-dispatch enrichment** to have the gateway fetch live ASG state before rule evaluation. See the commented `[[enrichments]]` section in `acteon.toml` and the [AWS Providers documentation](../../docs/book/features/aws-providers.md) for details.
 
 ### Testing the guardrails
 

--- a/examples/aws-cost-optimizer/README.md
+++ b/examples/aws-cost-optimizer/README.md
@@ -1,0 +1,111 @@
+# AWS Cost Optimizer
+
+A practical example using **Recurring Actions** with the **AWS Auto Scaling** provider to automatically scale down staging Auto Scaling Groups during off-hours and restore them each morning. This reduces overnight compute costs by ~87% for non-production environments.
+
+## Features Exercised
+
+| # | Feature | How |
+|---|---------|-----|
+| 1 | **AWS Auto Scaling** | `set_desired_capacity` to scale ASGs up and down |
+| 2 | **Recurring Actions** | 6 cron-scheduled jobs (3 scale-down, 3 scale-up) |
+| 3 | **Timezone-aware cron** | Schedules use `America/New_York` timezone |
+| 4 | **Quotas** | 100 scaling actions/day limit |
+| 5 | **Circuit breakers** | ASG provider trips after 2 failures, falls back to log |
+| 6 | **Rules** | Enrich scaling actions with cost-optimization metadata |
+| 7 | **Audit trail** | Full audit of all scaling operations |
+
+## Prerequisites
+
+- [LocalStack](https://localstack.cloud/) (provides Auto Scaling API)
+- `awslocal` CLI (`pip install awscli-local`)
+- `jq` (for script output formatting)
+
+## Quick Start
+
+```bash
+# 1. Start LocalStack
+docker run --rm -d --name localstack -p 4566:4566 localstack/localstack
+
+# 2. Create Auto Scaling Groups
+bash examples/aws-cost-optimizer/scripts/setup.sh
+
+# 3. Start Acteon
+cargo run -p acteon-server -- -c examples/aws-cost-optimizer/acteon.toml
+
+# 4. Create recurring scaling schedules and quota
+bash examples/aws-cost-optimizer/scripts/setup-api.sh
+
+# 5. (Optional) Send manual scaling actions to test the pipeline
+bash examples/aws-cost-optimizer/scripts/send-scaling.sh
+
+# 6. View report
+bash examples/aws-cost-optimizer/scripts/show-report.sh
+
+# 7. Cleanup API resources
+bash examples/aws-cost-optimizer/scripts/teardown.sh
+
+# 8. Stop LocalStack
+docker stop localstack
+```
+
+## File Structure
+
+```
+aws-cost-optimizer/
+├── acteon.toml              # Server config (ASG provider, background recurring, quota)
+├── rules/
+│   └── routing.yaml         # Route scaling actions, enrich metadata, catch-all
+├── scripts/
+│   ├── setup.sh             # Create LocalStack ASGs (staging-web, staging-api, staging-workers)
+│   ├── setup-api.sh         # Create 6 recurring actions + quota via API
+│   ├── send-scaling.sh      # Fire manual scaling actions (no waiting for cron)
+│   ├── show-report.sh       # Query audit/health/recurring/quotas
+│   └── teardown.sh          # Clean up API-created resources
+└── README.md
+```
+
+## Scaling Schedule
+
+```
+                Mon-Fri
+     7am EST              7pm EST
+        │                    │
+        ▼                    ▼
+  ┌──────────┐         ┌──────────┐
+  │ Scale Up │         │Scale Down│
+  └──────────┘         └──────────┘
+
+  staging-web:     4 instances  ──►  1 instance
+  staging-api:     6 instances  ──►  1 instance
+  staging-workers: 5 instances  ──►  0 instances
+  ─────────────────────────────────────────────
+  Total:          15 instances  ──►  2 instances
+                                    (87% reduction)
+```
+
+The recurring actions fire Monday through Friday:
+- **Scale-down** at 7pm EST (`0 19 * * 1-5`): reduce each ASG to minimum capacity
+- **Scale-up** at 7am EST (`0 7 * * 1-5`): restore daytime capacity
+
+Weekends keep off-hours capacity since the cron expression excludes Saturday/Sunday.
+
+## How It Works
+
+1. **`setup.sh`** creates 3 Auto Scaling Groups in LocalStack with daytime capacity
+2. **`setup-api.sh`** creates 6 recurring actions via the Acteon REST API, each with:
+   - A cron expression (e.g., `0 19 * * 1-5`)
+   - A timezone (`America/New_York`)
+   - An action template targeting the `cost-asg` provider with `set_desired_capacity`
+3. **Acteon's background processor** evaluates cron schedules every 30 seconds
+4. When a schedule fires, it dispatches the action through the full pipeline (rules, quotas, circuit breakers)
+5. The `cost-asg` provider calls the AWS Auto Scaling `SetDesiredCapacity` API
+6. All operations are recorded in the audit trail
+
+## Notes
+
+- **LocalStack** provides the Auto Scaling API locally. The provider endpoint points to `http://localhost:4566`.
+- **In-memory state** is used for simplicity. For production, use Redis or DynamoDB.
+- **Recurring actions** use the CAS (compare-and-swap) claim pattern to prevent duplicate execution in multi-instance deployments.
+- **`honor_cooldown: false`** is set on scaling actions to ensure immediate execution regardless of ASG cooldown periods.
+- **Weekend handling**: The `1-5` day-of-week range means no scaling happens on weekends, keeping capacity at whatever state it was in Friday evening.
+- **`send-scaling.sh`** sends the same actions manually, useful for testing without waiting for cron triggers.

--- a/examples/aws-cost-optimizer/acteon.toml
+++ b/examples/aws-cost-optimizer/acteon.toml
@@ -30,6 +30,13 @@ store_payload = true
 
 # ── Providers ────────────────────────────────────────────────────────────────
 
+# EC2: instance-level operations (terminate, reboot, describe)
+[[providers]]
+name = "cost-ec2"
+type = "aws-ec2"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+
 # Auto Scaling: manage ASG capacity
 [[providers]]
 name = "cost-asg"
@@ -58,6 +65,11 @@ enabled = true
 failure_threshold = 3
 success_threshold = 1
 recovery_timeout_seconds = 30
+
+[circuit_breaker.providers.cost-ec2]
+failure_threshold = 2
+recovery_timeout_seconds = 60
+fallback_provider = "local-fallback"
 
 [circuit_breaker.providers.cost-asg]
 failure_threshold = 2

--- a/examples/aws-cost-optimizer/acteon.toml
+++ b/examples/aws-cost-optimizer/acteon.toml
@@ -91,6 +91,23 @@ enable_retention_reaper = false
 namespace = "infra"
 tenant = "cost-optimizer"
 
+# ── Pre-Dispatch Enrichment (commented — requires real ASG state) ────────────
+# Uncomment to have the gateway automatically fetch live ASG state before rule
+# evaluation. Rules can then check `action.payload.current_asg_state.*` fields.
+#
+# [[enrichments]]
+# name = "fetch-asg-state"
+# action_type = "terminate_instances"
+# provider = "cost-ec2"
+# lookup_provider = "cost-asg"
+# resource_type = "auto_scaling_group"
+# merge_key = "current_asg_state"
+# timeout_seconds = 10
+# failure_policy = "fail_closed"
+#
+# [enrichments.params]
+# auto_scaling_group_names = ["{{payload.asg_name}}"]
+
 # ── Quotas ───────────────────────────────────────────────────────────────────
 # Quota enforcement enabled; policies created via the API in scripts/setup-api.sh.
 [quotas]

--- a/examples/aws-cost-optimizer/acteon.toml
+++ b/examples/aws-cost-optimizer/acteon.toml
@@ -1,0 +1,85 @@
+# AWS Cost Optimizer example.
+#
+# Uses Recurring Actions + Auto Scaling provider to schedule off-hours
+# scale-down and morning scale-up of Auto Scaling Groups, reducing
+# overnight compute costs for non-production environments.
+#
+# Requires LocalStack for AWS Auto Scaling:
+#   docker run --rm -d --name localstack -p 4566:4566 localstack/localstack
+#   bash examples/aws-cost-optimizer/scripts/setup.sh
+#
+# Start Acteon:
+#   cargo run -p acteon-server -- -c examples/aws-cost-optimizer/acteon.toml
+
+[server]
+host = "127.0.0.1"
+port = 8080
+
+# HMAC secret for signing approval URLs (hex-encoded, 256-bit).
+approval_secret = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+# ── State (in-memory for this demo) ─────────────────────────────────────────
+[state]
+backend = "memory"
+
+# ── Audit ────────────────────────────────────────────────────────────────────
+[audit]
+enabled = true
+backend = "memory"
+store_payload = true
+
+# ── Providers ────────────────────────────────────────────────────────────────
+
+# Auto Scaling: manage ASG capacity
+[[providers]]
+name = "cost-asg"
+type = "aws-autoscaling"
+aws_region = "us-east-1"
+aws_endpoint_url = "http://localhost:4566"
+
+# Log: fallback when AWS is unavailable
+[[providers]]
+name = "local-fallback"
+type = "log"
+
+# ── Rules ────────────────────────────────────────────────────────────────────
+[rules]
+directory = "examples/aws-cost-optimizer/rules"
+
+# ── Executor ─────────────────────────────────────────────────────────────────
+[executor]
+max_retries = 2
+timeout_seconds = 15
+max_concurrent = 8
+
+# ── Circuit Breaker ──────────────────────────────────────────────────────────
+[circuit_breaker]
+enabled = true
+failure_threshold = 3
+success_threshold = 1
+recovery_timeout_seconds = 30
+
+[circuit_breaker.providers.cost-asg]
+failure_threshold = 2
+recovery_timeout_seconds = 60
+fallback_provider = "local-fallback"
+
+# ── Background Processing ───────────────────────────────────────────────────
+[background]
+enabled = true
+group_flush_interval_seconds = 30
+timeout_check_interval_seconds = 30
+cleanup_interval_seconds = 120
+enable_group_flush = false
+enable_timeout_processing = true
+enable_recurring_actions = true
+recurring_check_interval_seconds = 30
+max_recurring_actions_per_tenant = 20
+enable_retention_reaper = false
+namespace = "infra"
+tenant = "cost-optimizer"
+
+# ── Quotas ───────────────────────────────────────────────────────────────────
+# Quota enforcement enabled; policies created via the API in scripts/setup-api.sh.
+[quotas]
+enabled = true

--- a/examples/aws-cost-optimizer/rules/routing.yaml
+++ b/examples/aws-cost-optimizer/rules/routing.yaml
@@ -61,6 +61,19 @@ rules:
     action:
       type: allow
 
+  # ── EC2 instance operations → EC2 provider ─────────────────────────────────
+  - name: route-ec2-ops
+    priority: 5
+    description: "Route EC2 instance operations to the EC2 provider"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "cost-optimizer"
+        - field: action.action_type
+          in_list: ["terminate_instances", "reboot_instances", "stop_instances", "start_instances", "describe_instances"]
+    action:
+      type: allow
+
   # ── Enrich all cost-optimizer actions with metadata ────────────────────────
   - name: enrich-cost-metadata
     priority: 15

--- a/examples/aws-cost-optimizer/rules/routing.yaml
+++ b/examples/aws-cost-optimizer/rules/routing.yaml
@@ -1,0 +1,94 @@
+# Routing rules: direct scaling actions to the Auto Scaling provider.
+
+rules:
+  # ── Scale-down requests → Auto Scaling provider ────────────────────────────
+  - name: route-scale-down
+    priority: 5
+    description: "Route set_desired_capacity scale-down actions to the ASG provider"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "cost-optimizer"
+        - field: action.action_type
+          eq: "set_desired_capacity"
+        - field: action.payload.tag
+          eq: "scale-down"
+    action:
+      type: modify
+      changes:
+        schedule_source: "cost-optimizer-cron"
+
+  # ── Scale-up requests → Auto Scaling provider ──────────────────────────────
+  - name: route-scale-up
+    priority: 5
+    description: "Route set_desired_capacity scale-up actions to the ASG provider"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "cost-optimizer"
+        - field: action.action_type
+          eq: "set_desired_capacity"
+        - field: action.payload.tag
+          eq: "scale-up"
+    action:
+      type: modify
+      changes:
+        schedule_source: "cost-optimizer-cron"
+
+  # ── Describe requests (health/audit queries) ───────────────────────────────
+  - name: route-describe
+    priority: 10
+    description: "Route describe_auto_scaling_groups requests to the ASG provider"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "cost-optimizer"
+        - field: action.action_type
+          eq: "describe_auto_scaling_groups"
+    action:
+      type: allow
+
+  # ── Update ASG config ──────────────────────────────────────────────────────
+  - name: route-update-asg
+    priority: 10
+    description: "Route update_auto_scaling_group requests to the ASG provider"
+    condition:
+      all:
+        - field: action.tenant
+          eq: "cost-optimizer"
+        - field: action.action_type
+          eq: "update_auto_scaling_group"
+    action:
+      type: allow
+
+  # ── Enrich all cost-optimizer actions with metadata ────────────────────────
+  - name: enrich-cost-metadata
+    priority: 15
+    description: "Add cost-optimization metadata to all actions"
+    condition:
+      field: action.tenant
+      eq: "cost-optimizer"
+    action:
+      type: modify
+      changes:
+        cost_optimization: "true"
+        managed_by: "acteon-cost-optimizer"
+
+  # ── Allow remaining actions ────────────────────────────────────────────────
+  - name: allow-remaining
+    priority: 20
+    description: "Allow any cost-optimizer action that passed prior rules"
+    condition:
+      field: action.tenant
+      eq: "cost-optimizer"
+    action:
+      type: allow
+
+  # ── Catch-all: deny unmatched ──────────────────────────────────────────────
+  - name: deny-unmatched
+    priority: 100
+    description: "Suppress unmatched actions from other tenants"
+    condition:
+      any: true
+    action:
+      type: suppress

--- a/examples/aws-cost-optimizer/rules/routing.yaml
+++ b/examples/aws-cost-optimizer/rules/routing.yaml
@@ -102,6 +102,7 @@ rules:
     priority: 100
     description: "Suppress unmatched actions from other tenants"
     condition:
-      any: true
+      field: action.tenant
+      ne: "cost-optimizer"
     action:
       type: suppress

--- a/examples/aws-cost-optimizer/rules/safety.yaml
+++ b/examples/aws-cost-optimizer/rules/safety.yaml
@@ -1,0 +1,68 @@
+# Safety guardrails: deny destructive EC2/ASG operations without capacity attestation.
+#
+# These rules run at high priority (1-2) so they are evaluated before any
+# routing or enrichment rules.  The pattern is "deny by default, allow when
+# the caller attests that capacity headroom has been verified."
+#
+# See docs/book/features/aws-providers.md § Guardrails for Destructive Operations.
+
+rules:
+  # ── EC2 destructive-operation guardrails ───────────────────────────────────
+
+  # Deny terminate_instances unless the caller sets capacity_verified: true.
+  - name: require-capacity-check-terminate
+    priority: 1
+    description: "Block EC2 instance termination unless capacity headroom is attested"
+    condition:
+      all:
+        - field: action.action_type
+          eq: "terminate_instances"
+        - field: action.payload.capacity_verified
+          ne: true
+    action:
+      type: deny
+
+  # Deny reboot_instances unless the caller sets capacity_verified: true.
+  - name: require-capacity-check-reboot
+    priority: 1
+    description: "Block EC2 instance reboot unless capacity headroom is attested"
+    condition:
+      all:
+        - field: action.action_type
+          eq: "reboot_instances"
+        - field: action.payload.capacity_verified
+          ne: true
+    action:
+      type: deny
+
+  # ── ASG scale-down guardrails ─────────────────────────────────────────────
+
+  # Deny scaling any non-worker ASG to zero capacity.
+  - name: block-zero-capacity-critical
+    priority: 2
+    description: "Prevent scaling critical (non-worker) ASGs to zero"
+    condition:
+      all:
+        - field: action.action_type
+          eq: "set_desired_capacity"
+        - field: action.payload.desired_capacity
+          lt: 1
+        - field: action.payload.auto_scaling_group_name
+          ne: "staging-workers"
+    action:
+      type: deny
+
+  # Deny scaling the staging-api ASG below 1 instance.
+  - name: minimum-capacity-api
+    priority: 2
+    description: "Enforce minimum capacity of 1 for staging-api"
+    condition:
+      all:
+        - field: action.action_type
+          eq: "set_desired_capacity"
+        - field: action.payload.auto_scaling_group_name
+          eq: "staging-api"
+        - field: action.payload.desired_capacity
+          lt: 1
+    action:
+      type: deny

--- a/examples/aws-cost-optimizer/scripts/send-scaling.sh
+++ b/examples/aws-cost-optimizer/scripts/send-scaling.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Sends manual scaling actions to demonstrate the cost optimizer pipeline.
+#
+# These actions simulate what the recurring cron jobs dispatch automatically.
+# Useful for testing without waiting for cron triggers.
+#
+# Usage: bash examples/aws-cost-optimizer/scripts/send-scaling.sh
+# Environment:
+#   ACTEON_URL - Acteon gateway URL (default: http://localhost:8080)
+set -euo pipefail
+
+ACTEON_URL="${ACTEON_URL:-http://localhost:8080}"
+
+echo "=== AWS Cost Optimizer: Manual Scaling Actions ==="
+echo ""
+
+# Helper: dispatch an action and show the result.
+dispatch() {
+  local desc="$1"
+  local payload="$2"
+
+  echo ">>> $desc"
+  curl -sf -X POST "$ACTEON_URL/v1/dispatch" \
+    -H "Content-Type: application/json" \
+    -d "$payload" | jq '{action_id, outcome}'
+  echo ""
+}
+
+# ── Scale-Down Actions (simulate 7pm off-hours) ─────────────────────────────
+echo "--- Scale-Down (off-hours) ---"
+echo ""
+
+dispatch "Scale down staging-web to 1 instance" '{
+  "namespace": "infra",
+  "tenant": "cost-optimizer",
+  "provider": "cost-asg",
+  "action_type": "set_desired_capacity",
+  "payload": {
+    "auto_scaling_group_name": "staging-web",
+    "desired_capacity": 1,
+    "honor_cooldown": false,
+    "tag": "scale-down"
+  }
+}'
+
+dispatch "Scale down staging-api to 1 instance" '{
+  "namespace": "infra",
+  "tenant": "cost-optimizer",
+  "provider": "cost-asg",
+  "action_type": "set_desired_capacity",
+  "payload": {
+    "auto_scaling_group_name": "staging-api",
+    "desired_capacity": 1,
+    "honor_cooldown": false,
+    "tag": "scale-down"
+  }
+}'
+
+dispatch "Scale down staging-workers to 0 instances" '{
+  "namespace": "infra",
+  "tenant": "cost-optimizer",
+  "provider": "cost-asg",
+  "action_type": "set_desired_capacity",
+  "payload": {
+    "auto_scaling_group_name": "staging-workers",
+    "desired_capacity": 0,
+    "honor_cooldown": false,
+    "tag": "scale-down"
+  }
+}'
+
+# ── Describe: check current state ───────────────────────────────────────────
+echo "--- Verify Current State ---"
+echo ""
+
+dispatch "Describe all staging ASGs" '{
+  "namespace": "infra",
+  "tenant": "cost-optimizer",
+  "provider": "cost-asg",
+  "action_type": "describe_auto_scaling_groups",
+  "payload": {
+    "auto_scaling_group_names": ["staging-web", "staging-api", "staging-workers"]
+  }
+}'
+
+# ── Scale-Up Actions (simulate 7am morning) ─────────────────────────────────
+echo "--- Scale-Up (morning) ---"
+echo ""
+
+dispatch "Scale up staging-web to 4 instances" '{
+  "namespace": "infra",
+  "tenant": "cost-optimizer",
+  "provider": "cost-asg",
+  "action_type": "set_desired_capacity",
+  "payload": {
+    "auto_scaling_group_name": "staging-web",
+    "desired_capacity": 4,
+    "honor_cooldown": false,
+    "tag": "scale-up"
+  }
+}'
+
+dispatch "Scale up staging-api to 6 instances" '{
+  "namespace": "infra",
+  "tenant": "cost-optimizer",
+  "provider": "cost-asg",
+  "action_type": "set_desired_capacity",
+  "payload": {
+    "auto_scaling_group_name": "staging-api",
+    "desired_capacity": 6,
+    "honor_cooldown": false,
+    "tag": "scale-up"
+  }
+}'
+
+dispatch "Scale up staging-workers to 5 instances" '{
+  "namespace": "infra",
+  "tenant": "cost-optimizer",
+  "provider": "cost-asg",
+  "action_type": "set_desired_capacity",
+  "payload": {
+    "auto_scaling_group_name": "staging-workers",
+    "desired_capacity": 5,
+    "honor_cooldown": false,
+    "tag": "scale-up"
+  }
+}'
+
+# ── Update ASG config ───────────────────────────────────────────────────────
+echo "--- Update ASG Config ---"
+echo ""
+
+dispatch "Update staging-workers max to 12 and health check" '{
+  "namespace": "infra",
+  "tenant": "cost-optimizer",
+  "provider": "cost-asg",
+  "action_type": "update_auto_scaling_group",
+  "payload": {
+    "auto_scaling_group_name": "staging-workers",
+    "max_size": 12,
+    "health_check_type": "ELB",
+    "health_check_grace_period": 120
+  }
+}'
+
+echo "=== Manual scaling actions complete ==="
+echo ""
+echo "Actions sent:"
+echo "  - 3 scale-down actions (simulate off-hours)"
+echo "  - 1 describe action (verify state)"
+echo "  - 3 scale-up actions (simulate morning)"
+echo "  - 1 update ASG config"
+echo ""
+echo "Run show-report.sh to see the audit trail."

--- a/examples/aws-cost-optimizer/scripts/setup-api.sh
+++ b/examples/aws-cost-optimizer/scripts/setup-api.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# Creates API-managed resources: recurring scale-down/scale-up actions and quota.
+#
+# This creates 6 recurring actions:
+#   - 3 scale-down actions (Mon-Fri 7pm EST → reduce to minimum capacity)
+#   - 3 scale-up actions   (Mon-Fri 7am EST → restore daytime capacity)
+#
+# Usage: bash examples/aws-cost-optimizer/scripts/setup-api.sh
+# Environment:
+#   ACTEON_URL - Acteon gateway URL (default: http://localhost:8080)
+set -euo pipefail
+
+ACTEON_URL="${ACTEON_URL:-http://localhost:8080}"
+
+echo "=== AWS Cost Optimizer: API Setup ==="
+echo ""
+
+# ── Quota: 100 scaling actions/day ──────────────────────────────────────────
+echo "Creating quota (100 actions/day)..."
+curl -sf -X POST "$ACTEON_URL/v1/quotas" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "infra",
+    "tenant": "cost-optimizer",
+    "max_actions": 100,
+    "window": "daily",
+    "overage_behavior": "block",
+    "enabled": true,
+    "description": "100 scaling actions per day for cost-optimizer"
+  }' | jq .
+echo ""
+
+# ── Scale-Down: staging-web (7pm EST, Mon-Fri) ─────────────────────────────
+echo "Creating recurring action: scale-down staging-web (7pm Mon-Fri)..."
+curl -sf -X POST "$ACTEON_URL/v1/recurring" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "infra",
+    "tenant": "cost-optimizer",
+    "cron_expr": "0 19 * * 1-5",
+    "timezone": "America/New_York",
+    "enabled": true,
+    "action_template": {
+      "provider": "cost-asg",
+      "action_type": "set_desired_capacity",
+      "payload": {
+        "auto_scaling_group_name": "staging-web",
+        "desired_capacity": 1,
+        "honor_cooldown": false,
+        "tag": "scale-down"
+      }
+    },
+    "description": "Scale down staging-web to 1 instance at 7pm EST"
+  }' | jq .
+echo ""
+
+# ── Scale-Down: staging-api (7pm EST, Mon-Fri) ─────────────────────────────
+echo "Creating recurring action: scale-down staging-api (7pm Mon-Fri)..."
+curl -sf -X POST "$ACTEON_URL/v1/recurring" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "infra",
+    "tenant": "cost-optimizer",
+    "cron_expr": "0 19 * * 1-5",
+    "timezone": "America/New_York",
+    "enabled": true,
+    "action_template": {
+      "provider": "cost-asg",
+      "action_type": "set_desired_capacity",
+      "payload": {
+        "auto_scaling_group_name": "staging-api",
+        "desired_capacity": 1,
+        "honor_cooldown": false,
+        "tag": "scale-down"
+      }
+    },
+    "description": "Scale down staging-api to 1 instance at 7pm EST"
+  }' | jq .
+echo ""
+
+# ── Scale-Down: staging-workers (7pm EST, Mon-Fri) ─────────────────────────
+echo "Creating recurring action: scale-down staging-workers (7pm Mon-Fri)..."
+curl -sf -X POST "$ACTEON_URL/v1/recurring" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "infra",
+    "tenant": "cost-optimizer",
+    "cron_expr": "0 19 * * 1-5",
+    "timezone": "America/New_York",
+    "enabled": true,
+    "action_template": {
+      "provider": "cost-asg",
+      "action_type": "set_desired_capacity",
+      "payload": {
+        "auto_scaling_group_name": "staging-workers",
+        "desired_capacity": 0,
+        "honor_cooldown": false,
+        "tag": "scale-down"
+      }
+    },
+    "description": "Scale down staging-workers to 0 instances at 7pm EST"
+  }' | jq .
+echo ""
+
+# ── Scale-Up: staging-web (7am EST, Mon-Fri) ───────────────────────────────
+echo "Creating recurring action: scale-up staging-web (7am Mon-Fri)..."
+curl -sf -X POST "$ACTEON_URL/v1/recurring" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "infra",
+    "tenant": "cost-optimizer",
+    "cron_expr": "0 7 * * 1-5",
+    "timezone": "America/New_York",
+    "enabled": true,
+    "action_template": {
+      "provider": "cost-asg",
+      "action_type": "set_desired_capacity",
+      "payload": {
+        "auto_scaling_group_name": "staging-web",
+        "desired_capacity": 4,
+        "honor_cooldown": false,
+        "tag": "scale-up"
+      }
+    },
+    "description": "Scale up staging-web to 4 instances at 7am EST"
+  }' | jq .
+echo ""
+
+# ── Scale-Up: staging-api (7am EST, Mon-Fri) ───────────────────────────────
+echo "Creating recurring action: scale-up staging-api (7am Mon-Fri)..."
+curl -sf -X POST "$ACTEON_URL/v1/recurring" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "infra",
+    "tenant": "cost-optimizer",
+    "cron_expr": "0 7 * * 1-5",
+    "timezone": "America/New_York",
+    "enabled": true,
+    "action_template": {
+      "provider": "cost-asg",
+      "action_type": "set_desired_capacity",
+      "payload": {
+        "auto_scaling_group_name": "staging-api",
+        "desired_capacity": 6,
+        "honor_cooldown": false,
+        "tag": "scale-up"
+      }
+    },
+    "description": "Scale up staging-api to 6 instances at 7am EST"
+  }' | jq .
+echo ""
+
+# ── Scale-Up: staging-workers (7am EST, Mon-Fri) ───────────────────────────
+echo "Creating recurring action: scale-up staging-workers (7am Mon-Fri)..."
+curl -sf -X POST "$ACTEON_URL/v1/recurring" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "infra",
+    "tenant": "cost-optimizer",
+    "cron_expr": "0 7 * * 1-5",
+    "timezone": "America/New_York",
+    "enabled": true,
+    "action_template": {
+      "provider": "cost-asg",
+      "action_type": "set_desired_capacity",
+      "payload": {
+        "auto_scaling_group_name": "staging-workers",
+        "desired_capacity": 5,
+        "honor_cooldown": false,
+        "tag": "scale-up"
+      }
+    },
+    "description": "Scale up staging-workers to 5 instances at 7am EST"
+  }' | jq .
+echo ""
+
+echo "=== API setup complete ==="
+echo ""
+echo "Resources created:"
+echo "  - Quota: 100/day for infra:cost-optimizer"
+echo "  - Recurring: 3 scale-down actions (Mon-Fri 7pm EST)"
+echo "    - staging-web:     4 -> 1 instance"
+echo "    - staging-api:     6 -> 1 instance"
+echo "    - staging-workers: 5 -> 0 instances"
+echo "  - Recurring: 3 scale-up actions (Mon-Fri 7am EST)"
+echo "    - staging-web:     1 -> 4 instances"
+echo "    - staging-api:     1 -> 6 instances"
+echo "    - staging-workers: 0 -> 5 instances"

--- a/examples/aws-cost-optimizer/scripts/setup.sh
+++ b/examples/aws-cost-optimizer/scripts/setup.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Creates LocalStack Auto Scaling Groups for the cost optimizer demo.
+#
+# Prerequisites:
+#   - LocalStack running: docker run --rm -d --name localstack -p 4566:4566 localstack/localstack
+#   - awslocal CLI: pip install awscli-local
+#
+# Usage: bash examples/aws-cost-optimizer/scripts/setup.sh
+set -euo pipefail
+
+ENDPOINT="http://localhost:4566"
+REGION="us-east-1"
+
+export AWS_DEFAULT_REGION="$REGION"
+export AWS_ACCESS_KEY_ID="test"
+export AWS_SECRET_ACCESS_KEY="test"
+
+echo "=== AWS Cost Optimizer: LocalStack Setup ==="
+echo ""
+
+# ── Launch Configuration (required to create ASGs) ──────────────────────────
+echo "Creating launch configuration: cost-opt-lc..."
+awslocal autoscaling create-launch-configuration \
+  --launch-configuration-name cost-opt-lc \
+  --image-id ami-12345678 \
+  --instance-type t3.medium 2>/dev/null || echo "  (may already exist)"
+echo ""
+
+# ── Auto Scaling Group: staging-web ─────────────────────────────────────────
+echo "Creating ASG: staging-web (min=1, max=6, desired=4)..."
+awslocal autoscaling create-auto-scaling-group \
+  --auto-scaling-group-name staging-web \
+  --launch-configuration-name cost-opt-lc \
+  --min-size 1 \
+  --max-size 6 \
+  --desired-capacity 4 \
+  --availability-zones "${REGION}a" 2>/dev/null || echo "  (may already exist)"
+echo ""
+
+# ── Auto Scaling Group: staging-api ─────────────────────────────────────────
+echo "Creating ASG: staging-api (min=1, max=8, desired=6)..."
+awslocal autoscaling create-auto-scaling-group \
+  --auto-scaling-group-name staging-api \
+  --launch-configuration-name cost-opt-lc \
+  --min-size 1 \
+  --max-size 8 \
+  --desired-capacity 6 \
+  --availability-zones "${REGION}a" 2>/dev/null || echo "  (may already exist)"
+echo ""
+
+# ── Auto Scaling Group: staging-workers ─────────────────────────────────────
+echo "Creating ASG: staging-workers (min=0, max=10, desired=5)..."
+awslocal autoscaling create-auto-scaling-group \
+  --auto-scaling-group-name staging-workers \
+  --launch-configuration-name cost-opt-lc \
+  --min-size 0 \
+  --max-size 10 \
+  --desired-capacity 5 \
+  --availability-zones "${REGION}a" 2>/dev/null || echo "  (may already exist)"
+echo ""
+
+# ── Verify ──────────────────────────────────────────────────────────────────
+echo "Verifying Auto Scaling Groups..."
+awslocal autoscaling describe-auto-scaling-groups \
+  --auto-scaling-group-names staging-web staging-api staging-workers \
+  | jq '.AutoScalingGroups[] | {Name: .AutoScalingGroupName, Min: .MinSize, Max: .MaxSize, Desired: .DesiredCapacity}'
+echo ""
+
+echo "=== LocalStack setup complete ==="
+echo ""
+echo "Resources created:"
+echo "  - Launch config: cost-opt-lc (t3.medium)"
+echo "  - ASG: staging-web       (desired=4, min=1, max=6)"
+echo "  - ASG: staging-api       (desired=6, min=1, max=8)"
+echo "  - ASG: staging-workers   (desired=5, min=0, max=10)"
+echo ""
+echo "Total daytime capacity: 15 instances"
+echo "Off-hours capacity:      2 instances (web=1, api=1, workers=0)"
+echo "Estimated savings:      ~87% overnight compute reduction"

--- a/examples/aws-cost-optimizer/scripts/show-report.sh
+++ b/examples/aws-cost-optimizer/scripts/show-report.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Queries API endpoints and displays a cost optimizer report.
+#
+# Usage: bash examples/aws-cost-optimizer/scripts/show-report.sh
+# Environment:
+#   ACTEON_URL - Acteon gateway URL (default: http://localhost:8080)
+set -euo pipefail
+
+ACTEON_URL="${ACTEON_URL:-http://localhost:8080}"
+NAMESPACE="infra"
+TENANT="cost-optimizer"
+
+echo "╔══════════════════════════════════════════════════════════════════╗"
+echo "║          AWS Cost Optimizer — Report                           ║"
+echo "╚══════════════════════════════════════════════════════════════════╝"
+echo ""
+
+# ── 1. Audit trail ──────────────────────────────────────────────────────────
+echo "━━━ 1. Audit Trail ━━━"
+AUDIT=$(curl -sf "$ACTEON_URL/v1/audit?namespace=$NAMESPACE&tenant=$TENANT&limit=100" 2>/dev/null) || AUDIT='{"records":[]}'
+RECORDS=$(echo "$AUDIT" | jq '.records // []')
+TOTAL=$(echo "$RECORDS" | jq 'length')
+
+echo "Total dispatches: $TOTAL"
+echo ""
+echo "Outcome breakdown:"
+echo "$RECORDS" | jq -r '
+  group_by(.outcome) |
+  map({outcome: .[0].outcome, count: length}) |
+  sort_by(-.count) |
+  .[] |
+  "  \(.outcome): \(.count)"
+'
+echo ""
+
+echo "Action type breakdown:"
+echo "$RECORDS" | jq -r '
+  group_by(.action_type) |
+  map({action_type: .[0].action_type, count: length}) |
+  sort_by(-.count) |
+  .[] |
+  "  \(.action_type): \(.count)"
+'
+echo ""
+
+# ── 2. Provider Health ──────────────────────────────────────────────────────
+echo "━━━ 2. Provider Health ━━━"
+HEALTH=$(curl -sf "$ACTEON_URL/v1/providers/health" 2>/dev/null) || HEALTH='{}'
+echo "$HEALTH" | jq -r '
+  to_entries[] |
+  "  \(.key): status=\(.value.status // "?") circuit=\(.value.circuit_breaker // "?")"
+' 2>/dev/null || echo "  (no health data)"
+echo ""
+
+# ── 3. Recurring Actions ───────────────────────────────────────────────────
+echo "━━━ 3. Recurring Actions ━━━"
+RECURRING=$(curl -sf "$ACTEON_URL/v1/recurring?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || RECURRING='[]'
+REC_COUNT=$(echo "$RECURRING" | jq 'if type == "array" then length else 0 end')
+echo "Recurring actions: $REC_COUNT"
+if [ "$REC_COUNT" -gt 0 ]; then
+  echo ""
+  echo "  Scale-down (off-hours):"
+  echo "$RECURRING" | jq -r '
+    if type == "array" then
+      .[] | select(.description | test("Scale down"; "i")) |
+      "    \(.description): cron=\(.cron_expr) executions=\(.execution_count // 0) [\(if .enabled then "active" else "paused" end)]"
+    else
+      empty
+    end
+  ' 2>/dev/null || true
+  echo ""
+  echo "  Scale-up (morning):"
+  echo "$RECURRING" | jq -r '
+    if type == "array" then
+      .[] | select(.description | test("Scale up"; "i")) |
+      "    \(.description): cron=\(.cron_expr) executions=\(.execution_count // 0) [\(if .enabled then "active" else "paused" end)]"
+    else
+      empty
+    end
+  ' 2>/dev/null || true
+fi
+echo ""
+
+# ── 4. Quotas ──────────────────────────────────────────────────────────────
+echo "━━━ 4. Quotas ━━━"
+QUOTAS=$(curl -sf "$ACTEON_URL/v1/quotas?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || QUOTAS='[]'
+QUOTA_COUNT=$(echo "$QUOTAS" | jq 'if type == "array" then length else 0 end')
+echo "Quota policies: $QUOTA_COUNT"
+if [ "$QUOTA_COUNT" -gt 0 ]; then
+  echo "$QUOTAS" | jq -r '
+    if type == "array" then
+      .[] |
+      "  \(.description // "unnamed"): \(.max_actions // "?")/\(.window // "?") [\(if .enabled then "enabled" else "disabled" end)]"
+    else
+      empty
+    end
+  ' 2>/dev/null || true
+fi
+echo ""
+
+# ── 5. Cost Savings Summary ────────────────────────────────────────────────
+echo "━━━ 5. Cost Savings Estimate ━━━"
+echo "  Daytime capacity:   15 instances (web=4, api=6, workers=5)"
+echo "  Off-hours capacity:  2 instances (web=1, api=1, workers=0)"
+echo "  Reduction:          13 instances / 87% during off-hours"
+echo "  Schedule:           Mon-Fri 7pm-7am EST (12 hrs/day)"
+echo "  Weekly off-hours:   60 hrs of reduced capacity"
+echo ""
+
+echo "═══════════════════════════════════════════════════════════════════"
+echo "Report complete."

--- a/examples/aws-cost-optimizer/scripts/teardown.sh
+++ b/examples/aws-cost-optimizer/scripts/teardown.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Cleans up API-created resources (quotas, recurring actions).
+#
+# Usage: bash examples/aws-cost-optimizer/scripts/teardown.sh
+# Environment:
+#   ACTEON_URL - Acteon gateway URL (default: http://localhost:8080)
+set -euo pipefail
+
+ACTEON_URL="${ACTEON_URL:-http://localhost:8080}"
+NAMESPACE="infra"
+TENANT="cost-optimizer"
+
+echo "=== AWS Cost Optimizer: Teardown ==="
+echo ""
+
+# ── Delete quotas ──────────────────────────────────────────────────────────
+echo "Deleting quotas..."
+QUOTAS=$(curl -sf "$ACTEON_URL/v1/quotas?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || QUOTAS='[]'
+echo "$QUOTAS" | jq -r 'if type == "array" then .[].id else empty end' 2>/dev/null | while read -r ID; do
+  echo "  Deleting quota $ID..."
+  curl -sf -X DELETE "$ACTEON_URL/v1/quotas/$ID" > /dev/null 2>&1 && echo "    done" || echo "    failed"
+done
+echo ""
+
+# ── Delete recurring actions ───────────────────────────────────────────────
+echo "Deleting recurring actions..."
+RECURRING=$(curl -sf "$ACTEON_URL/v1/recurring?namespace=$NAMESPACE&tenant=$TENANT" 2>/dev/null) || RECURRING='[]'
+echo "$RECURRING" | jq -r 'if type == "array" then .[].id else empty end' 2>/dev/null | while read -r ID; do
+  echo "  Deleting recurring action $ID..."
+  curl -sf -X DELETE "$ACTEON_URL/v1/recurring/$ID" > /dev/null 2>&1 && echo "    done" || echo "    failed"
+done
+echo ""
+
+echo "=== Teardown complete ==="
+echo ""
+echo "To also remove LocalStack resources, stop the container:"
+echo "  docker stop localstack"


### PR DESCRIPTION
## Summary
- Add **AWS EC2** provider with 9 action types: start/stop/reboot/terminate/hibernate instances, run instances, attach/detach volumes, describe instances
- Add **AWS Auto Scaling** provider with 3 action types: describe groups, set desired capacity, update group configuration
- Full stack integration: server config, Rust client builders, all 4 polyglot SDKs (Python, Node.js, Go, Java), simulation example (18 scenarios)
- New **Cost Optimizer** example (`examples/aws-cost-optimizer/`) demonstrating Recurring Actions with Auto Scaling for off-hours scale-down (~87% overnight compute reduction)

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace --no-deps -- -D warnings` passes (0 warnings)
- [x] `cargo test --workspace --lib --bins --tests` passes (all tests)
- [x] `cargo run -p acteon-simulation --example ec2_simulation` passes (18/18 scenarios)
- [x] `npm run lint && npm run build` passes (UI unchanged)
- [ ] Manual test with LocalStack: `bash examples/aws-cost-optimizer/scripts/setup.sh` + run server + `setup-api.sh` + `send-scaling.sh` + `show-report.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)