### PR TITLE
feat: add mutual TLS (mTLS) support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,13 +503,19 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "criterion",
+ "hyper 1.8.1",
+ "hyper-util",
  "parking_lot",
  "rand 0.8.5",
+ "rcgen",
  "reqwest",
+ "rustls 0.23.36",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls 0.26.4",
+ "tower 0.5.3",
  "tracing",
  "uuid",
 ]
@@ -4847,6 +4853,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redis"
 version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7593,6 +7612,15 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,9 +164,13 @@ dependencies = [
  "base64 0.22.1",
  "hex",
  "regex",
+ "reqwest",
+ "rustls 0.23.36",
+ "rustls-pemfile",
  "secrecy",
  "serde_json",
  "thiserror 2.0.18",
+ "webpki-roots 0.26.11",
  "zeroize",
 ]
 
@@ -439,6 +443,8 @@ dependencies = [
  "croner",
  "futures",
  "hex",
+ "hyper 1.8.1",
+ "hyper-util",
  "jsonwebtoken",
  "minijinja",
  "notify",
@@ -446,11 +452,13 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "reqwest",
+ "rustls 0.23.36",
  "serde",
  "serde_json",
  "sha2",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tokio-util",
  "toml",
@@ -1455,7 +1463,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.36",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1864,6 +1872,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -2995,9 +3009,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3331,11 +3347,12 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "rustls 0.23.36",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3876,6 +3893,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
@@ -4669,6 +4692,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.36",
+ "socket2 0.6.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4786,10 +4864,15 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.23.36",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "ryu",
  "sha1_smol",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "url",
 ]
@@ -4925,6 +5008,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4932,6 +5017,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -4941,6 +5027,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5148,11 +5235,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -5168,11 +5270,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -5660,6 +5772,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
+ "rustls 0.23.36",
  "serde",
  "serde_json",
  "sha2",
@@ -5670,6 +5783,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -7049,6 +7163,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ dashmap = "6"
 moka = { version = "0.12", features = ["future"] }
 
 # Redis
-redis = { version = "0.27", features = ["tokio-comp", "connection-manager", "script"] }
+redis = { version = "0.27", features = ["tokio-comp", "connection-manager", "script", "tokio-rustls-comp"] }
 deadpool-redis = "0.18"
 
 # AWS
@@ -177,7 +177,7 @@ aws-sdk-autoscaling = "1"
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 
 # PostgreSQL
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono", "uuid"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono", "uuid", "tls-rustls"] }
 
 # ClickHouse
 clickhouse = "0.13"
@@ -186,7 +186,7 @@ clickhouse = "0.13"
 lettre = { version = "0.11", features = ["tokio1-native-tls", "smtp-transport"] }
 
 # HTTP client
-reqwest = { version = "0.12", features = ["json", "multipart", "stream"] }
+reqwest = { version = "0.12", features = ["json", "multipart", "stream", "rustls-tls"] }
 
 # URL-encoded forms
 serde_urlencoded = "0.7"
@@ -202,6 +202,8 @@ minijinja = { version = "2", features = ["fuel", "loader"] }
 
 # HTTP server
 axum = "0.8"
+hyper = "1"
+hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http1", "http2"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace", "fs"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
@@ -244,6 +246,12 @@ croner = "2"
 # MCP
 rmcp = { version = "0.15", features = ["server", "transport-io"] }
 schemars = "1"
+
+# TLS
+rustls = { version = "0.23", features = ["ring"] }
+rustls-pemfile = "2"
+webpki-roots = "0.26"
+tokio-rustls = "0.26"
 
 # WASM
 wasmtime = "29"

--- a/crates/audit/elasticsearch/src/store.rs
+++ b/crates/audit/elasticsearch/src/store.rs
@@ -31,6 +31,16 @@ impl ElasticsearchAuditStore {
             .build()
             .map_err(|e| AuditError::Storage(e.to_string()))?;
 
+        Self::from_client(config, client).await
+    }
+
+    /// Create a new store with a custom `reqwest::Client`.
+    ///
+    /// Useful for sharing a TLS-configured client across components.
+    pub async fn from_client(
+        config: &ElasticsearchAuditConfig,
+        client: reqwest::Client,
+    ) -> Result<Self, AuditError> {
         let base_url = config.url.trim_end_matches('/').to_owned();
         let index = config.index_name();
 

--- a/crates/audit/postgres/src/config.rs
+++ b/crates/audit/postgres/src/config.rs
@@ -6,6 +6,14 @@ pub struct PostgresAuditConfig {
     pub prefix: String,
     /// Background cleanup interval in seconds.
     pub cleanup_interval_seconds: u64,
+    /// SSL mode (`disable`, `prefer`, `require`, `verify-ca`, `verify-full`).
+    pub ssl_mode: Option<String>,
+    /// Path to the CA certificate for SSL server verification.
+    pub ssl_root_cert: Option<String>,
+    /// Path to the client certificate for mTLS.
+    pub ssl_cert: Option<String>,
+    /// Path to the client private key for mTLS.
+    pub ssl_key: Option<String>,
 }
 
 impl PostgresAuditConfig {
@@ -15,6 +23,10 @@ impl PostgresAuditConfig {
             url: url.into(),
             prefix: "acteon_".to_owned(),
             cleanup_interval_seconds: 3600,
+            ssl_mode: None,
+            ssl_root_cert: None,
+            ssl_cert: None,
+            ssl_key: None,
         }
     }
 
@@ -29,6 +41,34 @@ impl PostgresAuditConfig {
     #[must_use]
     pub fn with_cleanup_interval(mut self, seconds: u64) -> Self {
         self.cleanup_interval_seconds = seconds;
+        self
+    }
+
+    /// Set the SSL mode.
+    #[must_use]
+    pub fn with_ssl_mode(mut self, mode: impl Into<String>) -> Self {
+        self.ssl_mode = Some(mode.into());
+        self
+    }
+
+    /// Set the SSL root certificate path.
+    #[must_use]
+    pub fn with_ssl_root_cert(mut self, path: impl Into<String>) -> Self {
+        self.ssl_root_cert = Some(path.into());
+        self
+    }
+
+    /// Set the client certificate path for mTLS.
+    #[must_use]
+    pub fn with_ssl_cert(mut self, path: impl Into<String>) -> Self {
+        self.ssl_cert = Some(path.into());
+        self
+    }
+
+    /// Set the client key path for mTLS.
+    #[must_use]
+    pub fn with_ssl_key(mut self, path: impl Into<String>) -> Self {
+        self.ssl_key = Some(path.into());
         self
     }
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -214,6 +214,7 @@ impl ActeonClientBuilder {
             c
         } else {
             let mut builder = Client::builder()
+                .use_rustls_tls()
                 .timeout(self.timeout)
                 .danger_accept_invalid_certs(self.danger_accept_invalid_certs);
 

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -6,14 +6,22 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[features]
+default = []
+tls = ["dep:rustls", "dep:rustls-pemfile", "dep:webpki-roots", "dep:reqwest"]
+
 [dependencies]
 aes-gcm = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }
 regex = { workspace = true }
+reqwest = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
+rustls-pemfile = { workspace = true, optional = true }
 secrecy = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+webpki-roots = { workspace = true, optional = true }
 zeroize = { workspace = true }
 
 [lints]

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -9,6 +9,9 @@
 //! Decrypted values are returned as [`SecretString`] to prevent accidental
 //! logging. The [`MasterKey`] wrapper zeroizes key material on drop.
 
+#[cfg(feature = "tls")]
+pub mod tls;
+
 use std::fmt;
 use std::sync::LazyLock;
 

--- a/crates/crypto/src/tls.rs
+++ b/crates/crypto/src/tls.rs
@@ -1,0 +1,383 @@
+//! TLS certificate loading and configuration utilities.
+//!
+//! Provides helpers for building `rustls` server and client configurations,
+//! as well as a pre-configured `reqwest::Client` with mTLS support.
+
+use std::fs;
+use std::io::BufReader;
+use std::path::Path;
+use std::sync::Arc;
+
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use thiserror::Error;
+
+/// Errors that can occur during TLS setup.
+#[derive(Debug, Error)]
+pub enum TlsError {
+    /// Failed to read a file from disk.
+    #[error("failed to read {path}: {source}")]
+    FileRead {
+        path: String,
+        source: std::io::Error,
+    },
+
+    /// No certificates were found in the PEM file.
+    #[error("no certificates found in {0}")]
+    NoCertificates(String),
+
+    /// No private key was found in the PEM file.
+    #[error("no private key found in {0}")]
+    NoPrivateKey(String),
+
+    /// The `rustls` configuration could not be built.
+    #[error("rustls config error: {0}")]
+    RustlsConfig(String),
+
+    /// The `reqwest` client could not be built.
+    #[error("reqwest client error: {0}")]
+    ReqwestBuild(String),
+}
+
+/// Load a PEM certificate chain from a file.
+///
+/// Returns all certificates found in the PEM file, in order.
+pub fn load_certs(path: impl AsRef<Path>) -> Result<Vec<CertificateDer<'static>>, TlsError> {
+    let path = path.as_ref();
+    let file = fs::File::open(path).map_err(|e| TlsError::FileRead {
+        path: path.display().to_string(),
+        source: e,
+    })?;
+    let mut reader = BufReader::new(file);
+
+    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut reader)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| TlsError::FileRead {
+            path: path.display().to_string(),
+            source: e,
+        })?;
+
+    if certs.is_empty() {
+        return Err(TlsError::NoCertificates(path.display().to_string()));
+    }
+
+    Ok(certs)
+}
+
+/// Load a private key from a PEM file.
+///
+/// Supports PKCS#8, RSA, and EC private keys. Returns the first key found.
+pub fn load_private_key(path: impl AsRef<Path>) -> Result<PrivateKeyDer<'static>, TlsError> {
+    let path = path.as_ref();
+    let file = fs::File::open(path).map_err(|e| TlsError::FileRead {
+        path: path.display().to_string(),
+        source: e,
+    })?;
+    let mut reader = BufReader::new(file);
+
+    for item in rustls_pemfile::read_all(&mut reader) {
+        match item {
+            Ok(rustls_pemfile::Item::Pkcs1Key(key)) => return Ok(PrivateKeyDer::Pkcs1(key)),
+            Ok(rustls_pemfile::Item::Pkcs8Key(key)) => return Ok(PrivateKeyDer::Pkcs8(key)),
+            Ok(rustls_pemfile::Item::Sec1Key(key)) => return Ok(PrivateKeyDer::Sec1(key)),
+            Ok(_) => {}
+            Err(e) => {
+                return Err(TlsError::FileRead {
+                    path: path.display().to_string(),
+                    source: e,
+                });
+            }
+        }
+    }
+
+    Err(TlsError::NoPrivateKey(path.display().to_string()))
+}
+
+/// Minimum TLS protocol version.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum MinTlsVersion {
+    /// TLS 1.2 (default).
+    #[default]
+    Tls12,
+    /// TLS 1.3.
+    Tls13,
+}
+
+impl MinTlsVersion {
+    /// Parse a version string like `"1.2"` or `"1.3"`.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim() {
+            "1.2" => Some(Self::Tls12),
+            "1.3" => Some(Self::Tls13),
+            _ => None,
+        }
+    }
+}
+
+/// Build a `rustls::ServerConfig` for HTTPS termination.
+///
+/// - `cert_path` / `key_path`: server certificate and private key (required).
+/// - `client_ca_path`: if provided, enables client certificate verification (mTLS).
+/// - `min_version`: minimum TLS protocol version.
+pub fn build_server_config(
+    cert_path: &str,
+    key_path: &str,
+    client_ca_path: Option<&str>,
+    min_version: MinTlsVersion,
+) -> Result<Arc<rustls::ServerConfig>, TlsError> {
+    let certs = load_certs(cert_path)?;
+    let key = load_private_key(key_path)?;
+
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let versions: &[&'static rustls::SupportedProtocolVersion] = match min_version {
+        MinTlsVersion::Tls12 => &[&rustls::version::TLS12, &rustls::version::TLS13],
+        MinTlsVersion::Tls13 => &[&rustls::version::TLS13],
+    };
+    let builder = rustls::ServerConfig::builder_with_provider(provider)
+        .with_protocol_versions(versions)
+        .map_err(|e| TlsError::RustlsConfig(e.to_string()))?;
+
+    let config = if let Some(ca_path) = client_ca_path {
+        let ca_certs = load_certs(ca_path)?;
+        let mut root_store = rustls::RootCertStore::empty();
+        for cert in ca_certs {
+            root_store
+                .add(cert)
+                .map_err(|e| TlsError::RustlsConfig(format!("failed to add CA cert: {e}")))?;
+        }
+        let verifier = rustls::server::WebPkiClientVerifier::builder(Arc::new(root_store))
+            .build()
+            .map_err(|e| TlsError::RustlsConfig(format!("client verifier: {e}")))?;
+        builder
+            .with_client_cert_verifier(verifier)
+            .with_single_cert(certs, key)
+            .map_err(|e| TlsError::RustlsConfig(e.to_string()))?
+    } else {
+        builder
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .map_err(|e| TlsError::RustlsConfig(e.to_string()))?
+    };
+
+    Ok(Arc::new(config))
+}
+
+/// Build a `rustls::ClientConfig` for outbound mTLS connections.
+///
+/// - `client_cert_path` / `client_key_path`: client certificate and key (optional, for mTLS).
+/// - `ca_bundle_path`: custom CA bundle (optional; uses Mozilla roots if omitted).
+/// - `danger_accept_invalid_certs`: skip certificate verification (dev/test only).
+pub fn build_client_config(
+    client_cert_path: Option<&str>,
+    client_key_path: Option<&str>,
+    ca_bundle_path: Option<&str>,
+    danger_accept_invalid_certs: bool,
+) -> Result<Arc<rustls::ClientConfig>, TlsError> {
+    let mut root_store = rustls::RootCertStore::empty();
+
+    if let Some(ca_path) = ca_bundle_path {
+        let ca_certs = load_certs(ca_path)?;
+        for cert in ca_certs {
+            root_store
+                .add(cert)
+                .map_err(|e| TlsError::RustlsConfig(format!("failed to add CA cert: {e}")))?;
+        }
+    } else {
+        root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    }
+
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let builder = rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| TlsError::RustlsConfig(e.to_string()))?
+        .with_root_certificates(root_store);
+
+    let mut config = if let (Some(cert_path), Some(key_path)) = (client_cert_path, client_key_path)
+    {
+        let certs = load_certs(cert_path)?;
+        let key = load_private_key(key_path)?;
+        builder
+            .with_client_auth_cert(certs, key)
+            .map_err(|e| TlsError::RustlsConfig(e.to_string()))?
+    } else {
+        builder.with_no_client_auth()
+    };
+
+    if danger_accept_invalid_certs {
+        config
+            .dangerous()
+            .set_certificate_verifier(Arc::new(NoCertificateVerification));
+    }
+
+    Ok(Arc::new(config))
+}
+
+/// Build a `reqwest::Client` with the given TLS client configuration.
+///
+/// The client uses `rustls` as its TLS backend and optionally includes a
+/// client certificate for mTLS.
+pub fn build_reqwest_client(
+    client_cert_path: Option<&str>,
+    client_key_path: Option<&str>,
+    ca_bundle_path: Option<&str>,
+    danger_accept_invalid_certs: bool,
+) -> Result<reqwest::Client, TlsError> {
+    let mut builder = reqwest::Client::builder()
+        .use_rustls_tls()
+        .danger_accept_invalid_certs(danger_accept_invalid_certs);
+
+    if let Some(ca_path) = ca_bundle_path {
+        let ca_pem = fs::read(ca_path).map_err(|e| TlsError::FileRead {
+            path: ca_path.to_owned(),
+            source: e,
+        })?;
+        let ca_cert = reqwest::Certificate::from_pem(&ca_pem)
+            .map_err(|e| TlsError::ReqwestBuild(format!("invalid CA bundle: {e}")))?;
+        builder = builder.add_root_certificate(ca_cert);
+    }
+
+    if let (Some(cert_path), Some(key_path)) = (client_cert_path, client_key_path) {
+        let cert_pem = fs::read(cert_path).map_err(|e| TlsError::FileRead {
+            path: cert_path.to_owned(),
+            source: e,
+        })?;
+        let key_pem = fs::read(key_path).map_err(|e| TlsError::FileRead {
+            path: key_path.to_owned(),
+            source: e,
+        })?;
+
+        let mut combined = cert_pem;
+        combined.push(b'\n');
+        combined.extend_from_slice(&key_pem);
+
+        let identity = reqwest::Identity::from_pem(&combined)
+            .map_err(|e| TlsError::ReqwestBuild(format!("invalid client identity: {e}")))?;
+        builder = builder.identity(identity);
+    }
+
+    builder
+        .build()
+        .map_err(|e| TlsError::ReqwestBuild(e.to_string()))
+}
+
+/// Certificate verifier that accepts any certificate (for dev/test use only).
+///
+/// # Safety
+///
+/// This completely bypasses TLS certificate validation. Only use in
+/// development or testing environments with `danger_accept_invalid_certs = true`.
+#[derive(Debug)]
+struct NoCertificateVerification;
+
+impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        vec![
+            rustls::SignatureScheme::RSA_PKCS1_SHA256,
+            rustls::SignatureScheme::RSA_PKCS1_SHA384,
+            rustls::SignatureScheme::RSA_PKCS1_SHA512,
+            rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+            rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+            rustls::SignatureScheme::RSA_PSS_SHA256,
+            rustls::SignatureScheme::RSA_PSS_SHA384,
+            rustls::SignatureScheme::RSA_PSS_SHA512,
+            rustls::SignatureScheme::ED25519,
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_certs_nonexistent_file() {
+        let err = load_certs("/nonexistent/path.pem").unwrap_err();
+        assert!(matches!(err, TlsError::FileRead { .. }));
+    }
+
+    #[test]
+    fn load_private_key_nonexistent_file() {
+        let err = load_private_key("/nonexistent/key.pem").unwrap_err();
+        assert!(matches!(err, TlsError::FileRead { .. }));
+    }
+
+    #[test]
+    fn min_tls_version_parse() {
+        assert!(matches!(
+            MinTlsVersion::parse("1.2"),
+            Some(MinTlsVersion::Tls12)
+        ));
+        assert!(matches!(
+            MinTlsVersion::parse("1.3"),
+            Some(MinTlsVersion::Tls13)
+        ));
+        assert!(MinTlsVersion::parse("1.1").is_none());
+        assert!(MinTlsVersion::parse("").is_none());
+    }
+
+    #[test]
+    fn build_server_config_missing_cert() {
+        let err = build_server_config(
+            "/nonexistent/cert.pem",
+            "/nonexistent/key.pem",
+            None,
+            MinTlsVersion::Tls12,
+        )
+        .unwrap_err();
+        assert!(matches!(err, TlsError::FileRead { .. }));
+    }
+
+    #[test]
+    fn build_client_config_no_certs_uses_mozilla_roots() {
+        let config = build_client_config(None, None, None, false).unwrap();
+        // Should succeed with default Mozilla root certificates.
+        assert!(!config.alpn_protocols.is_empty() || config.alpn_protocols.is_empty());
+    }
+
+    #[test]
+    fn build_client_config_danger_mode() {
+        // Should succeed building with danger mode enabled.
+        let _config = build_client_config(None, None, None, true).unwrap();
+    }
+
+    #[test]
+    fn build_reqwest_client_default() {
+        let client = build_reqwest_client(None, None, None, false).unwrap();
+        // Should build successfully.
+        drop(client);
+    }
+
+    #[test]
+    fn build_reqwest_client_missing_ca() {
+        let err = build_reqwest_client(None, None, Some("/nonexistent/ca.pem"), false).unwrap_err();
+        assert!(matches!(err, TlsError::FileRead { .. }));
+    }
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -49,11 +49,16 @@ acteon-executor = { workspace = true }
 acteon-gateway = { workspace = true }
 acteon-llm = { workspace = true }
 acteon-embedding = { workspace = true }
-acteon-crypto = { workspace = true }
+acteon-crypto = { workspace = true, features = ["tls"] }
 acteon-wasm-runtime = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
 futures = { workspace = true }
+hyper = { workspace = true }
+hyper-util = { workspace = true }
+reqwest = { workspace = true }
+rustls = { workspace = true }
+tokio-rustls = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
 clap = { workspace = true }
@@ -88,7 +93,6 @@ uuid = { workspace = true }
 acteon-audit = { workspace = true }
 acteon-audit-memory = { workspace = true }
 axum-test = { workspace = true }
-reqwest = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 
 [lints]

--- a/crates/server/src/config/audit.rs
+++ b/crates/server/src/config/audit.rs
@@ -33,6 +33,23 @@ pub struct AuditConfig {
     /// `DynamoDB` table name for the audit backend.
     #[serde(default)]
     pub table_name: Option<String>,
+
+    // ---- Postgres SSL fields ----
+    /// SSL mode for `PostgreSQL` audit connections.
+    #[serde(default)]
+    pub ssl_mode: Option<String>,
+
+    /// Path to the CA certificate for `PostgreSQL` SSL verification.
+    #[serde(default)]
+    pub ssl_root_cert: Option<String>,
+
+    /// Path to the client certificate for `PostgreSQL` mTLS.
+    #[serde(default)]
+    pub ssl_cert: Option<String>,
+
+    /// Path to the client private key for `PostgreSQL` mTLS.
+    #[serde(default)]
+    pub ssl_key: Option<String>,
 }
 
 /// Configuration for redacting sensitive fields from audit payloads.
@@ -78,6 +95,10 @@ impl Default for AuditConfig {
             redact: AuditRedactConfig::default(),
             region: None,
             table_name: None,
+            ssl_mode: None,
+            ssl_root_cert: None,
+            ssl_cert: None,
+            ssl_key: None,
         }
     }
 }

--- a/crates/server/src/config/mod.rs
+++ b/crates/server/src/config/mod.rs
@@ -12,6 +12,7 @@ mod server;
 mod snapshot;
 mod state;
 mod telemetry;
+mod tls;
 
 #[cfg(test)]
 mod tests;
@@ -30,6 +31,7 @@ pub use server::*;
 pub use snapshot::*;
 pub use state::*;
 pub use telemetry::*;
+pub use tls::*;
 
 use serde::Deserialize;
 
@@ -93,6 +95,9 @@ pub struct ActeonConfig {
     /// Payload template configuration.
     #[serde(default)]
     pub templates: TemplateServerConfig,
+    /// TLS configuration for inbound HTTPS and outbound mTLS.
+    #[serde(default)]
+    pub tls: TlsConfig,
     /// Attachment size and count limits.
     #[serde(default)]
     pub attachments: AttachmentConfig,

--- a/crates/server/src/config/state.rs
+++ b/crates/server/src/config/state.rs
@@ -19,6 +19,36 @@ pub struct StateConfig {
 
     /// `DynamoDB` table name.
     pub table_name: Option<String>,
+
+    // ---- Postgres SSL fields ----
+    /// SSL mode for `PostgreSQL` connections.
+    #[serde(default)]
+    pub ssl_mode: Option<String>,
+
+    /// Path to the CA certificate for `PostgreSQL` SSL verification.
+    #[serde(default)]
+    pub ssl_root_cert: Option<String>,
+
+    /// Path to the client certificate for `PostgreSQL` mTLS.
+    #[serde(default)]
+    pub ssl_cert: Option<String>,
+
+    /// Path to the client private key for `PostgreSQL` mTLS.
+    #[serde(default)]
+    pub ssl_key: Option<String>,
+
+    // ---- Redis TLS fields ----
+    /// Whether to use TLS for Redis connections (uses `rediss://` scheme internally).
+    #[serde(default)]
+    pub tls_enabled: Option<bool>,
+
+    /// Path to the CA certificate for Redis TLS verification.
+    #[serde(default)]
+    pub tls_ca_cert_path: Option<String>,
+
+    /// Accept invalid certificates for Redis (dev/test only).
+    #[serde(default)]
+    pub tls_insecure: Option<bool>,
 }
 
 impl Default for StateConfig {
@@ -29,6 +59,13 @@ impl Default for StateConfig {
             prefix: None,
             region: None,
             table_name: None,
+            ssl_mode: None,
+            ssl_root_cert: None,
+            ssl_cert: None,
+            ssl_key: None,
+            tls_enabled: None,
+            tls_ca_cert_path: None,
+            tls_insecure: None,
         }
     }
 }

--- a/crates/server/src/config/tls.rs
+++ b/crates/server/src/config/tls.rs
@@ -1,0 +1,78 @@
+use serde::Deserialize;
+
+/// Top-level TLS configuration.
+///
+/// Controls both inbound HTTPS termination and outbound mTLS for backend
+/// connections and provider HTTP calls.
+///
+/// # Example
+///
+/// ```toml
+/// [tls]
+/// enabled = true
+///
+/// [tls.server]
+/// cert_path = "/etc/acteon/tls/server.crt"
+/// key_path = "/etc/acteon/tls/server.key"
+///
+/// [tls.client]
+/// ca_bundle_path = "/etc/acteon/tls/ca-bundle.crt"
+/// ```
+#[derive(Debug, Default, Deserialize)]
+pub struct TlsConfig {
+    /// Whether TLS is enabled.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Server-side TLS for HTTPS termination.
+    #[serde(default)]
+    pub server: ServerTlsConfig,
+
+    /// Client-side TLS for outbound connections.
+    #[serde(default)]
+    pub client: ClientTlsConfig,
+}
+
+/// Server-side TLS configuration for HTTPS termination.
+#[derive(Debug, Default, Deserialize)]
+pub struct ServerTlsConfig {
+    /// Path to the server certificate PEM file.
+    #[serde(default)]
+    pub cert_path: Option<String>,
+
+    /// Path to the server private key PEM file.
+    #[serde(default)]
+    pub key_path: Option<String>,
+
+    /// Path to the CA certificate for client cert verification (enables inbound mTLS).
+    #[serde(default)]
+    pub client_ca_path: Option<String>,
+
+    /// Minimum TLS version: `"1.2"` (default) or `"1.3"`.
+    #[serde(default = "default_min_version")]
+    pub min_version: String,
+}
+
+/// Client-side TLS configuration for outbound mTLS.
+#[derive(Debug, Default, Deserialize)]
+pub struct ClientTlsConfig {
+    /// Path to the client certificate PEM file.
+    #[serde(default)]
+    pub cert_path: Option<String>,
+
+    /// Path to the client private key PEM file.
+    #[serde(default)]
+    pub key_path: Option<String>,
+
+    /// Path to a custom CA bundle PEM file. If omitted, Mozilla roots are used.
+    #[serde(default)]
+    pub ca_bundle_path: Option<String>,
+
+    /// Accept invalid certificates (dev/test only).
+    #[serde(default)]
+    pub danger_accept_invalid_certs: bool,
+}
+
+fn default_min_version() -> String {
+    "1.2".to_owned()
+}

--- a/crates/server/src/state_factory.rs
+++ b/crates/server/src/state_factory.rs
@@ -50,6 +50,8 @@ fn create_redis(config: &StateConfig) -> Result<StatePair, ServerError> {
     let redis_config = RedisConfig {
         url: url.to_owned(),
         prefix: config.prefix.clone().unwrap_or_else(|| "acteon".to_owned()),
+        tls_enabled: config.tls_enabled.unwrap_or(false),
+        tls_insecure: config.tls_insecure.unwrap_or(false),
         ..RedisConfig::default()
     };
     let store = Arc::new(
@@ -75,6 +77,10 @@ async fn create_postgres(config: &StateConfig) -> Result<StatePair, ServerError>
             .prefix
             .clone()
             .unwrap_or_else(|| "acteon_".to_owned()),
+        ssl_mode: config.ssl_mode.clone(),
+        ssl_root_cert: config.ssl_root_cert.clone(),
+        ssl_cert: config.ssl_cert.clone(),
+        ssl_key: config.ssl_key.clone(),
         ..PostgresConfig::default()
     };
     let store = Arc::new(

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -9,7 +9,7 @@ description = "Simulation and testing framework for Acteon"
 
 [dependencies]
 acteon-core.workspace = true
-acteon-crypto.workspace = true
+acteon-crypto = { workspace = true, features = ["tls"] }
 acteon-gateway.workspace = true
 acteon-state.workspace = true
 acteon-state-memory.workspace = true
@@ -32,6 +32,11 @@ acteon-server.workspace = true
 
 tokio.workspace = true
 axum.workspace = true
+hyper.workspace = true
+hyper-util.workspace = true
+tokio-rustls.workspace = true
+rustls.workspace = true
+tower.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
@@ -48,6 +53,7 @@ rand = "0.8"
 [dev-dependencies]
 criterion.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+rcgen = "0.13"
 
 [features]
 default = []
@@ -170,6 +176,10 @@ name = "ec2_simulation"
 
 [[example]]
 name = "template_simulation"
+# No required-features - uses in-memory backends
+
+[[example]]
+name = "mtls_simulation"
 # No required-features - uses in-memory backends
 
 [lints]

--- a/crates/simulation/examples/mtls_simulation.rs
+++ b/crates/simulation/examples/mtls_simulation.rs
@@ -1,0 +1,573 @@
+//! Mutual TLS (mTLS) end-to-end simulation.
+//!
+//! This self-contained example demonstrates full mTLS between an Acteon client
+//! and server. It generates a CA, server certificate, and client certificate at
+//! runtime using `rcgen`, starts an HTTPS server with client certificate
+//! verification, and dispatches actions over a mutually authenticated channel.
+//!
+//! No external processes or pre-existing certificate files are needed.
+//!
+//! Run with:
+//!   cargo run -p acteon-simulation --example mtls_simulation
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use acteon_client::ActeonClientBuilder;
+use acteon_core::{Action, ActionOutcome};
+use acteon_gateway::GatewayBuilder;
+use acteon_state_memory::{MemoryDistributedLock, MemoryStateStore};
+use rcgen::{CertificateParams, KeyPair};
+use tokio::sync::RwLock;
+
+// ---------------------------------------------------------------------------
+// Certificate generation helpers
+// ---------------------------------------------------------------------------
+
+struct CertBundle {
+    ca_cert_pem: String,
+    server_cert_pem: String,
+    server_key_pem: String,
+    client_cert_pem: String,
+    client_key_pem: String,
+}
+
+fn generate_certs() -> CertBundle {
+    // --- CA ---
+    let mut ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+    ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+    ca_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "Acteon Simulation CA");
+    let ca_key = KeyPair::generate().unwrap();
+    let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+
+    // --- Server cert (signed by CA) ---
+    let mut server_params =
+        CertificateParams::new(vec!["localhost".to_string(), "127.0.0.1".to_string()]).unwrap();
+    server_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "localhost");
+    server_params
+        .subject_alt_names
+        .push(rcgen::SanType::IpAddress(
+            "127.0.0.1".parse::<std::net::IpAddr>().unwrap(),
+        ));
+    let server_key = KeyPair::generate().unwrap();
+    let server_cert = server_params
+        .signed_by(&server_key, &ca_cert, &ca_key)
+        .unwrap();
+
+    // --- Client cert (signed by CA) ---
+    let mut client_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+    client_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "acteon-client");
+    let client_key = KeyPair::generate().unwrap();
+    let client_cert = client_params
+        .signed_by(&client_key, &ca_cert, &ca_key)
+        .unwrap();
+
+    CertBundle {
+        ca_cert_pem: ca_cert.pem(),
+        server_cert_pem: server_cert.pem(),
+        server_key_pem: server_key.serialize_pem(),
+        client_cert_pem: client_cert.pem(),
+        client_key_pem: client_key.serialize_pem(),
+    }
+}
+
+/// Write PEM strings to temp files and return their paths.
+fn write_certs_to_temp(bundle: &CertBundle) -> (String, String, String, String, String) {
+    let dir = std::env::temp_dir().join(format!("acteon-mtls-sim-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let ca = dir.join("ca.pem");
+    let server_cert = dir.join("server.crt");
+    let server_key = dir.join("server.key");
+    let client_cert = dir.join("client.crt");
+    let client_key = dir.join("client.key");
+
+    std::fs::write(&ca, &bundle.ca_cert_pem).unwrap();
+    std::fs::write(&server_cert, &bundle.server_cert_pem).unwrap();
+    std::fs::write(&server_key, &bundle.server_key_pem).unwrap();
+    std::fs::write(&client_cert, &bundle.client_cert_pem).unwrap();
+    std::fs::write(&client_key, &bundle.client_key_pem).unwrap();
+
+    (
+        ca.display().to_string(),
+        server_cert.display().to_string(),
+        server_key.display().to_string(),
+        client_cert.display().to_string(),
+        client_key.display().to_string(),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Minimal HTTPS server backed by a Gateway
+// ---------------------------------------------------------------------------
+
+async fn run_tls_server(
+    addr: SocketAddr,
+    gateway: Arc<RwLock<acteon_gateway::Gateway>>,
+    server_cert_path: &str,
+    server_key_path: &str,
+    client_ca_path: &str,
+    ready_tx: tokio::sync::oneshot::Sender<()>,
+    mut shutdown_rx: tokio::sync::oneshot::Receiver<()>,
+) {
+    use tower::ServiceExt;
+
+    // Health handler
+    async fn health() -> axum::http::StatusCode {
+        axum::http::StatusCode::OK
+    }
+
+    // Dispatch handler
+    async fn dispatch(
+        axum::extract::State(gw): axum::extract::State<Arc<RwLock<acteon_gateway::Gateway>>>,
+        axum::Json(action): axum::Json<Action>,
+    ) -> axum::response::Result<axum::Json<ActionOutcome>, axum::http::StatusCode> {
+        let gateway = gw.read().await;
+        match gateway.dispatch(action, None).await {
+            Ok(outcome) => Ok(axum::Json(outcome)),
+            Err(_) => Err(axum::http::StatusCode::INTERNAL_SERVER_ERROR),
+        }
+    }
+
+    let app = axum::Router::new()
+        .route("/health", axum::routing::get(health))
+        .route("/v1/dispatch", axum::routing::post(dispatch))
+        .with_state(gateway);
+
+    // Build TLS config with mTLS (client cert required)
+    let tls_config = acteon_crypto::tls::build_server_config(
+        server_cert_path,
+        server_key_path,
+        Some(client_ca_path),
+        acteon_crypto::tls::MinTlsVersion::Tls12,
+    )
+    .expect("failed to build TLS server config");
+
+    let tls_acceptor = tokio_rustls::TlsAcceptor::from(tls_config);
+
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .expect("failed to bind TLS listener");
+
+    // Signal that the server is ready
+    let _ = ready_tx.send(());
+
+    loop {
+        tokio::select! {
+            result = listener.accept() => {
+                let (tcp_stream, remote_addr) = match result {
+                    Ok(r) => r,
+                    Err(_) => continue,
+                };
+                let acceptor = tls_acceptor.clone();
+                let app = app.clone();
+
+                tokio::spawn(async move {
+                    let tls_stream = match acceptor.accept(tcp_stream).await {
+                        Ok(s) => s,
+                        Err(_) => return,
+                    };
+
+                    let io = hyper_util::rt::TokioIo::new(tls_stream);
+                    let tower_service = app;
+                    let hyper_service = hyper::service::service_fn(
+                        move |request: hyper::Request<hyper::body::Incoming>| {
+                            tower_service.clone().oneshot(request)
+                        },
+                    );
+
+                    let _ = hyper_util::server::conn::auto::Builder::new(
+                        hyper_util::rt::TokioExecutor::new(),
+                    )
+                    .serve_connection(io, hyper_service)
+                    .await;
+
+                    let _ = remote_addr;
+                });
+            }
+            _ = &mut shutdown_rx => {
+                break;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main simulation
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Install the ring crypto provider globally — needed because both ring and
+    // aws-lc-rs are in the dependency tree (from AWS SDK).
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("failed to install ring CryptoProvider");
+
+    println!(
+        "{}",
+        "╔══════════════════════════════════════════════════════════════╗"
+    );
+    println!(
+        "{}",
+        "║          mTLS END-TO-END SIMULATION                         ║"
+    );
+    println!(
+        "{}",
+        "╚══════════════════════════════════════════════════════════════╝\n"
+    );
+
+    // =========================================================================
+    // Step 1: Generate certificates
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  STEP 1: CERTIFICATE GENERATION");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let bundle = generate_certs();
+    let (ca_path, server_cert_path, server_key_path, client_cert_path, client_key_path) =
+        write_certs_to_temp(&bundle);
+
+    println!("  Generated at runtime (no pre-existing files needed):");
+    println!("    CA certificate:     {ca_path}");
+    println!("    Server certificate: {server_cert_path}");
+    println!("    Server private key: {server_key_path}");
+    println!("    Client certificate: {client_cert_path}");
+    println!("    Client private key: {client_key_path}");
+    println!();
+
+    // =========================================================================
+    // Step 2: Build in-process Gateway (memory backend)
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  STEP 2: GATEWAY SETUP (memory backend)");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let state: Arc<dyn acteon_state::StateStore> = Arc::new(MemoryStateStore::new());
+    let lock: Arc<dyn acteon_state::DistributedLock> = Arc::new(MemoryDistributedLock::new());
+    let audit: Arc<dyn acteon_audit::AuditStore> =
+        Arc::new(acteon_audit_memory::MemoryAuditStore::new());
+
+    let recording_provider = Arc::new(acteon_simulation::RecordingProvider::new("webhook"));
+
+    // Parse a simple rule
+    let rules_yaml = r#"
+rules:
+  - name: block-spam
+    priority: 1
+    condition:
+      field: action.action_type
+      eq: "spam"
+    action:
+      type: suppress
+"#;
+    use acteon_rules::RuleFrontend;
+    let rules = acteon_rules_yaml::YamlFrontend
+        .parse(rules_yaml)
+        .expect("failed to parse rules");
+
+    let gateway = GatewayBuilder::new()
+        .state(state)
+        .lock(lock)
+        .audit(audit)
+        .rules(rules)
+        .provider(recording_provider.clone() as Arc<dyn acteon_provider::DynProvider>)
+        .build()
+        .expect("failed to build gateway");
+
+    let gateway = Arc::new(RwLock::new(gateway));
+
+    println!("  State backend:  memory");
+    println!("  Audit backend:  memory");
+    println!("  Provider:       webhook (recording)");
+    println!("  Rules:          block-spam (suppress action_type='spam')");
+    println!();
+
+    // =========================================================================
+    // Step 3: Start HTTPS server with mTLS
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  STEP 3: START HTTPS SERVER (mTLS enabled)");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    // Bind first to get the actual port
+    let temp_listener = tokio::net::TcpListener::bind(addr).await?;
+    let actual_addr = temp_listener.local_addr()?;
+    drop(temp_listener);
+
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+
+    let server_cert = server_cert_path.clone();
+    let server_key = server_key_path.clone();
+    let ca = ca_path.clone();
+    let gw = Arc::clone(&gateway);
+
+    tokio::spawn(async move {
+        run_tls_server(
+            actual_addr,
+            gw,
+            &server_cert,
+            &server_key,
+            &ca,
+            ready_tx,
+            shutdown_rx,
+        )
+        .await;
+    });
+
+    // Wait for server to be ready
+    ready_rx.await?;
+
+    let base_url = format!("https://127.0.0.1:{}", actual_addr.port());
+    println!("  Server listening at: {base_url}");
+    println!("  TLS version:        1.2+");
+    println!("  Client cert verify: REQUIRED (mTLS)");
+    println!();
+
+    // =========================================================================
+    // Demo 1: Successful mTLS connection
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  DEMO 1: SUCCESSFUL mTLS CONNECTION");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let client = ActeonClientBuilder::new(&base_url)
+        .ca_cert_path(&ca_path)
+        .client_cert(&client_cert_path, &client_key_path)
+        .build()?;
+
+    println!("  Client configured with:");
+    println!("    CA cert:     {ca_path}");
+    println!("    Client cert: {client_cert_path}");
+    println!("    Client key:  {client_key_path}\n");
+
+    // Health check over mTLS
+    match client.health().await {
+        Ok(true) => println!("  Health check: PASSED (mTLS handshake successful)"),
+        Ok(false) => println!("  Health check: server unhealthy"),
+        Err(e) => println!("  Health check: FAILED - {e}"),
+    }
+    println!();
+
+    // Dispatch an action over mTLS
+    let action = Action::new(
+        "notifications",
+        "tenant-mtls",
+        "webhook",
+        "send_alert",
+        serde_json::json!({
+            "to": "ops-team@example.com",
+            "message": "Dispatched over mTLS!"
+        }),
+    );
+
+    println!("  Dispatching action over mTLS...");
+    println!("    Provider:    webhook");
+    println!("    Action type: send_alert");
+
+    match client.dispatch(&action).await {
+        Ok(outcome) => {
+            println!("    Outcome:     {outcome:?}");
+            println!(
+                "    Provider called: {} time(s)",
+                recording_provider.call_count()
+            );
+        }
+        Err(e) => println!("    Error: {e}"),
+    }
+    println!();
+
+    // =========================================================================
+    // Demo 2: Rule enforcement over mTLS
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  DEMO 2: RULE ENFORCEMENT OVER mTLS");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let spam_action = Action::new(
+        "notifications",
+        "tenant-mtls",
+        "webhook",
+        "spam",
+        serde_json::json!({"subject": "Buy now!!!"}),
+    );
+
+    println!("  Dispatching SPAM action (should be suppressed by rule)...");
+    match client.dispatch(&spam_action).await {
+        Ok(outcome) => {
+            let suppressed = matches!(outcome, ActionOutcome::Suppressed { .. });
+            println!("    Outcome:     {outcome:?}");
+            println!(
+                "    Suppressed:  {} (block-spam rule active)",
+                if suppressed { "YES" } else { "NO" }
+            );
+        }
+        Err(e) => println!("    Error: {e}"),
+    }
+    println!();
+
+    // =========================================================================
+    // Demo 3: Batch dispatch over mTLS
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  DEMO 3: BATCH DISPATCH OVER mTLS");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let start = std::time::Instant::now();
+    let mut success = 0;
+    let mut errors = 0;
+    let count = 50;
+
+    for i in 0..count {
+        let action = Action::new(
+            "benchmark",
+            "tenant-mtls",
+            "webhook",
+            "throughput_test",
+            serde_json::json!({"seq": i}),
+        );
+        match client.dispatch(&action).await {
+            Ok(_) => success += 1,
+            Err(_) => errors += 1,
+        }
+    }
+
+    let elapsed = start.elapsed();
+    let throughput = count as f64 / elapsed.as_secs_f64();
+
+    println!("  {count} sequential HTTPS+mTLS requests:");
+    println!("    Success:    {success}");
+    println!("    Errors:     {errors}");
+    println!("    Duration:   {elapsed:?}");
+    println!("    Throughput: {throughput:.0} req/sec");
+    println!();
+
+    // =========================================================================
+    // Demo 4: Connection WITHOUT client cert (should be rejected)
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  DEMO 4: REJECTED CONNECTION (no client certificate)");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let no_cert_client = ActeonClientBuilder::new(&base_url)
+        .ca_cert_path(&ca_path)
+        // No client_cert() — server should reject
+        .build()?;
+
+    println!("  Client configured WITHOUT client certificate");
+    println!("  Attempting health check...");
+
+    match no_cert_client.health().await {
+        Ok(true) => println!("    UNEXPECTED: connection accepted without client cert!"),
+        Ok(false) => println!("    Server returned unhealthy (connection may have succeeded)"),
+        Err(e) => {
+            println!("    REJECTED: {e}");
+            println!("    (Server correctly refused the TLS handshake)");
+        }
+    }
+    println!();
+
+    // =========================================================================
+    // Demo 5: Connection with invalid CA (should be rejected by client)
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  DEMO 5: REJECTED CONNECTION (wrong CA - untrusted server)");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    // Generate a different CA that didn't sign the server cert
+    let mut rogue_ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+    rogue_ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+    rogue_ca_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "Rogue CA");
+    let rogue_key = KeyPair::generate().unwrap();
+    let rogue_ca = rogue_ca_params.self_signed(&rogue_key).unwrap();
+
+    let rogue_ca_path = std::env::temp_dir()
+        .join(format!("acteon-mtls-sim-{}", std::process::id()))
+        .join("rogue-ca.pem");
+    std::fs::write(&rogue_ca_path, rogue_ca.pem()).unwrap();
+
+    let wrong_ca_client = ActeonClientBuilder::new(&base_url)
+        .ca_cert_path(rogue_ca_path.display().to_string())
+        .client_cert(&client_cert_path, &client_key_path)
+        .build()?;
+
+    println!("  Client configured with WRONG CA (server cert not trusted)");
+    println!("  Attempting health check...");
+
+    match wrong_ca_client.health().await {
+        Ok(true) => println!("    UNEXPECTED: connection accepted with wrong CA!"),
+        Ok(false) => println!("    Server returned unhealthy"),
+        Err(e) => {
+            println!("    REJECTED: {e}");
+            println!("    (Client correctly refused the untrusted server certificate)");
+        }
+    }
+    println!();
+
+    // =========================================================================
+    // Architecture recap
+    // =========================================================================
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  ARCHITECTURE");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    println!("    ┌─────────────────┐  TLS 1.2+ (mTLS)  ┌──────────────────┐");
+    println!("    │  ActeonClient   │ ═══════════════════│  HTTPS Server    │");
+    println!("    │  (rustls)       │  client cert +     │  (tokio-rustls)  │");
+    println!("    │                 │  server cert       │                  │");
+    println!("    └─────────────────┘  verified by CA    └────────┬─────────┘");
+    println!("                                                    │");
+    println!("                                           ┌────────▼─────────┐");
+    println!("                                           │    Gateway       │");
+    println!("                                           │  ┌────────────┐  │");
+    println!("                                           │  │   Rules    │  │");
+    println!("                                           │  │ (in-mem)   │  │");
+    println!("                                           │  └────────────┘  │");
+    println!("                                           │  ┌────────────┐  │");
+    println!("                                           │  │   State    │  │");
+    println!("                                           │  │ (memory)   │  │");
+    println!("                                           │  └────────────┘  │");
+    println!("                                           └────────┬─────────┘");
+    println!("                                                    │");
+    println!("                                           ┌────────▼─────────┐");
+    println!("                                           │    Provider      │");
+    println!("                                           │  (recording)     │");
+    println!("                                           └──────────────────┘");
+    println!();
+    println!("  All certificates generated at runtime by rcgen (no openssl needed).");
+    println!("  Server requires client certificates (mTLS enforced).");
+    println!("  Memory backends used for state, audit, and locking.");
+    println!();
+
+    // Shutdown the server
+    let _ = shutdown_tx.send(());
+
+    // Cleanup temp files
+    let temp_dir = std::env::temp_dir().join(format!("acteon-mtls-sim-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(temp_dir);
+
+    println!(
+        "{}",
+        "╔══════════════════════════════════════════════════════════════╗"
+    );
+    println!(
+        "{}",
+        "║              mTLS SIMULATION COMPLETE                        ║"
+    );
+    println!(
+        "{}",
+        "╚══════════════════════════════════════════════════════════════╝"
+    );
+
+    Ok(())
+}

--- a/crates/state/postgres/src/config.rs
+++ b/crates/state/postgres/src/config.rs
@@ -12,6 +12,18 @@ pub struct PostgresConfig {
 
     /// Prefix applied to table names to avoid collisions (e.g. `"acteon_"`).
     pub table_prefix: String,
+
+    /// SSL mode for the connection (`disable`, `prefer`, `require`, `verify-ca`, `verify-full`).
+    pub ssl_mode: Option<String>,
+
+    /// Path to the CA certificate for SSL server verification.
+    pub ssl_root_cert: Option<String>,
+
+    /// Path to the client certificate for mTLS.
+    pub ssl_cert: Option<String>,
+
+    /// Path to the client private key for mTLS.
+    pub ssl_key: Option<String>,
 }
 
 impl Default for PostgresConfig {
@@ -21,6 +33,10 @@ impl Default for PostgresConfig {
             pool_size: 5,
             schema: String::from("public"),
             table_prefix: String::from("acteon_"),
+            ssl_mode: None,
+            ssl_root_cert: None,
+            ssl_cert: None,
+            ssl_key: None,
         }
     }
 }

--- a/crates/state/postgres/src/lock.rs
+++ b/crates/state/postgres/src/lock.rs
@@ -35,9 +35,10 @@ impl PostgresDistributedLock {
     /// Returns [`StateError::Connection`] if pool creation fails, or
     /// [`StateError::Backend`] if migrations fail.
     pub async fn new(config: PostgresConfig) -> Result<Self, StateError> {
+        let connect_options = crate::store::build_connect_options(&config)?;
         let pool = sqlx::postgres::PgPoolOptions::new()
             .max_connections(config.pool_size)
-            .connect(&config.url)
+            .connect_with(connect_options)
             .await
             .map_err(|e| StateError::Connection(e.to_string()))?;
 

--- a/crates/state/redis/src/lock.rs
+++ b/crates/state/redis/src/lock.rs
@@ -118,7 +118,8 @@ impl RedisDistributedLock {
     ///
     /// Returns [`StateError::Connection`] if the pool cannot be created.
     pub fn new(config: &RedisConfig) -> Result<Self, StateError> {
-        let cfg = Config::from_url(&config.url);
+        let effective_url = config.effective_url();
+        let cfg = Config::from_url(&effective_url);
         let pool = cfg
             .builder()
             .map(|b| {

--- a/crates/state/redis/src/store.rs
+++ b/crates/state/redis/src/store.rs
@@ -30,7 +30,8 @@ impl RedisStateStore {
     ///
     /// Returns [`StateError::Connection`] if the pool cannot be created.
     pub fn new(config: &RedisConfig) -> Result<Self, StateError> {
-        let cfg = Config::from_url(&config.url);
+        let effective_url = config.effective_url();
+        let cfg = Config::from_url(&effective_url);
         let pool = cfg
             .builder()
             .map(|b| {

--- a/docs/book/features/mtls.md
+++ b/docs/book/features/mtls.md
@@ -1,0 +1,110 @@
+# Mutual TLS (mTLS) Support
+
+Acteon supports TLS across the full stack: HTTPS termination for the server, client certificate authentication for outbound backend connections, and TLS-enabled HTTP clients for provider egress. All TLS is backed by `rustls` (pure Rust).
+
+## Configuration
+
+Add a `[tls]` section to your `acteon.toml`:
+
+```toml
+[tls]
+enabled = true
+
+# Server-side: HTTPS termination
+[tls.server]
+cert_path = "/etc/acteon/tls/server.crt"
+key_path = "/etc/acteon/tls/server.key"
+# Optional: require client certificates (inbound mTLS)
+# client_ca_path = "/etc/acteon/tls/client-ca.crt"
+min_version = "1.2"  # "1.2" (default) or "1.3"
+
+# Client-side: outbound mTLS for backends and providers
+[tls.client]
+cert_path = "/etc/acteon/tls/client.crt"
+key_path = "/etc/acteon/tls/client.key"
+ca_bundle_path = "/etc/acteon/tls/ca-bundle.crt"  # omit to use Mozilla roots
+danger_accept_invalid_certs = false                # dev/test only
+```
+
+## Server HTTPS
+
+When `tls.enabled = true` and `tls.server.cert_path`/`key_path` are set, the server binds an HTTPS listener instead of plain TCP. The server uses `tokio-rustls` for the TLS handshake and `hyper-util` to serve HTTP/1.1 and HTTP/2 over TLS.
+
+### Client Certificate Verification (Inbound mTLS)
+
+Set `tls.server.client_ca_path` to a PEM file containing the CA certificate(s) that sign client certificates. When configured, the server requires valid client certificates for all connections.
+
+## Provider TLS
+
+When TLS is enabled, a shared `reqwest::Client` is built with the client TLS configuration and injected into all HTTP-based providers (webhook, Twilio, Teams, Discord). This ensures outbound calls use the configured client certificates and CA bundle.
+
+## Backend TLS
+
+### PostgreSQL
+
+Add SSL fields to the `[state]` or `[audit]` section:
+
+```toml
+[state]
+backend = "postgres"
+url = "postgres://user:pass@db.example.com/acteon"
+ssl_mode = "verify-full"       # disable, prefer, require, verify-ca, verify-full
+ssl_root_cert = "/etc/acteon/tls/pg-ca.crt"
+ssl_cert = "/etc/acteon/tls/pg-client.crt"
+ssl_key = "/etc/acteon/tls/pg-client.key"
+
+[audit]
+backend = "postgres"
+url = "postgres://user:pass@db.example.com/acteon_audit"
+ssl_mode = "require"
+ssl_root_cert = "/etc/acteon/tls/pg-ca.crt"
+```
+
+These fields map to `sqlx` `PgConnectOptions` SSL settings. The `tls-rustls` feature is used for the TLS backend.
+
+### Redis
+
+Redis TLS works via URL scheme. Set `tls_enabled = true` to automatically upgrade `redis://` to `rediss://`:
+
+```toml
+[state]
+backend = "redis"
+url = "redis://redis.example.com:6380"
+tls_enabled = true
+# tls_insecure = false  # dev/test only
+```
+
+You can also use `rediss://` directly in the URL:
+
+```toml
+[state]
+backend = "redis"
+url = "rediss://redis.example.com:6380"
+```
+
+### Elasticsearch
+
+The Elasticsearch audit backend shares the global TLS-configured HTTP client when `tls.enabled = true`. No additional configuration is needed beyond the global `[tls.client]` section.
+
+## Architecture
+
+```
+                 TLS Config (acteon.toml)
+                        |
+        +---------------+---------------+
+        |               |               |
+   Server TLS     Client TLS      Backend TLS
+   (inbound)      (providers)   (Postgres/Redis/ES)
+        |               |               |
+   rustls         reqwest+rustls    sqlx+rustls
+   ServerConfig    Client          PgConnectOptions
+   TlsAcceptor                    deadpool-redis
+```
+
+- **acteon-crypto**: Certificate loading (`load_certs`, `load_private_key`), `rustls` config builders, `reqwest::Client` builder
+- **acteon-server**: TLS listener wrapping, shared HTTP client injection, config threading to backend factories
+- **Backend crates**: SSL fields on config structs, `connect_with()` for Postgres, `rediss://` for Redis
+
+## Certificate Formats
+
+All certificate and key files must be in PEM format. The server certificate file may contain the full certificate chain (leaf + intermediates). Private keys may be PKCS#8, RSA (PKCS#1), or EC (SEC1) encoded.


### PR DESCRIPTION
## Summary

- Add `rustls`-based TLS utilities in `acteon-crypto` (cert/key loading, server/client config builders, shared `reqwest::Client` builder)
- New `[tls]` config section in `acteon.toml` with `server` (HTTPS termination + client cert verification) and `client` (outbound mTLS) sub-configs
- HTTPS termination via `tokio-rustls` TLS acceptor with graceful shutdown support
- Shared `reqwest::Client` with mTLS injected into webhook, Slack, PagerDuty, Teams, Discord, and Twilio providers
- Postgres SSL support for both state and audit backends via `PgConnectOptions` with `ssl_mode`, `ssl_root_cert`, `ssl_cert`, `ssl_key`
- Redis TLS via automatic `redis://` → `rediss://` URL upgrade when `tls_enabled = true`
- Elasticsearch TLS via shared HTTP client injection (`from_client()` constructor)
- Documentation at `docs/book/features/mtls.md`

## Test plan

- [x] All existing tests pass (`cargo test --workspace --lib --bins --tests`)
- [x] Clippy clean (`cargo clippy --workspace --no-deps -- -D warnings`)
- [x] Unit tests for TLS cert loading, error cases, and config building in `crates/crypto/src/tls.rs`
- [x] Frontend lint and build pass (`npm run lint && npm run build`)
- [ ] Manual test: start server with self-signed certs, verify HTTPS termination
- [ ] Manual test: connect to Postgres with SSL enabled
- [ ] Manual test: connect to Redis with TLS enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)