### PR TITLE
feat: Azure providers — Blob Storage + Event Hubs (Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
       - run: cargo nextest run --workspace --lib --bins --tests
       - name: Test AWS providers
         run: cargo nextest run -p acteon-aws --features full --lib --tests
+      - name: Test Azure providers
+        run: cargo nextest run -p acteon-azure --features full --lib --tests
       - name: Run doctests
         run: cargo test --workspace --doc
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
  "acteon-audit",
  "async-trait",
  "chrono",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tracing",
@@ -113,6 +113,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "acteon-azure"
+version = "0.1.0"
+dependencies = [
+ "acteon-core",
+ "acteon-provider",
+ "async-trait",
+ "azure_core",
+ "azure_identity",
+ "azure_messaging_eventhubs",
+ "azure_storage_blob",
+ "base64 0.22.1",
+ "futures",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "acteon-cli"
 version = "0.1.0"
 dependencies = [
@@ -135,7 +155,7 @@ dependencies = [
  "acteon-core",
  "chrono",
  "futures",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -167,7 +187,7 @@ dependencies = [
  "base64 0.22.1",
  "hex",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls 0.23.36",
  "rustls-pemfile",
  "secrecy",
@@ -183,7 +203,7 @@ version = "0.1.0"
 dependencies = [
  "acteon-core",
  "acteon-provider",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -214,7 +234,7 @@ dependencies = [
  "acteon-rules",
  "async-trait",
  "moka",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -281,7 +301,7 @@ version = "0.1.0"
 dependencies = [
  "acteon-core",
  "async-trait",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -330,7 +350,7 @@ dependencies = [
  "acteon-core",
  "acteon-crypto",
  "acteon-provider",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -346,7 +366,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -417,6 +437,7 @@ dependencies = [
  "acteon-audit-memory",
  "acteon-audit-postgres",
  "acteon-aws",
+ "acteon-azure",
  "acteon-core",
  "acteon-crypto",
  "acteon-discord",
@@ -455,7 +476,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls 0.23.36",
  "serde",
  "serde_json",
@@ -512,7 +533,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "rcgen",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls 0.23.36",
  "serde",
  "serde_json",
@@ -530,7 +551,7 @@ version = "0.1.0"
 dependencies = [
  "acteon-core",
  "acteon-provider",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -632,7 +653,7 @@ version = "0.1.0"
 dependencies = [
  "acteon-core",
  "acteon-provider",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -646,7 +667,7 @@ version = "0.1.0"
 dependencies = [
  "acteon-core",
  "acteon-provider",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -680,7 +701,7 @@ dependencies = [
  "base64 0.22.1",
  "hex",
  "hmac",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2",
@@ -884,6 +905,18 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1738,6 +1771,115 @@ dependencies = [
 ]
 
 [[package]]
+name = "azure_core"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39d6a5261cefb8d793df91fac2ca2d6b43301b84f4fddd576f94cd4f36fe67a1"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core_macros",
+ "bytes",
+ "futures",
+ "pin-project",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_client_core",
+]
+
+[[package]]
+name = "azure_core_amqp"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b239810c7c0980661d74dca44cc0df77551d176c9b1312ede4cb3ff5e711177"
+dependencies = [
+ "async-trait",
+ "azure_core",
+ "fe2o3-amqp",
+ "fe2o3-amqp-cbs",
+ "fe2o3-amqp-ext",
+ "fe2o3-amqp-management",
+ "fe2o3-amqp-types",
+ "serde",
+ "serde_amqp",
+ "serde_bytes",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_macros",
+]
+
+[[package]]
+name = "azure_core_macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "574c1d5ef13ec181f8e686d67e167b79085221debebe01f9df360aae65733327"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "tracing",
+]
+
+[[package]]
+name = "azure_identity"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825f8df144a4dc10dc6e81014906568363ef8e2b94c9234ddb951675161eb972"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core",
+ "futures",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "azure_messaging_eventhubs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bdb02d10cddea756ba40357e4549cd1174651be20199b6f103d60a5c968b446"
+dependencies = [
+ "async-lock",
+ "async-stream",
+ "async-trait",
+ "azure_core",
+ "azure_core_amqp",
+ "futures",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
+name = "azure_storage_blob"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b924ffd24eefebf8840775e78b43f4154f2102122bcd56d04b9d5c987f50e1ee"
+dependencies = [
+ "async-trait",
+ "azure_core",
+ "bytes",
+ "futures",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,9 +1981,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"
@@ -2082,6 +2224,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,6 +2254,15 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -2434,12 +2602,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -2457,11 +2649,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -2548,6 +2751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -2766,6 +2970,79 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fe2o3-amqp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a579ef4f1fb186f04bcdc9caf0c335adedebe879227c96d56876d473aa3d20a"
+dependencies = [
+ "bytes",
+ "fe2o3-amqp-types",
+ "futures-util",
+ "getrandom 0.3.4",
+ "native-tls",
+ "parking_lot",
+ "pin-project-lite",
+ "serde",
+ "serde_amqp",
+ "serde_bytes",
+ "slab",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+ "uuid",
+ "wasmtimer",
+]
+
+[[package]]
+name = "fe2o3-amqp-cbs"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cae904b214ffa3c9bae26e4129d300fe79189d2ef70503071fb25ff9127531e"
+dependencies = [
+ "fe2o3-amqp",
+ "fe2o3-amqp-management",
+ "trait-variant",
+]
+
+[[package]]
+name = "fe2o3-amqp-ext"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6362c13b91a80dca77360eecdfbe85425e6dff1523f16c3a79fac541c47cf27d"
+dependencies = [
+ "fe2o3-amqp-types",
+ "serde_amqp",
+]
+
+[[package]]
+name = "fe2o3-amqp-management"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0582084762bdf022540c37868a0808e9f54dbcc51fe56f6212da59c167569cda"
+dependencies = [
+ "fe2o3-amqp",
+ "fe2o3-amqp-types",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "fe2o3-amqp-types"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bcc8d13ed13fbb2fb664a6df114bcc32f8ca85c9cb6b89d4e7576c47f583706"
+dependencies = [
+ "ordered-float",
+ "serde",
+ "serde_amqp",
+ "serde_bytes",
+ "serde_repr",
+]
 
 [[package]]
 name = "ff"
@@ -3024,6 +3301,19 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -4316,7 +4606,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
  "tracing",
 ]
 
@@ -4334,7 +4624,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -4372,6 +4662,17 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]
@@ -4648,6 +4949,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4699,6 +5010,16 @@ dependencies = [
  "log",
  "sptr",
  "wasmtime-math",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -4786,6 +5107,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -4825,6 +5147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+ "serde",
 ]
 
 [[package]]
@@ -5048,9 +5371,45 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -5115,7 +5474,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -5503,6 +5862,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_amqp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e76738e7a058df01b5b33194359930a1aa5bc233dc07e510f458aca47189aea2"
+dependencies = [
+ "bytes",
+ "indexmap 2.13.0",
+ "ordered-float",
+ "serde",
+ "serde_amqp_derive",
+ "serde_bytes",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "serde_amqp_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22da57ecf44834259b4416250608e11da620750be91305bf6ae5d398954ddc6d"
+dependencies = [
+ "convert_case",
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5555,6 +5953,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6141,12 +6550,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -6162,9 +6572,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6401,6 +6811,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.10.0",
  "bytes",
  "futures-core",
@@ -6539,6 +6950,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "typespec"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "970ab7587a808af0594c3ad83471cd422fe5baa9991b0f2bdd56a85691c3ced9"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "quick-xml",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "typespec_client_core"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96fb9eef3cc12d6a9a2f9711c8f7c3b87c84eb50a9b7ac78b38647be7a7efae0"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "dyn-clone",
+ "futures",
+ "getrandom 0.3.4",
+ "pin-project",
+ "rand 0.9.2",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_macros",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "typespec_macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a3604ddfa94cf776cd7e9123451d9efb06d5e2323c9f3aa02fa94d33ad96db"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6570,6 +7033,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -6698,7 +7167,17 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "serde_core",
+ "uuid-rng-internal",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-rng-internal"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef224d01f8c31f8c11c90290766fd622fb0a7d7025b9589d4a34a36ccf35b28"
+dependencies = [
+ "getrandom 0.4.1",
 ]
 
 [[package]]
@@ -6755,6 +7234,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -6836,6 +7324,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
@@ -6845,10 +7343,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -6868,6 +7391,18 @@ dependencies = [
  "indexmap 2.13.0",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
 ]
 
 [[package]]
@@ -6991,7 +7526,7 @@ dependencies = [
  "syn",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.221.3",
 ]
 
 [[package]]
@@ -7142,7 +7677,21 @@ dependencies = [
  "anyhow",
  "heck",
  "indexmap 2.13.0",
- "wit-parser",
+ "wit-parser 0.221.3",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7579,6 +8128,70 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
+]
 
 [[package]]
 name = "wit-parser"
@@ -7596,6 +8209,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.221.3",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ members = [
     # AWS providers
     "crates/aws",
 
+    # Azure providers
+    "crates/azure",
+
     # Integrations
     "crates/integrations/email",
     "crates/integrations/slack",
@@ -110,6 +113,9 @@ acteon-embedding = { path = "crates/embedding" }
 # AWS providers
 acteon-aws = { path = "crates/aws" }
 
+# Azure providers
+acteon-azure = { path = "crates/azure" }
+
 # Integrations
 acteon-email = { path = "crates/integrations/email" }
 acteon-slack = { path = "crates/integrations/slack" }
@@ -175,6 +181,12 @@ aws-sdk-s3 = "1"
 aws-sdk-ec2 = "1"
 aws-sdk-autoscaling = "1"
 aws-config = { version = "1", features = ["behavior-version-latest"] }
+
+# Azure
+azure_core = "0.32"
+azure_identity = "0.32"
+azure_storage_blob = "0.9"
+azure_messaging_eventhubs = "0.11"
 
 # PostgreSQL
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono", "uuid", "tls-rustls"] }

--- a/clients/go/acteon/models.go
+++ b/clients/go/acteon/models.go
@@ -1726,3 +1726,110 @@ func NewAsgUpdateGroupPayloadWithOptions(groupName string, minSize, maxSize, des
 	}
 	return p
 }
+
+// =============================================================================
+// Azure Blob Storage Provider Payload Helpers
+// =============================================================================
+
+// NewAzureBlobUploadPayload creates a payload for the Azure Blob Storage upload-blob action.
+func NewAzureBlobUploadPayload(blobName, body string) map[string]any {
+	return map[string]any{
+		"blob_name": blobName,
+		"body":      body,
+	}
+}
+
+// NewAzureBlobUploadPayloadWithOptions creates an Azure Blob upload payload with optional fields.
+func NewAzureBlobUploadPayloadWithOptions(blobName, container, body, bodyBase64, contentType string, metadata map[string]string) map[string]any {
+	p := map[string]any{"blob_name": blobName}
+	if container != "" {
+		p["container"] = container
+	}
+	if body != "" {
+		p["body"] = body
+	}
+	if bodyBase64 != "" {
+		p["body_base64"] = bodyBase64
+	}
+	if contentType != "" {
+		p["content_type"] = contentType
+	}
+	if len(metadata) > 0 {
+		p["metadata"] = metadata
+	}
+	return p
+}
+
+// NewAzureBlobDownloadPayload creates a payload for the Azure Blob Storage download-blob action.
+func NewAzureBlobDownloadPayload(blobName string) map[string]any {
+	return map[string]any{
+		"blob_name": blobName,
+	}
+}
+
+// NewAzureBlobDownloadPayloadWithContainer creates an Azure Blob download payload with a container override.
+func NewAzureBlobDownloadPayloadWithContainer(blobName, container string) map[string]any {
+	p := NewAzureBlobDownloadPayload(blobName)
+	if container != "" {
+		p["container"] = container
+	}
+	return p
+}
+
+// NewAzureBlobDeletePayload creates a payload for the Azure Blob Storage delete-blob action.
+func NewAzureBlobDeletePayload(blobName string) map[string]any {
+	return map[string]any{
+		"blob_name": blobName,
+	}
+}
+
+// NewAzureBlobDeletePayloadWithContainer creates an Azure Blob delete payload with a container override.
+func NewAzureBlobDeletePayloadWithContainer(blobName, container string) map[string]any {
+	p := NewAzureBlobDeletePayload(blobName)
+	if container != "" {
+		p["container"] = container
+	}
+	return p
+}
+
+// =============================================================================
+// Azure Event Hubs Provider Payload Helpers
+// =============================================================================
+
+// NewAzureEventHubsSendPayload creates a payload for the Azure Event Hubs send-event action.
+func NewAzureEventHubsSendPayload(body any) map[string]any {
+	return map[string]any{
+		"body": body,
+	}
+}
+
+// NewAzureEventHubsSendPayloadWithOptions creates an Azure Event Hubs send payload with optional fields.
+func NewAzureEventHubsSendPayloadWithOptions(body any, eventHubName, partitionID string, properties map[string]string) map[string]any {
+	p := NewAzureEventHubsSendPayload(body)
+	if eventHubName != "" {
+		p["event_hub_name"] = eventHubName
+	}
+	if partitionID != "" {
+		p["partition_id"] = partitionID
+	}
+	if len(properties) > 0 {
+		p["properties"] = properties
+	}
+	return p
+}
+
+// NewAzureEventHubsSendBatchPayload creates a payload for the Azure Event Hubs send-batch action.
+func NewAzureEventHubsSendBatchPayload(events []map[string]any) map[string]any {
+	return map[string]any{
+		"events": events,
+	}
+}
+
+// NewAzureEventHubsSendBatchPayloadWithOptions creates an Azure Event Hubs send-batch payload with optional fields.
+func NewAzureEventHubsSendBatchPayloadWithOptions(events []map[string]any, eventHubName string) map[string]any {
+	p := NewAzureEventHubsSendBatchPayload(events)
+	if eventHubName != "" {
+		p["event_hub_name"] = eventHubName
+	}
+	return p
+}

--- a/clients/java/src/main/java/com/acteon/client/models/AzureBlobDeletePayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/AzureBlobDeletePayload.java
@@ -1,0 +1,28 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the Azure Blob Storage delete action ({@code azure-blob}, action type {@code delete_blob}).
+ */
+public class AzureBlobDeletePayload {
+    private final String blobName;
+    private String container;
+
+    public AzureBlobDeletePayload(String blobName) {
+        this.blobName = blobName;
+    }
+
+    public AzureBlobDeletePayload withContainer(String container) {
+        this.container = container;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("blob_name", blobName);
+        if (container != null) payload.put("container", container);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/AzureBlobDownloadPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/AzureBlobDownloadPayload.java
@@ -1,0 +1,28 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the Azure Blob Storage download action ({@code azure-blob}, action type {@code download_blob}).
+ */
+public class AzureBlobDownloadPayload {
+    private final String blobName;
+    private String container;
+
+    public AzureBlobDownloadPayload(String blobName) {
+        this.blobName = blobName;
+    }
+
+    public AzureBlobDownloadPayload withContainer(String container) {
+        this.container = container;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("blob_name", blobName);
+        if (container != null) payload.put("container", container);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/AzureBlobUploadPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/AzureBlobUploadPayload.java
@@ -1,0 +1,56 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the Azure Blob Storage upload action ({@code azure-blob}, action type {@code upload_blob}).
+ */
+public class AzureBlobUploadPayload {
+    private final String blobName;
+    private String container;
+    private String body;
+    private String bodyBase64;
+    private String contentType;
+    private Map<String, String> metadata;
+
+    public AzureBlobUploadPayload(String blobName) {
+        this.blobName = blobName;
+    }
+
+    public AzureBlobUploadPayload withContainer(String container) {
+        this.container = container;
+        return this;
+    }
+
+    public AzureBlobUploadPayload withBody(String body) {
+        this.body = body;
+        return this;
+    }
+
+    public AzureBlobUploadPayload withBodyBase64(String bodyBase64) {
+        this.bodyBase64 = bodyBase64;
+        return this;
+    }
+
+    public AzureBlobUploadPayload withContentType(String contentType) {
+        this.contentType = contentType;
+        return this;
+    }
+
+    public AzureBlobUploadPayload withMetadata(Map<String, String> metadata) {
+        this.metadata = metadata;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("blob_name", blobName);
+        if (container != null) payload.put("container", container);
+        if (body != null) payload.put("body", body);
+        if (bodyBase64 != null) payload.put("body_base64", bodyBase64);
+        if (contentType != null) payload.put("content_type", contentType);
+        if (metadata != null) payload.put("metadata", metadata);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/AzureEventHubsSendBatchPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/AzureEventHubsSendBatchPayload.java
@@ -1,0 +1,29 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Payload builder for the Azure Event Hubs send-batch action ({@code azure-eventhubs}, action type {@code send_batch}).
+ */
+public class AzureEventHubsSendBatchPayload {
+    private final List<Map<String, Object>> events;
+    private String eventHubName;
+
+    public AzureEventHubsSendBatchPayload(List<Map<String, Object>> events) {
+        this.events = events;
+    }
+
+    public AzureEventHubsSendBatchPayload withEventHubName(String eventHubName) {
+        this.eventHubName = eventHubName;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("events", events);
+        if (eventHubName != null) payload.put("event_hub_name", eventHubName);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/AzureEventHubsSendPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/AzureEventHubsSendPayload.java
@@ -1,0 +1,42 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the Azure Event Hubs send action ({@code azure-eventhubs}, action type {@code send_event}).
+ */
+public class AzureEventHubsSendPayload {
+    private final Object body;
+    private String eventHubName;
+    private String partitionId;
+    private Map<String, String> properties;
+
+    public AzureEventHubsSendPayload(Object body) {
+        this.body = body;
+    }
+
+    public AzureEventHubsSendPayload withEventHubName(String eventHubName) {
+        this.eventHubName = eventHubName;
+        return this;
+    }
+
+    public AzureEventHubsSendPayload withPartitionId(String partitionId) {
+        this.partitionId = partitionId;
+        return this;
+    }
+
+    public AzureEventHubsSendPayload withProperties(Map<String, String> properties) {
+        this.properties = properties;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("body", body);
+        if (eventHubName != null) payload.put("event_hub_name", eventHubName);
+        if (partitionId != null) payload.put("partition_id", partitionId);
+        if (properties != null) payload.put("properties", properties);
+        return payload;
+    }
+}

--- a/clients/nodejs/src/models.ts
+++ b/clients/nodejs/src/models.ts
@@ -2765,3 +2765,113 @@ export function createAsgUpdateGroupPayload(
     payload.health_check_grace_period = options.healthCheckGracePeriod;
   return payload;
 }
+
+// =============================================================================
+// Azure Blob Storage Provider Payload Helpers
+// =============================================================================
+
+/** Payload for the Azure Blob Storage upload-blob action. */
+export interface AzureBlobUploadPayload {
+  blob_name: string;
+  container?: string;
+  body?: string;
+  body_base64?: string;
+  content_type?: string;
+  metadata?: Record<string, string>;
+}
+
+/** Create a payload for the Azure Blob Storage upload-blob action. */
+export function createAzureBlobUploadPayload(
+  blobName: string,
+  options?: {
+    container?: string;
+    body?: string;
+    bodyBase64?: string;
+    contentType?: string;
+    metadata?: Record<string, string>;
+  }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { blob_name: blobName };
+  if (options?.container) payload.container = options.container;
+  if (options?.body !== undefined) payload.body = options.body;
+  if (options?.bodyBase64) payload.body_base64 = options.bodyBase64;
+  if (options?.contentType) payload.content_type = options.contentType;
+  if (options?.metadata) payload.metadata = options.metadata;
+  return payload;
+}
+
+/** Payload for the Azure Blob Storage download-blob action. */
+export interface AzureBlobDownloadPayload {
+  blob_name: string;
+  container?: string;
+}
+
+/** Create a payload for the Azure Blob Storage download-blob action. */
+export function createAzureBlobDownloadPayload(
+  blobName: string,
+  options?: { container?: string }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { blob_name: blobName };
+  if (options?.container) payload.container = options.container;
+  return payload;
+}
+
+/** Payload for the Azure Blob Storage delete-blob action. */
+export interface AzureBlobDeletePayload {
+  blob_name: string;
+  container?: string;
+}
+
+/** Create a payload for the Azure Blob Storage delete-blob action. */
+export function createAzureBlobDeletePayload(
+  blobName: string,
+  options?: { container?: string }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { blob_name: blobName };
+  if (options?.container) payload.container = options.container;
+  return payload;
+}
+
+// =============================================================================
+// Azure Event Hubs Provider Payload Helpers
+// =============================================================================
+
+/** Payload for the Azure Event Hubs send-event action. */
+export interface AzureEventHubsSendPayload {
+  body: unknown;
+  event_hub_name?: string;
+  partition_id?: string;
+  properties?: Record<string, string>;
+}
+
+/** Create a payload for the Azure Event Hubs send-event action. */
+export function createAzureEventHubsSendPayload(
+  body: unknown,
+  options?: {
+    eventHubName?: string;
+    partitionId?: string;
+    properties?: Record<string, string>;
+  }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { body };
+  if (options?.eventHubName) payload.event_hub_name = options.eventHubName;
+  if (options?.partitionId) payload.partition_id = options.partitionId;
+  if (options?.properties) payload.properties = options.properties;
+  return payload;
+}
+
+/** Payload for the Azure Event Hubs send-batch action. */
+export interface AzureEventHubsSendBatchPayload {
+  events: Record<string, unknown>[];
+  event_hub_name?: string;
+}
+
+/** Create a payload for the Azure Event Hubs send-batch action. */
+export function createAzureEventHubsSendBatchPayload(
+  events: Record<string, unknown>[],
+  options?: { eventHubName?: string }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { events };
+  if (options?.eventHubName) payload.event_hub_name = options.eventHubName;
+  return payload;
+}

--- a/clients/python/acteon_client/models.py
+++ b/clients/python/acteon_client/models.py
@@ -3149,3 +3149,142 @@ def autoscaling_update_group_payload(
     if health_check_grace_period is not None:
         payload["health_check_grace_period"] = health_check_grace_period
     return payload
+
+
+# =============================================================================
+# Azure Blob Storage Provider Payload Helpers
+# =============================================================================
+
+
+def azure_blob_upload_payload(
+    blob_name: str,
+    *,
+    container: Optional[str] = None,
+    body: Optional[str] = None,
+    body_base64: Optional[str] = None,
+    content_type: Optional[str] = None,
+    metadata: Optional[dict[str, str]] = None,
+) -> dict[str, Any]:
+    """Build a payload for an Azure Blob Storage upload action.
+
+    Args:
+        blob_name: Name of the blob to upload.
+        container: Override the container name configured on the provider.
+        body: Blob body as a UTF-8 string.
+        body_base64: Blob body as base64-encoded bytes.
+        content_type: Content type (e.g., ``"application/json"``).
+        metadata: Blob metadata as key-value pairs.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``azure-blob``
+        provider with action type ``upload_blob``.
+    """
+    payload: dict[str, Any] = {"blob_name": blob_name}
+    if container is not None:
+        payload["container"] = container
+    if body is not None:
+        payload["body"] = body
+    if body_base64 is not None:
+        payload["body_base64"] = body_base64
+    if content_type is not None:
+        payload["content_type"] = content_type
+    if metadata is not None:
+        payload["metadata"] = metadata
+    return payload
+
+
+def azure_blob_download_payload(
+    blob_name: str,
+    *,
+    container: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a payload for an Azure Blob Storage download action.
+
+    Args:
+        blob_name: Name of the blob to download.
+        container: Override the container name configured on the provider.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``azure-blob``
+        provider with action type ``download_blob``.
+    """
+    payload: dict[str, Any] = {"blob_name": blob_name}
+    if container is not None:
+        payload["container"] = container
+    return payload
+
+
+def azure_blob_delete_payload(
+    blob_name: str,
+    *,
+    container: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a payload for an Azure Blob Storage delete action.
+
+    Args:
+        blob_name: Name of the blob to delete.
+        container: Override the container name configured on the provider.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``azure-blob``
+        provider with action type ``delete_blob``.
+    """
+    payload: dict[str, Any] = {"blob_name": blob_name}
+    if container is not None:
+        payload["container"] = container
+    return payload
+
+
+# =============================================================================
+# Azure Event Hubs Provider Payload Helpers
+# =============================================================================
+
+
+def azure_eventhubs_send_payload(
+    body: Any,
+    *,
+    event_hub_name: Optional[str] = None,
+    partition_id: Optional[str] = None,
+    properties: Optional[dict[str, str]] = None,
+) -> dict[str, Any]:
+    """Build a payload for an Azure Event Hubs send action.
+
+    Args:
+        body: Event body as a JSON-serializable value.
+        event_hub_name: Override the Event Hub name configured on the provider.
+        partition_id: Target a specific partition.
+        properties: Application properties as key-value pairs.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``azure-eventhubs``
+        provider with action type ``send_event``.
+    """
+    payload: dict[str, Any] = {"body": body}
+    if event_hub_name is not None:
+        payload["event_hub_name"] = event_hub_name
+    if partition_id is not None:
+        payload["partition_id"] = partition_id
+    if properties is not None:
+        payload["properties"] = properties
+    return payload
+
+
+def azure_eventhubs_send_batch_payload(
+    events: List[dict[str, Any]],
+    *,
+    event_hub_name: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a payload for an Azure Event Hubs send-batch action.
+
+    Args:
+        events: List of event objects to send as a batch.
+        event_hub_name: Override the Event Hub name configured on the provider.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``azure-eventhubs``
+        provider with action type ``send_batch``.
+    """
+    payload: dict[str, Any] = {"events": events}
+    if event_hub_name is not None:
+        payload["event_hub_name"] = event_hub_name
+    return payload

--- a/crates/azure/Cargo.toml
+++ b/crates/azure/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "acteon-azure"
+description = "Azure service providers for Acteon (Blob Storage, Event Hubs)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+integration = []
+blob = ["dep:azure_storage_blob"]
+eventhubs = ["dep:azure_messaging_eventhubs"]
+# Phase 2/3 placeholders (REST-based, no SDK deps yet)
+functions = []
+servicebus = []
+email = []
+vm = []
+vmss = []
+eventgrid = []
+full = ["blob", "eventhubs", "functions", "servicebus", "email", "vm", "vmss", "eventgrid"]
+
+[dependencies]
+acteon-core = { workspace = true }
+acteon-provider = { workspace = true }
+azure_core = { workspace = true }
+azure_identity = { workspace = true }
+azure_storage_blob = { workspace = true, optional = true }
+azure_messaging_eventhubs = { workspace = true, optional = true }
+async-trait = { workspace = true }
+base64 = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/azure/src/auth.rs
+++ b/crates/azure/src/auth.rs
@@ -1,0 +1,51 @@
+use std::sync::Arc;
+
+use azure_core::credentials::{Secret, TokenCredential};
+use tracing::{debug, info};
+
+use crate::config::AzureBaseConfig;
+use crate::error::AzureProviderError;
+
+/// Build an Azure credential from the given [`AzureBaseConfig`].
+///
+/// If `tenant_id`, `client_id`, and `client_credential` are all present,
+/// uses `ClientSecretCredential` for service-principal authentication.
+/// Otherwise falls back to `AzureCliCredential` which uses the Azure CLI
+/// login context (suitable for development and CI/CD environments).
+///
+/// For production environments without service principal credentials,
+/// use `ManagedIdentityCredential` by providing tenant/client/credential
+/// config or by configuring the Azure environment externally.
+///
+/// # Errors
+///
+/// Returns [`AzureProviderError::CredentialError`] if credential construction fails.
+#[allow(clippy::unused_async)]
+pub async fn build_azure_credential(
+    config: &AzureBaseConfig,
+) -> Result<Arc<dyn TokenCredential>, AzureProviderError> {
+    if let (Some(tenant_id), Some(client_id), Some(client_cred)) = (
+        &config.tenant_id,
+        &config.client_id,
+        &config.client_credential,
+    ) {
+        info!("using service-principal credentials for Azure");
+        debug!(tenant_id = %tenant_id, "building ClientSecretCredential");
+
+        let credential = azure_identity::ClientSecretCredential::new(
+            tenant_id,
+            client_id.clone(),
+            Secret::new(client_cred.clone()),
+            None,
+        )
+        .map_err(|e| AzureProviderError::CredentialError(e.to_string()))?;
+
+        Ok(credential)
+    } else {
+        info!("using AzureCliCredential for Azure (dev/CI fallback)");
+        let credential = azure_identity::AzureCliCredential::new(None)
+            .map_err(|e| AzureProviderError::CredentialError(e.to_string()))?;
+
+        Ok(credential)
+    }
+}

--- a/crates/azure/src/blob.rs
+++ b/crates/azure/src/blob.rs
@@ -1,0 +1,531 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::ProviderError;
+use acteon_provider::provider::Provider;
+use azure_core::credentials::TokenCredential;
+use azure_storage_blob::BlobServiceClient;
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, instrument};
+
+use crate::auth::build_azure_credential;
+use crate::config::AzureBaseConfig;
+use crate::error::classify_azure_error;
+
+/// Configuration for the Azure Blob Storage provider.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct BlobConfig {
+    /// Shared Azure configuration.
+    #[serde(flatten)]
+    pub azure: AzureBaseConfig,
+
+    /// Azure Storage account name.
+    pub account_name: Option<String>,
+
+    /// Default container name. Can be overridden per-action in the payload.
+    pub container_name: Option<String>,
+
+    /// Default blob name prefix (e.g. `"acteon/artifacts/"`).
+    pub prefix: Option<String>,
+}
+
+impl std::fmt::Debug for BlobConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BlobConfig")
+            .field("azure", &self.azure)
+            .field("account_name", &self.account_name)
+            .field("container_name", &self.container_name)
+            .field("prefix", &self.prefix)
+            .finish()
+    }
+}
+
+impl BlobConfig {
+    /// Create a new `BlobConfig` with the given Azure location.
+    pub fn new(location: impl Into<String>) -> Self {
+        Self {
+            azure: AzureBaseConfig::new(location),
+            account_name: None,
+            container_name: None,
+            prefix: None,
+        }
+    }
+
+    /// Set the storage account name.
+    #[must_use]
+    pub fn with_account_name(mut self, account_name: impl Into<String>) -> Self {
+        self.account_name = Some(account_name.into());
+        self
+    }
+
+    /// Set the default container name.
+    #[must_use]
+    pub fn with_container_name(mut self, container_name: impl Into<String>) -> Self {
+        self.container_name = Some(container_name.into());
+        self
+    }
+
+    /// Set the default blob name prefix.
+    #[must_use]
+    pub fn with_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = Some(prefix.into());
+        self
+    }
+
+    /// Set the endpoint URL override (for `Azurite`).
+    #[must_use]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.azure.endpoint_url = Some(endpoint_url.into());
+        self
+    }
+
+    /// Set the Azure AD tenant ID.
+    #[must_use]
+    pub fn with_tenant_id(mut self, tenant_id: impl Into<String>) -> Self {
+        self.azure.tenant_id = Some(tenant_id.into());
+        self
+    }
+
+    /// Set the Azure AD client ID.
+    #[must_use]
+    pub fn with_client_id(mut self, client_id: impl Into<String>) -> Self {
+        self.azure.client_id = Some(client_id.into());
+        self
+    }
+
+    /// Set the Azure AD client credential.
+    #[must_use]
+    pub fn with_client_credential(mut self, client_credential: impl Into<String>) -> Self {
+        self.azure.client_credential = Some(client_credential.into());
+        self
+    }
+}
+
+/// Payload for the `upload_blob` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlobUploadPayload {
+    /// Container name. Overrides config default.
+    pub container: Option<String>,
+
+    /// Blob name (path within the container).
+    pub blob_name: String,
+
+    /// Blob body as a UTF-8 string.
+    /// Mutually exclusive with `body_base64`.
+    pub body: Option<String>,
+
+    /// Blob body as base64-encoded bytes.
+    /// Mutually exclusive with `body`.
+    pub body_base64: Option<String>,
+
+    /// Optional `Content-Type` for the blob.
+    pub content_type: Option<String>,
+
+    /// Optional metadata key-value pairs attached to the blob.
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+/// Payload for the `download_blob` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlobDownloadPayload {
+    /// Container name. Overrides config default.
+    pub container: Option<String>,
+
+    /// Blob name to download.
+    pub blob_name: String,
+}
+
+/// Payload for the `delete_blob` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlobDeletePayload {
+    /// Container name. Overrides config default.
+    pub container: Option<String>,
+
+    /// Blob name to delete.
+    pub blob_name: String,
+}
+
+/// Azure Blob Storage provider for storing and retrieving blobs.
+pub struct BlobProvider {
+    config: BlobConfig,
+    service_client: BlobServiceClient,
+    credential: Arc<dyn TokenCredential>,
+    endpoint: String,
+}
+
+impl std::fmt::Debug for BlobProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BlobProvider")
+            .field("config", &self.config)
+            .field("endpoint", &self.endpoint)
+            .finish_non_exhaustive()
+    }
+}
+
+impl BlobProvider {
+    /// Create a new `BlobProvider` by building an Azure Blob Storage client.
+    pub async fn new(config: BlobConfig) -> Result<Self, ProviderError> {
+        let account_name = config.account_name.as_deref().ok_or_else(|| {
+            ProviderError::Configuration("azure blob: account_name is required".to_owned())
+        })?;
+
+        let credential = build_azure_credential(&config.azure)
+            .await
+            .map_err(|e| ProviderError::Configuration(e.to_string()))?;
+
+        let endpoint = config
+            .azure
+            .endpoint_url
+            .clone()
+            .unwrap_or_else(|| format!("https://{account_name}.blob.core.windows.net"));
+
+        let service_client = BlobServiceClient::new(&endpoint, Some(Arc::clone(&credential)), None)
+            .map_err(|e| ProviderError::Configuration(format!("blob client error: {e}")))?;
+
+        Ok(Self {
+            config,
+            service_client,
+            credential,
+            endpoint,
+        })
+    }
+
+    /// Resolve the container name from the payload or config default.
+    fn resolve_container<'a>(&'a self, payload_container: Option<&'a str>) -> Option<&'a str> {
+        payload_container.or(self.config.container_name.as_deref())
+    }
+
+    /// Apply the configured prefix to a blob name.
+    fn prefixed_name(&self, blob_name: &str) -> String {
+        match &self.config.prefix {
+            Some(prefix) => format!("{prefix}{blob_name}"),
+            None => blob_name.to_owned(),
+        }
+    }
+}
+
+impl Provider for BlobProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "azure-blob"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "azure-blob"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        match action.action_type.as_str() {
+            "upload_blob" => self.upload_blob(action).await,
+            "download_blob" => self.download_blob(action).await,
+            "delete_blob" => self.delete_blob(action).await,
+            other => Err(ProviderError::Configuration(format!(
+                "unknown Blob action type '{other}' (expected 'upload_blob', 'download_blob', or 'delete_blob')"
+            ))),
+        }
+    }
+
+    #[instrument(skip(self), fields(provider = "azure-blob"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        debug!("performing Azure Blob health check");
+        // List containers to verify connectivity.
+        let _pager = self.service_client.list_containers(None).map_err(|e| {
+            error!(error = %e, "Azure Blob health check failed");
+            ProviderError::Connection(format!("Azure Blob health check failed: {e}"))
+        })?;
+        info!("Azure Blob health check passed");
+        Ok(())
+    }
+}
+
+impl BlobProvider {
+    async fn upload_blob(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing Blob upload_blob payload");
+        let payload: BlobUploadPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let container = self
+            .resolve_container(payload.container.as_deref())
+            .ok_or_else(|| {
+                ProviderError::Configuration(
+                    "no container in payload or provider config".to_owned(),
+                )
+            })?;
+
+        let blob_name = self.prefixed_name(&payload.blob_name);
+
+        // Resolve the body from either string or base64.
+        let body_bytes: Vec<u8> = if let Some(ref b64) = payload.body_base64 {
+            base64::engine::general_purpose::STANDARD
+                .decode(b64)
+                .map_err(|e| ProviderError::Serialization(format!("invalid base64 body: {e}")))?
+        } else if let Some(ref text) = payload.body {
+            text.as_bytes().to_vec()
+        } else {
+            Vec::new()
+        };
+
+        let content_length = body_bytes.len() as u64;
+        debug!(container = %container, blob_name = %blob_name, size = content_length, "uploading blob");
+
+        let blob_client = self.service_client.blob_client(container, &blob_name);
+        let data: azure_core::Bytes = body_bytes.into();
+
+        blob_client
+            .upload(data.into(), true, content_length, None)
+            .await
+            .map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "Blob upload failed");
+                let azure_err: ProviderError = classify_azure_error(&err_str).into();
+                azure_err
+            })?;
+
+        info!(container = %container, blob_name = %blob_name, "blob uploaded");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "container": container,
+            "blob_name": blob_name,
+            "status": "uploaded"
+        })))
+    }
+
+    async fn download_blob(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing Blob download_blob payload");
+        let payload: BlobDownloadPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let container = self
+            .resolve_container(payload.container.as_deref())
+            .ok_or_else(|| {
+                ProviderError::Configuration(
+                    "no container in payload or provider config".to_owned(),
+                )
+            })?;
+
+        let blob_name = self.prefixed_name(&payload.blob_name);
+
+        debug!(container = %container, blob_name = %blob_name, "downloading blob");
+
+        let blob_client = azure_storage_blob::BlobClient::new(
+            &self.endpoint,
+            container,
+            &blob_name,
+            Some(Arc::clone(&self.credential)),
+            None,
+        )
+        .map_err(|e| ProviderError::Configuration(format!("blob client error: {e}")))?;
+
+        let response = blob_client.download(None).await.map_err(|e| {
+            let err_str = e.to_string();
+            error!(error = %err_str, "Blob download failed");
+            let azure_err: ProviderError = classify_azure_error(&err_str).into();
+            azure_err
+        })?;
+
+        let body_bytes: azure_core::Bytes = response.into_body().collect().await.map_err(|e| {
+            ProviderError::ExecutionFailed(format!("failed to read blob body: {e}"))
+        })?;
+
+        let (body_field, body_value) = match std::str::from_utf8(&body_bytes) {
+            Ok(text) => ("body", serde_json::Value::String(text.to_owned())),
+            Err(_) => (
+                "body_base64",
+                serde_json::Value::String(
+                    base64::engine::general_purpose::STANDARD.encode(&body_bytes),
+                ),
+            ),
+        };
+
+        info!(container = %container, blob_name = %blob_name, size = body_bytes.len(), "blob downloaded");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "container": container,
+            "blob_name": blob_name,
+            "content_length": body_bytes.len(),
+            body_field: body_value,
+            "status": "downloaded"
+        })))
+    }
+
+    async fn delete_blob(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing Blob delete_blob payload");
+        let payload: BlobDeletePayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let container = self
+            .resolve_container(payload.container.as_deref())
+            .ok_or_else(|| {
+                ProviderError::Configuration(
+                    "no container in payload or provider config".to_owned(),
+                )
+            })?;
+
+        let blob_name = self.prefixed_name(&payload.blob_name);
+
+        debug!(container = %container, blob_name = %blob_name, "deleting blob");
+
+        let blob_client = self.service_client.blob_client(container, &blob_name);
+
+        blob_client.delete(None).await.map_err(|e| {
+            let err_str = e.to_string();
+            error!(error = %err_str, "Blob delete failed");
+            let azure_err: ProviderError = classify_azure_error(&err_str).into();
+            azure_err
+        })?;
+
+        info!(container = %container, blob_name = %blob_name, "blob deleted");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "container": container,
+            "blob_name": blob_name,
+            "status": "deleted"
+        })))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_new_sets_location() {
+        let config = BlobConfig::new("westeurope");
+        assert_eq!(config.azure.location, "westeurope");
+        assert!(config.account_name.is_none());
+        assert!(config.container_name.is_none());
+        assert!(config.prefix.is_none());
+    }
+
+    #[test]
+    fn config_with_account_name() {
+        let config = BlobConfig::new("eastus").with_account_name("mystorageaccount");
+        assert_eq!(config.account_name.as_deref(), Some("mystorageaccount"));
+    }
+
+    #[test]
+    fn config_with_container_name() {
+        let config = BlobConfig::new("eastus").with_container_name("my-container");
+        assert_eq!(config.container_name.as_deref(), Some("my-container"));
+    }
+
+    #[test]
+    fn config_with_prefix() {
+        let config = BlobConfig::new("eastus").with_prefix("acteon/");
+        assert_eq!(config.prefix.as_deref(), Some("acteon/"));
+    }
+
+    #[test]
+    fn config_builder_chain() {
+        let config = BlobConfig::new("eastus2")
+            .with_account_name("teststorage")
+            .with_container_name("data")
+            .with_prefix("logs/")
+            .with_endpoint_url("http://127.0.0.1:10000")
+            .with_tenant_id("tid-123")
+            .with_client_id("cid-456")
+            .with_client_credential("cred-789");
+        assert_eq!(config.account_name.as_deref(), Some("teststorage"));
+        assert_eq!(config.container_name.as_deref(), Some("data"));
+        assert_eq!(config.prefix.as_deref(), Some("logs/"));
+        assert_eq!(
+            config.azure.endpoint_url.as_deref(),
+            Some("http://127.0.0.1:10000")
+        );
+        assert!(config.azure.tenant_id.is_some());
+    }
+
+    #[test]
+    fn config_debug_format() {
+        let config = BlobConfig::new("eastus")
+            .with_account_name("mystorageaccount")
+            .with_client_credential("private-val");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("BlobConfig"));
+        assert!(debug.contains("[REDACTED]"));
+        assert!(debug.contains("mystorageaccount"));
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config = BlobConfig::new("northeurope")
+            .with_account_name("archive")
+            .with_container_name("backups")
+            .with_prefix("data/");
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: BlobConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.azure.location, "northeurope");
+        assert_eq!(deserialized.account_name.as_deref(), Some("archive"));
+        assert_eq!(deserialized.container_name.as_deref(), Some("backups"));
+        assert_eq!(deserialized.prefix.as_deref(), Some("data/"));
+    }
+
+    #[test]
+    fn deserialize_upload_payload() {
+        let json = serde_json::json!({
+            "blob_name": "reports/2026/report.json",
+            "body": "{\"total\": 42}",
+            "content_type": "application/json",
+            "container": "my-container",
+            "metadata": {
+                "source": "acteon"
+            }
+        });
+        let payload: BlobUploadPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.blob_name, "reports/2026/report.json");
+        assert_eq!(payload.body.as_deref(), Some("{\"total\": 42}"));
+        assert_eq!(payload.content_type.as_deref(), Some("application/json"));
+        assert_eq!(payload.container.as_deref(), Some("my-container"));
+        assert_eq!(payload.metadata.get("source").unwrap(), "acteon");
+    }
+
+    #[test]
+    fn deserialize_upload_payload_base64() {
+        let json = serde_json::json!({
+            "blob_name": "images/logo.png",
+            "body_base64": "iVBORw0KGgo=",
+            "content_type": "image/png"
+        });
+        let payload: BlobUploadPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.blob_name, "images/logo.png");
+        assert!(payload.body.is_none());
+        assert_eq!(payload.body_base64.as_deref(), Some("iVBORw0KGgo="));
+    }
+
+    #[test]
+    fn deserialize_minimal_upload_payload() {
+        let json = serde_json::json!({
+            "blob_name": "test.txt"
+        });
+        let payload: BlobUploadPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.blob_name, "test.txt");
+        assert!(payload.body.is_none());
+        assert!(payload.body_base64.is_none());
+        assert!(payload.content_type.is_none());
+        assert!(payload.container.is_none());
+        assert!(payload.metadata.is_empty());
+    }
+
+    #[test]
+    fn deserialize_download_payload() {
+        let json = serde_json::json!({
+            "blob_name": "reports/latest.json",
+            "container": "data-container"
+        });
+        let payload: BlobDownloadPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.blob_name, "reports/latest.json");
+        assert_eq!(payload.container.as_deref(), Some("data-container"));
+    }
+
+    #[test]
+    fn deserialize_delete_payload() {
+        let json = serde_json::json!({
+            "blob_name": "old/data.csv"
+        });
+        let payload: BlobDeletePayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.blob_name, "old/data.csv");
+        assert!(payload.container.is_none());
+    }
+}

--- a/crates/azure/src/config.rs
+++ b/crates/azure/src/config.rs
@@ -1,0 +1,198 @@
+use serde::{Deserialize, Serialize};
+
+/// Shared base configuration for all Azure providers.
+///
+/// Contains common settings like tenant ID, service principal credentials,
+/// subscription/resource group, and an optional endpoint URL override for
+/// local development (e.g. `Azurite`).
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AzureBaseConfig {
+    /// Azure AD tenant ID.
+    #[serde(default)]
+    pub tenant_id: Option<String>,
+
+    /// Azure AD application (client) ID.
+    #[serde(default)]
+    pub client_id: Option<String>,
+
+    /// Azure AD client credential (service principal). Redacted in `Debug`.
+    #[serde(default)]
+    pub client_credential: Option<String>,
+
+    /// Azure subscription ID.
+    #[serde(default)]
+    pub subscription_id: Option<String>,
+
+    /// Azure resource group name.
+    #[serde(default)]
+    pub resource_group: Option<String>,
+
+    /// Azure region / location (e.g. `"eastus"`).
+    pub location: String,
+
+    /// Optional endpoint URL override for local development (e.g. `Azurite`).
+    #[serde(default)]
+    pub endpoint_url: Option<String>,
+}
+
+impl std::fmt::Debug for AzureBaseConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AzureBaseConfig")
+            .field("tenant_id", &self.tenant_id)
+            .field("client_id", &self.client_id.as_ref().map(|_| "[REDACTED]"))
+            .field(
+                "client_credential",
+                &self.client_credential.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("subscription_id", &self.subscription_id)
+            .field("resource_group", &self.resource_group)
+            .field("location", &self.location)
+            .field("endpoint_url", &self.endpoint_url)
+            .finish()
+    }
+}
+
+impl AzureBaseConfig {
+    /// Create a new `AzureBaseConfig` with the given location.
+    pub fn new(location: impl Into<String>) -> Self {
+        Self {
+            tenant_id: None,
+            client_id: None,
+            client_credential: None,
+            subscription_id: None,
+            resource_group: None,
+            location: location.into(),
+            endpoint_url: None,
+        }
+    }
+
+    /// Set the Azure AD tenant ID.
+    #[must_use]
+    pub fn with_tenant_id(mut self, tenant_id: impl Into<String>) -> Self {
+        self.tenant_id = Some(tenant_id.into());
+        self
+    }
+
+    /// Set the Azure AD application (client) ID.
+    #[must_use]
+    pub fn with_client_id(mut self, client_id: impl Into<String>) -> Self {
+        self.client_id = Some(client_id.into());
+        self
+    }
+
+    /// Set the Azure AD client credential.
+    #[must_use]
+    pub fn with_client_credential(mut self, client_credential: impl Into<String>) -> Self {
+        self.client_credential = Some(client_credential.into());
+        self
+    }
+
+    /// Set the Azure subscription ID.
+    #[must_use]
+    pub fn with_subscription_id(mut self, subscription_id: impl Into<String>) -> Self {
+        self.subscription_id = Some(subscription_id.into());
+        self
+    }
+
+    /// Set the Azure resource group name.
+    #[must_use]
+    pub fn with_resource_group(mut self, resource_group: impl Into<String>) -> Self {
+        self.resource_group = Some(resource_group.into());
+        self
+    }
+
+    /// Set the endpoint URL override for local development.
+    #[must_use]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.endpoint_url = Some(endpoint_url.into());
+        self
+    }
+}
+
+impl Default for AzureBaseConfig {
+    fn default() -> Self {
+        Self {
+            tenant_id: None,
+            client_id: None,
+            client_credential: None,
+            subscription_id: None,
+            resource_group: None,
+            location: "eastus".to_owned(),
+            endpoint_url: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_config_sets_location() {
+        let config = AzureBaseConfig::new("westeurope");
+        assert_eq!(config.location, "westeurope");
+        assert!(config.tenant_id.is_none());
+        assert!(config.client_id.is_none());
+        assert!(config.endpoint_url.is_none());
+    }
+
+    #[test]
+    fn builder_chain() {
+        let config = AzureBaseConfig::new("eastus2")
+            .with_tenant_id("tid-123")
+            .with_client_id("cid-456")
+            .with_client_credential("cred-789")
+            .with_subscription_id("sub-abc")
+            .with_resource_group("rg-test")
+            .with_endpoint_url("http://127.0.0.1:10000");
+        assert_eq!(config.tenant_id.as_deref(), Some("tid-123"));
+        assert_eq!(config.client_id.as_deref(), Some("cid-456"));
+        assert_eq!(config.client_credential.as_deref(), Some("cred-789"));
+        assert_eq!(config.subscription_id.as_deref(), Some("sub-abc"));
+        assert_eq!(config.resource_group.as_deref(), Some("rg-test"));
+        assert_eq!(
+            config.endpoint_url.as_deref(),
+            Some("http://127.0.0.1:10000")
+        );
+    }
+
+    #[test]
+    fn debug_redacts_credentials() {
+        let config = AzureBaseConfig::new("eastus")
+            .with_client_id("my-app-id")
+            .with_client_credential("super-private");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("my-app-id"));
+        assert!(!debug.contains("super-private"));
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let config = AzureBaseConfig::new("northeurope")
+            .with_tenant_id("tid-round")
+            .with_endpoint_url("http://azurite:10000");
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: AzureBaseConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.location, "northeurope");
+        assert_eq!(deserialized.tenant_id.as_deref(), Some("tid-round"));
+        assert_eq!(
+            deserialized.endpoint_url.as_deref(),
+            Some("http://azurite:10000")
+        );
+    }
+
+    #[test]
+    fn default_config() {
+        let config = AzureBaseConfig::default();
+        assert_eq!(config.location, "eastus");
+        assert!(config.tenant_id.is_none());
+        assert!(config.client_id.is_none());
+        assert!(config.client_credential.is_none());
+        assert!(config.subscription_id.is_none());
+        assert!(config.resource_group.is_none());
+        assert!(config.endpoint_url.is_none());
+    }
+}

--- a/crates/azure/src/error.rs
+++ b/crates/azure/src/error.rs
@@ -1,0 +1,170 @@
+use acteon_provider::ProviderError;
+use thiserror::Error;
+
+/// Errors specific to Azure provider operations.
+#[derive(Debug, Error)]
+pub enum AzureProviderError {
+    /// The Azure service returned an error.
+    #[error("Azure service error: {0}")]
+    ServiceError(String),
+
+    /// The request was throttled by the Azure service.
+    #[error("Azure request throttled")]
+    Throttled,
+
+    /// A network or connection error occurred communicating with Azure.
+    #[error("Azure connection error: {0}")]
+    Connection(String),
+
+    /// The request timed out.
+    #[error("Azure request timed out")]
+    Timeout,
+
+    /// The action payload was invalid or missing required fields.
+    #[error("invalid payload: {0}")]
+    InvalidPayload(String),
+
+    /// Azure credential resolution failed.
+    #[error("credential error: {0}")]
+    CredentialError(String),
+
+    /// Configuration is invalid.
+    #[error("invalid configuration: {0}")]
+    Configuration(String),
+}
+
+impl From<AzureProviderError> for ProviderError {
+    fn from(err: AzureProviderError) -> Self {
+        match err {
+            AzureProviderError::ServiceError(msg) => ProviderError::ExecutionFailed(msg),
+            AzureProviderError::Throttled => ProviderError::RateLimited,
+            AzureProviderError::Connection(msg) => ProviderError::Connection(msg),
+            AzureProviderError::Timeout => {
+                ProviderError::Timeout(std::time::Duration::from_secs(30))
+            }
+            AzureProviderError::InvalidPayload(msg) => ProviderError::Serialization(msg),
+            AzureProviderError::CredentialError(msg) | AzureProviderError::Configuration(msg) => {
+                ProviderError::Configuration(msg)
+            }
+        }
+    }
+}
+
+/// Classify an Azure SDK error string into the appropriate [`AzureProviderError`].
+///
+/// Inspects the error message for common patterns (throttling, timeout,
+/// connection) and maps them to the correct variant.
+pub fn classify_azure_error(error_str: &str) -> AzureProviderError {
+    let lower = error_str.to_lowercase();
+    if lower.contains("429")
+        || lower.contains("throttl")
+        || lower.contains("rate exceed")
+        || lower.contains("too many")
+    {
+        AzureProviderError::Throttled
+    } else if lower.contains("timeout") || lower.contains("timed out") {
+        AzureProviderError::Timeout
+    } else if lower.contains("connection")
+        || lower.contains("connect")
+        || lower.contains("dns")
+        || lower.contains("network")
+    {
+        AzureProviderError::Connection(error_str.to_owned())
+    } else {
+        AzureProviderError::ServiceError(error_str.to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn throttled_maps_to_rate_limited() {
+        let err: ProviderError = AzureProviderError::Throttled.into();
+        assert!(matches!(err, ProviderError::RateLimited));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn timeout_maps_to_timeout() {
+        let err: ProviderError = AzureProviderError::Timeout.into();
+        assert!(matches!(err, ProviderError::Timeout(_)));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn connection_maps_to_connection() {
+        let err: ProviderError = AzureProviderError::Connection("reset".into()).into();
+        assert!(matches!(err, ProviderError::Connection(_)));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn service_error_maps_to_execution_failed() {
+        let err: ProviderError =
+            AzureProviderError::ServiceError("container not found".into()).into();
+        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn invalid_payload_maps_to_serialization() {
+        let err: ProviderError = AzureProviderError::InvalidPayload("missing field".into()).into();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn credential_error_maps_to_configuration() {
+        let err: ProviderError =
+            AzureProviderError::CredentialError("no credentials".into()).into();
+        assert!(matches!(err, ProviderError::Configuration(_)));
+    }
+
+    #[test]
+    fn classify_throttled_429() {
+        let err = classify_azure_error("HTTP 429: Too Many Requests");
+        assert!(matches!(err, AzureProviderError::Throttled));
+    }
+
+    #[test]
+    fn classify_throttled_keyword() {
+        let err = classify_azure_error("Throttling: Rate exceeded");
+        assert!(matches!(err, AzureProviderError::Throttled));
+    }
+
+    #[test]
+    fn classify_timeout() {
+        let err = classify_azure_error("Request timed out after 30s");
+        assert!(matches!(err, AzureProviderError::Timeout));
+    }
+
+    #[test]
+    fn classify_connection() {
+        let err = classify_azure_error("Connection refused: 10.0.0.1:443");
+        assert!(matches!(err, AzureProviderError::Connection(_)));
+    }
+
+    #[test]
+    fn classify_generic_service_error() {
+        let err = classify_azure_error("ContainerNotFound: The specified container does not exist");
+        assert!(matches!(err, AzureProviderError::ServiceError(_)));
+    }
+
+    #[test]
+    fn error_display() {
+        assert_eq!(
+            AzureProviderError::Throttled.to_string(),
+            "Azure request throttled"
+        );
+        assert_eq!(
+            AzureProviderError::Timeout.to_string(),
+            "Azure request timed out"
+        );
+        assert_eq!(
+            AzureProviderError::ServiceError("bad".into()).to_string(),
+            "Azure service error: bad"
+        );
+    }
+}

--- a/crates/azure/src/eventhubs.rs
+++ b/crates/azure/src/eventhubs.rs
@@ -1,0 +1,418 @@
+use std::collections::HashMap;
+
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::ProviderError;
+use acteon_provider::provider::Provider;
+use azure_messaging_eventhubs::{ProducerClient, SendEventOptions};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, instrument};
+
+use crate::auth::build_azure_credential;
+use crate::config::AzureBaseConfig;
+use crate::error::classify_azure_error;
+
+/// Configuration for the Azure Event Hubs provider.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct EventHubsConfig {
+    /// Shared Azure configuration.
+    #[serde(flatten)]
+    pub azure: AzureBaseConfig,
+
+    /// Event Hubs fully-qualified namespace (e.g. `"mynamespace.servicebus.windows.net"`).
+    pub namespace: Option<String>,
+
+    /// Default Event Hub name. Can be overridden per-action in the payload.
+    pub event_hub_name: Option<String>,
+}
+
+impl std::fmt::Debug for EventHubsConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventHubsConfig")
+            .field("azure", &self.azure)
+            .field("namespace", &self.namespace)
+            .field("event_hub_name", &self.event_hub_name)
+            .finish()
+    }
+}
+
+impl EventHubsConfig {
+    /// Create a new `EventHubsConfig` with the given Azure location.
+    pub fn new(location: impl Into<String>) -> Self {
+        Self {
+            azure: AzureBaseConfig::new(location),
+            namespace: None,
+            event_hub_name: None,
+        }
+    }
+
+    /// Set the Event Hubs fully-qualified namespace.
+    #[must_use]
+    pub fn with_namespace(mut self, namespace: impl Into<String>) -> Self {
+        self.namespace = Some(namespace.into());
+        self
+    }
+
+    /// Set the default Event Hub name.
+    #[must_use]
+    pub fn with_event_hub_name(mut self, event_hub_name: impl Into<String>) -> Self {
+        self.event_hub_name = Some(event_hub_name.into());
+        self
+    }
+
+    /// Set the endpoint URL override.
+    #[must_use]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.azure.endpoint_url = Some(endpoint_url.into());
+        self
+    }
+
+    /// Set the Azure AD tenant ID.
+    #[must_use]
+    pub fn with_tenant_id(mut self, tenant_id: impl Into<String>) -> Self {
+        self.azure.tenant_id = Some(tenant_id.into());
+        self
+    }
+
+    /// Set the Azure AD client ID.
+    #[must_use]
+    pub fn with_client_id(mut self, client_id: impl Into<String>) -> Self {
+        self.azure.client_id = Some(client_id.into());
+        self
+    }
+
+    /// Set the Azure AD client credential.
+    #[must_use]
+    pub fn with_client_credential(mut self, client_credential: impl Into<String>) -> Self {
+        self.azure.client_credential = Some(client_credential.into());
+        self
+    }
+}
+
+/// A single event to send to Event Hubs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventDataPayload {
+    /// Event body (JSON or plain text).
+    pub body: serde_json::Value,
+
+    /// Optional partition ID for routing.
+    pub partition_id: Option<String>,
+
+    /// Optional application properties.
+    #[serde(default)]
+    pub properties: HashMap<String, String>,
+}
+
+/// Payload for the `send_event` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventHubsSendPayload {
+    /// Event Hub name. Overrides config default.
+    pub event_hub_name: Option<String>,
+
+    /// Event body (JSON or plain text).
+    pub body: serde_json::Value,
+
+    /// Optional partition ID for routing.
+    pub partition_id: Option<String>,
+
+    /// Optional application properties.
+    #[serde(default)]
+    pub properties: HashMap<String, String>,
+}
+
+/// Payload for the `send_batch` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventHubsSendBatchPayload {
+    /// Event Hub name. Overrides config default.
+    pub event_hub_name: Option<String>,
+
+    /// List of events to send.
+    pub events: Vec<EventDataPayload>,
+}
+
+/// Azure Event Hubs provider for sending events.
+pub struct EventHubsProvider {
+    config: EventHubsConfig,
+    producer: ProducerClient,
+}
+
+impl std::fmt::Debug for EventHubsProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventHubsProvider")
+            .field("config", &self.config)
+            .field("producer", &"<ProducerClient>")
+            .finish()
+    }
+}
+
+impl EventHubsProvider {
+    /// Create a new `EventHubsProvider` by building an Event Hubs producer client.
+    pub async fn new(config: EventHubsConfig) -> Result<Self, ProviderError> {
+        let namespace = config.namespace.as_deref().ok_or_else(|| {
+            ProviderError::Configuration("azure eventhubs: namespace is required".to_owned())
+        })?;
+
+        let event_hub_name = config.event_hub_name.as_deref().ok_or_else(|| {
+            ProviderError::Configuration("azure eventhubs: event_hub_name is required".to_owned())
+        })?;
+
+        let credential = build_azure_credential(&config.azure)
+            .await
+            .map_err(|e| ProviderError::Configuration(e.to_string()))?;
+
+        let mut builder = ProducerClient::builder();
+        if let Some(ref endpoint) = config.azure.endpoint_url {
+            builder = builder.with_custom_endpoint(endpoint.clone());
+        }
+
+        let producer = builder
+            .open(namespace, event_hub_name, credential)
+            .await
+            .map_err(|e| {
+                ProviderError::Configuration(format!("failed to open Event Hubs producer: {e}"))
+            })?;
+
+        Ok(Self { config, producer })
+    }
+}
+
+impl Provider for EventHubsProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "azure-eventhubs"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "azure-eventhubs"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        match action.action_type.as_str() {
+            "send_event" => self.send_event(action).await,
+            "send_batch" => self.send_batch(action).await,
+            other => Err(ProviderError::Configuration(format!(
+                "unknown Event Hubs action type '{other}' (expected 'send_event' or 'send_batch')"
+            ))),
+        }
+    }
+
+    #[instrument(skip(self), fields(provider = "azure-eventhubs"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        debug!("performing Event Hubs health check");
+        self.producer.get_eventhub_properties().await.map_err(|e| {
+            error!(error = %e, "Event Hubs health check failed");
+            ProviderError::Connection(format!("Event Hubs health check failed: {e}"))
+        })?;
+        info!("Event Hubs health check passed");
+        Ok(())
+    }
+}
+
+impl EventHubsProvider {
+    async fn send_event(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing Event Hubs send_event payload");
+        let payload: EventHubsSendPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let event_hub_name = payload
+            .event_hub_name
+            .as_deref()
+            .or(self.config.event_hub_name.as_deref())
+            .unwrap_or("default");
+
+        debug!(event_hub_name = %event_hub_name, "sending event to Event Hubs");
+
+        let body_str = serde_json::to_string(&payload.body)
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let event = azure_messaging_eventhubs::models::EventData::builder()
+            .with_body(body_str.into_bytes())
+            .build();
+
+        let options = payload.partition_id.map(|pid| SendEventOptions {
+            partition_id: Some(pid),
+        });
+
+        self.producer
+            .send_event(event, options)
+            .await
+            .map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "Event Hubs send failed");
+                let azure_err: ProviderError = classify_azure_error(&err_str).into();
+                azure_err
+            })?;
+
+        info!(event_hub_name = %event_hub_name, "event sent to Event Hubs");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "event_hub_name": event_hub_name,
+            "event_count": 1,
+            "status": "sent"
+        })))
+    }
+
+    async fn send_batch(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing Event Hubs send_batch payload");
+        let payload: EventHubsSendBatchPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let event_hub_name = payload
+            .event_hub_name
+            .as_deref()
+            .or(self.config.event_hub_name.as_deref())
+            .unwrap_or("default");
+
+        let event_count = payload.events.len();
+        debug!(event_hub_name = %event_hub_name, count = event_count, "sending batch to Event Hubs");
+
+        let batch = self.producer.create_batch(None).await.map_err(|e| {
+            let err_str = e.to_string();
+            error!(error = %err_str, "Event Hubs create_batch failed");
+            let azure_err: ProviderError = classify_azure_error(&err_str).into();
+            azure_err
+        })?;
+
+        for ed in &payload.events {
+            let body_str = serde_json::to_string(&ed.body).unwrap_or_default();
+            let event = azure_messaging_eventhubs::models::EventData::builder()
+                .with_body(body_str.into_bytes())
+                .build();
+
+            batch.try_add_event_data(event, None).map_err(|e| {
+                ProviderError::Serialization(format!("event too large for batch: {e}"))
+            })?;
+        }
+
+        self.producer.send_batch(batch, None).await.map_err(|e| {
+            let err_str = e.to_string();
+            error!(error = %err_str, "Event Hubs batch send failed");
+            let azure_err: ProviderError = classify_azure_error(&err_str).into();
+            azure_err
+        })?;
+
+        info!(event_hub_name = %event_hub_name, count = event_count, "batch sent to Event Hubs");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "event_hub_name": event_hub_name,
+            "event_count": event_count,
+            "status": "sent"
+        })))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_new_sets_location() {
+        let config = EventHubsConfig::new("westeurope");
+        assert_eq!(config.azure.location, "westeurope");
+        assert!(config.namespace.is_none());
+        assert!(config.event_hub_name.is_none());
+    }
+
+    #[test]
+    fn config_with_namespace() {
+        let config =
+            EventHubsConfig::new("eastus").with_namespace("mynamespace.servicebus.windows.net");
+        assert_eq!(
+            config.namespace.as_deref(),
+            Some("mynamespace.servicebus.windows.net")
+        );
+    }
+
+    #[test]
+    fn config_with_event_hub_name() {
+        let config = EventHubsConfig::new("eastus").with_event_hub_name("my-hub");
+        assert_eq!(config.event_hub_name.as_deref(), Some("my-hub"));
+    }
+
+    #[test]
+    fn config_builder_chain() {
+        let config = EventHubsConfig::new("eastus2")
+            .with_namespace("ns.servicebus.windows.net")
+            .with_event_hub_name("events")
+            .with_endpoint_url("http://localhost:5672")
+            .with_tenant_id("tid-123")
+            .with_client_id("cid-456")
+            .with_client_credential("cred-789");
+        assert_eq!(
+            config.namespace.as_deref(),
+            Some("ns.servicebus.windows.net")
+        );
+        assert_eq!(config.event_hub_name.as_deref(), Some("events"));
+        assert!(config.azure.endpoint_url.is_some());
+        assert!(config.azure.tenant_id.is_some());
+    }
+
+    #[test]
+    fn config_debug_format() {
+        let config = EventHubsConfig::new("eastus")
+            .with_namespace("ns.servicebus.windows.net")
+            .with_client_credential("private-val");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("EventHubsConfig"));
+        assert!(debug.contains("[REDACTED]"));
+        assert!(debug.contains("ns.servicebus.windows.net"));
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config = EventHubsConfig::new("northeurope")
+            .with_namespace("ns.servicebus.windows.net")
+            .with_event_hub_name("telemetry");
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: EventHubsConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.azure.location, "northeurope");
+        assert_eq!(
+            deserialized.namespace.as_deref(),
+            Some("ns.servicebus.windows.net")
+        );
+        assert_eq!(deserialized.event_hub_name.as_deref(), Some("telemetry"));
+    }
+
+    #[test]
+    fn deserialize_send_payload() {
+        let json = serde_json::json!({
+            "body": {"temperature": 72.5, "unit": "F"},
+            "partition_id": "0",
+            "event_hub_name": "telemetry",
+            "properties": {
+                "source": "sensor"
+            }
+        });
+        let payload: EventHubsSendPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.event_hub_name.as_deref(), Some("telemetry"));
+        assert_eq!(payload.partition_id.as_deref(), Some("0"));
+        assert!(payload.body.is_object());
+        assert_eq!(payload.properties.get("source").unwrap(), "sensor");
+    }
+
+    #[test]
+    fn deserialize_minimal_send_payload() {
+        let json = serde_json::json!({
+            "body": "hello"
+        });
+        let payload: EventHubsSendPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.body, "hello");
+        assert!(payload.event_hub_name.is_none());
+        assert!(payload.partition_id.is_none());
+        assert!(payload.properties.is_empty());
+    }
+
+    #[test]
+    fn deserialize_batch_payload() {
+        let json = serde_json::json!({
+            "event_hub_name": "logs",
+            "events": [
+                {"body": "event 1"},
+                {"body": {"key": "value"}, "partition_id": "1"}
+            ]
+        });
+        let payload: EventHubsSendBatchPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.event_hub_name.as_deref(), Some("logs"));
+        assert_eq!(payload.events.len(), 2);
+        assert_eq!(payload.events[0].body, "event 1");
+        assert_eq!(payload.events[1].partition_id.as_deref(), Some("1"));
+    }
+}

--- a/crates/azure/src/lib.rs
+++ b/crates/azure/src/lib.rs
@@ -1,0 +1,29 @@
+//! Azure service providers for the Acteon action gateway.
+//!
+//! This crate provides feature-gated integrations with Azure services:
+//!
+//! - **Blob Storage** (`blob` feature) — Upload/download/delete blobs
+//! - **Event Hubs** (`eventhubs` feature) — Send events and batches
+//!
+//! All providers share a common [`AzureBaseConfig`] for
+//! location, endpoint override, and optional service principal credentials.
+
+pub mod auth;
+pub mod config;
+pub mod error;
+
+#[cfg(feature = "blob")]
+pub mod blob;
+
+#[cfg(feature = "eventhubs")]
+pub mod eventhubs;
+
+// Re-exports for convenience.
+pub use config::AzureBaseConfig;
+pub use error::AzureProviderError;
+
+#[cfg(feature = "blob")]
+pub use blob::{BlobConfig, BlobProvider};
+
+#[cfg(feature = "eventhubs")]
+pub use eventhubs::{EventHubsConfig, EventHubsProvider};

--- a/crates/client/src/azure.rs
+++ b/crates/client/src/azure.rs
@@ -1,0 +1,691 @@
+//! Convenience helpers for creating Azure-targeted actions.
+//!
+//! Provides builder types for each supported Azure provider:
+//! [`blob`] and [`eventhubs`].
+//!
+//! # Example
+//!
+//! ```no_run
+//! use acteon_client::azure;
+//!
+//! // Upload a blob
+//! let action = azure::blob::upload("storage", "tenant-1")
+//!     .blob_name("data.json")
+//!     .body(r#"{"hello":"world"}"#)
+//!     .content_type("application/json")
+//!     .build();
+//!
+//! // Send an event to Event Hubs
+//! let action = azure::eventhubs::send_event("events", "tenant-1")
+//!     .body(serde_json::json!({"key": "value"}))
+//!     .build();
+//! ```
+
+// =============================================================================
+// Blob Storage
+// =============================================================================
+
+/// Helpers for creating Azure Blob Storage actions.
+pub mod blob {
+    use acteon_core::Action;
+    use std::collections::HashMap;
+
+    /// Create a builder for an Azure Blob Storage `upload_blob` action.
+    pub fn upload(namespace: impl Into<String>, tenant: impl Into<String>) -> BlobUploadBuilder {
+        BlobUploadBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            blob_name: String::new(),
+            container: None,
+            body: None,
+            body_base64: None,
+            content_type: None,
+            metadata: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Create a builder for an Azure Blob Storage `download_blob` action.
+    pub fn download(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> BlobDownloadBuilder {
+        BlobDownloadBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            blob_name: String::new(),
+            container: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Create a builder for an Azure Blob Storage `delete_blob` action.
+    pub fn delete(namespace: impl Into<String>, tenant: impl Into<String>) -> BlobDeleteBuilder {
+        BlobDeleteBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            blob_name: String::new(),
+            container: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an Azure Blob Storage `upload_blob` action.
+    #[derive(Debug)]
+    pub struct BlobUploadBuilder {
+        namespace: String,
+        tenant: String,
+        blob_name: String,
+        container: Option<String>,
+        body: Option<String>,
+        body_base64: Option<String>,
+        content_type: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+        dedup_key: Option<String>,
+    }
+
+    impl BlobUploadBuilder {
+        /// Set the blob name.
+        #[must_use]
+        pub fn blob_name(mut self, name: impl Into<String>) -> Self {
+            self.blob_name = name.into();
+            self
+        }
+
+        /// Override the container name configured on the provider.
+        #[must_use]
+        pub fn container(mut self, container: impl Into<String>) -> Self {
+            self.container = Some(container.into());
+            self
+        }
+
+        /// Set the blob body as a UTF-8 string.
+        #[must_use]
+        pub fn body(mut self, body: impl Into<String>) -> Self {
+            self.body = Some(body.into());
+            self
+        }
+
+        /// Set the blob body as base64-encoded bytes.
+        #[must_use]
+        pub fn body_base64(mut self, data: impl Into<String>) -> Self {
+            self.body_base64 = Some(data.into());
+            self
+        }
+
+        /// Set the content type (e.g., `"application/json"`).
+        #[must_use]
+        pub fn content_type(mut self, ct: impl Into<String>) -> Self {
+            self.content_type = Some(ct.into());
+            self
+        }
+
+        /// Set blob metadata as key-value string pairs.
+        #[must_use]
+        pub fn metadata(mut self, metadata: HashMap<String, String>) -> Self {
+            self.metadata = Some(metadata);
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the Azure Blob Storage `upload_blob` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `blob_name` has not been set.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.blob_name.is_empty(),
+                "Azure Blob blob_name must be set"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "blob_name".to_string(),
+                serde_json::Value::String(self.blob_name),
+            );
+
+            if let Some(v) = self.container {
+                payload.insert("container".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.body {
+                payload.insert("body".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.body_base64 {
+                payload.insert("body_base64".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.content_type {
+                payload.insert("content_type".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.metadata {
+                payload.insert(
+                    "metadata".to_string(),
+                    serde_json::to_value(v)
+                        .expect("HashMap<String, String> serialization cannot fail"),
+                );
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "azure-blob",
+                "upload_blob",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Builder for an Azure Blob Storage `download_blob` action.
+    #[derive(Debug)]
+    pub struct BlobDownloadBuilder {
+        namespace: String,
+        tenant: String,
+        blob_name: String,
+        container: Option<String>,
+        dedup_key: Option<String>,
+    }
+
+    impl BlobDownloadBuilder {
+        /// Set the blob name.
+        #[must_use]
+        pub fn blob_name(mut self, name: impl Into<String>) -> Self {
+            self.blob_name = name.into();
+            self
+        }
+
+        /// Override the container name configured on the provider.
+        #[must_use]
+        pub fn container(mut self, container: impl Into<String>) -> Self {
+            self.container = Some(container.into());
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the Azure Blob Storage `download_blob` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `blob_name` has not been set.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.blob_name.is_empty(),
+                "Azure Blob blob_name must be set"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "blob_name".to_string(),
+                serde_json::Value::String(self.blob_name),
+            );
+
+            if let Some(v) = self.container {
+                payload.insert("container".to_string(), serde_json::Value::String(v));
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "azure-blob",
+                "download_blob",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Builder for an Azure Blob Storage `delete_blob` action.
+    #[derive(Debug)]
+    pub struct BlobDeleteBuilder {
+        namespace: String,
+        tenant: String,
+        blob_name: String,
+        container: Option<String>,
+        dedup_key: Option<String>,
+    }
+
+    impl BlobDeleteBuilder {
+        /// Set the blob name.
+        #[must_use]
+        pub fn blob_name(mut self, name: impl Into<String>) -> Self {
+            self.blob_name = name.into();
+            self
+        }
+
+        /// Override the container name configured on the provider.
+        #[must_use]
+        pub fn container(mut self, container: impl Into<String>) -> Self {
+            self.container = Some(container.into());
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the Azure Blob Storage `delete_blob` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `blob_name` has not been set.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.blob_name.is_empty(),
+                "Azure Blob blob_name must be set"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "blob_name".to_string(),
+                serde_json::Value::String(self.blob_name),
+            );
+
+            if let Some(v) = self.container {
+                payload.insert("container".to_string(), serde_json::Value::String(v));
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "azure-blob",
+                "delete_blob",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+}
+
+// =============================================================================
+// Event Hubs
+// =============================================================================
+
+/// Helpers for creating Azure Event Hubs actions.
+pub mod eventhubs {
+    use acteon_core::Action;
+    use std::collections::HashMap;
+
+    /// Create a builder for an Azure Event Hubs `send_event` action.
+    pub fn send_event(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> EventHubsSendBuilder {
+        EventHubsSendBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            body: serde_json::Value::Object(serde_json::Map::new()),
+            event_hub_name: None,
+            partition_id: None,
+            properties: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Create a builder for an Azure Event Hubs `send_batch` action.
+    pub fn send_batch(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> EventHubsSendBatchBuilder {
+        EventHubsSendBatchBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            events: Vec::new(),
+            event_hub_name: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for an Azure Event Hubs `send_event` action.
+    #[derive(Debug)]
+    pub struct EventHubsSendBuilder {
+        namespace: String,
+        tenant: String,
+        body: serde_json::Value,
+        event_hub_name: Option<String>,
+        partition_id: Option<String>,
+        properties: Option<HashMap<String, String>>,
+        dedup_key: Option<String>,
+    }
+
+    impl EventHubsSendBuilder {
+        /// Set the event body as a JSON value.
+        #[must_use]
+        pub fn body(mut self, body: serde_json::Value) -> Self {
+            self.body = body;
+            self
+        }
+
+        /// Override the Event Hub name configured on the provider.
+        #[must_use]
+        pub fn event_hub_name(mut self, name: impl Into<String>) -> Self {
+            self.event_hub_name = Some(name.into());
+            self
+        }
+
+        /// Target a specific partition.
+        #[must_use]
+        pub fn partition_id(mut self, id: impl Into<String>) -> Self {
+            self.partition_id = Some(id.into());
+            self
+        }
+
+        /// Set application properties as key-value string pairs.
+        #[must_use]
+        pub fn properties(mut self, props: HashMap<String, String>) -> Self {
+            self.properties = Some(props);
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the Azure Event Hubs `send_event` Action.
+        pub fn build(self) -> Action {
+            let mut payload = serde_json::Map::new();
+            payload.insert("body".to_string(), self.body);
+
+            if let Some(v) = self.event_hub_name {
+                payload.insert("event_hub_name".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.partition_id {
+                payload.insert("partition_id".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.properties {
+                payload.insert(
+                    "properties".to_string(),
+                    serde_json::to_value(v)
+                        .expect("HashMap<String, String> serialization cannot fail"),
+                );
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "azure-eventhubs",
+                "send_event",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Builder for an Azure Event Hubs `send_batch` action.
+    #[derive(Debug)]
+    pub struct EventHubsSendBatchBuilder {
+        namespace: String,
+        tenant: String,
+        events: Vec<serde_json::Value>,
+        event_hub_name: Option<String>,
+        dedup_key: Option<String>,
+    }
+
+    impl EventHubsSendBatchBuilder {
+        /// Set the list of events to send as a batch.
+        #[must_use]
+        pub fn events(mut self, events: Vec<serde_json::Value>) -> Self {
+            self.events = events;
+            self
+        }
+
+        /// Override the Event Hub name configured on the provider.
+        #[must_use]
+        pub fn event_hub_name(mut self, name: impl Into<String>) -> Self {
+            self.event_hub_name = Some(name.into());
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the Azure Event Hubs `send_batch` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `events` is empty.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.events.is_empty(),
+                "Event Hubs events must not be empty"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "events".to_string(),
+                serde_json::to_value(&self.events).expect("Vec<Value> serialization cannot fail"),
+            );
+
+            if let Some(v) = self.event_hub_name {
+                payload.insert("event_hub_name".to_string(), serde_json::Value::String(v));
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "azure-eventhubs",
+                "send_batch",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    // =========================================================================
+    // Blob Storage tests
+    // =========================================================================
+
+    #[test]
+    fn blob_upload_basic() {
+        let a = blob::upload("ns", "t1")
+            .blob_name("data.json")
+            .body(r#"{"hello":"world"}"#)
+            .build();
+
+        assert_eq!(a.provider.as_str(), "azure-blob");
+        assert_eq!(a.action_type, "upload_blob");
+        assert_eq!(a.payload["blob_name"], "data.json");
+        assert_eq!(a.payload["body"], r#"{"hello":"world"}"#);
+    }
+
+    #[test]
+    fn blob_upload_with_all_options() {
+        let mut meta = HashMap::new();
+        meta.insert("env".to_string(), "staging".to_string());
+
+        let a = blob::upload("ns", "t1")
+            .blob_name("data.bin")
+            .container("my-container")
+            .body_base64("SGVsbG8gV29ybGQ=")
+            .content_type("application/octet-stream")
+            .metadata(meta)
+            .dedup_key("upload-dedup")
+            .build();
+
+        assert_eq!(a.payload["blob_name"], "data.bin");
+        assert_eq!(a.payload["container"], "my-container");
+        assert_eq!(a.payload["body_base64"], "SGVsbG8gV29ybGQ=");
+        assert_eq!(a.payload["content_type"], "application/octet-stream");
+        assert_eq!(a.payload["metadata"]["env"], "staging");
+        assert_eq!(a.dedup_key.as_deref(), Some("upload-dedup"));
+    }
+
+    #[test]
+    fn blob_download_basic() {
+        let a = blob::download("ns", "t1").blob_name("data.json").build();
+
+        assert_eq!(a.provider.as_str(), "azure-blob");
+        assert_eq!(a.action_type, "download_blob");
+        assert_eq!(a.payload["blob_name"], "data.json");
+    }
+
+    #[test]
+    fn blob_download_with_container() {
+        let a = blob::download("ns", "t1")
+            .blob_name("data.json")
+            .container("my-container")
+            .build();
+
+        assert_eq!(a.payload["container"], "my-container");
+    }
+
+    #[test]
+    fn blob_delete_basic() {
+        let a = blob::delete("ns", "t1").blob_name("data.json").build();
+
+        assert_eq!(a.provider.as_str(), "azure-blob");
+        assert_eq!(a.action_type, "delete_blob");
+        assert_eq!(a.payload["blob_name"], "data.json");
+    }
+
+    #[test]
+    fn blob_delete_with_container() {
+        let a = blob::delete("ns", "t1")
+            .blob_name("data.json")
+            .container("my-container")
+            .dedup_key("del-dedup")
+            .build();
+
+        assert_eq!(a.payload["container"], "my-container");
+        assert_eq!(a.dedup_key.as_deref(), Some("del-dedup"));
+    }
+
+    #[test]
+    #[should_panic(expected = "Azure Blob blob_name must be set")]
+    fn blob_upload_panics_without_blob_name() {
+        blob::upload("ns", "t1").build();
+    }
+
+    #[test]
+    #[should_panic(expected = "Azure Blob blob_name must be set")]
+    fn blob_download_panics_without_blob_name() {
+        blob::download("ns", "t1").build();
+    }
+
+    #[test]
+    #[should_panic(expected = "Azure Blob blob_name must be set")]
+    fn blob_delete_panics_without_blob_name() {
+        blob::delete("ns", "t1").build();
+    }
+
+    // =========================================================================
+    // Event Hubs tests
+    // =========================================================================
+
+    #[test]
+    fn eventhubs_send_basic() {
+        let a = eventhubs::send_event("ns", "t1")
+            .body(serde_json::json!({"key": "value"}))
+            .build();
+
+        assert_eq!(a.provider.as_str(), "azure-eventhubs");
+        assert_eq!(a.action_type, "send_event");
+        assert_eq!(a.payload["body"]["key"], "value");
+    }
+
+    #[test]
+    fn eventhubs_send_with_all_options() {
+        let mut props = HashMap::new();
+        props.insert("source".to_string(), "my-app".to_string());
+
+        let a = eventhubs::send_event("ns", "t1")
+            .body(serde_json::json!({"data": 42}))
+            .event_hub_name("my-hub")
+            .partition_id("0")
+            .properties(props)
+            .dedup_key("send-dedup")
+            .build();
+
+        assert_eq!(a.payload["event_hub_name"], "my-hub");
+        assert_eq!(a.payload["partition_id"], "0");
+        assert_eq!(a.payload["properties"]["source"], "my-app");
+        assert_eq!(a.dedup_key.as_deref(), Some("send-dedup"));
+    }
+
+    #[test]
+    fn eventhubs_send_batch_basic() {
+        let events = vec![
+            serde_json::json!({"body": "event1"}),
+            serde_json::json!({"body": "event2"}),
+        ];
+
+        let a = eventhubs::send_batch("ns", "t1").events(events).build();
+
+        assert_eq!(a.provider.as_str(), "azure-eventhubs");
+        assert_eq!(a.action_type, "send_batch");
+        assert_eq!(a.payload["events"][0]["body"], "event1");
+        assert_eq!(a.payload["events"][1]["body"], "event2");
+    }
+
+    #[test]
+    fn eventhubs_send_batch_with_hub_name() {
+        let events = vec![serde_json::json!({"body": "event1"})];
+
+        let a = eventhubs::send_batch("ns", "t1")
+            .events(events)
+            .event_hub_name("my-hub")
+            .dedup_key("batch-dedup")
+            .build();
+
+        assert_eq!(a.payload["event_hub_name"], "my-hub");
+        assert_eq!(a.dedup_key.as_deref(), Some("batch-dedup"));
+    }
+
+    #[test]
+    #[should_panic(expected = "Event Hubs events must not be empty")]
+    fn eventhubs_send_batch_panics_without_events() {
+        eventhubs::send_batch("ns", "t1").build();
+    }
+}

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -58,6 +58,7 @@
 //! ```
 
 pub mod aws;
+pub mod azure;
 mod error;
 pub mod stream;
 pub mod webhook;

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -32,6 +32,10 @@ aws-s3 = ["acteon-aws/s3"]
 aws-ec2 = ["acteon-aws/ec2"]
 aws-autoscaling = ["acteon-aws/autoscaling"]
 aws-all = ["aws-sns", "aws-lambda", "aws-eventbridge", "aws-sqs", "aws-ses", "aws-s3", "aws-ec2", "aws-autoscaling"]
+# Azure provider features — only compile the SDKs you need
+azure-blob = ["acteon-azure/blob"]
+azure-eventhubs = ["acteon-azure/eventhubs"]
+azure-all = ["azure-blob", "azure-eventhubs"]
 
 [dependencies]
 acteon-audit = { workspace = true, features = ["openapi"] }
@@ -52,6 +56,7 @@ acteon-rules-yaml = { workspace = true }
 acteon-provider = { workspace = true, features = ["webhook"] }
 acteon-email = { workspace = true, features = ["ses"] }
 acteon-aws = { workspace = true }
+acteon-azure = { workspace = true }
 acteon-twilio = { workspace = true }
 acteon-teams = { workspace = true }
 acteon-discord = { workspace = true }

--- a/crates/server/src/config/providers.rs
+++ b/crates/server/src/config/providers.rs
@@ -22,7 +22,8 @@ pub struct ProviderConfig {
     pub name: String,
     /// Provider type: `"webhook"`, `"log"`, `"twilio"`, `"teams"`, `"discord"`,
     /// `"email"`, `"aws-sns"`, `"aws-lambda"`, `"aws-eventbridge"`, `"aws-sqs"`,
-    /// `"aws-s3"`, `"aws-ec2"`, or `"aws-autoscaling"`.
+    /// `"aws-s3"`, `"aws-ec2"`, `"aws-autoscaling"`, `"azure-blob"`,
+    /// or `"azure-eventhubs"`.
     #[serde(rename = "type")]
     pub provider_type: String,
     /// Target URL (required for `"webhook"` type).
@@ -96,4 +97,30 @@ pub struct ProviderConfig {
     pub default_subnet_id: Option<String>,
     /// Default key-pair name (used by `"aws-ec2"` type).
     pub default_key_name: Option<String>,
+
+    // ---- Azure provider fields ----
+    /// Azure AD tenant ID (used by `"azure-*"` types).
+    pub azure_tenant_id: Option<String>,
+    /// Azure AD client ID (used by `"azure-*"` types).
+    pub azure_client_id: Option<String>,
+    /// Azure AD client credential (used by `"azure-*"` types). Supports `ENC[...]`.
+    pub azure_client_credential: Option<String>,
+    /// Azure subscription ID (used by `"azure-*"` types).
+    pub azure_subscription_id: Option<String>,
+    /// Azure resource group (used by `"azure-*"` types).
+    pub azure_resource_group: Option<String>,
+    /// Azure region/location (used by `"azure-*"` types).
+    pub azure_location: Option<String>,
+    /// Azure endpoint URL override for `Azurite` (used by `"azure-*"` types).
+    pub azure_endpoint_url: Option<String>,
+    /// Azure Storage account name (used by `"azure-blob"` type).
+    pub azure_account_name: Option<String>,
+    /// Default Azure container name (used by `"azure-blob"` type).
+    pub azure_container_name: Option<String>,
+    /// Azure blob name prefix (used by `"azure-blob"` type).
+    pub azure_blob_prefix: Option<String>,
+    /// Azure Event Hubs namespace (used by `"azure-eventhubs"` type).
+    pub azure_namespace: Option<String>,
+    /// Azure Event Hub name (used by `"azure-eventhubs"` type).
+    pub azure_event_hub_name: Option<String>,
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -944,7 +944,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     blob_config = blob_config.with_client_id(cid);
                 }
                 if let Some(ref cred) = provider_cfg.azure_client_credential {
-                    blob_config = blob_config.with_client_credential(cred);
+                    let decrypted = require_decrypt(cred, master_key.as_ref())?;
+                    blob_config = blob_config.with_client_credential(decrypted);
                 }
                 std::sync::Arc::new(
                     acteon_azure::BlobProvider::new(blob_config)
@@ -972,7 +973,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     eh_config = eh_config.with_client_id(cid);
                 }
                 if let Some(ref cred) = provider_cfg.azure_client_credential {
-                    eh_config = eh_config.with_client_credential(cred);
+                    let decrypted = require_decrypt(cred, master_key.as_ref())?;
+                    eh_config = eh_config.with_client_credential(decrypted);
                 }
                 std::sync::Arc::new(
                     acteon_azure::EventHubsProvider::new(eh_config)

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -186,5 +186,9 @@ name = "mtls_simulation"
 name = "analytics_simulation"
 # No required-features - uses in-memory backends
 
+[[example]]
+name = "azure_simulation"
+# No required-features - uses in-memory backends
+
 [lints]
 workspace = true

--- a/crates/simulation/examples/azure_simulation.rs
+++ b/crates/simulation/examples/azure_simulation.rs
@@ -1,0 +1,270 @@
+//! Simulation demonstrating Azure Blob Storage and Event Hubs provider action types.
+//!
+//! Covers all Blob Storage operations (upload, upload base64, download, delete) and
+//! Event Hubs operations (send event, send event with partition, send batch).
+//!
+//! Run with:
+//! ```bash
+//! cargo run -p acteon-simulation --example azure_simulation
+//! ```
+
+use acteon_core::{Action, ActionOutcome};
+use acteon_simulation::prelude::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("==================================================================");
+    println!("       AZURE BLOB STORAGE & EVENT HUBS SIMULATION");
+    println!("==================================================================\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("azure-blob")
+            .add_recording_provider("azure-eventhubs")
+            .build(),
+    )
+    .await?;
+
+    println!("Started simulation cluster with 1 node");
+    println!("Registered providers: azure-blob, azure-eventhubs\n");
+
+    let mut results: Vec<(&str, ActionOutcome)> = Vec::new();
+
+    // =========================================================================
+    // 1. Blob: Upload (text body)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  1. BLOB: UPLOAD (text body)");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "storage",
+        "acme-corp",
+        "azure-blob",
+        "upload_blob",
+        serde_json::json!({
+            "container": "data-lake",
+            "blob_name": "reports/2026/02/daily.json",
+            "body": "{\"readings\": [72.5, 68.1, 75.3]}",
+            "content_type": "application/json",
+            "metadata": {
+                "source": "acteon",
+                "pipeline_version": "2.0"
+            }
+        }),
+    );
+
+    println!("  Dispatching upload_blob with text body, content_type, and metadata...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("blob/upload_blob(text)", outcome));
+    println!();
+
+    // =========================================================================
+    // 2. Blob: Upload (base64 body)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  2. BLOB: UPLOAD (base64 body)");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "storage",
+        "acme-corp",
+        "azure-blob",
+        "upload_blob",
+        serde_json::json!({
+            "container": "data-lake",
+            "blob_name": "images/logo.png",
+            "body_base64": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk",
+            "content_type": "image/png"
+        }),
+    );
+
+    println!("  Dispatching upload_blob with base64-encoded binary body...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("blob/upload_blob(base64)", outcome));
+    println!();
+
+    // =========================================================================
+    // 3. Blob: Download
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  3. BLOB: DOWNLOAD");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "storage",
+        "acme-corp",
+        "azure-blob",
+        "download_blob",
+        serde_json::json!({
+            "container": "data-lake",
+            "blob_name": "reports/2026/02/daily.json"
+        }),
+    );
+
+    println!("  Dispatching download_blob...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("blob/download_blob", outcome));
+    println!();
+
+    // =========================================================================
+    // 4. Blob: Delete
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  4. BLOB: DELETE");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "storage",
+        "acme-corp",
+        "azure-blob",
+        "delete_blob",
+        serde_json::json!({
+            "container": "data-lake",
+            "blob_name": "old/data.csv"
+        }),
+    );
+
+    println!("  Dispatching delete_blob...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("blob/delete_blob", outcome));
+    println!();
+
+    // =========================================================================
+    // 5. Event Hubs: Send Event (JSON body)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  5. EVENT HUBS: SEND EVENT (JSON body)");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "events",
+        "acme-corp",
+        "azure-eventhubs",
+        "send_event",
+        serde_json::json!({
+            "body": {
+                "device_id": "sensor-001",
+                "temperature": 72.5,
+                "unit": "F"
+            },
+            "properties": {
+                "source": "iot-gateway",
+                "region": "us-west"
+            }
+        }),
+    );
+
+    println!("  Dispatching send_event with JSON body and application properties...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("eventhubs/send_event(json)", outcome));
+    println!();
+
+    // =========================================================================
+    // 6. Event Hubs: Send Event (with partition)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  6. EVENT HUBS: SEND EVENT (with partition)");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "events",
+        "acme-corp",
+        "azure-eventhubs",
+        "send_event",
+        serde_json::json!({
+            "event_hub_name": "telemetry",
+            "body": {
+                "device_id": "sensor-042",
+                "temperature": 68.1,
+                "unit": "F"
+            },
+            "partition_id": "0"
+        }),
+    );
+
+    println!("  Dispatching send_event with explicit partition_id and event_hub_name override...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("eventhubs/send_event(partition)", outcome));
+    println!();
+
+    // =========================================================================
+    // 7. Event Hubs: Send Batch
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  7. EVENT HUBS: SEND BATCH");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "events",
+        "acme-corp",
+        "azure-eventhubs",
+        "send_batch",
+        serde_json::json!({
+            "event_hub_name": "telemetry",
+            "events": [
+                {
+                    "body": {"device_id": "sensor-001", "temperature": 72.5},
+                    "properties": {"region": "us-west"}
+                },
+                {
+                    "body": {"device_id": "sensor-002", "temperature": 68.1},
+                    "partition_id": "1"
+                },
+                {
+                    "body": {"device_id": "sensor-003", "temperature": 75.3}
+                }
+            ]
+        }),
+    );
+
+    println!("  Dispatching send_batch with 3 events (mixed properties/partitions)...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("eventhubs/send_batch", outcome));
+    println!();
+
+    // =========================================================================
+    // Summary
+    // =========================================================================
+    println!("==================================================================");
+    println!("  SUMMARY");
+    println!("==================================================================\n");
+
+    let mut all_passed = true;
+    for (name, outcome) in &results {
+        let passed = matches!(outcome, ActionOutcome::Executed(_));
+        let status = if passed { "PASS" } else { "FAIL" };
+        println!("  [{status}] {name}: {outcome:?}");
+        if !passed {
+            all_passed = false;
+        }
+    }
+
+    println!();
+    println!(
+        "  Total dispatched: {}  |  Blob calls: {}  |  Event Hubs calls: {}",
+        results.len(),
+        harness.provider("azure-blob").unwrap().call_count(),
+        harness.provider("azure-eventhubs").unwrap().call_count(),
+    );
+
+    harness.teardown().await?;
+    println!("\n  Simulation cluster shut down");
+
+    if all_passed {
+        println!("\n  All Azure Blob Storage and Event Hubs actions dispatched successfully.");
+    } else {
+        println!("\n  Some actions failed. See details above.");
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/docs/book/features/azure-providers.md
+++ b/docs/book/features/azure-providers.md
@@ -1,0 +1,468 @@
+# Azure Providers
+
+Acteon ships with native Azure provider integrations for **Blob Storage** and **Event Hubs**. Both are first-class citizens -- they implement the same `Provider` trait, participate in circuit breaking, health checks, and per-provider metrics, and require no external plugins.
+
+## Compile-Time Feature Selection
+
+Azure providers are **not compiled by default**. Each provider maps to a feature flag on `acteon-server`, so you only compile the Azure SDKs you need:
+
+```bash
+# Only Blob Storage
+cargo build -p acteon-server --features "azure-blob"
+
+# Only Event Hubs
+cargo build -p acteon-server --features "azure-eventhubs"
+
+# Both Azure providers
+cargo build -p acteon-server --features azure-all
+```
+
+| Server Feature | Provider Type | Azure Service |
+|----------------|---------------|---------------|
+| `azure-blob` | `azure-blob` | Azure Blob Storage |
+| `azure-eventhubs` | `azure-eventhubs` | Azure Event Hubs |
+| `azure-all` | All of the above | All of the above |
+
+The `acteon-azure` crate uses the same pattern internally -- each provider is behind a matching feature flag (`blob`, `eventhubs`), and provider registration in `main.rs` is guarded by `#[cfg(feature = "azure-*")]`.
+
+## Overview
+
+| Provider | Azure Service | Action Types | Use Case |
+|----------|--------------|--------------|----------|
+| `azure-blob` | Blob Storage | `upload_blob`, `download_blob`, `delete_blob` | Store and retrieve blobs (logs, artifacts, images, archives) |
+| `azure-eventhubs` | Event Hubs | `send_event`, `send_batch` | Publish events and telemetry for stream processing |
+
+All Azure providers:
+
+- Share a common authentication layer with Azure AD service principal or Azure CLI fallback
+- Support endpoint URL overrides for `Azurite` and other Azure-compatible services
+- Report per-provider health metrics (success rate, latency percentiles, error tracking)
+- Map Azure SDK errors to the standard `ProviderError` enum for circuit breaker integration
+
+## TOML Configuration
+
+### Azure Blob Storage
+
+```toml
+[[providers]]
+name = "archive"
+type = "azure-blob"
+location = "eastus"
+account_name = "mystorageaccount"
+container_name = "data-lake"
+# prefix = "acteon/artifacts/"                   # Optional key prefix
+# endpoint_url = "http://127.0.0.1:10000"        # Azurite
+# tenant_id = "00000000-0000-0000-0000-000000000000"
+# client_id = "00000000-0000-0000-0000-000000000001"
+# client_credential = "my-app-credential"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used in action dispatch |
+| `type` | Yes | Must be `"azure-blob"` |
+| `location` | Yes | Azure region (e.g. `"eastus"`) |
+| `account_name` | Yes | Azure Storage account name |
+| `container_name` | No | Default container name. Can be overridden per-action in the payload |
+| `prefix` | No | Blob name prefix prepended to all blob names |
+| `endpoint_url` | No | Endpoint URL override (for `Azurite`) |
+| `tenant_id` | No | Azure AD tenant ID for service principal auth |
+| `client_id` | No | Azure AD application (client) ID |
+| `client_credential` | No | Azure AD client credential |
+
+### Azure Event Hubs
+
+```toml
+[[providers]]
+name = "telemetry-hub"
+type = "azure-eventhubs"
+location = "eastus"
+namespace = "mynamespace.servicebus.windows.net"
+event_hub_name = "telemetry"
+# endpoint_url = "http://localhost:5672"           # Local emulator
+# tenant_id = "00000000-0000-0000-0000-000000000000"
+# client_id = "00000000-0000-0000-0000-000000000001"
+# client_credential = "my-app-credential"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used in action dispatch |
+| `type` | Yes | Must be `"azure-eventhubs"` |
+| `location` | Yes | Azure region (e.g. `"eastus"`) |
+| `namespace` | Yes | Event Hubs fully-qualified namespace (e.g. `"mynamespace.servicebus.windows.net"`) |
+| `event_hub_name` | Yes | Default Event Hub name. Can be overridden per-action in the payload |
+| `endpoint_url` | No | Endpoint URL override |
+| `tenant_id` | No | Azure AD tenant ID for service principal auth |
+| `client_id` | No | Azure AD application (client) ID |
+| `client_credential` | No | Azure AD client credential |
+
+## Payload Formats
+
+### Blob Storage: `upload_blob`
+
+```json
+{
+  "container": "data-lake",
+  "blob_name": "reports/2026/02/daily.json",
+  "body": "{\"readings\": [72.5, 68.1]}",
+  "content_type": "application/json",
+  "metadata": {
+    "source": "acteon",
+    "pipeline_version": "2.0"
+  }
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `blob_name` | Yes | string | Blob name (path within the container) |
+| `container` | No | string | Override the default container |
+| `body` | No | string | Blob body as UTF-8 text. Mutually exclusive with `body_base64` |
+| `body_base64` | No | string | Blob body as base64-encoded bytes. Mutually exclusive with `body` |
+| `content_type` | No | string | MIME type for the blob |
+| `metadata` | No | object | Key-value metadata pairs attached to the blob |
+
+**Response:**
+
+```json
+{
+  "container": "data-lake",
+  "blob_name": "reports/2026/02/daily.json",
+  "status": "uploaded"
+}
+```
+
+### Blob Storage: `download_blob`
+
+```json
+{
+  "container": "data-lake",
+  "blob_name": "reports/2026/02/daily.json"
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `blob_name` | Yes | string | Blob name to download |
+| `container` | No | string | Override the default container |
+
+**Response** (UTF-8 content):
+
+```json
+{
+  "container": "data-lake",
+  "blob_name": "reports/2026/02/daily.json",
+  "content_length": 1234,
+  "body": "{\"readings\": [72.5, 68.1]}",
+  "status": "downloaded"
+}
+```
+
+**Response** (binary content):
+
+```json
+{
+  "container": "data-lake",
+  "blob_name": "images/logo.png",
+  "content_length": 5678,
+  "body_base64": "iVBORw0KGgo...",
+  "status": "downloaded"
+}
+```
+
+### Blob Storage: `delete_blob`
+
+```json
+{
+  "container": "data-lake",
+  "blob_name": "old/data.csv"
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `blob_name` | Yes | string | Blob name to delete |
+| `container` | No | string | Override the default container |
+
+**Response:**
+
+```json
+{
+  "container": "data-lake",
+  "blob_name": "old/data.csv",
+  "status": "deleted"
+}
+```
+
+### Event Hubs: `send_event`
+
+```json
+{
+  "body": {"device_id": "sensor-001", "temperature": 72.5},
+  "event_hub_name": "telemetry",
+  "partition_id": "0",
+  "properties": {
+    "source": "iot-gateway"
+  }
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `body` | Yes | any | Event body (JSON object or string) |
+| `event_hub_name` | No | string | Override the default Event Hub name |
+| `partition_id` | No | string | Partition ID for routing |
+| `properties` | No | object | Application properties (key-value string pairs) |
+
+**Response:**
+
+```json
+{
+  "event_hub_name": "telemetry",
+  "event_count": 1,
+  "status": "sent"
+}
+```
+
+### Event Hubs: `send_batch`
+
+```json
+{
+  "event_hub_name": "telemetry",
+  "events": [
+    {
+      "body": {"device_id": "sensor-001", "temperature": 72.5},
+      "properties": {"region": "us-west"}
+    },
+    {
+      "body": {"device_id": "sensor-002", "temperature": 68.1},
+      "partition_id": "1"
+    }
+  ]
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `event_hub_name` | No | string | Override the default Event Hub name |
+| `events` | Yes | array | List of events to send |
+| `events[].body` | Yes | any | Event body (JSON object or string) |
+| `events[].partition_id` | No | string | Partition ID for routing this event |
+| `events[].properties` | No | object | Application properties for this event |
+
+**Response:**
+
+```json
+{
+  "event_hub_name": "telemetry",
+  "event_count": 2,
+  "status": "sent"
+}
+```
+
+## Authentication
+
+Azure providers share a common authentication layer in `acteon-azure`. Credentials are resolved in this order:
+
+1. **Service principal** -- if `tenant_id`, `client_id`, and `client_credential` are all configured, uses `ClientSecretCredential` for Azure AD authentication
+2. **Azure CLI** (fallback) -- if service principal fields are not fully configured, falls back to `AzureCliCredential` which uses the Azure CLI login context (suitable for development and CI/CD environments)
+
+For production deployments, use one of these approaches:
+
+- **Service principal credentials** in TOML config or environment variables -- best for non-Azure hosted workloads
+- **Managed identity** -- for workloads running on Azure VMs, AKS, App Service, or Azure Functions; configure externally via the Azure environment and omit service principal fields from TOML config
+
+### Service Principal Setup
+
+```bash
+# Create a service principal for Acteon
+az ad sp create-for-rbac \
+  --name "acteon-blob-writer" \
+  --role "Storage Blob Data Contributor" \
+  --scopes "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.Storage/storageAccounts/<account>"
+
+# The output provides the tenant_id, client_id (appId), and client_credential (credential value)
+```
+
+## Health Check Behavior
+
+| Provider | Health Check Method | Notes |
+|----------|-------------------|-------|
+| `azure-blob` | `ListContainers` | Verifies API connectivity and credentials |
+| `azure-eventhubs` | `GetEventHubProperties` | Verifies namespace connectivity and permissions |
+
+All health checks are lightweight read-only operations that do not modify any resources.
+
+## Error Handling
+
+Azure SDK errors are classified into the standard `ProviderError` enum:
+
+| Azure Error Pattern | ProviderError Variant | Retryable | Circuit Breaker |
+|---------------------|----------------------|-----------|-----------------|
+| Connection / DNS / network failure | `Connection` | Yes | Counts toward trip |
+| HTTP 429 / throttling / rate exceeded | `RateLimited` | Yes | Counts toward trip |
+| Timeout | `Timeout` | Yes | Counts toward trip |
+| Credential errors | `Configuration` | No | Does not count |
+| Invalid payload | `Serialization` | No | Does not count |
+| Other service errors | `ExecutionFailed` | No | Counts toward trip |
+
+## Example: Dispatching via the API
+
+```bash
+# Upload a blob
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "storage",
+    "tenant": "acme-corp",
+    "provider": "archive",
+    "action_type": "upload_blob",
+    "payload": {
+      "blob_name": "reports/2026/02/daily.json",
+      "body": "{\"total\": 42}",
+      "content_type": "application/json"
+    }
+  }'
+
+# Download a blob
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "storage",
+    "tenant": "acme-corp",
+    "provider": "archive",
+    "action_type": "download_blob",
+    "payload": {
+      "blob_name": "reports/2026/02/daily.json"
+    }
+  }'
+
+# Delete a blob
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "storage",
+    "tenant": "acme-corp",
+    "provider": "archive",
+    "action_type": "delete_blob",
+    "payload": {
+      "blob_name": "old/data.csv"
+    }
+  }'
+
+# Send an event to Event Hubs
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "events",
+    "tenant": "acme-corp",
+    "provider": "telemetry-hub",
+    "action_type": "send_event",
+    "payload": {
+      "body": {"device_id": "sensor-001", "temperature": 72.5}
+    }
+  }'
+
+# Send a batch of events
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "events",
+    "tenant": "acme-corp",
+    "provider": "telemetry-hub",
+    "action_type": "send_batch",
+    "payload": {
+      "events": [
+        {"body": {"device_id": "sensor-001", "temperature": 72.5}},
+        {"body": {"device_id": "sensor-002", "temperature": 68.1}}
+      ]
+    }
+  }'
+```
+
+## Example: Rust Client
+
+```rust
+use acteon_client::ActeonClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = ActeonClient::new("http://localhost:8080", "your-api-token")?;
+
+    // Upload a blob
+    client.dispatch_action(
+        "storage", "acme-corp", "archive", "upload_blob",
+        serde_json::json!({
+            "blob_name": "data/report.json",
+            "body": "{\"total\": 42}",
+            "content_type": "application/json"
+        }),
+    ).await?;
+
+    // Download a blob
+    client.dispatch_action(
+        "storage", "acme-corp", "archive", "download_blob",
+        serde_json::json!({
+            "blob_name": "data/report.json"
+        }),
+    ).await?;
+
+    // Delete a blob
+    client.dispatch_action(
+        "storage", "acme-corp", "archive", "delete_blob",
+        serde_json::json!({
+            "blob_name": "old/data.csv"
+        }),
+    ).await?;
+
+    // Send an event to Event Hubs
+    client.dispatch_action(
+        "events", "acme-corp", "telemetry-hub", "send_event",
+        serde_json::json!({
+            "body": {"device_id": "sensor-001", "temperature": 72.5}
+        }),
+    ).await?;
+
+    // Send a batch of events
+    client.dispatch_action(
+        "events", "acme-corp", "telemetry-hub", "send_batch",
+        serde_json::json!({
+            "events": [
+                {"body": {"device_id": "sensor-001", "temperature": 72.5}},
+                {"body": {"device_id": "sensor-002", "temperature": 68.1}}
+            ]
+        }),
+    ).await?;
+
+    Ok(())
+}
+```
+
+## Local Development with Azurite
+
+Azure Blob Storage supports endpoint URL overrides, making it easy to develop and test locally with [Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite), the official Azure Storage emulator:
+
+```bash
+# Start Azurite via Docker
+docker run --rm -d --name azurite -p 10000:10000 -p 10001:10001 -p 10002:10002 \
+  mcr.microsoft.com/azure-storage/azurite
+
+# Or install and run locally via npm
+npm install -g azurite
+azurite --silent --location /tmp/azurite
+```
+
+Point the Blob provider at the Azurite endpoint:
+
+```toml
+[[providers]]
+name = "archive"
+type = "azure-blob"
+location = "local"
+account_name = "devstoreaccount1"
+container_name = "test-container"
+endpoint_url = "http://127.0.0.1:10000"
+```
+
+> **Note:** `Azurite` uses the well-known development storage account `devstoreaccount1`. There is no official local emulator for Azure Event Hubs; for Event Hubs integration testing, use an Azure subscription with a dedicated test namespace.


### PR DESCRIPTION
## Summary

- Add `acteon-azure` crate with two SDK-backed providers: **Azure Blob Storage** (`upload_blob`, `download_blob`, `delete_blob`) and **Azure Event Hubs** (`send_event`, `send_batch`)
- Feature-gated server integration (`azure-blob`, `azure-eventhubs`, `azure-all`) mirroring the existing AWS pattern
- All 5 polyglot SDKs updated (Python, Node.js, Go, Java, Rust client) with payload builders

### New crate: `crates/azure/`

| Module | Purpose |
|--------|---------|
| `config.rs` | `AzureBaseConfig` — shared auth fields, builder pattern, secret redaction |
| `auth.rs` | `build_azure_credential()` — `ClientSecretCredential` or `AzureCliCredential` fallback |
| `error.rs` | `AzureProviderError` enum + `classify_azure_error()` string classifier |
| `blob.rs` | `BlobProvider` — Azure Blob Storage operations via `azure_storage_blob` 0.9 |
| `eventhubs.rs` | `EventHubsProvider` — Azure Event Hubs messaging via `azure_messaging_eventhubs` 0.11 |

### Also included
- Server config fields + feature-gated provider registration in `main.rs`
- Simulation example: `crates/simulation/examples/azure_simulation.rs` (7 scenarios)
- Documentation: `docs/book/features/azure-providers.md`
- CI: Azure test step added to workflow

### Phase 2/3 (future PRs)
- Phase 2: `azure-functions`, `azure-servicebus`, `azure-email` (REST API)
- Phase 3: `azure-vm`, `azure-vmss`, `azure-eventgrid` (REST API)

## Test plan

- [x] `cargo test -p acteon-azure --features full --lib --tests` — 38 tests pass
- [x] `cargo test -p acteon-client --lib` — 14 new Azure client tests pass
- [x] `cargo clippy --workspace --no-deps -- -D warnings` — zero warnings
- [x] `cargo test --workspace --lib --bins --tests` — all 44 suites pass
- [x] `cd ui && npm run lint && npm run build` — clean
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)