### PR TITLE
feat: API parity for MCP server & CLI

### DIFF
--- a/crates/cli/src/commands/approvals.rs
+++ b/crates/cli/src/commands/approvals.rs
@@ -1,0 +1,54 @@
+use acteon_ops::OpsClient;
+use clap::{Args, Subcommand};
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct ApprovalsArgs {
+    #[command(subcommand)]
+    pub command: ApprovalsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ApprovalsCommand {
+    /// List pending approvals.
+    List {
+        /// Namespace.
+        #[arg(long, default_value = "default")]
+        namespace: String,
+        /// Tenant.
+        #[arg(long)]
+        tenant: String,
+    },
+}
+
+pub async fn run(
+    ops: &OpsClient,
+    args: &ApprovalsArgs,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    match &args.command {
+        ApprovalsCommand::List { namespace, tenant } => {
+            let resp = ops.list_approvals(namespace, tenant).await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("{} pending approvals:", resp.count);
+                    for a in &resp.approvals {
+                        let msg = a.message.as_deref().unwrap_or("");
+                        println!(
+                            "  {token} | {status} | rule: {rule} | expires: {expires} {msg}",
+                            token = &a.token[..8.min(a.token.len())],
+                            status = a.status,
+                            rule = a.rule,
+                            expires = a.expires_at,
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/audit.rs
+++ b/crates/cli/src/commands/audit.rs
@@ -1,40 +1,128 @@
 use acteon_ops::OpsClient;
-use acteon_ops::acteon_client::AuditQuery;
-use clap::Args;
+use acteon_ops::acteon_client::{AuditQuery, ReplayQuery};
+use clap::{Args, Subcommand};
 
 use crate::OutputFormat;
 
 #[derive(Args, Debug)]
 pub struct AuditArgs {
-    /// Filter by tenant.
-    #[arg(long)]
-    pub tenant: Option<String>,
-    /// Filter by namespace.
-    #[arg(long)]
-    pub namespace: Option<String>,
-    /// Filter by provider.
-    #[arg(long)]
-    pub provider: Option<String>,
-    /// Filter by action type.
-    #[arg(long, name = "type")]
-    pub action_type: Option<String>,
-    /// Maximum records to return.
-    #[arg(long, default_value = "20")]
-    pub limit: u32,
+    #[command(subcommand)]
+    pub command: AuditCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AuditCommand {
+    /// Query the audit trail.
+    Query {
+        /// Filter by tenant.
+        #[arg(long)]
+        tenant: Option<String>,
+        /// Filter by namespace.
+        #[arg(long)]
+        namespace: Option<String>,
+        /// Filter by provider.
+        #[arg(long)]
+        provider: Option<String>,
+        /// Filter by action type.
+        #[arg(long, name = "type")]
+        action_type: Option<String>,
+        /// Maximum records to return.
+        #[arg(long, default_value = "20")]
+        limit: u32,
+    },
+    /// Get a single audit record by action ID.
+    Get {
+        /// Action ID.
+        action_id: String,
+    },
+    /// Replay a single action from the audit trail.
+    Replay {
+        /// Action ID.
+        action_id: String,
+    },
+    /// Replay multiple actions matching filters.
+    ReplayBulk {
+        /// Filter by namespace.
+        #[arg(long)]
+        namespace: Option<String>,
+        /// Filter by tenant.
+        #[arg(long)]
+        tenant: Option<String>,
+        /// Filter by provider.
+        #[arg(long)]
+        provider: Option<String>,
+        /// Filter by action type.
+        #[arg(long, name = "type")]
+        action_type: Option<String>,
+        /// Maximum records to replay.
+        #[arg(long, default_value = "50")]
+        limit: u32,
+    },
 }
 
 pub async fn run(ops: &OpsClient, args: &AuditArgs, format: &OutputFormat) -> anyhow::Result<()> {
+    match &args.command {
+        AuditCommand::Query {
+            tenant,
+            namespace,
+            provider,
+            action_type,
+            limit,
+        } => {
+            run_query(
+                ops,
+                tenant.as_ref(),
+                namespace.as_ref(),
+                provider.as_ref(),
+                action_type.as_ref(),
+                *limit,
+                format,
+            )
+            .await
+        }
+        AuditCommand::Get { action_id } => run_get(ops, action_id, format).await,
+        AuditCommand::Replay { action_id } => run_replay(ops, action_id, format).await,
+        AuditCommand::ReplayBulk {
+            namespace,
+            tenant,
+            provider,
+            action_type,
+            limit,
+        } => {
+            run_replay_bulk(
+                ops,
+                namespace.as_ref(),
+                tenant.as_ref(),
+                provider.as_ref(),
+                action_type.as_ref(),
+                *limit,
+                format,
+            )
+            .await
+        }
+    }
+}
+
+async fn run_query(
+    ops: &OpsClient,
+    tenant: Option<&String>,
+    namespace: Option<&String>,
+    provider: Option<&String>,
+    action_type: Option<&String>,
+    limit: u32,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
     let query = AuditQuery {
-        tenant: args.tenant.clone(),
-        namespace: args.namespace.clone(),
-        provider: args.provider.clone(),
-        action_type: args.action_type.clone(),
+        tenant: tenant.cloned(),
+        namespace: namespace.cloned(),
+        provider: provider.cloned(),
+        action_type: action_type.cloned(),
         outcome: None,
-        limit: Some(args.limit),
+        limit: Some(limit),
         offset: None,
     };
 
-    let page = ops.client().query_audit(&query).await?;
+    let page = ops.query_audit(query).await?;
 
     match format {
         OutputFormat::Json => {
@@ -59,6 +147,99 @@ pub async fn run(ops: &OpsClient, args: &AuditArgs, format: &OutputFormat) -> an
             }
         }
     }
+    Ok(())
+}
 
+async fn run_get(ops: &OpsClient, action_id: &str, format: &OutputFormat) -> anyhow::Result<()> {
+    let record = ops.get_audit_record(action_id).await?;
+
+    match record {
+        Some(rec) => match format {
+            OutputFormat::Json => {
+                println!("{}", serde_json::to_string_pretty(&rec)?);
+            }
+            OutputFormat::Text => {
+                println!("Action ID:    {}", rec.action_id);
+                println!("Namespace:    {}", rec.namespace);
+                println!("Tenant:       {}", rec.tenant);
+                println!("Provider:     {}", rec.provider);
+                println!("Action Type:  {}", rec.action_type);
+                println!("Verdict:      {}", rec.verdict);
+                println!("Outcome:      {}", rec.outcome);
+                println!("Duration:     {}ms", rec.duration_ms);
+                println!("Dispatched:   {}", rec.dispatched_at);
+                if let Some(ref rule) = rec.matched_rule {
+                    println!("Matched Rule: {rule}");
+                }
+            }
+        },
+        None => {
+            println!("Audit record not found: {action_id}");
+        }
+    }
+    Ok(())
+}
+
+async fn run_replay(ops: &OpsClient, action_id: &str, format: &OutputFormat) -> anyhow::Result<()> {
+    let result = ops.replay_action(action_id).await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&result)?);
+        }
+        OutputFormat::Text => {
+            if result.success {
+                println!(
+                    "Replayed {} -> {} (success)",
+                    result.original_action_id, result.new_action_id
+                );
+            } else {
+                let err = result.error.as_deref().unwrap_or("unknown");
+                println!("Replay failed for {}: {err}", result.original_action_id);
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_replay_bulk(
+    ops: &OpsClient,
+    namespace: Option<&String>,
+    tenant: Option<&String>,
+    provider: Option<&String>,
+    action_type: Option<&String>,
+    limit: u32,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    let query = ReplayQuery {
+        namespace: namespace.cloned(),
+        tenant: tenant.cloned(),
+        provider: provider.cloned(),
+        action_type: action_type.cloned(),
+        limit: Some(limit),
+        ..Default::default()
+    };
+
+    let summary = ops.replay_audit(query).await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&summary)?);
+        }
+        OutputFormat::Text => {
+            println!(
+                "Replay complete: {} replayed, {} failed, {} skipped",
+                summary.replayed, summary.failed, summary.skipped
+            );
+            for r in &summary.results {
+                if r.success {
+                    println!("  OK  {} -> {}", r.original_action_id, r.new_action_id);
+                } else {
+                    let err = r.error.as_deref().unwrap_or("unknown");
+                    println!("  ERR {} ({err})", r.original_action_id);
+                }
+            }
+        }
+    }
     Ok(())
 }

--- a/crates/cli/src/commands/chains.rs
+++ b/crates/cli/src/commands/chains.rs
@@ -1,0 +1,356 @@
+use acteon_ops::OpsClient;
+use clap::{Args, Subcommand};
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct ChainsArgs {
+    #[command(subcommand)]
+    pub command: ChainsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ChainsCommand {
+    /// List action chains.
+    List {
+        /// Namespace.
+        #[arg(long, default_value = "default")]
+        namespace: String,
+        /// Tenant.
+        #[arg(long)]
+        tenant: String,
+        /// Filter by status.
+        #[arg(long)]
+        status: Option<String>,
+    },
+    /// Get chain details.
+    Get {
+        /// Chain ID.
+        id: String,
+        /// Namespace.
+        #[arg(long, default_value = "default")]
+        namespace: String,
+        /// Tenant.
+        #[arg(long)]
+        tenant: String,
+    },
+    /// Cancel a running chain.
+    Cancel {
+        /// Chain ID.
+        id: String,
+        /// Namespace.
+        #[arg(long, default_value = "default")]
+        namespace: String,
+        /// Tenant.
+        #[arg(long)]
+        tenant: String,
+        /// Reason for cancellation.
+        #[arg(long)]
+        reason: Option<String>,
+        /// Who cancelled the chain.
+        #[arg(long)]
+        cancelled_by: Option<String>,
+    },
+    /// Get the DAG for a chain instance.
+    Dag {
+        /// Chain ID.
+        id: String,
+        /// Namespace.
+        #[arg(long, default_value = "default")]
+        namespace: String,
+        /// Tenant.
+        #[arg(long)]
+        tenant: String,
+    },
+    /// Manage chain definitions.
+    Definitions(DefinitionsArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct DefinitionsArgs {
+    #[command(subcommand)]
+    pub command: DefinitionsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum DefinitionsCommand {
+    /// List all chain definitions.
+    List,
+    /// Get a chain definition by name.
+    Get {
+        /// Chain definition name.
+        name: String,
+    },
+    /// Create or update a chain definition.
+    Put {
+        /// Chain definition name.
+        name: String,
+        /// JSON config (string or @file path).
+        #[arg(long)]
+        config: String,
+    },
+    /// Delete a chain definition.
+    Delete {
+        /// Chain definition name.
+        name: String,
+    },
+    /// Get the DAG for a chain definition.
+    Dag {
+        /// Chain definition name.
+        name: String,
+    },
+}
+
+fn parse_json_data(input: &str) -> anyhow::Result<serde_json::Value> {
+    if let Some(path) = input.strip_prefix('@') {
+        let content = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&content)?)
+    } else {
+        Ok(serde_json::from_str(input)?)
+    }
+}
+
+pub async fn run(ops: &OpsClient, args: &ChainsArgs, format: &OutputFormat) -> anyhow::Result<()> {
+    match &args.command {
+        ChainsCommand::List {
+            namespace,
+            tenant,
+            status,
+        } => run_list(ops, namespace, tenant, status.as_ref(), format).await,
+        ChainsCommand::Get {
+            id,
+            namespace,
+            tenant,
+        } => run_get(ops, id, namespace, tenant, format).await,
+        ChainsCommand::Cancel {
+            id,
+            namespace,
+            tenant,
+            reason,
+            cancelled_by,
+        } => {
+            run_cancel(
+                ops,
+                id,
+                namespace,
+                tenant,
+                reason.as_ref(),
+                cancelled_by.as_ref(),
+                format,
+            )
+            .await
+        }
+        ChainsCommand::Dag {
+            id,
+            namespace,
+            tenant,
+        } => run_dag(ops, id, namespace, tenant, format).await,
+        ChainsCommand::Definitions(def_args) => run_definitions(ops, def_args, format).await,
+    }
+}
+
+async fn run_list(
+    ops: &OpsClient,
+    namespace: &str,
+    tenant: &str,
+    status: Option<&String>,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    let resp = ops
+        .list_chains(namespace.to_string(), tenant.to_string(), status.cloned())
+        .await?;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Text => {
+            println!("{} chains:", resp.chains.len());
+            for chain in &resp.chains {
+                println!(
+                    "  {id} | {name} | {status} | step {current}/{total}",
+                    id = &chain.chain_id[..8.min(chain.chain_id.len())],
+                    name = chain.chain_name,
+                    status = chain.status,
+                    current = chain.current_step,
+                    total = chain.total_steps,
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_get(
+    ops: &OpsClient,
+    id: &str,
+    namespace: &str,
+    tenant: &str,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    let resp = ops.get_chain(id, namespace, tenant).await?;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Text => {
+            println!("Chain ID:     {}", resp.chain_id);
+            println!("Name:         {}", resp.chain_name);
+            println!("Status:       {}", resp.status);
+            println!("Progress:     {}/{}", resp.current_step, resp.total_steps);
+            println!("Started:      {}", resp.started_at);
+            println!("Updated:      {}", resp.updated_at);
+            if let Some(ref reason) = resp.cancel_reason {
+                println!("Cancel:       {reason}");
+            }
+            for step in &resp.steps {
+                let err = step.error.as_deref().unwrap_or("");
+                println!(
+                    "  [{status}] {name} -> {provider} {err}",
+                    status = step.status,
+                    name = step.name,
+                    provider = step.provider,
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_cancel(
+    ops: &OpsClient,
+    id: &str,
+    namespace: &str,
+    tenant: &str,
+    reason: Option<&String>,
+    cancelled_by: Option<&String>,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    let resp = ops
+        .cancel_chain(
+            id,
+            namespace,
+            tenant,
+            reason.map(String::as_str),
+            cancelled_by.map(String::as_str),
+        )
+        .await?;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Text => {
+            println!(
+                "Chain {} cancelled (status: {}).",
+                resp.chain_id, resp.status
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn run_dag(
+    ops: &OpsClient,
+    id: &str,
+    namespace: &str,
+    tenant: &str,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    let resp = ops.get_chain_dag(id, namespace, tenant).await?;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Text => {
+            println!(
+                "DAG for chain '{}': {} nodes, {} edges",
+                resp.chain_name,
+                resp.nodes.len(),
+                resp.edges.len()
+            );
+            for node in &resp.nodes {
+                let provider = node.provider.as_deref().unwrap_or("-");
+                let status = node.status.as_deref().unwrap_or("-");
+                println!(
+                    "  [{node_type}] {name} | provider: {provider} | status: {status}",
+                    node_type = node.node_type,
+                    name = node.name,
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_definitions(
+    ops: &OpsClient,
+    args: &DefinitionsArgs,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    match &args.command {
+        DefinitionsCommand::List => {
+            let resp = ops.list_chain_definitions().await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("{} definitions:", resp.definitions.len());
+                    for def in &resp.definitions {
+                        println!(
+                            "  {name} | {steps} steps | on_failure: {on_failure}",
+                            name = def.name,
+                            steps = def.steps_count,
+                            on_failure = def.on_failure,
+                        );
+                    }
+                }
+            }
+        }
+        DefinitionsCommand::Get { name } => {
+            let resp = ops.get_chain_definition(name).await?;
+            // Definition config is raw JSON, so always pretty-print.
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        DefinitionsCommand::Put { name, config } => {
+            let config_value = parse_json_data(config)?;
+            let resp = ops.put_chain_definition(name, &config_value).await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("Chain definition '{name}' saved.");
+                }
+            }
+        }
+        DefinitionsCommand::Delete { name } => {
+            ops.delete_chain_definition(name).await?;
+            println!("Chain definition '{name}' deleted.");
+        }
+        DefinitionsCommand::Dag { name } => {
+            let resp = ops.get_chain_definition_dag(name).await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!(
+                        "DAG for definition '{}': {} nodes, {} edges",
+                        resp.chain_name,
+                        resp.nodes.len(),
+                        resp.edges.len()
+                    );
+                    for node in &resp.nodes {
+                        let provider = node.provider.as_deref().unwrap_or("-");
+                        println!(
+                            "  [{node_type}] {name} | provider: {provider}",
+                            node_type = node.node_type,
+                            name = node.name,
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/compliance.rs
+++ b/crates/cli/src/commands/compliance.rs
@@ -1,0 +1,79 @@
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::VerifyHashChainRequest;
+use clap::{Args, Subcommand};
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct ComplianceArgs {
+    #[command(subcommand)]
+    pub command: ComplianceCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ComplianceCommand {
+    /// Show compliance configuration status.
+    Status,
+    /// Verify audit hash chain integrity.
+    Verify {
+        /// JSON data (string or @file path).
+        #[arg(long)]
+        data: String,
+    },
+}
+
+fn parse_json_data(input: &str) -> anyhow::Result<serde_json::Value> {
+    if let Some(path) = input.strip_prefix('@') {
+        let content = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&content)?)
+    } else {
+        Ok(serde_json::from_str(input)?)
+    }
+}
+
+pub async fn run(
+    ops: &OpsClient,
+    args: &ComplianceArgs,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    match &args.command {
+        ComplianceCommand::Status => {
+            let resp = ops.get_compliance_status().await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("Compliance Mode:    {}", resp.mode);
+                    println!("Sync Audit Writes:  {}", resp.sync_audit_writes);
+                    println!("Immutable Audit:    {}", resp.immutable_audit);
+                    println!("Hash Chain:         {}", resp.hash_chain);
+                }
+            }
+        }
+        ComplianceCommand::Verify { data } => {
+            let value = parse_json_data(data)?;
+            let req: VerifyHashChainRequest = serde_json::from_value(value)?;
+            let resp = ops.verify_audit_chain(&req).await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("Valid:           {}", resp.valid);
+                    println!("Records Checked: {}", resp.records_checked);
+                    if let Some(ref broken) = resp.first_broken_at {
+                        println!("First Broken:    {broken}");
+                    }
+                    if let Some(ref first) = resp.first_record_id {
+                        println!("First Record:    {first}");
+                    }
+                    if let Some(ref last) = resp.last_record_id {
+                        println!("Last Record:     {last}");
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/dlq.rs
+++ b/crates/cli/src/commands/dlq.rs
@@ -1,0 +1,57 @@
+use acteon_ops::OpsClient;
+use clap::{Args, Subcommand};
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct DlqArgs {
+    #[command(subcommand)]
+    pub command: DlqCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum DlqCommand {
+    /// Show dead letter queue statistics.
+    Stats,
+    /// Drain all entries from the dead letter queue.
+    Drain,
+}
+
+pub async fn run(ops: &OpsClient, args: &DlqArgs, format: &OutputFormat) -> anyhow::Result<()> {
+    match &args.command {
+        DlqCommand::Stats => {
+            let resp = ops.dlq_stats().await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("DLQ enabled: {}", resp.enabled);
+                    println!("Entries:     {}", resp.count);
+                }
+            }
+        }
+        DlqCommand::Drain => {
+            let resp = ops.dlq_drain().await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("Drained {} entries:", resp.count);
+                    for entry in &resp.entries {
+                        println!(
+                            "  {id} | {provider}/{action_type} | {err} (attempts: {attempts})",
+                            id = &entry.action_id[..8.min(entry.action_id.len())],
+                            provider = entry.provider,
+                            action_type = entry.action_type,
+                            err = entry.error,
+                            attempts = entry.attempts,
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/groups.rs
+++ b/crates/cli/src/commands/groups.rs
@@ -1,0 +1,92 @@
+use acteon_ops::OpsClient;
+use clap::{Args, Subcommand};
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct GroupsArgs {
+    #[command(subcommand)]
+    pub command: GroupsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum GroupsCommand {
+    /// List event groups.
+    List,
+    /// Get an event group by key.
+    Get {
+        /// Group key.
+        key: String,
+    },
+    /// Flush an event group (trigger immediate notification).
+    Flush {
+        /// Group key.
+        key: String,
+    },
+}
+
+pub async fn run(ops: &OpsClient, args: &GroupsArgs, format: &OutputFormat) -> anyhow::Result<()> {
+    match &args.command {
+        GroupsCommand::List => {
+            let resp = ops.list_groups().await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("{} groups:", resp.total);
+                    for g in &resp.groups {
+                        let notify = g.notify_at.as_deref().unwrap_or("-");
+                        println!(
+                            "  {key} | {state} | {count} events | notify: {notify}",
+                            key = g.group_key,
+                            state = g.state,
+                            count = g.event_count,
+                        );
+                    }
+                }
+            }
+        }
+        GroupsCommand::Get { key } => {
+            let resp = ops.get_group(key).await?;
+            match resp {
+                Some(detail) => match format {
+                    OutputFormat::Json => {
+                        println!("{}", serde_json::to_string_pretty(&detail)?);
+                    }
+                    OutputFormat::Text => {
+                        println!("Group ID:  {}", detail.group.group_id);
+                        println!("Key:       {}", detail.group.group_key);
+                        println!("State:     {}", detail.group.state);
+                        println!("Events:    {}", detail.group.event_count);
+                        println!("Created:   {}", detail.group.created_at);
+                        if !detail.events.is_empty() {
+                            println!("Event fingerprints:");
+                            for fp in &detail.events {
+                                println!("  - {fp}");
+                            }
+                        }
+                    }
+                },
+                None => {
+                    println!("Group not found: {key}");
+                }
+            }
+        }
+        GroupsCommand::Flush { key } => {
+            let resp = ops.flush_group(key).await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!(
+                        "Flushed group '{}': {} events, notified: {}",
+                        resp.group_id, resp.event_count, resp.notified
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,5 +1,16 @@
+pub mod approvals;
 pub mod audit;
+pub mod chains;
+pub mod compliance;
 pub mod dispatch;
+pub mod dlq;
 pub mod events;
+pub mod groups;
 pub mod health;
+pub mod plugins;
+pub mod providers;
+pub mod quotas;
+pub mod recurring;
+pub mod retention;
 pub mod rules;
+pub mod templates;

--- a/crates/cli/src/commands/plugins.rs
+++ b/crates/cli/src/commands/plugins.rs
@@ -1,0 +1,52 @@
+use acteon_ops::OpsClient;
+use clap::{Args, Subcommand};
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct PluginsArgs {
+    #[command(subcommand)]
+    pub command: PluginsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum PluginsCommand {
+    /// List registered WASM plugins.
+    List,
+    /// Delete a WASM plugin by name.
+    Delete {
+        /// Plugin name.
+        name: String,
+    },
+}
+
+pub async fn run(ops: &OpsClient, args: &PluginsArgs, format: &OutputFormat) -> anyhow::Result<()> {
+    match &args.command {
+        PluginsCommand::List => {
+            let resp = ops.list_plugins().await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("{} plugins:", resp.count);
+                    for p in &resp.plugins {
+                        let enabled = if p.enabled { "ON " } else { "OFF" };
+                        let desc = p.description.as_deref().unwrap_or("");
+                        println!(
+                            "  [{enabled}] {name} | {status} | invocations: {count} {desc}",
+                            name = p.name,
+                            status = p.status,
+                            count = p.invocation_count,
+                        );
+                    }
+                }
+            }
+        }
+        PluginsCommand::Delete { name } => {
+            ops.delete_plugin(name).await?;
+            println!("Plugin '{name}' deleted.");
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/providers.rs
+++ b/crates/cli/src/commands/providers.rs
@@ -1,0 +1,49 @@
+use acteon_ops::OpsClient;
+use clap::{Args, Subcommand};
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct ProvidersArgs {
+    #[command(subcommand)]
+    pub command: ProvidersCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ProvidersCommand {
+    /// Show provider health status and metrics.
+    Health,
+}
+
+pub async fn run(
+    ops: &OpsClient,
+    args: &ProvidersArgs,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    match &args.command {
+        ProvidersCommand::Health => {
+            let resp = ops.list_provider_health().await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("{} providers:", resp.providers.len());
+                    for p in &resp.providers {
+                        let health = if p.healthy { "OK " } else { "ERR" };
+                        let cb = p.circuit_breaker_state.as_deref().unwrap_or("-");
+                        println!(
+                            "  [{health}] {provider} | reqs: {total} | success: {rate:.1}% | p50: {p50:.1}ms | p99: {p99:.1}ms | cb: {cb}",
+                            provider = p.provider,
+                            total = p.total_requests,
+                            rate = p.success_rate,
+                            p50 = p.p50_latency_ms,
+                            p99 = p.p99_latency_ms,
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/quotas.rs
+++ b/crates/cli/src/commands/quotas.rs
@@ -1,0 +1,197 @@
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::{CreateQuotaRequest, UpdateQuotaRequest};
+use clap::{Args, Subcommand};
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct QuotasArgs {
+    #[command(subcommand)]
+    pub command: QuotasCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum QuotasCommand {
+    /// List quota policies.
+    List {
+        /// Filter by namespace.
+        #[arg(long)]
+        namespace: Option<String>,
+        /// Filter by tenant.
+        #[arg(long)]
+        tenant: Option<String>,
+    },
+    /// Get a quota policy by ID.
+    Get {
+        /// Quota policy ID.
+        id: String,
+    },
+    /// Create a quota policy.
+    Create {
+        /// JSON data (string or @file path).
+        #[arg(long)]
+        data: String,
+    },
+    /// Update a quota policy.
+    Update {
+        /// Quota policy ID.
+        id: String,
+        /// JSON data (string or @file path).
+        #[arg(long)]
+        data: String,
+    },
+    /// Delete a quota policy.
+    Delete {
+        /// Quota policy ID.
+        id: String,
+        /// Namespace.
+        #[arg(long, default_value = "default")]
+        namespace: String,
+        /// Tenant.
+        #[arg(long)]
+        tenant: String,
+    },
+    /// Get quota usage.
+    Usage {
+        /// Quota policy ID.
+        id: String,
+    },
+}
+
+fn parse_json_data(input: &str) -> anyhow::Result<serde_json::Value> {
+    if let Some(path) = input.strip_prefix('@') {
+        let content = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&content)?)
+    } else {
+        Ok(serde_json::from_str(input)?)
+    }
+}
+
+pub async fn run(ops: &OpsClient, args: &QuotasArgs, format: &OutputFormat) -> anyhow::Result<()> {
+    match &args.command {
+        QuotasCommand::List { namespace, tenant } => {
+            run_list(ops, namespace.as_ref(), tenant.as_ref(), format).await
+        }
+        QuotasCommand::Get { id } => run_get(ops, id, format).await,
+        QuotasCommand::Create { data } => run_create(ops, data, format).await,
+        QuotasCommand::Update { id, data } => run_update(ops, id, data, format).await,
+        QuotasCommand::Delete {
+            id,
+            namespace,
+            tenant,
+        } => {
+            ops.delete_quota(id, namespace, tenant).await?;
+            println!("Quota '{id}' deleted.");
+            Ok(())
+        }
+        QuotasCommand::Usage { id } => run_usage(ops, id, format).await,
+    }
+}
+
+async fn run_list(
+    ops: &OpsClient,
+    namespace: Option<&String>,
+    tenant: Option<&String>,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    let resp = ops
+        .list_quotas(namespace.map(String::as_str), tenant.map(String::as_str))
+        .await?;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Text => {
+            println!("{} quotas:", resp.count);
+            for q in &resp.quotas {
+                let enabled = if q.enabled { "ON " } else { "OFF" };
+                println!(
+                    "  [{enabled}] {id} | {ns}:{tenant} | {max}/{window} ({behavior})",
+                    id = &q.id[..8.min(q.id.len())],
+                    ns = q.namespace,
+                    tenant = q.tenant,
+                    max = q.max_actions,
+                    window = q.window,
+                    behavior = q.overage_behavior,
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_get(ops: &OpsClient, id: &str, format: &OutputFormat) -> anyhow::Result<()> {
+    let resp = ops.get_quota(id).await?;
+    match resp {
+        Some(q) => match format {
+            OutputFormat::Json => {
+                println!("{}", serde_json::to_string_pretty(&q)?);
+            }
+            OutputFormat::Text => {
+                println!("ID:        {}", q.id);
+                println!("Namespace: {}", q.namespace);
+                println!("Tenant:    {}", q.tenant);
+                println!("Max:       {} / {}", q.max_actions, q.window);
+                println!("Behavior:  {}", q.overage_behavior);
+                println!("Enabled:   {}", q.enabled);
+            }
+        },
+        None => {
+            println!("Quota not found: {id}");
+        }
+    }
+    Ok(())
+}
+
+async fn run_create(ops: &OpsClient, data: &str, format: &OutputFormat) -> anyhow::Result<()> {
+    let value = parse_json_data(data)?;
+    let req: CreateQuotaRequest = serde_json::from_value(value)?;
+    let resp = ops.create_quota(&req).await?;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Text => {
+            println!("Created quota: {}", resp.id);
+        }
+    }
+    Ok(())
+}
+
+async fn run_update(
+    ops: &OpsClient,
+    id: &str,
+    data: &str,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    let value = parse_json_data(data)?;
+    let req: UpdateQuotaRequest = serde_json::from_value(value)?;
+    let resp = ops.update_quota(id, &req).await?;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Text => {
+            println!("Updated quota: {}", resp.id);
+        }
+    }
+    Ok(())
+}
+
+async fn run_usage(ops: &OpsClient, id: &str, format: &OutputFormat) -> anyhow::Result<()> {
+    let resp = ops.get_quota_usage(id).await?;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Text => {
+            println!("Quota Usage:");
+            println!("  Used:      {}/{}", resp.used, resp.limit);
+            println!("  Remaining: {}", resp.remaining);
+            println!("  Window:    {}", resp.window);
+            println!("  Resets:    {}", resp.resets_at);
+            println!("  Behavior:  {}", resp.overage_behavior);
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/recurring.rs
+++ b/crates/cli/src/commands/recurring.rs
@@ -1,0 +1,278 @@
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::{CreateRecurringAction, RecurringFilter, UpdateRecurringAction};
+use clap::{Args, Subcommand};
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct RecurringArgs {
+    #[command(subcommand)]
+    pub command: RecurringCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum RecurringCommand {
+    /// List recurring actions.
+    List {
+        /// Namespace.
+        #[arg(long, default_value = "default")]
+        namespace: String,
+        /// Tenant.
+        #[arg(long)]
+        tenant: String,
+        /// Filter by status (active/paused).
+        #[arg(long)]
+        status: Option<String>,
+    },
+    /// Get a recurring action by ID.
+    Get {
+        /// Recurring action ID.
+        id: String,
+        /// Namespace.
+        #[arg(long, default_value = "default")]
+        namespace: String,
+        /// Tenant.
+        #[arg(long)]
+        tenant: String,
+    },
+    /// Create a recurring action.
+    Create {
+        /// JSON data (string or @file path).
+        #[arg(long)]
+        data: String,
+    },
+    /// Update a recurring action.
+    Update {
+        /// Recurring action ID.
+        id: String,
+        /// JSON data (string or @file path).
+        #[arg(long)]
+        data: String,
+    },
+    /// Delete a recurring action.
+    Delete {
+        /// Recurring action ID.
+        id: String,
+        /// Namespace.
+        #[arg(long, default_value = "default")]
+        namespace: String,
+        /// Tenant.
+        #[arg(long)]
+        tenant: String,
+    },
+    /// Pause a recurring action.
+    Pause {
+        /// Recurring action ID.
+        id: String,
+        /// Namespace.
+        #[arg(long, default_value = "default")]
+        namespace: String,
+        /// Tenant.
+        #[arg(long)]
+        tenant: String,
+    },
+    /// Resume a recurring action.
+    Resume {
+        /// Recurring action ID.
+        id: String,
+        /// Namespace.
+        #[arg(long, default_value = "default")]
+        namespace: String,
+        /// Tenant.
+        #[arg(long)]
+        tenant: String,
+    },
+}
+
+fn parse_json_data(input: &str) -> anyhow::Result<serde_json::Value> {
+    if let Some(path) = input.strip_prefix('@') {
+        let content = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&content)?)
+    } else {
+        Ok(serde_json::from_str(input)?)
+    }
+}
+
+pub async fn run(
+    ops: &OpsClient,
+    args: &RecurringArgs,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    match &args.command {
+        RecurringCommand::List {
+            namespace,
+            tenant,
+            status,
+        } => run_list(ops, namespace, tenant, status.as_ref(), format).await,
+        RecurringCommand::Get {
+            id,
+            namespace,
+            tenant,
+        } => run_get(ops, id, namespace, tenant, format).await,
+        RecurringCommand::Create { data } => run_create(ops, data, format).await,
+        RecurringCommand::Update { id, data } => run_update(ops, id, data, format).await,
+        RecurringCommand::Delete {
+            id,
+            namespace,
+            tenant,
+        } => {
+            ops.delete_recurring(id, namespace, tenant).await?;
+            println!("Recurring action '{id}' deleted.");
+            Ok(())
+        }
+        RecurringCommand::Pause {
+            id,
+            namespace,
+            tenant,
+        } => run_pause(ops, id, namespace, tenant, format).await,
+        RecurringCommand::Resume {
+            id,
+            namespace,
+            tenant,
+        } => run_resume(ops, id, namespace, tenant, format).await,
+    }
+}
+
+async fn run_list(
+    ops: &OpsClient,
+    namespace: &str,
+    tenant: &str,
+    status: Option<&String>,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    let filter = RecurringFilter {
+        namespace: namespace.to_string(),
+        tenant: tenant.to_string(),
+        status: status.cloned(),
+        ..Default::default()
+    };
+    let resp = ops.list_recurring(&filter).await?;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Text => {
+            println!("{} recurring actions:", resp.count);
+            for r in &resp.recurring_actions {
+                let enabled = if r.enabled { "ON " } else { "OFF" };
+                println!(
+                    "  [{enabled}] {id} | {cron} | {provider}/{action_type}",
+                    id = &r.id[..8.min(r.id.len())],
+                    cron = r.cron_expr,
+                    provider = r.provider,
+                    action_type = r.action_type,
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_get(
+    ops: &OpsClient,
+    id: &str,
+    namespace: &str,
+    tenant: &str,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    let resp = ops.get_recurring(id, namespace, tenant).await?;
+    match resp {
+        Some(detail) => match format {
+            OutputFormat::Json => {
+                println!("{}", serde_json::to_string_pretty(&detail)?);
+            }
+            OutputFormat::Text => {
+                println!("ID:          {}", detail.id);
+                println!("Provider:    {}", detail.provider);
+                println!("Action Type: {}", detail.action_type);
+                println!("Cron:        {}", detail.cron_expr);
+                println!("Timezone:    {}", detail.timezone);
+                println!("Enabled:     {}", detail.enabled);
+                println!("Executions:  {}", detail.execution_count);
+                if let Some(ref next) = detail.next_execution_at {
+                    println!("Next Run:    {next}");
+                }
+            }
+        },
+        None => {
+            println!("Recurring action not found: {id}");
+        }
+    }
+    Ok(())
+}
+
+async fn run_create(ops: &OpsClient, data: &str, format: &OutputFormat) -> anyhow::Result<()> {
+    let value = parse_json_data(data)?;
+    let req: CreateRecurringAction = serde_json::from_value(value)?;
+    let resp = ops.create_recurring(&req).await?;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Text => {
+            println!(
+                "Created recurring action: {} (status: {})",
+                resp.id, resp.status
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn run_update(
+    ops: &OpsClient,
+    id: &str,
+    data: &str,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    let value = parse_json_data(data)?;
+    let req: UpdateRecurringAction = serde_json::from_value(value)?;
+    let resp = ops.update_recurring(id, &req).await?;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Text => {
+            println!("Updated recurring action: {}", resp.id);
+        }
+    }
+    Ok(())
+}
+
+async fn run_pause(
+    ops: &OpsClient,
+    id: &str,
+    namespace: &str,
+    tenant: &str,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    let resp = ops.pause_recurring(id, namespace, tenant).await?;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Text => {
+            println!("Recurring action '{}' paused.", resp.id);
+        }
+    }
+    Ok(())
+}
+
+async fn run_resume(
+    ops: &OpsClient,
+    id: &str,
+    namespace: &str,
+    tenant: &str,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    let resp = ops.resume_recurring(id, namespace, tenant).await?;
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Text => {
+            println!("Recurring action '{}' resumed.", resp.id);
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/retention.rs
+++ b/crates/cli/src/commands/retention.rs
@@ -1,0 +1,149 @@
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::{CreateRetentionRequest, UpdateRetentionRequest};
+use clap::{Args, Subcommand};
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct RetentionArgs {
+    #[command(subcommand)]
+    pub command: RetentionCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum RetentionCommand {
+    /// List retention policies.
+    List {
+        /// Filter by namespace.
+        #[arg(long)]
+        namespace: Option<String>,
+        /// Filter by tenant.
+        #[arg(long)]
+        tenant: Option<String>,
+    },
+    /// Get a retention policy by ID.
+    Get {
+        /// Retention policy ID.
+        id: String,
+    },
+    /// Create a retention policy.
+    Create {
+        /// JSON data (string or @file path).
+        #[arg(long)]
+        data: String,
+    },
+    /// Update a retention policy.
+    Update {
+        /// Retention policy ID.
+        id: String,
+        /// JSON data (string or @file path).
+        #[arg(long)]
+        data: String,
+    },
+    /// Delete a retention policy.
+    Delete {
+        /// Retention policy ID.
+        id: String,
+    },
+}
+
+fn parse_json_data(input: &str) -> anyhow::Result<serde_json::Value> {
+    if let Some(path) = input.strip_prefix('@') {
+        let content = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&content)?)
+    } else {
+        Ok(serde_json::from_str(input)?)
+    }
+}
+
+pub async fn run(
+    ops: &OpsClient,
+    args: &RetentionArgs,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    match &args.command {
+        RetentionCommand::List { namespace, tenant } => {
+            let resp = ops
+                .list_retention(namespace.clone(), tenant.clone())
+                .await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("{} retention policies:", resp.count);
+                    for p in &resp.policies {
+                        let enabled = if p.enabled { "ON " } else { "OFF" };
+                        let hold = if p.compliance_hold { " [HOLD]" } else { "" };
+                        println!(
+                            "  [{enabled}] {id} | {ns}:{tenant}{hold}",
+                            id = &p.id[..8.min(p.id.len())],
+                            ns = p.namespace,
+                            tenant = p.tenant,
+                        );
+                    }
+                }
+            }
+        }
+        RetentionCommand::Get { id } => {
+            let resp = ops.get_retention(id).await?;
+            match resp {
+                Some(p) => match format {
+                    OutputFormat::Json => {
+                        println!("{}", serde_json::to_string_pretty(&p)?);
+                    }
+                    OutputFormat::Text => {
+                        println!("ID:              {}", p.id);
+                        println!("Namespace:       {}", p.namespace);
+                        println!("Tenant:          {}", p.tenant);
+                        println!("Enabled:         {}", p.enabled);
+                        println!("Compliance Hold: {}", p.compliance_hold);
+                        if let Some(ttl) = p.audit_ttl_seconds {
+                            println!("Audit TTL:       {ttl}s");
+                        }
+                        if let Some(ttl) = p.state_ttl_seconds {
+                            println!("State TTL:       {ttl}s");
+                        }
+                        if let Some(ttl) = p.event_ttl_seconds {
+                            println!("Event TTL:       {ttl}s");
+                        }
+                    }
+                },
+                None => {
+                    println!("Retention policy not found: {id}");
+                }
+            }
+        }
+        RetentionCommand::Create { data } => {
+            let value = parse_json_data(data)?;
+            let req: CreateRetentionRequest = serde_json::from_value(value)?;
+            let resp = ops.create_retention(&req).await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("Created retention policy: {}", resp.id);
+                }
+            }
+        }
+        RetentionCommand::Update { id, data } => {
+            let value = parse_json_data(data)?;
+            let req: UpdateRetentionRequest = serde_json::from_value(value)?;
+            let resp = ops.update_retention(id, &req).await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("Updated retention policy: {}", resp.id);
+                }
+            }
+        }
+        RetentionCommand::Delete { id } => {
+            ops.delete_retention(id).await?;
+            println!("Retention policy '{id}' deleted.");
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/rules.rs
+++ b/crates/cli/src/commands/rules.rs
@@ -34,6 +34,8 @@ pub enum RulesCommand {
         #[arg(long)]
         filter: Option<String>,
     },
+    /// Reload rules from the YAML directory.
+    Reload,
 }
 
 pub async fn run(ops: &OpsClient, args: &RulesArgs, format: &OutputFormat) -> anyhow::Result<()> {
@@ -83,6 +85,23 @@ pub async fn run(ops: &OpsClient, args: &RulesArgs, format: &OutputFormat) -> an
 
             if summary.failed > 0 {
                 std::process::exit(1);
+            }
+        }
+        RulesCommand::Reload => {
+            let result = ops.reload_rules().await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&result)?);
+                }
+                OutputFormat::Text => {
+                    println!("Reloaded {} rules.", result.loaded);
+                    if !result.errors.is_empty() {
+                        println!("Errors:");
+                        for err in &result.errors {
+                            println!("  - {err}");
+                        }
+                    }
+                }
             }
         }
     }

--- a/crates/cli/src/commands/templates.rs
+++ b/crates/cli/src/commands/templates.rs
@@ -1,0 +1,303 @@
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::{
+    CreateProfileRequest, CreateTemplateRequest, RenderPreviewRequest, UpdateProfileRequest,
+    UpdateTemplateRequest,
+};
+use clap::{Args, Subcommand};
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct TemplatesArgs {
+    #[command(subcommand)]
+    pub command: TemplatesCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TemplatesCommand {
+    /// List templates.
+    List {
+        /// Filter by namespace.
+        #[arg(long)]
+        namespace: Option<String>,
+        /// Filter by tenant.
+        #[arg(long)]
+        tenant: Option<String>,
+    },
+    /// Get a template by ID.
+    Get {
+        /// Template ID.
+        id: String,
+    },
+    /// Create a template.
+    Create {
+        /// JSON data (string or @file path).
+        #[arg(long)]
+        data: String,
+    },
+    /// Update a template.
+    Update {
+        /// Template ID.
+        id: String,
+        /// JSON data (string or @file path).
+        #[arg(long)]
+        data: String,
+    },
+    /// Delete a template.
+    Delete {
+        /// Template ID.
+        id: String,
+    },
+    /// Manage template profiles.
+    Profiles(ProfilesArgs),
+    /// Render a template preview.
+    Render {
+        /// JSON data (string or @file path).
+        #[arg(long)]
+        data: String,
+    },
+}
+
+#[derive(Args, Debug)]
+pub struct ProfilesArgs {
+    #[command(subcommand)]
+    pub command: ProfilesCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ProfilesCommand {
+    /// List template profiles.
+    List {
+        /// Filter by namespace.
+        #[arg(long)]
+        namespace: Option<String>,
+        /// Filter by tenant.
+        #[arg(long)]
+        tenant: Option<String>,
+    },
+    /// Get a template profile by ID.
+    Get {
+        /// Profile ID.
+        id: String,
+    },
+    /// Create a template profile.
+    Create {
+        /// JSON data (string or @file path).
+        #[arg(long)]
+        data: String,
+    },
+    /// Update a template profile.
+    Update {
+        /// Profile ID.
+        id: String,
+        /// JSON data (string or @file path).
+        #[arg(long)]
+        data: String,
+    },
+    /// Delete a template profile.
+    Delete {
+        /// Profile ID.
+        id: String,
+    },
+}
+
+fn parse_json_data(input: &str) -> anyhow::Result<serde_json::Value> {
+    if let Some(path) = input.strip_prefix('@') {
+        let content = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&content)?)
+    } else {
+        Ok(serde_json::from_str(input)?)
+    }
+}
+
+pub async fn run(
+    ops: &OpsClient,
+    args: &TemplatesArgs,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    match &args.command {
+        TemplatesCommand::List { namespace, tenant } => {
+            let resp = ops
+                .list_templates(namespace.as_deref(), tenant.as_deref())
+                .await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("{} templates:", resp.count);
+                    for t in &resp.templates {
+                        let desc = t.description.as_deref().unwrap_or("");
+                        println!(
+                            "  {id} | {name} | {ns}:{tenant} {desc}",
+                            id = &t.id[..8.min(t.id.len())],
+                            name = t.name,
+                            ns = t.namespace,
+                            tenant = t.tenant,
+                        );
+                    }
+                }
+            }
+        }
+        TemplatesCommand::Get { id } => {
+            let resp = ops.get_template(id).await?;
+            match resp {
+                Some(t) => match format {
+                    OutputFormat::Json => {
+                        println!("{}", serde_json::to_string_pretty(&t)?);
+                    }
+                    OutputFormat::Text => {
+                        println!("ID:        {}", t.id);
+                        println!("Name:      {}", t.name);
+                        println!("Namespace: {}", t.namespace);
+                        println!("Tenant:    {}", t.tenant);
+                        if let Some(ref desc) = t.description {
+                            println!("Desc:      {desc}");
+                        }
+                        println!("Content:\n{}", t.content);
+                    }
+                },
+                None => {
+                    println!("Template not found: {id}");
+                }
+            }
+        }
+        TemplatesCommand::Create { data } => {
+            let value = parse_json_data(data)?;
+            let req: CreateTemplateRequest = serde_json::from_value(value)?;
+            let resp = ops.create_template(&req).await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("Created template: {} ({})", resp.id, resp.name);
+                }
+            }
+        }
+        TemplatesCommand::Update { id, data } => {
+            let value = parse_json_data(data)?;
+            let req: UpdateTemplateRequest = serde_json::from_value(value)?;
+            let resp = ops.update_template(id, &req).await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("Updated template: {}", resp.id);
+                }
+            }
+        }
+        TemplatesCommand::Delete { id } => {
+            ops.delete_template(id).await?;
+            println!("Template '{id}' deleted.");
+        }
+        TemplatesCommand::Profiles(profiles_args) => {
+            run_profiles(ops, profiles_args, format).await?;
+        }
+        TemplatesCommand::Render { data } => {
+            let value = parse_json_data(data)?;
+            let req: RenderPreviewRequest = serde_json::from_value(value)?;
+            let resp = ops.render_preview(&req).await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("Rendered fields:");
+                    for (field, content) in &resp.rendered {
+                        println!("  {field}: {content}");
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_profiles(
+    ops: &OpsClient,
+    args: &ProfilesArgs,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    match &args.command {
+        ProfilesCommand::List { namespace, tenant } => {
+            let resp = ops
+                .list_profiles(namespace.as_deref(), tenant.as_deref())
+                .await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("{} profiles:", resp.count);
+                    for p in &resp.profiles {
+                        let desc = p.description.as_deref().unwrap_or("");
+                        println!(
+                            "  {id} | {name} | {ns}:{tenant} | {fields} fields {desc}",
+                            id = &p.id[..8.min(p.id.len())],
+                            name = p.name,
+                            ns = p.namespace,
+                            tenant = p.tenant,
+                            fields = p.fields.len(),
+                        );
+                    }
+                }
+            }
+        }
+        ProfilesCommand::Get { id } => {
+            let resp = ops.get_profile(id).await?;
+            match resp {
+                Some(p) => match format {
+                    OutputFormat::Json => {
+                        println!("{}", serde_json::to_string_pretty(&p)?);
+                    }
+                    OutputFormat::Text => {
+                        println!("ID:        {}", p.id);
+                        println!("Name:      {}", p.name);
+                        println!("Namespace: {}", p.namespace);
+                        println!("Tenant:    {}", p.tenant);
+                        println!("Fields:    {}", p.fields.len());
+                        if let Some(ref desc) = p.description {
+                            println!("Desc:      {desc}");
+                        }
+                    }
+                },
+                None => {
+                    println!("Profile not found: {id}");
+                }
+            }
+        }
+        ProfilesCommand::Create { data } => {
+            let value = parse_json_data(data)?;
+            let req: CreateProfileRequest = serde_json::from_value(value)?;
+            let resp = ops.create_profile(&req).await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("Created profile: {} ({})", resp.id, resp.name);
+                }
+            }
+        }
+        ProfilesCommand::Update { id, data } => {
+            let value = parse_json_data(data)?;
+            let req: UpdateProfileRequest = serde_json::from_value(value)?;
+            let resp = ops.update_profile(id, &req).await?;
+            match format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&resp)?);
+                }
+                OutputFormat::Text => {
+                    println!("Updated profile: {}", resp.id);
+                }
+            }
+        }
+        ProfilesCommand::Delete { id } => {
+            ops.delete_profile(id).await?;
+            println!("Profile '{id}' deleted.");
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -45,12 +45,34 @@ enum Command {
     Health,
     /// Dispatch an action through the gateway.
     Dispatch(commands::dispatch::DispatchArgs),
-    /// Query the audit trail.
+    /// Query and replay audit records.
     Audit(commands::audit::AuditArgs),
     /// Manage routing rules.
     Rules(commands::rules::RulesArgs),
     /// Manage stateful events.
     Events(commands::events::EventsArgs),
+    /// Manage action chains.
+    Chains(commands::chains::ChainsArgs),
+    /// Manage recurring actions.
+    Recurring(commands::recurring::RecurringArgs),
+    /// Manage tenant quotas.
+    Quotas(commands::quotas::QuotasArgs),
+    /// Manage retention policies.
+    Retention(commands::retention::RetentionArgs),
+    /// Manage templates and profiles.
+    Templates(commands::templates::TemplatesArgs),
+    /// Manage WASM plugins.
+    Plugins(commands::plugins::PluginsArgs),
+    /// Manage event groups.
+    Groups(commands::groups::GroupsArgs),
+    /// Manage dead letter queue.
+    Dlq(commands::dlq::DlqArgs),
+    /// Check compliance status.
+    Compliance(commands::compliance::ComplianceArgs),
+    /// Provider health information.
+    Providers(commands::providers::ProvidersArgs),
+    /// List pending approvals.
+    Approvals(commands::approvals::ApprovalsArgs),
 }
 
 #[tokio::main]
@@ -75,5 +97,16 @@ async fn main() -> anyhow::Result<()> {
         Command::Audit(args) => commands::audit::run(&ops, &args, &cli.format).await,
         Command::Rules(args) => commands::rules::run(&ops, &args, &cli.format).await,
         Command::Events(args) => commands::events::run(&ops, &args, &cli.format).await,
+        Command::Chains(args) => commands::chains::run(&ops, &args, &cli.format).await,
+        Command::Recurring(args) => commands::recurring::run(&ops, &args, &cli.format).await,
+        Command::Quotas(args) => commands::quotas::run(&ops, &args, &cli.format).await,
+        Command::Retention(args) => commands::retention::run(&ops, &args, &cli.format).await,
+        Command::Templates(args) => commands::templates::run(&ops, &args, &cli.format).await,
+        Command::Plugins(args) => commands::plugins::run(&ops, &args, &cli.format).await,
+        Command::Groups(args) => commands::groups::run(&ops, &args, &cli.format).await,
+        Command::Dlq(args) => commands::dlq::run(&ops, &args, &cli.format).await,
+        Command::Compliance(args) => commands::compliance::run(&ops, &args, &cli.format).await,
+        Command::Providers(args) => commands::providers::run(&ops, &args, &cli.format).await,
+        Command::Approvals(args) => commands::approvals::run(&ops, &args, &cli.format).await,
     }
 }

--- a/crates/client/src/quotas.rs
+++ b/crates/client/src/quotas.rs
@@ -4,7 +4,7 @@ use crate::dispatch::ErrorResponse;
 use crate::{ActeonClient, Error};
 
 /// Request to create a quota policy.
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct CreateQuotaRequest {
     /// Namespace.
     pub namespace: String,
@@ -25,7 +25,7 @@ pub struct CreateQuotaRequest {
 }
 
 /// Request to update a quota policy.
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct UpdateQuotaRequest {
     /// Namespace (required for key lookup).
     pub namespace: String,

--- a/crates/client/src/recurring.rs
+++ b/crates/client/src/recurring.rs
@@ -4,7 +4,7 @@ use crate::dispatch::ErrorResponse;
 use crate::{ActeonClient, Error};
 
 /// Request to create a recurring action.
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct CreateRecurringAction {
     /// Namespace.
     pub namespace: String,
@@ -156,7 +156,7 @@ pub struct RecurringDetail {
 }
 
 /// Request to update a recurring action.
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct UpdateRecurringAction {
     /// Namespace (required for key lookup).
     pub namespace: String,

--- a/crates/client/src/retention.rs
+++ b/crates/client/src/retention.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{ActeonClient, Error};
 
 /// Request to create a data retention policy.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateRetentionRequest {
     /// Namespace.
     pub namespace: String,
@@ -30,7 +30,7 @@ pub struct CreateRetentionRequest {
 }
 
 /// Request to update a data retention policy.
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct UpdateRetentionRequest {
     /// Updated enabled state.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/client/src/templates.rs
+++ b/crates/client/src/templates.rs
@@ -54,7 +54,7 @@ pub struct TemplateProfileInfo {
 }
 
 /// Request to create a new template.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateTemplateRequest {
     /// Template name.
     pub name: String,
@@ -73,7 +73,7 @@ pub struct CreateTemplateRequest {
 }
 
 /// Request to update an existing template.
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct UpdateTemplateRequest {
     /// Updated template content.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -87,7 +87,7 @@ pub struct UpdateTemplateRequest {
 }
 
 /// Request to create a new template profile.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateProfileRequest {
     /// Profile name.
     pub name: String,
@@ -106,7 +106,7 @@ pub struct CreateProfileRequest {
 }
 
 /// Request to update an existing template profile.
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct UpdateProfileRequest {
     /// Updated field-to-template mappings.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -138,7 +138,7 @@ pub struct ListProfilesResponse {
 }
 
 /// Request to render a template preview.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RenderPreviewRequest {
     /// Profile name to render.
     pub profile: String,

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -3,7 +3,13 @@
 //! Each tool maps to one or more operations on the Acteon gateway
 //! via the HTTP client.
 
-use acteon_ops::acteon_client::{AuditQuery, EventQuery, RecurringFilter};
+use acteon_ops::acteon_client::{
+    AuditQuery, CreateProfileRequest, CreateQuotaRequest, CreateRecurringAction,
+    CreateRetentionRequest, CreateTemplateRequest, EventQuery, RecurringFilter,
+    RenderPreviewRequest, ReplayQuery, UpdateProfileRequest, UpdateQuotaRequest,
+    UpdateRecurringAction, UpdateRetentionRequest, UpdateTemplateRequest, VerifyHashChainRequest,
+};
+use acteon_ops::acteon_core::Action;
 use acteon_ops::test_rules;
 use rmcp::{
     ErrorData as McpError,
@@ -12,8 +18,234 @@ use rmcp::{
     schemars, tool, tool_router,
 };
 use serde::Deserialize;
+use std::collections::HashMap;
 
 use crate::server::ActeonMcpServer;
+
+// ---------------------------------------------------------------------------
+// JSON value extraction helpers (for types that only derive Serialize)
+// ---------------------------------------------------------------------------
+
+fn val_str(v: &serde_json::Value, key: &str) -> Result<String, McpError> {
+    v.get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(ToString::to_string)
+        .ok_or_else(|| mcp_err(format!("missing or invalid field '{key}'")))
+}
+
+fn val_opt_str(v: &serde_json::Value, key: &str) -> Option<String> {
+    v.get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(ToString::to_string)
+}
+
+fn val_u64(v: &serde_json::Value, key: &str) -> Result<u64, McpError> {
+    v.get(key)
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| mcp_err(format!("missing or invalid field '{key}'")))
+}
+
+fn val_opt_u64(v: &serde_json::Value, key: &str) -> Option<u64> {
+    v.get(key).and_then(serde_json::Value::as_u64)
+}
+
+fn val_opt_bool(v: &serde_json::Value, key: &str) -> Option<bool> {
+    v.get(key).and_then(serde_json::Value::as_bool)
+}
+
+fn val_bool_or(v: &serde_json::Value, key: &str, default: bool) -> bool {
+    v.get(key)
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(default)
+}
+
+fn val_json(v: &serde_json::Value, key: &str) -> Result<serde_json::Value, McpError> {
+    v.get(key)
+        .cloned()
+        .ok_or_else(|| mcp_err(format!("missing field '{key}'")))
+}
+
+fn val_opt_json(v: &serde_json::Value, key: &str) -> Option<serde_json::Value> {
+    v.get(key).cloned()
+}
+
+fn val_hashmap(v: &serde_json::Value, key: &str) -> HashMap<String, String> {
+    v.get(key)
+        .and_then(serde_json::Value::as_object)
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn val_opt_hashmap_str(v: &serde_json::Value, key: &str) -> Option<HashMap<String, String>> {
+    v.get(key)
+        .and_then(serde_json::Value::as_object)
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+}
+
+fn val_opt_hashmap_json(
+    v: &serde_json::Value,
+    key: &str,
+) -> Option<HashMap<String, serde_json::Value>> {
+    v.get(key)
+        .and_then(serde_json::Value::as_object)
+        .map(|obj| obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+}
+
+fn val_hashmap_json(
+    v: &serde_json::Value,
+    key: &str,
+) -> Result<HashMap<String, serde_json::Value>, McpError> {
+    v.get(key)
+        .and_then(serde_json::Value::as_object)
+        .map(|obj| obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+        .ok_or_else(|| mcp_err(format!("missing or invalid field '{key}'")))
+}
+
+// ---------------------------------------------------------------------------
+// Struct builders from serde_json::Value (for types without Deserialize)
+// ---------------------------------------------------------------------------
+
+fn build_create_recurring(v: &serde_json::Value) -> Result<CreateRecurringAction, McpError> {
+    Ok(CreateRecurringAction {
+        namespace: val_str(v, "namespace")?,
+        tenant: val_str(v, "tenant")?,
+        provider: val_str(v, "provider")?,
+        action_type: val_str(v, "action_type")?,
+        payload: val_json(v, "payload")?,
+        cron_expression: val_str(v, "cron_expression")?,
+        name: val_opt_str(v, "name"),
+        timezone: val_opt_str(v, "timezone"),
+        metadata: val_hashmap(v, "metadata"),
+        end_date: val_opt_str(v, "end_date"),
+        description: val_opt_str(v, "description"),
+        dedup_key: val_opt_str(v, "dedup_key"),
+        labels: val_hashmap(v, "labels"),
+    })
+}
+
+fn build_update_recurring(v: &serde_json::Value) -> Result<UpdateRecurringAction, McpError> {
+    Ok(UpdateRecurringAction {
+        namespace: val_str(v, "namespace")?,
+        tenant: val_str(v, "tenant")?,
+        name: val_opt_str(v, "name"),
+        payload: val_opt_json(v, "payload"),
+        metadata: v.get("metadata").and_then(|v| v.as_object()).map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        }),
+        cron_expression: val_opt_str(v, "cron_expression"),
+        timezone: val_opt_str(v, "timezone"),
+        end_date: val_opt_str(v, "end_date"),
+        description: val_opt_str(v, "description"),
+        dedup_key: val_opt_str(v, "dedup_key"),
+        labels: val_opt_hashmap_str(v, "labels"),
+    })
+}
+
+fn build_create_quota(v: &serde_json::Value) -> Result<CreateQuotaRequest, McpError> {
+    Ok(CreateQuotaRequest {
+        namespace: val_str(v, "namespace")?,
+        tenant: val_str(v, "tenant")?,
+        max_actions: val_u64(v, "max_actions")?,
+        window: val_str(v, "window")?,
+        overage_behavior: val_str(v, "overage_behavior")?,
+        description: val_opt_str(v, "description"),
+        labels: val_opt_hashmap_str(v, "labels"),
+    })
+}
+
+fn build_update_quota(v: &serde_json::Value) -> Result<UpdateQuotaRequest, McpError> {
+    Ok(UpdateQuotaRequest {
+        namespace: val_str(v, "namespace")?,
+        tenant: val_str(v, "tenant")?,
+        max_actions: val_opt_u64(v, "max_actions"),
+        window: val_opt_str(v, "window"),
+        overage_behavior: val_opt_str(v, "overage_behavior"),
+        description: val_opt_str(v, "description"),
+        enabled: val_opt_bool(v, "enabled"),
+    })
+}
+
+fn build_create_retention(v: &serde_json::Value) -> Result<CreateRetentionRequest, McpError> {
+    Ok(CreateRetentionRequest {
+        namespace: val_str(v, "namespace")?,
+        tenant: val_str(v, "tenant")?,
+        audit_ttl_seconds: val_opt_u64(v, "audit_ttl_seconds"),
+        state_ttl_seconds: val_opt_u64(v, "state_ttl_seconds"),
+        event_ttl_seconds: val_opt_u64(v, "event_ttl_seconds"),
+        compliance_hold: val_bool_or(v, "compliance_hold", false),
+        description: val_opt_str(v, "description"),
+        labels: val_opt_hashmap_str(v, "labels"),
+    })
+}
+
+fn build_update_retention(v: &serde_json::Value) -> UpdateRetentionRequest {
+    UpdateRetentionRequest {
+        enabled: val_opt_bool(v, "enabled"),
+        audit_ttl_seconds: val_opt_u64(v, "audit_ttl_seconds"),
+        state_ttl_seconds: val_opt_u64(v, "state_ttl_seconds"),
+        event_ttl_seconds: val_opt_u64(v, "event_ttl_seconds"),
+        compliance_hold: val_opt_bool(v, "compliance_hold"),
+        description: val_opt_str(v, "description"),
+        labels: val_opt_hashmap_str(v, "labels"),
+    }
+}
+
+fn build_create_template(v: &serde_json::Value) -> Result<CreateTemplateRequest, McpError> {
+    Ok(CreateTemplateRequest {
+        name: val_str(v, "name")?,
+        namespace: val_str(v, "namespace")?,
+        tenant: val_str(v, "tenant")?,
+        content: val_str(v, "content")?,
+        description: val_opt_str(v, "description"),
+        labels: val_opt_hashmap_str(v, "labels"),
+    })
+}
+
+fn build_update_template(v: &serde_json::Value) -> UpdateTemplateRequest {
+    UpdateTemplateRequest {
+        content: val_opt_str(v, "content"),
+        description: val_opt_str(v, "description"),
+        labels: val_opt_hashmap_str(v, "labels"),
+    }
+}
+
+fn build_create_profile(v: &serde_json::Value) -> Result<CreateProfileRequest, McpError> {
+    Ok(CreateProfileRequest {
+        name: val_str(v, "name")?,
+        namespace: val_str(v, "namespace")?,
+        tenant: val_str(v, "tenant")?,
+        fields: val_hashmap_json(v, "fields")?,
+        description: val_opt_str(v, "description"),
+        labels: val_opt_hashmap_str(v, "labels"),
+    })
+}
+
+fn build_update_profile(v: &serde_json::Value) -> UpdateProfileRequest {
+    UpdateProfileRequest {
+        fields: val_opt_hashmap_json(v, "fields"),
+        description: val_opt_str(v, "description"),
+        labels: val_opt_hashmap_str(v, "labels"),
+    }
+}
+
+fn build_render_preview(v: &serde_json::Value) -> Result<RenderPreviewRequest, McpError> {
+    Ok(RenderPreviewRequest {
+        profile: val_str(v, "profile")?,
+        namespace: val_str(v, "namespace")?,
+        tenant: val_str(v, "tenant")?,
+        payload: val_json(v, "payload")?,
+    })
+}
 
 // ---------------------------------------------------------------------------
 // Parameter types
@@ -35,6 +267,15 @@ pub struct DispatchParams {
     #[serde(default)]
     pub metadata: std::collections::HashMap<String, String>,
     /// When true, evaluate rules without executing the action.
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct BatchDispatchParams {
+    /// Array of action JSON objects to dispatch.
+    pub actions: Vec<serde_json::Value>,
+    /// When true, evaluate rules without executing the actions.
     #[serde(default)]
     pub dry_run: bool,
 }
@@ -64,6 +305,11 @@ pub struct QueryAuditParams {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListRulesParams {
     // Currently no parameters — lists all rules.
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ReloadRulesParams {
+    // No parameters needed.
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -222,6 +468,235 @@ pub struct TestRulesParams {
     pub filter: Option<String>,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetAuditRecordParams {
+    /// The action ID of the audit record to retrieve.
+    pub action_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ReplayActionParams {
+    /// The action ID to replay from the audit trail.
+    pub action_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ReplayAuditParams {
+    /// Filter by namespace.
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// Filter by tenant.
+    #[serde(default)]
+    pub tenant: Option<String>,
+    /// Filter by provider.
+    #[serde(default)]
+    pub provider: Option<String>,
+    /// Filter by action type.
+    #[serde(default)]
+    pub action_type: Option<String>,
+    /// Maximum number of actions to replay.
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetChainParams {
+    /// Chain instance ID.
+    pub chain_id: String,
+    /// Namespace.
+    pub namespace: String,
+    /// Tenant.
+    pub tenant: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct CancelChainParams {
+    /// Chain instance ID.
+    pub chain_id: String,
+    /// Namespace.
+    pub namespace: String,
+    /// Tenant.
+    pub tenant: String,
+    /// Optional cancellation reason.
+    #[serde(default)]
+    pub reason: Option<String>,
+    /// Optional identifier of who cancelled.
+    #[serde(default)]
+    pub cancelled_by: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetChainDagParams {
+    /// Chain instance ID (provide this OR name, not both).
+    #[serde(default)]
+    pub chain_id: Option<String>,
+    /// Chain definition name (provide this OR `chain_id`, not both).
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Namespace (required when using `chain_id`).
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// Tenant (required when using `chain_id`).
+    #[serde(default)]
+    pub tenant: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ManageChainDefinitionsParams {
+    /// Action to perform: "list", "get", "put", "delete".
+    pub action: String,
+    /// Chain definition name (required for get, put, delete).
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Chain configuration JSON (required for put).
+    #[serde(default)]
+    pub config: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ManageRecurringParams {
+    /// Action to perform: "list", "get", "create", "update", "delete", "pause", "resume".
+    pub action: String,
+    /// Recurring action ID (required for get, update, delete, pause, resume).
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Namespace (required for list, get, delete, pause, resume).
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// Tenant (required for list, get, delete, pause, resume).
+    #[serde(default)]
+    pub tenant: Option<String>,
+    /// Status filter for list (e.g. "active", "paused").
+    #[serde(default)]
+    pub status: Option<String>,
+    /// JSON data for create or update operations.
+    #[serde(default)]
+    pub data: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ManageQuotasParams {
+    /// Action to perform: "list", "get", "create", "update", "delete", "usage".
+    pub action: String,
+    /// Quota ID (required for get, update, delete, usage).
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Namespace filter for list; required for delete.
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// Tenant filter for list; required for delete.
+    #[serde(default)]
+    pub tenant: Option<String>,
+    /// JSON data for create or update operations.
+    #[serde(default)]
+    pub data: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ManageRetentionParams {
+    /// Action to perform: "list", "get", "create", "update", "delete".
+    pub action: String,
+    /// Retention policy ID (required for get, update, delete).
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Namespace filter for list.
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// Tenant filter for list.
+    #[serde(default)]
+    pub tenant: Option<String>,
+    /// JSON data for create or update operations.
+    #[serde(default)]
+    pub data: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ManageTemplatesParams {
+    /// Action to perform: "list", "get", "create", "update", "delete".
+    pub action: String,
+    /// Template ID (required for get, update, delete).
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Namespace filter for list.
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// Tenant filter for list.
+    #[serde(default)]
+    pub tenant: Option<String>,
+    /// JSON data for create or update operations.
+    #[serde(default)]
+    pub data: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ManageTemplateProfilesParams {
+    /// Action to perform: "list", "get", "create", "update", "delete", "render".
+    pub action: String,
+    /// Profile ID (required for get, update, delete).
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Namespace filter for list.
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// Tenant filter for list.
+    #[serde(default)]
+    pub tenant: Option<String>,
+    /// JSON data for create, update, or render operations.
+    #[serde(default)]
+    pub data: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ManagePluginsParams {
+    /// Action to perform: "list", "delete".
+    pub action: String,
+    /// Plugin name (required for delete).
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ManageGroupsParams {
+    /// Action to perform: "list", "get", "flush".
+    pub action: String,
+    /// Group key (required for get, flush).
+    #[serde(default)]
+    pub key: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ManageDlqParams {
+    /// Action to perform: "stats", "drain".
+    pub action: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ComplianceStatusParams {
+    /// Action to perform: "status" (default) or "verify".
+    #[serde(default = "default_status_action")]
+    pub action: String,
+    /// JSON data for verify action (`VerifyHashChainRequest`).
+    #[serde(default)]
+    pub data: Option<serde_json::Value>,
+}
+
+fn default_status_action() -> String {
+    "status".to_string()
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ProviderHealthParams {
+    // No params.
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListApprovalsParams {
+    /// Namespace.
+    pub namespace: String,
+    /// Tenant.
+    pub tenant: String,
+}
+
 // ---------------------------------------------------------------------------
 // Tool implementations
 // ---------------------------------------------------------------------------
@@ -271,6 +746,30 @@ impl ActeonMcpServer {
         }
     }
 
+    /// Dispatch a batch of actions through the gateway.
+    #[tool(
+        description = "Dispatch multiple actions in a single batch. Each element in 'actions' is a full action JSON object. Set dry_run=true to preview."
+    )]
+    async fn batch_dispatch(
+        &self,
+        Parameters(p): Parameters<BatchDispatchParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let actions: Vec<Action> = p
+            .actions
+            .into_iter()
+            .map(serde_json::from_value)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| mcp_err(format!("failed to parse actions: {e}")))?;
+
+        match self.ops.dispatch_batch(&actions, p.dry_run).await {
+            Ok(resp) => {
+                let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
     /// Search the audit trail for historical events. Returns recent dispatch
     /// records filtered by tenant, provider, action type, or outcome.
     #[tool(
@@ -299,6 +798,66 @@ impl ActeonMcpServer {
         }
     }
 
+    /// Get a single audit record by action ID.
+    #[tool(description = "Retrieve a single audit record by its action ID.")]
+    async fn get_audit_record(
+        &self,
+        Parameters(p): Parameters<GetAuditRecordParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.ops.get_audit_record(&p.action_id).await {
+            Ok(resp) => {
+                let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// Replay a single action from the audit trail.
+    #[tool(description = "Replay a previously dispatched action by its action ID.")]
+    async fn replay_action(
+        &self,
+        Parameters(p): Parameters<ReplayActionParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.ops.replay_action(&p.action_id).await {
+            Ok(resp) => {
+                let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// Replay multiple actions matching a query filter.
+    #[tool(
+        description = "Replay multiple actions from the audit trail matching optional filters (namespace, tenant, provider, action_type, limit)."
+    )]
+    async fn replay_audit(
+        &self,
+        Parameters(p): Parameters<ReplayAuditParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let query = ReplayQuery {
+            namespace: p.namespace,
+            tenant: p.tenant,
+            provider: p.provider,
+            action_type: p.action_type,
+            outcome: None,
+            verdict: None,
+            matched_rule: None,
+            from: None,
+            to: None,
+            limit: p.limit,
+        };
+
+        match self.ops.replay_audit(query).await {
+            Ok(resp) => {
+                let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
     /// List all loaded routing rules. Shows rule name, priority, enabled
     /// status, and description.
     #[tool(description = "List all active routing and filtering rules loaded in the gateway.")]
@@ -309,6 +868,21 @@ impl ActeonMcpServer {
         match self.ops.list_rules().await {
             Ok(rules) => {
                 let json = serde_json::to_string_pretty(&rules).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// Reload rules from the configured rule source.
+    #[tool(description = "Reload all routing rules from the YAML directory or configured source.")]
+    async fn reload_rules(
+        &self,
+        Parameters(_p): Parameters<ReloadRulesParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.ops.reload_rules().await {
+            Ok(resp) => {
+                let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
                 Ok(CallToolResult::success(vec![Content::text(json)]))
             }
             Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
@@ -409,6 +983,149 @@ impl ActeonMcpServer {
         }
     }
 
+    /// Get the full details of a chain instance.
+    #[tool(description = "Get the full details of a chain instance by ID, namespace, and tenant.")]
+    async fn get_chain(
+        &self,
+        Parameters(p): Parameters<GetChainParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .ops
+            .get_chain(&p.chain_id, &p.namespace, &p.tenant)
+            .await
+        {
+            Ok(resp) => {
+                let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// Cancel a running chain.
+    #[tool(description = "Cancel a running chain by ID with an optional reason.")]
+    async fn cancel_chain(
+        &self,
+        Parameters(p): Parameters<CancelChainParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .ops
+            .cancel_chain(
+                &p.chain_id,
+                &p.namespace,
+                &p.tenant,
+                p.reason.as_deref(),
+                p.cancelled_by.as_deref(),
+            )
+            .await
+        {
+            Ok(resp) => {
+                let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// Get the DAG visualization for a chain instance or definition.
+    #[tool(
+        description = "Get the DAG (directed acyclic graph) for a chain. Provide chain_id+namespace+tenant for an instance, or name for a definition."
+    )]
+    async fn get_chain_dag(
+        &self,
+        Parameters(p): Parameters<GetChainDagParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let result = if let Some(ref chain_id) = p.chain_id {
+            let ns = p
+                .namespace
+                .as_deref()
+                .ok_or_else(|| mcp_err("'namespace' is required when using chain_id"))?;
+            let tenant = p
+                .tenant
+                .as_deref()
+                .ok_or_else(|| mcp_err("'tenant' is required when using chain_id"))?;
+            self.ops.get_chain_dag(chain_id, ns, tenant).await
+        } else if let Some(ref name) = p.name {
+            self.ops.get_chain_definition_dag(name).await
+        } else {
+            return Ok(CallToolResult::error(vec![Content::text(
+                "Either 'chain_id' or 'name' must be provided.",
+            )]));
+        };
+
+        match result {
+            Ok(resp) => {
+                let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// Manage chain definitions (list, get, put, delete).
+    #[tool(
+        description = "Manage chain definitions. Actions: list, get, put (create/update), delete. Provide 'name' for get/put/delete, 'config' JSON for put."
+    )]
+    async fn manage_chain_definitions(
+        &self,
+        Parameters(p): Parameters<ManageChainDefinitionsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match p.action.as_str() {
+            "list" => match self.ops.list_chain_definitions().await {
+                Ok(resp) => {
+                    let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                    Ok(CallToolResult::success(vec![Content::text(json)]))
+                }
+                Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+            },
+            "get" => {
+                let name = p
+                    .name
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'name' is required for get"))?;
+                match self.ops.get_chain_definition(name).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "put" => {
+                let name = p
+                    .name
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'name' is required for put"))?;
+                let config = p
+                    .config
+                    .as_ref()
+                    .ok_or_else(|| mcp_err("'config' is required for put"))?;
+                match self.ops.put_chain_definition(name, config).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "delete" => {
+                let name = p
+                    .name
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'name' is required for delete"))?;
+                match self.ops.delete_chain_definition(name).await {
+                    Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Chain definition '{name}' deleted."
+                    ))])),
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            other => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Unknown action: {other}. Valid: list, get, put, delete"
+            ))])),
+        }
+    }
+
     /// Enable or disable a routing rule by name.
     #[tool(description = "Enable or disable a routing rule by name.")]
     async fn set_rule_enabled(
@@ -460,7 +1177,7 @@ impl ActeonMcpServer {
             ..Default::default()
         };
 
-        match self.ops.client().list_recurring(&filter).await {
+        match self.ops.list_recurring(&filter).await {
             Ok(resp) => {
                 let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
                 Ok(CallToolResult::success(vec![Content::text(json)]))
@@ -475,7 +1192,7 @@ impl ActeonMcpServer {
         &self,
         Parameters(_p): Parameters<ListGroupsParams>,
     ) -> Result<CallToolResult, McpError> {
-        match self.ops.client().list_groups().await {
+        match self.ops.list_groups().await {
             Ok(resp) => {
                 let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
                 Ok(CallToolResult::success(vec![Content::text(json)]))
@@ -492,7 +1209,6 @@ impl ActeonMcpServer {
     ) -> Result<CallToolResult, McpError> {
         match self
             .ops
-            .client()
             .list_quotas(p.namespace.as_deref(), p.tenant.as_deref())
             .await
         {
@@ -635,6 +1351,668 @@ impl ActeonMcpServer {
         };
 
         match result {
+            Ok(resp) => {
+                let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// Manage recurring actions (CRUD + pause/resume).
+    #[tool(
+        description = "Manage recurring actions. Actions: list, get, create, update, delete, pause, resume. Provide namespace/tenant for list; id+namespace+tenant for get/delete/pause/resume; data JSON for create/update."
+    )]
+    async fn manage_recurring(
+        &self,
+        Parameters(p): Parameters<ManageRecurringParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match p.action.as_str() {
+            "list" => {
+                let filter = RecurringFilter {
+                    namespace: p.namespace.unwrap_or_default(),
+                    tenant: p.tenant.unwrap_or_default(),
+                    status: p.status,
+                    ..Default::default()
+                };
+                match self.ops.list_recurring(&filter).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "get" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for get"))?;
+                let ns = p
+                    .namespace
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'namespace' is required for get"))?;
+                let tenant = p
+                    .tenant
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'tenant' is required for get"))?;
+                match self.ops.get_recurring(id, ns, tenant).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "create" => {
+                let data = p
+                    .data
+                    .ok_or_else(|| mcp_err("'data' is required for create"))?;
+                let req = build_create_recurring(&data)?;
+                match self.ops.create_recurring(&req).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "update" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for update"))?;
+                let data = p
+                    .data
+                    .ok_or_else(|| mcp_err("'data' is required for update"))?;
+                let update = build_update_recurring(&data)?;
+                match self.ops.update_recurring(id, &update).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "delete" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for delete"))?;
+                let ns = p
+                    .namespace
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'namespace' is required for delete"))?;
+                let tenant = p
+                    .tenant
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'tenant' is required for delete"))?;
+                match self.ops.delete_recurring(id, ns, tenant).await {
+                    Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Recurring action '{id}' deleted."
+                    ))])),
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "pause" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for pause"))?;
+                let ns = p
+                    .namespace
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'namespace' is required for pause"))?;
+                let tenant = p
+                    .tenant
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'tenant' is required for pause"))?;
+                match self.ops.pause_recurring(id, ns, tenant).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "resume" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for resume"))?;
+                let ns = p
+                    .namespace
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'namespace' is required for resume"))?;
+                let tenant = p
+                    .tenant
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'tenant' is required for resume"))?;
+                match self.ops.resume_recurring(id, ns, tenant).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            other => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Unknown action: {other}. Valid: list, get, create, update, delete, pause, resume"
+            ))])),
+        }
+    }
+
+    /// Manage quota policies (CRUD + usage).
+    #[tool(
+        description = "Manage quota policies. Actions: list, get, create, update, delete, usage. Provide namespace/tenant for list/delete; id for get/update/delete/usage; data JSON for create/update."
+    )]
+    async fn manage_quotas(
+        &self,
+        Parameters(p): Parameters<ManageQuotasParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match p.action.as_str() {
+            "list" => {
+                match self
+                    .ops
+                    .list_quotas(p.namespace.as_deref(), p.tenant.as_deref())
+                    .await
+                {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "get" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for get"))?;
+                match self.ops.get_quota(id).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "create" => {
+                let data = p
+                    .data
+                    .ok_or_else(|| mcp_err("'data' is required for create"))?;
+                let req = build_create_quota(&data)?;
+                match self.ops.create_quota(&req).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "update" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for update"))?;
+                let data = p
+                    .data
+                    .ok_or_else(|| mcp_err("'data' is required for update"))?;
+                let update = build_update_quota(&data)?;
+                match self.ops.update_quota(id, &update).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "delete" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for delete"))?;
+                let ns = p
+                    .namespace
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'namespace' is required for delete"))?;
+                let tenant = p
+                    .tenant
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'tenant' is required for delete"))?;
+                match self.ops.delete_quota(id, ns, tenant).await {
+                    Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Quota '{id}' deleted."
+                    ))])),
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "usage" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for usage"))?;
+                match self.ops.get_quota_usage(id).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            other => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Unknown action: {other}. Valid: list, get, create, update, delete, usage"
+            ))])),
+        }
+    }
+
+    /// Manage data retention policies (CRUD).
+    #[tool(
+        description = "Manage data retention policies. Actions: list, get, create, update, delete. Provide namespace/tenant for list; id for get/update/delete; data JSON for create/update."
+    )]
+    async fn manage_retention(
+        &self,
+        Parameters(p): Parameters<ManageRetentionParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match p.action.as_str() {
+            "list" => match self.ops.list_retention(p.namespace, p.tenant).await {
+                Ok(resp) => {
+                    let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                    Ok(CallToolResult::success(vec![Content::text(json)]))
+                }
+                Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+            },
+            "get" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for get"))?;
+                match self.ops.get_retention(id).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "create" => {
+                let data = p
+                    .data
+                    .ok_or_else(|| mcp_err("'data' is required for create"))?;
+                let req = build_create_retention(&data)?;
+                match self.ops.create_retention(&req).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "update" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for update"))?;
+                let data = p
+                    .data
+                    .ok_or_else(|| mcp_err("'data' is required for update"))?;
+                let update = build_update_retention(&data);
+                match self.ops.update_retention(id, &update).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "delete" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for delete"))?;
+                match self.ops.delete_retention(id).await {
+                    Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Retention policy '{id}' deleted."
+                    ))])),
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            other => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Unknown action: {other}. Valid: list, get, create, update, delete"
+            ))])),
+        }
+    }
+
+    /// Manage payload templates (CRUD).
+    #[tool(
+        description = "Manage payload templates. Actions: list, get, create, update, delete. Provide namespace/tenant for list; id for get/update/delete; data JSON for create/update."
+    )]
+    async fn manage_templates(
+        &self,
+        Parameters(p): Parameters<ManageTemplatesParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match p.action.as_str() {
+            "list" => {
+                match self
+                    .ops
+                    .list_templates(p.namespace.as_deref(), p.tenant.as_deref())
+                    .await
+                {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "get" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for get"))?;
+                match self.ops.get_template(id).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "create" => {
+                let data = p
+                    .data
+                    .ok_or_else(|| mcp_err("'data' is required for create"))?;
+                let req = build_create_template(&data)?;
+                match self.ops.create_template(&req).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "update" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for update"))?;
+                let data = p
+                    .data
+                    .ok_or_else(|| mcp_err("'data' is required for update"))?;
+                let update = build_update_template(&data);
+                match self.ops.update_template(id, &update).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "delete" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for delete"))?;
+                match self.ops.delete_template(id).await {
+                    Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Template '{id}' deleted."
+                    ))])),
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            other => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Unknown action: {other}. Valid: list, get, create, update, delete"
+            ))])),
+        }
+    }
+
+    /// Manage template profiles (CRUD + render preview).
+    #[tool(
+        description = "Manage template profiles. Actions: list, get, create, update, delete, render. Provide namespace/tenant for list; id for get/update/delete; data JSON for create/update/render."
+    )]
+    async fn manage_template_profiles(
+        &self,
+        Parameters(p): Parameters<ManageTemplateProfilesParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match p.action.as_str() {
+            "list" => {
+                match self
+                    .ops
+                    .list_profiles(p.namespace.as_deref(), p.tenant.as_deref())
+                    .await
+                {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "get" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for get"))?;
+                match self.ops.get_profile(id).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "create" => {
+                let data = p
+                    .data
+                    .ok_or_else(|| mcp_err("'data' is required for create"))?;
+                let req = build_create_profile(&data)?;
+                match self.ops.create_profile(&req).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "update" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for update"))?;
+                let data = p
+                    .data
+                    .ok_or_else(|| mcp_err("'data' is required for update"))?;
+                let update = build_update_profile(&data);
+                match self.ops.update_profile(id, &update).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "delete" => {
+                let id =
+                    p.id.as_deref()
+                        .ok_or_else(|| mcp_err("'id' is required for delete"))?;
+                match self.ops.delete_profile(id).await {
+                    Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Template profile '{id}' deleted."
+                    ))])),
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "render" => {
+                let data = p
+                    .data
+                    .ok_or_else(|| mcp_err("'data' is required for render"))?;
+                let req = build_render_preview(&data)?;
+                match self.ops.render_preview(&req).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            other => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Unknown action: {other}. Valid: list, get, create, update, delete, render"
+            ))])),
+        }
+    }
+
+    /// Manage WASM plugins (list, delete).
+    #[tool(description = "Manage WASM plugins. Actions: list, delete. Provide 'name' for delete.")]
+    async fn manage_plugins(
+        &self,
+        Parameters(p): Parameters<ManagePluginsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match p.action.as_str() {
+            "list" => match self.ops.list_plugins().await {
+                Ok(resp) => {
+                    let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                    Ok(CallToolResult::success(vec![Content::text(json)]))
+                }
+                Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+            },
+            "delete" => {
+                let name = p
+                    .name
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'name' is required for delete"))?;
+                match self.ops.delete_plugin(name).await {
+                    Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Plugin '{name}' deleted."
+                    ))])),
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            other => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Unknown action: {other}. Valid: list, delete"
+            ))])),
+        }
+    }
+
+    /// Manage event groups (list, get, flush).
+    #[tool(
+        description = "Manage event groups. Actions: list, get, flush. Provide 'key' for get/flush."
+    )]
+    async fn manage_groups(
+        &self,
+        Parameters(p): Parameters<ManageGroupsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match p.action.as_str() {
+            "list" => match self.ops.list_groups().await {
+                Ok(resp) => {
+                    let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                    Ok(CallToolResult::success(vec![Content::text(json)]))
+                }
+                Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+            },
+            "get" => {
+                let key = p
+                    .key
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'key' is required for get"))?;
+                match self.ops.get_group(key).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            "flush" => {
+                let key = p
+                    .key
+                    .as_deref()
+                    .ok_or_else(|| mcp_err("'key' is required for flush"))?;
+                match self.ops.flush_group(key).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            other => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Unknown action: {other}. Valid: list, get, flush"
+            ))])),
+        }
+    }
+
+    /// Manage the dead letter queue (stats, drain).
+    #[tool(
+        description = "Manage the dead letter queue. Actions: stats (view statistics), drain (reprocess all DLQ entries)."
+    )]
+    async fn manage_dlq(
+        &self,
+        Parameters(p): Parameters<ManageDlqParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match p.action.as_str() {
+            "stats" => match self.ops.dlq_stats().await {
+                Ok(resp) => {
+                    let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                    Ok(CallToolResult::success(vec![Content::text(json)]))
+                }
+                Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+            },
+            "drain" => match self.ops.dlq_drain().await {
+                Ok(resp) => {
+                    let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                    Ok(CallToolResult::success(vec![Content::text(json)]))
+                }
+                Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+            },
+            other => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Unknown action: {other}. Valid: stats, drain"
+            ))])),
+        }
+    }
+
+    /// Check compliance status or verify audit hash chain integrity.
+    #[tool(
+        description = "Check compliance status or verify audit hash chain integrity. Actions: status (default), verify (requires data with VerifyHashChainRequest)."
+    )]
+    async fn compliance_status(
+        &self,
+        Parameters(p): Parameters<ComplianceStatusParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match p.action.as_str() {
+            "status" => match self.ops.get_compliance_status().await {
+                Ok(resp) => {
+                    let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                    Ok(CallToolResult::success(vec![Content::text(json)]))
+                }
+                Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+            },
+            "verify" => {
+                let data = p
+                    .data
+                    .ok_or_else(|| mcp_err("'data' is required for verify"))?;
+                let req: VerifyHashChainRequest = serde_json::from_value(data)
+                    .map_err(|e| mcp_err(format!("invalid data: {e}")))?;
+                match self.ops.verify_audit_chain(&req).await {
+                    Ok(resp) => {
+                        let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                }
+            }
+            other => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Unknown action: {other}. Valid: status, verify"
+            ))])),
+        }
+    }
+
+    /// Get health status for all configured providers.
+    #[tool(
+        description = "Get health status, latency metrics, and circuit breaker state for all configured providers."
+    )]
+    async fn provider_health(
+        &self,
+        Parameters(_p): Parameters<ProviderHealthParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.ops.list_provider_health().await {
+            Ok(resp) => {
+                let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
+    }
+
+    /// List pending approvals for a namespace and tenant.
+    #[tool(description = "List pending approval requests for a namespace and tenant.")]
+    async fn list_approvals(
+        &self,
+        Parameters(p): Parameters<ListApprovalsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.ops.list_approvals(&p.namespace, &p.tenant).await {
             Ok(resp) => {
                 let json = serde_json::to_string_pretty(&resp).map_err(mcp_err)?;
                 Ok(CallToolResult::success(vec![Content::text(json)]))

--- a/crates/ops/src/lib.rs
+++ b/crates/ops/src/lib.rs
@@ -11,13 +11,24 @@ pub use config::OpsConfig;
 pub use error::OpsError;
 
 use acteon_client::{
-    ActeonClient, ActeonClientBuilder, AuditPage, AuditQuery, EvaluateRulesOptions,
-    EventListResponse, EventQuery, ListChainsResponse, RuleEvaluationTrace, RuleInfo,
-    TransitionResponse,
+    ActeonClient, ActeonClientBuilder, ApprovalListResponse, AuditPage, AuditQuery, AuditRecord,
+    BatchResult, ChainDetailResponse, ComplianceStatus, CreateProfileRequest, CreateQuotaRequest,
+    CreateRecurringAction, CreateRecurringResponse, CreateRetentionRequest, CreateTemplateRequest,
+    DagResponse, DlqDrainResponse, DlqStatsResponse, EvaluateRulesOptions, EventListResponse,
+    EventQuery, EventState, FlushGroupResponse, GroupDetail, GroupListResponse,
+    HashChainVerification, ListChainDefinitionsResponse, ListChainsResponse, ListPluginsResponse,
+    ListProfilesResponse, ListQuotasResponse, ListRecurringResponse, ListTemplatesResponse,
+    QuotaPolicy, QuotaUsage, RecurringDetail, RecurringFilter, ReloadResult, RenderPreviewRequest,
+    RenderPreviewResponse, ReplayQuery, ReplayResult, ReplaySummary, RetentionPolicy,
+    RuleEvaluationTrace, RuleInfo, TemplateInfo, TemplateProfileInfo, TransitionResponse,
+    UpdateProfileRequest, UpdateQuotaRequest, UpdateRecurringAction, UpdateRetentionRequest,
+    UpdateTemplateRequest, VerifyHashChainRequest,
 };
 use acteon_core::{
     Action, ActionOutcome, CircuitBreakerActionResponse, ListCircuitBreakersResponse,
+    ListProviderHealthResponse,
 };
+use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -210,5 +221,453 @@ impl OpsClient {
         provider: String,
     ) -> Result<CircuitBreakerActionResponse, OpsError> {
         Ok(self.inner.reset_circuit_breaker(&provider).await?)
+    }
+
+    // =========================================================================
+    // Dispatch — batch
+    // =========================================================================
+
+    /// Dispatch a batch of actions.
+    pub async fn dispatch_batch(
+        &self,
+        actions: &[Action],
+        dry_run: bool,
+    ) -> Result<Vec<BatchResult>, OpsError> {
+        let result = if dry_run {
+            self.inner.dispatch_batch_dry_run(actions).await?
+        } else {
+            self.inner.dispatch_batch(actions).await?
+        };
+        Ok(result)
+    }
+
+    // =========================================================================
+    // Rules — reload
+    // =========================================================================
+
+    /// Reload rules from the YAML directory.
+    pub async fn reload_rules(&self) -> Result<ReloadResult, OpsError> {
+        Ok(self.inner.reload_rules().await?)
+    }
+
+    // =========================================================================
+    // Audit — get record, replay
+    // =========================================================================
+
+    /// Get a single audit record by action ID.
+    pub async fn get_audit_record(&self, action_id: &str) -> Result<Option<AuditRecord>, OpsError> {
+        Ok(self.inner.get_audit_record(action_id).await?)
+    }
+
+    /// Replay a single action from the audit trail.
+    pub async fn replay_action(&self, action_id: &str) -> Result<ReplayResult, OpsError> {
+        Ok(self.inner.replay_action(action_id).await?)
+    }
+
+    /// Replay multiple actions matching a query.
+    pub async fn replay_audit(&self, query: ReplayQuery) -> Result<ReplaySummary, OpsError> {
+        Ok(self.inner.replay_audit(&query).await?)
+    }
+
+    // =========================================================================
+    // Events — get single
+    // =========================================================================
+
+    /// Get a single event by fingerprint.
+    pub async fn get_event(
+        &self,
+        fingerprint: &str,
+        namespace: &str,
+        tenant: &str,
+    ) -> Result<Option<EventState>, OpsError> {
+        Ok(self.inner.get_event(fingerprint, namespace, tenant).await?)
+    }
+
+    // =========================================================================
+    // Chains — get, cancel, DAG, definitions CRUD
+    // =========================================================================
+
+    /// Get the full details of a chain by ID.
+    pub async fn get_chain(
+        &self,
+        chain_id: &str,
+        namespace: &str,
+        tenant: &str,
+    ) -> Result<ChainDetailResponse, OpsError> {
+        Ok(self.inner.get_chain(chain_id, namespace, tenant).await?)
+    }
+
+    /// Cancel a running chain.
+    pub async fn cancel_chain(
+        &self,
+        chain_id: &str,
+        namespace: &str,
+        tenant: &str,
+        reason: Option<&str>,
+        cancelled_by: Option<&str>,
+    ) -> Result<ChainDetailResponse, OpsError> {
+        Ok(self
+            .inner
+            .cancel_chain(chain_id, namespace, tenant, reason, cancelled_by)
+            .await?)
+    }
+
+    /// Get the DAG for a chain instance.
+    pub async fn get_chain_dag(
+        &self,
+        chain_id: &str,
+        namespace: &str,
+        tenant: &str,
+    ) -> Result<DagResponse, OpsError> {
+        Ok(self
+            .inner
+            .get_chain_dag(chain_id, namespace, tenant)
+            .await?)
+    }
+
+    /// Get the DAG for a chain definition.
+    pub async fn get_chain_definition_dag(&self, name: &str) -> Result<DagResponse, OpsError> {
+        Ok(self.inner.get_chain_definition_dag(name).await?)
+    }
+
+    /// List all chain definitions.
+    pub async fn list_chain_definitions(&self) -> Result<ListChainDefinitionsResponse, OpsError> {
+        Ok(self.inner.list_chain_definitions().await?)
+    }
+
+    /// Get a chain definition by name.
+    pub async fn get_chain_definition(&self, name: &str) -> Result<Value, OpsError> {
+        Ok(self.inner.get_chain_definition(name).await?)
+    }
+
+    /// Create or update a chain definition.
+    pub async fn put_chain_definition(
+        &self,
+        name: &str,
+        config: &Value,
+    ) -> Result<Value, OpsError> {
+        Ok(self.inner.put_chain_definition(name, config).await?)
+    }
+
+    /// Delete a chain definition.
+    pub async fn delete_chain_definition(&self, name: &str) -> Result<(), OpsError> {
+        Ok(self.inner.delete_chain_definition(name).await?)
+    }
+
+    // =========================================================================
+    // Recurring actions
+    // =========================================================================
+
+    /// Create a recurring action.
+    pub async fn create_recurring(
+        &self,
+        req: &CreateRecurringAction,
+    ) -> Result<CreateRecurringResponse, OpsError> {
+        Ok(self.inner.create_recurring(req).await?)
+    }
+
+    /// List recurring actions.
+    pub async fn list_recurring(
+        &self,
+        filter: &RecurringFilter,
+    ) -> Result<ListRecurringResponse, OpsError> {
+        Ok(self.inner.list_recurring(filter).await?)
+    }
+
+    /// Get a recurring action by ID.
+    pub async fn get_recurring(
+        &self,
+        id: &str,
+        namespace: &str,
+        tenant: &str,
+    ) -> Result<Option<RecurringDetail>, OpsError> {
+        Ok(self.inner.get_recurring(id, namespace, tenant).await?)
+    }
+
+    /// Update a recurring action.
+    pub async fn update_recurring(
+        &self,
+        id: &str,
+        update: &UpdateRecurringAction,
+    ) -> Result<RecurringDetail, OpsError> {
+        Ok(self.inner.update_recurring(id, update).await?)
+    }
+
+    /// Delete a recurring action.
+    pub async fn delete_recurring(
+        &self,
+        id: &str,
+        namespace: &str,
+        tenant: &str,
+    ) -> Result<(), OpsError> {
+        Ok(self.inner.delete_recurring(id, namespace, tenant).await?)
+    }
+
+    /// Pause a recurring action.
+    pub async fn pause_recurring(
+        &self,
+        id: &str,
+        namespace: &str,
+        tenant: &str,
+    ) -> Result<RecurringDetail, OpsError> {
+        Ok(self.inner.pause_recurring(id, namespace, tenant).await?)
+    }
+
+    /// Resume a recurring action.
+    pub async fn resume_recurring(
+        &self,
+        id: &str,
+        namespace: &str,
+        tenant: &str,
+    ) -> Result<RecurringDetail, OpsError> {
+        Ok(self.inner.resume_recurring(id, namespace, tenant).await?)
+    }
+
+    // =========================================================================
+    // Quotas
+    // =========================================================================
+
+    /// Create a quota policy.
+    pub async fn create_quota(&self, req: &CreateQuotaRequest) -> Result<QuotaPolicy, OpsError> {
+        Ok(self.inner.create_quota(req).await?)
+    }
+
+    /// List quota policies.
+    pub async fn list_quotas(
+        &self,
+        namespace: Option<&str>,
+        tenant: Option<&str>,
+    ) -> Result<ListQuotasResponse, OpsError> {
+        Ok(self.inner.list_quotas(namespace, tenant).await?)
+    }
+
+    /// Get a quota policy by ID.
+    pub async fn get_quota(&self, id: &str) -> Result<Option<QuotaPolicy>, OpsError> {
+        Ok(self.inner.get_quota(id).await?)
+    }
+
+    /// Update a quota policy.
+    pub async fn update_quota(
+        &self,
+        id: &str,
+        update: &UpdateQuotaRequest,
+    ) -> Result<QuotaPolicy, OpsError> {
+        Ok(self.inner.update_quota(id, update).await?)
+    }
+
+    /// Delete a quota policy.
+    pub async fn delete_quota(
+        &self,
+        id: &str,
+        namespace: &str,
+        tenant: &str,
+    ) -> Result<(), OpsError> {
+        Ok(self.inner.delete_quota(id, namespace, tenant).await?)
+    }
+
+    /// Get quota usage.
+    pub async fn get_quota_usage(&self, id: &str) -> Result<QuotaUsage, OpsError> {
+        Ok(self.inner.get_quota_usage(id).await?)
+    }
+
+    // =========================================================================
+    // Retention
+    // =========================================================================
+
+    /// Create a retention policy.
+    pub async fn create_retention(
+        &self,
+        req: &CreateRetentionRequest,
+    ) -> Result<RetentionPolicy, OpsError> {
+        Ok(self.inner.create_retention(req).await?)
+    }
+
+    /// Get a retention policy by ID.
+    pub async fn get_retention(&self, id: &str) -> Result<Option<RetentionPolicy>, OpsError> {
+        Ok(self.inner.get_retention(id).await?)
+    }
+
+    /// Update a retention policy.
+    pub async fn update_retention(
+        &self,
+        id: &str,
+        update: &UpdateRetentionRequest,
+    ) -> Result<RetentionPolicy, OpsError> {
+        Ok(self.inner.update_retention(id, update).await?)
+    }
+
+    /// Delete a retention policy.
+    pub async fn delete_retention(&self, id: &str) -> Result<(), OpsError> {
+        Ok(self.inner.delete_retention(id).await?)
+    }
+
+    // =========================================================================
+    // Templates
+    // =========================================================================
+
+    /// Create a template.
+    pub async fn create_template(
+        &self,
+        req: &CreateTemplateRequest,
+    ) -> Result<TemplateInfo, OpsError> {
+        Ok(self.inner.create_template(req).await?)
+    }
+
+    /// List templates.
+    pub async fn list_templates(
+        &self,
+        namespace: Option<&str>,
+        tenant: Option<&str>,
+    ) -> Result<ListTemplatesResponse, OpsError> {
+        Ok(self.inner.list_templates(namespace, tenant).await?)
+    }
+
+    /// Get a template by ID.
+    pub async fn get_template(&self, id: &str) -> Result<Option<TemplateInfo>, OpsError> {
+        Ok(self.inner.get_template(id).await?)
+    }
+
+    /// Update a template.
+    pub async fn update_template(
+        &self,
+        id: &str,
+        update: &UpdateTemplateRequest,
+    ) -> Result<TemplateInfo, OpsError> {
+        Ok(self.inner.update_template(id, update).await?)
+    }
+
+    /// Delete a template.
+    pub async fn delete_template(&self, id: &str) -> Result<(), OpsError> {
+        Ok(self.inner.delete_template(id).await?)
+    }
+
+    /// Create a template profile.
+    pub async fn create_profile(
+        &self,
+        req: &CreateProfileRequest,
+    ) -> Result<TemplateProfileInfo, OpsError> {
+        Ok(self.inner.create_profile(req).await?)
+    }
+
+    /// List template profiles.
+    pub async fn list_profiles(
+        &self,
+        namespace: Option<&str>,
+        tenant: Option<&str>,
+    ) -> Result<ListProfilesResponse, OpsError> {
+        Ok(self.inner.list_profiles(namespace, tenant).await?)
+    }
+
+    /// Get a template profile by ID.
+    pub async fn get_profile(&self, id: &str) -> Result<Option<TemplateProfileInfo>, OpsError> {
+        Ok(self.inner.get_profile(id).await?)
+    }
+
+    /// Update a template profile.
+    pub async fn update_profile(
+        &self,
+        id: &str,
+        update: &UpdateProfileRequest,
+    ) -> Result<TemplateProfileInfo, OpsError> {
+        Ok(self.inner.update_profile(id, update).await?)
+    }
+
+    /// Delete a template profile.
+    pub async fn delete_profile(&self, id: &str) -> Result<(), OpsError> {
+        Ok(self.inner.delete_profile(id).await?)
+    }
+
+    /// Render a template preview.
+    pub async fn render_preview(
+        &self,
+        req: &RenderPreviewRequest,
+    ) -> Result<RenderPreviewResponse, OpsError> {
+        Ok(self.inner.render_preview(req).await?)
+    }
+
+    // =========================================================================
+    // WASM Plugins
+    // =========================================================================
+
+    /// List WASM plugins.
+    pub async fn list_plugins(&self) -> Result<ListPluginsResponse, OpsError> {
+        Ok(self.inner.list_plugins().await?)
+    }
+
+    /// Delete a WASM plugin.
+    pub async fn delete_plugin(&self, name: &str) -> Result<(), OpsError> {
+        Ok(self.inner.delete_plugin(name).await?)
+    }
+
+    // =========================================================================
+    // Groups
+    // =========================================================================
+
+    /// List event groups.
+    pub async fn list_groups(&self) -> Result<GroupListResponse, OpsError> {
+        Ok(self.inner.list_groups().await?)
+    }
+
+    /// Get an event group by key.
+    pub async fn get_group(&self, key: &str) -> Result<Option<GroupDetail>, OpsError> {
+        Ok(self.inner.get_group(key).await?)
+    }
+
+    /// Flush an event group.
+    pub async fn flush_group(&self, key: &str) -> Result<FlushGroupResponse, OpsError> {
+        Ok(self.inner.flush_group(key).await?)
+    }
+
+    // =========================================================================
+    // DLQ
+    // =========================================================================
+
+    /// Get DLQ statistics.
+    pub async fn dlq_stats(&self) -> Result<DlqStatsResponse, OpsError> {
+        Ok(self.inner.dlq_stats().await?)
+    }
+
+    /// Drain the DLQ.
+    pub async fn dlq_drain(&self) -> Result<DlqDrainResponse, OpsError> {
+        Ok(self.inner.dlq_drain().await?)
+    }
+
+    // =========================================================================
+    // Compliance
+    // =========================================================================
+
+    /// Get compliance status.
+    pub async fn get_compliance_status(&self) -> Result<ComplianceStatus, OpsError> {
+        Ok(self.inner.get_compliance_status().await?)
+    }
+
+    /// Verify audit hash chain integrity.
+    pub async fn verify_audit_chain(
+        &self,
+        req: &VerifyHashChainRequest,
+    ) -> Result<HashChainVerification, OpsError> {
+        Ok(self.inner.verify_audit_chain(req).await?)
+    }
+
+    // =========================================================================
+    // Providers
+    // =========================================================================
+
+    /// List provider health status.
+    pub async fn list_provider_health(&self) -> Result<ListProviderHealthResponse, OpsError> {
+        Ok(self.inner.list_provider_health().await?)
+    }
+
+    // =========================================================================
+    // Approvals
+    // =========================================================================
+
+    /// List pending approvals.
+    pub async fn list_approvals(
+        &self,
+        namespace: &str,
+        tenant: &str,
+    ) -> Result<ApprovalListResponse, OpsError> {
+        Ok(self.inner.list_approvals(namespace, tenant).await?)
     }
 }


### PR DESCRIPTION
## Summary

- **ActeonClient**: Add chain definition CRUD (list/get/put/delete) + `Deserialize` on 11 request types for CLI JSON parsing
- **OpsClient**: Add ~55 wrapper methods spanning all 16 API domains (was ~16 methods)
- **MCP server**: Add 20 new tools + refactor 3 existing → **37 tools total** (was 18)
- **CLI**: Add 11 new command modules + extend audit (subcommands) and rules (reload) → **16 commands total** (was 5)

### New MCP tools

`batch_dispatch`, `reload_rules`, `get_audit_record`, `replay_action`, `replay_audit`, `get_chain`, `cancel_chain`, `get_chain_dag`, `manage_chain_definitions`, `manage_recurring`, `manage_quotas`, `manage_retention`, `manage_templates`, `manage_template_profiles`, `manage_plugins`, `manage_groups`, `manage_dlq`, `compliance_status`, `provider_health`, `list_approvals`

### New CLI commands

`chains` (list/get/cancel/dag/definitions), `recurring` (list/get/create/update/delete/pause/resume), `quotas` (list/get/create/update/delete/usage), `retention` (list/get/create/update/delete), `templates` (list/get/create/update/delete/profiles/render), `plugins` (list/delete), `groups` (list/get/flush), `dlq` (stats/drain), `compliance` (status/verify), `providers` (health), `approvals` (list)

### Excluded from MCP/CLI (by design)

SSE streaming, auth login/logout, metrics/prometheus, admin config, approval approve/reject (HMAC callbacks), embeddings similarity

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --no-deps -- -D warnings` — zero warnings
- [x] `cargo test --workspace --lib --bins --tests` — all tests pass
- [x] `cd ui && npm run lint && npm run build` — clean
- [x] `cargo run -p acteon-cli -- --help` — shows all 16 commands
- [ ] Smoke test new CLI commands against running server
- [ ] Verify MCP tools discoverable via MCP protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)