### PR TITLE
feat: GCP providers — Pub/Sub + Cloud Storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "acteon-gcp"
+version = "0.1.0"
+dependencies = [
+ "acteon-core",
+ "acteon-provider",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "google-cloud-auth",
+ "google-cloud-pubsub",
+ "google-cloud-storage",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "acteon-llm"
 version = "0.1.0"
 dependencies = [
@@ -319,7 +338,7 @@ dependencies = [
  "chrono",
  "clap",
  "rmcp",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -445,6 +464,7 @@ dependencies = [
  "acteon-embedding",
  "acteon-executor",
  "acteon-gateway",
+ "acteon-gcp",
  "acteon-llm",
  "acteon-provider",
  "acteon-rules",
@@ -743,7 +763,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -893,7 +913,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -1984,6 +2004,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -2020,6 +2043,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,6 +2059,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "chrono"
@@ -2319,6 +2359,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cranelift-bforest"
 version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,6 +2500,15 @@ dependencies = [
  "rand 0.9.2",
  "regex",
  "rustversion",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -2612,6 +2670,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -2625,6 +2693,20 @@ name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
  "ident_case",
@@ -2654,6 +2736,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn",
 ]
@@ -3312,6 +3405,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -3342,6 +3436,248 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "google-cloud-auth"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ad774d41426ab205eeec577540f209a5485c366814dd5c89a7e3018fe84e7c"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "google-cloud-gax",
+ "http 1.4.0",
+ "reqwest 0.13.2",
+ "rustc_version",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2973715fe664ecb0d883926c8b5f66cb9d52a44add1d0be1cad1907d832bf0af"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http 1.4.0",
+ "pin-project",
+ "rand 0.10.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-gax-internal"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598e5ffec2c1c9b43e83847b2badc0f128a03e541b75f1ecd8acf0a2605c40cf"
+dependencies = [
+ "bytes",
+ "futures",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "opentelemetry-semantic-conventions",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.14.3",
+ "prost-types",
+ "reqwest 0.13.2",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.14.5",
+ "tonic-prost",
+ "tower 0.5.3",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-iam-v1"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41025359d1f52c24966c24d5ecb7f91198ded13c9cbf57c2d2e735dae93c814"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-type",
+ "google-cloud-wkt",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-longrunning"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daafe6c2859976ca51571db6c7bbf96bdce0122e81e6854a6c62554c4f63bae8"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-lro"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef3969c85cf6b163c655f7ddcdee5bb5c3241f680ab648951239ef9cd4ffb0f"
+dependencies = [
+ "google-cloud-gax",
+ "google-cloud-longrunning",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-pubsub"
+version = "0.32.3-preview"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9606f3714a84048be4b4d1789a22518d19dbf265aac78a25d60847f0472ed1fd"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-iam-v1",
+ "google-cloud-wkt",
+ "http 1.4.0",
+ "lazy_static",
+ "prost 0.14.3",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "google-cloud-rpc"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd10e97751ca894f9dad6be69fcef1cb72f5bc187329e0254817778fc8235030"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ce225eccfece751251e07ac787199cfc53bc2b5d60ac0570f58404507ceb309"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc32c",
+ "futures",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-iam-v1",
+ "google-cloud-longrunning",
+ "google-cloud-lro",
+ "google-cloud-rpc",
+ "google-cloud-type",
+ "google-cloud-wkt",
+ "hex",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
+ "lazy_static",
+ "md5",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.14.3",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "google-cloud-type"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9390ac2f3f9882ff42956b25ea65b9f546c8dd44c131726d75a96bf744ec75f6"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-wkt"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ade65b0e4fa9cb4b6f147c8e726803bff453e3190910a53cbd3b0c019f5c2a"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
 
 [[package]]
 name = "group"
@@ -3855,6 +4191,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -3992,6 +4329,28 @@ checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
@@ -4245,6 +4604,12 @@ dependencies = [
  "cfg-if",
  "digest",
 ]
+
+[[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
@@ -4623,11 +4988,11 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.13.5",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
- "tonic",
+ "tonic 0.12.3",
  "tracing",
 ]
 
@@ -4639,9 +5004,15 @@ checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
- "tonic",
+ "prost 0.13.5",
+ "tonic 0.12.3",
 ]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -4891,7 +5262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4974,7 +5345,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -4988,6 +5369,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -5048,6 +5451,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -5121,6 +5525,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5158,6 +5573,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rayon"
@@ -5390,17 +5811,26 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
  "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.36",
  "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -5459,7 +5889,7 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "rmcp-macros",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -5671,6 +6101,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.36",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.9",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5720,6 +6177,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5988,6 +6457,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6007,7 +6507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -6024,7 +6524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -6759,7 +7259,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "socket2 0.5.10",
  "tokio",
  "tokio-stream",
@@ -6767,6 +7267,44 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "rustls-native-certs 0.8.3",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost 0.14.3",
+ "tonic 0.14.5",
 ]
 
 [[package]]
@@ -6797,9 +7335,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.13.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7737,6 +8278,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7885,6 +8435,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -7926,6 +8485,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7978,6 +8552,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -7996,6 +8576,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -8011,6 +8597,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8044,6 +8636,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -8059,6 +8657,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8080,6 +8684,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -8095,6 +8705,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
+ "dashmap",
  "google-cloud-auth",
  "google-cloud-pubsub",
  "google-cloud-storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ members = [
     # Azure providers
     "crates/azure",
 
+    # GCP providers
+    "crates/gcp",
+
     # Integrations
     "crates/integrations/email",
     "crates/integrations/slack",
@@ -115,6 +118,9 @@ acteon-aws = { path = "crates/aws" }
 
 # Azure providers
 acteon-azure = { path = "crates/azure" }
+
+# GCP providers
+acteon-gcp = { path = "crates/gcp" }
 
 # Integrations
 acteon-email = { path = "crates/integrations/email" }
@@ -187,6 +193,11 @@ azure_core = "0.32"
 azure_identity = "0.32"
 azure_storage_blob = "0.9"
 azure_messaging_eventhubs = "0.11"
+
+# GCP
+google-cloud-pubsub = "=0.32.3-preview"
+google-cloud-storage = "1"
+google-cloud-auth = { version = "1", default-features = false }
 
 # PostgreSQL
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono", "uuid", "tls-rustls"] }

--- a/clients/go/acteon/models.go
+++ b/clients/go/acteon/models.go
@@ -1833,3 +1833,110 @@ func NewAzureEventHubsSendBatchPayloadWithOptions(events []map[string]any, event
 	}
 	return p
 }
+
+// =============================================================================
+// GCP Pub/Sub Provider Payload Helpers
+// =============================================================================
+
+// NewGcpPubSubPublishPayload creates a payload for the GCP Pub/Sub publish action.
+func NewGcpPubSubPublishPayload(data string) map[string]any {
+	return map[string]any{
+		"data": data,
+	}
+}
+
+// NewGcpPubSubPublishPayloadWithOptions creates a GCP Pub/Sub publish payload with optional fields.
+func NewGcpPubSubPublishPayloadWithOptions(data, topic, orderingKey string, attributes map[string]string) map[string]any {
+	p := NewGcpPubSubPublishPayload(data)
+	if topic != "" {
+		p["topic"] = topic
+	}
+	if orderingKey != "" {
+		p["ordering_key"] = orderingKey
+	}
+	if len(attributes) > 0 {
+		p["attributes"] = attributes
+	}
+	return p
+}
+
+// NewGcpPubSubPublishBatchPayload creates a payload for the GCP Pub/Sub publish-batch action.
+func NewGcpPubSubPublishBatchPayload(messages []map[string]any) map[string]any {
+	return map[string]any{
+		"messages": messages,
+	}
+}
+
+// NewGcpPubSubPublishBatchPayloadWithOptions creates a GCP Pub/Sub publish-batch payload with optional fields.
+func NewGcpPubSubPublishBatchPayloadWithOptions(messages []map[string]any, topic string) map[string]any {
+	p := NewGcpPubSubPublishBatchPayload(messages)
+	if topic != "" {
+		p["topic"] = topic
+	}
+	return p
+}
+
+// =============================================================================
+// GCP Cloud Storage Provider Payload Helpers
+// =============================================================================
+
+// NewGcpStorageUploadPayload creates a payload for the GCP Cloud Storage upload-object action.
+func NewGcpStorageUploadPayload(objectName, body string) map[string]any {
+	return map[string]any{
+		"object_name": objectName,
+		"body":        body,
+	}
+}
+
+// NewGcpStorageUploadPayloadWithOptions creates a GCP Cloud Storage upload payload with optional fields.
+func NewGcpStorageUploadPayloadWithOptions(objectName, bucket, body, bodyBase64, contentType string, metadata map[string]string) map[string]any {
+	p := map[string]any{"object_name": objectName}
+	if bucket != "" {
+		p["bucket"] = bucket
+	}
+	if body != "" {
+		p["body"] = body
+	}
+	if bodyBase64 != "" {
+		p["body_base64"] = bodyBase64
+	}
+	if contentType != "" {
+		p["content_type"] = contentType
+	}
+	if len(metadata) > 0 {
+		p["metadata"] = metadata
+	}
+	return p
+}
+
+// NewGcpStorageDownloadPayload creates a payload for the GCP Cloud Storage download-object action.
+func NewGcpStorageDownloadPayload(objectName string) map[string]any {
+	return map[string]any{
+		"object_name": objectName,
+	}
+}
+
+// NewGcpStorageDownloadPayloadWithContainer creates a GCP Cloud Storage download payload with a bucket override.
+func NewGcpStorageDownloadPayloadWithContainer(objectName, bucket string) map[string]any {
+	p := NewGcpStorageDownloadPayload(objectName)
+	if bucket != "" {
+		p["bucket"] = bucket
+	}
+	return p
+}
+
+// NewGcpStorageDeletePayload creates a payload for the GCP Cloud Storage delete-object action.
+func NewGcpStorageDeletePayload(objectName string) map[string]any {
+	return map[string]any{
+		"object_name": objectName,
+	}
+}
+
+// NewGcpStorageDeletePayloadWithContainer creates a GCP Cloud Storage delete payload with a bucket override.
+func NewGcpStorageDeletePayloadWithContainer(objectName, bucket string) map[string]any {
+	p := NewGcpStorageDeletePayload(objectName)
+	if bucket != "" {
+		p["bucket"] = bucket
+	}
+	return p
+}

--- a/clients/java/src/main/java/com/acteon/client/models/GcpPubSubPublishBatchPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/GcpPubSubPublishBatchPayload.java
@@ -1,0 +1,29 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Payload builder for the GCP Pub/Sub publish-batch action ({@code gcp-pubsub}, action type {@code publish_batch}).
+ */
+public class GcpPubSubPublishBatchPayload {
+    private final List<Map<String, Object>> messages;
+    private String topic;
+
+    public GcpPubSubPublishBatchPayload(List<Map<String, Object>> messages) {
+        this.messages = messages;
+    }
+
+    public GcpPubSubPublishBatchPayload withTopic(String topic) {
+        this.topic = topic;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("messages", messages);
+        if (topic != null) payload.put("topic", topic);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/GcpPubSubPublishPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/GcpPubSubPublishPayload.java
@@ -1,0 +1,49 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the GCP Pub/Sub publish action ({@code gcp-pubsub}, action type {@code publish}).
+ */
+public class GcpPubSubPublishPayload {
+    private final String data;
+    private String dataBase64;
+    private Map<String, String> attributes;
+    private String orderingKey;
+    private String topic;
+
+    public GcpPubSubPublishPayload(String data) {
+        this.data = data;
+    }
+
+    public GcpPubSubPublishPayload withDataBase64(String dataBase64) {
+        this.dataBase64 = dataBase64;
+        return this;
+    }
+
+    public GcpPubSubPublishPayload withAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+        return this;
+    }
+
+    public GcpPubSubPublishPayload withOrderingKey(String orderingKey) {
+        this.orderingKey = orderingKey;
+        return this;
+    }
+
+    public GcpPubSubPublishPayload withTopic(String topic) {
+        this.topic = topic;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("data", data);
+        if (dataBase64 != null) payload.put("data_base64", dataBase64);
+        if (attributes != null) payload.put("attributes", attributes);
+        if (orderingKey != null) payload.put("ordering_key", orderingKey);
+        if (topic != null) payload.put("topic", topic);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/GcpStorageDeletePayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/GcpStorageDeletePayload.java
@@ -1,0 +1,28 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the GCP Cloud Storage delete action ({@code gcp-storage}, action type {@code delete_object}).
+ */
+public class GcpStorageDeletePayload {
+    private final String objectName;
+    private String bucket;
+
+    public GcpStorageDeletePayload(String objectName) {
+        this.objectName = objectName;
+    }
+
+    public GcpStorageDeletePayload withBucket(String bucket) {
+        this.bucket = bucket;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("object_name", objectName);
+        if (bucket != null) payload.put("bucket", bucket);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/GcpStorageDownloadPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/GcpStorageDownloadPayload.java
@@ -1,0 +1,28 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the GCP Cloud Storage download action ({@code gcp-storage}, action type {@code download_object}).
+ */
+public class GcpStorageDownloadPayload {
+    private final String objectName;
+    private String bucket;
+
+    public GcpStorageDownloadPayload(String objectName) {
+        this.objectName = objectName;
+    }
+
+    public GcpStorageDownloadPayload withBucket(String bucket) {
+        this.bucket = bucket;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("object_name", objectName);
+        if (bucket != null) payload.put("bucket", bucket);
+        return payload;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/GcpStorageUploadPayload.java
+++ b/clients/java/src/main/java/com/acteon/client/models/GcpStorageUploadPayload.java
@@ -1,0 +1,56 @@
+package com.acteon.client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Payload builder for the GCP Cloud Storage upload action ({@code gcp-storage}, action type {@code upload_object}).
+ */
+public class GcpStorageUploadPayload {
+    private final String objectName;
+    private String bucket;
+    private String body;
+    private String bodyBase64;
+    private String contentType;
+    private Map<String, String> metadata;
+
+    public GcpStorageUploadPayload(String objectName) {
+        this.objectName = objectName;
+    }
+
+    public GcpStorageUploadPayload withBucket(String bucket) {
+        this.bucket = bucket;
+        return this;
+    }
+
+    public GcpStorageUploadPayload withBody(String body) {
+        this.body = body;
+        return this;
+    }
+
+    public GcpStorageUploadPayload withBodyBase64(String bodyBase64) {
+        this.bodyBase64 = bodyBase64;
+        return this;
+    }
+
+    public GcpStorageUploadPayload withContentType(String contentType) {
+        this.contentType = contentType;
+        return this;
+    }
+
+    public GcpStorageUploadPayload withMetadata(Map<String, String> metadata) {
+        this.metadata = metadata;
+        return this;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("object_name", objectName);
+        if (bucket != null) payload.put("bucket", bucket);
+        if (body != null) payload.put("body", body);
+        if (bodyBase64 != null) payload.put("body_base64", bodyBase64);
+        if (contentType != null) payload.put("content_type", contentType);
+        if (metadata != null) payload.put("metadata", metadata);
+        return payload;
+    }
+}

--- a/clients/nodejs/src/models.ts
+++ b/clients/nodejs/src/models.ts
@@ -2875,3 +2875,116 @@ export function createAzureEventHubsSendBatchPayload(
   if (options?.eventHubName) payload.event_hub_name = options.eventHubName;
   return payload;
 }
+
+// =============================================================================
+// GCP Pub/Sub Provider Payload Helpers
+// =============================================================================
+
+/** Payload for the GCP Pub/Sub publish action. */
+export interface GcpPubSubPublishPayload {
+  data: string;
+  data_base64?: string;
+  attributes?: Record<string, string>;
+  ordering_key?: string;
+  topic?: string;
+}
+
+/** Create a payload for the GCP Pub/Sub publish action. */
+export function createGcpPubSubPublishPayload(
+  data: string,
+  options?: {
+    dataBase64?: string;
+    attributes?: Record<string, string>;
+    orderingKey?: string;
+    topic?: string;
+  }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { data };
+  if (options?.dataBase64) payload.data_base64 = options.dataBase64;
+  if (options?.attributes) payload.attributes = options.attributes;
+  if (options?.orderingKey) payload.ordering_key = options.orderingKey;
+  if (options?.topic) payload.topic = options.topic;
+  return payload;
+}
+
+/** Payload for the GCP Pub/Sub publish-batch action. */
+export interface GcpPubSubPublishBatchPayload {
+  messages: Record<string, unknown>[];
+  topic?: string;
+}
+
+/** Create a payload for the GCP Pub/Sub publish-batch action. */
+export function createGcpPubSubPublishBatchPayload(
+  messages: Record<string, unknown>[],
+  options?: { topic?: string }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { messages };
+  if (options?.topic) payload.topic = options.topic;
+  return payload;
+}
+
+// =============================================================================
+// GCP Cloud Storage Provider Payload Helpers
+// =============================================================================
+
+/** Payload for the GCP Cloud Storage upload-object action. */
+export interface GcpStorageUploadPayload {
+  object_name: string;
+  bucket?: string;
+  body?: string;
+  body_base64?: string;
+  content_type?: string;
+  metadata?: Record<string, string>;
+}
+
+/** Create a payload for the GCP Cloud Storage upload-object action. */
+export function createGcpStorageUploadPayload(
+  objectName: string,
+  options?: {
+    bucket?: string;
+    body?: string;
+    bodyBase64?: string;
+    contentType?: string;
+    metadata?: Record<string, string>;
+  }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { object_name: objectName };
+  if (options?.bucket) payload.bucket = options.bucket;
+  if (options?.body !== undefined) payload.body = options.body;
+  if (options?.bodyBase64) payload.body_base64 = options.bodyBase64;
+  if (options?.contentType) payload.content_type = options.contentType;
+  if (options?.metadata) payload.metadata = options.metadata;
+  return payload;
+}
+
+/** Payload for the GCP Cloud Storage download-object action. */
+export interface GcpStorageDownloadPayload {
+  object_name: string;
+  bucket?: string;
+}
+
+/** Create a payload for the GCP Cloud Storage download-object action. */
+export function createGcpStorageDownloadPayload(
+  objectName: string,
+  options?: { bucket?: string }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { object_name: objectName };
+  if (options?.bucket) payload.bucket = options.bucket;
+  return payload;
+}
+
+/** Payload for the GCP Cloud Storage delete-object action. */
+export interface GcpStorageDeletePayload {
+  object_name: string;
+  bucket?: string;
+}
+
+/** Create a payload for the GCP Cloud Storage delete-object action. */
+export function createGcpStorageDeletePayload(
+  objectName: string,
+  options?: { bucket?: string }
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { object_name: objectName };
+  if (options?.bucket) payload.bucket = options.bucket;
+  return payload;
+}

--- a/clients/python/acteon_client/models.py
+++ b/clients/python/acteon_client/models.py
@@ -3288,3 +3288,146 @@ def azure_eventhubs_send_batch_payload(
     if event_hub_name is not None:
         payload["event_hub_name"] = event_hub_name
     return payload
+
+
+# =============================================================================
+# GCP Pub/Sub Provider Payload Helpers
+# =============================================================================
+
+
+def gcp_pubsub_publish_payload(
+    data: str,
+    *,
+    data_base64: Optional[str] = None,
+    attributes: Optional[dict[str, str]] = None,
+    ordering_key: Optional[str] = None,
+    topic: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a payload for a GCP Pub/Sub publish action.
+
+    Args:
+        data: Message data as a UTF-8 string.
+        data_base64: Message data as base64-encoded bytes.
+        attributes: Message attributes as key-value pairs.
+        ordering_key: Ordering key for ordered delivery.
+        topic: Override the topic configured on the provider.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``gcp-pubsub``
+        provider with action type ``publish``.
+    """
+    payload: dict[str, Any] = {"data": data}
+    if data_base64 is not None:
+        payload["data_base64"] = data_base64
+    if attributes is not None:
+        payload["attributes"] = attributes
+    if ordering_key is not None:
+        payload["ordering_key"] = ordering_key
+    if topic is not None:
+        payload["topic"] = topic
+    return payload
+
+
+def gcp_pubsub_publish_batch_payload(
+    messages: List[dict[str, Any]],
+    *,
+    topic: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a payload for a GCP Pub/Sub publish-batch action.
+
+    Args:
+        messages: List of message objects to publish as a batch.
+        topic: Override the topic configured on the provider.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``gcp-pubsub``
+        provider with action type ``publish_batch``.
+    """
+    payload: dict[str, Any] = {"messages": messages}
+    if topic is not None:
+        payload["topic"] = topic
+    return payload
+
+
+# =============================================================================
+# GCP Cloud Storage Provider Payload Helpers
+# =============================================================================
+
+
+def gcp_storage_upload_payload(
+    object_name: str,
+    *,
+    bucket: Optional[str] = None,
+    body: Optional[str] = None,
+    body_base64: Optional[str] = None,
+    content_type: Optional[str] = None,
+    metadata: Optional[dict[str, str]] = None,
+) -> dict[str, Any]:
+    """Build a payload for a GCP Cloud Storage upload action.
+
+    Args:
+        object_name: Name of the object to upload.
+        bucket: Override the bucket name configured on the provider.
+        body: Object body as a UTF-8 string.
+        body_base64: Object body as base64-encoded bytes.
+        content_type: Content type (e.g., ``"application/json"``).
+        metadata: Object metadata as key-value pairs.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``gcp-storage``
+        provider with action type ``upload_object``.
+    """
+    payload: dict[str, Any] = {"object_name": object_name}
+    if bucket is not None:
+        payload["bucket"] = bucket
+    if body is not None:
+        payload["body"] = body
+    if body_base64 is not None:
+        payload["body_base64"] = body_base64
+    if content_type is not None:
+        payload["content_type"] = content_type
+    if metadata is not None:
+        payload["metadata"] = metadata
+    return payload
+
+
+def gcp_storage_download_payload(
+    object_name: str,
+    *,
+    bucket: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a payload for a GCP Cloud Storage download action.
+
+    Args:
+        object_name: Name of the object to download.
+        bucket: Override the bucket name configured on the provider.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``gcp-storage``
+        provider with action type ``download_object``.
+    """
+    payload: dict[str, Any] = {"object_name": object_name}
+    if bucket is not None:
+        payload["bucket"] = bucket
+    return payload
+
+
+def gcp_storage_delete_payload(
+    object_name: str,
+    *,
+    bucket: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a payload for a GCP Cloud Storage delete action.
+
+    Args:
+        object_name: Name of the object to delete.
+        bucket: Override the bucket name configured on the provider.
+
+    Returns:
+        Payload dictionary suitable for an Action targeting the ``gcp-storage``
+        provider with action type ``delete_object``.
+    """
+    payload: dict[str, Any] = {"object_name": object_name}
+    if bucket is not None:
+        payload["bucket"] = bucket
+    return payload

--- a/crates/client/src/gcp.rs
+++ b/crates/client/src/gcp.rs
@@ -1,0 +1,719 @@
+//! Convenience helpers for creating GCP-targeted actions.
+//!
+//! Provides builder types for each supported GCP provider:
+//! [`pubsub`] and [`storage`].
+//!
+//! # Example
+//!
+//! ```no_run
+//! use acteon_client::gcp;
+//!
+//! // Publish a message to Pub/Sub
+//! let action = gcp::pubsub::publish("messaging", "tenant-1")
+//!     .data(r#"{"hello":"world"}"#)
+//!     .topic("my-topic")
+//!     .build();
+//!
+//! // Upload an object to Cloud Storage
+//! let action = gcp::storage::upload("storage", "tenant-1")
+//!     .object_name("data.json")
+//!     .body(r#"{"hello":"world"}"#)
+//!     .content_type("application/json")
+//!     .build();
+//! ```
+
+// =============================================================================
+// Pub/Sub
+// =============================================================================
+
+/// Helpers for creating GCP `Pub/Sub` actions.
+pub mod pubsub {
+    use acteon_core::Action;
+    use std::collections::HashMap;
+
+    /// Create a builder for a GCP `Pub/Sub` `publish` action.
+    pub fn publish(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> PubSubPublishBuilder {
+        PubSubPublishBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            data: None,
+            data_base64: None,
+            attributes: None,
+            ordering_key: None,
+            topic: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Create a builder for a GCP `Pub/Sub` `publish_batch` action.
+    pub fn publish_batch(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> PubSubPublishBatchBuilder {
+        PubSubPublishBatchBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            messages: Vec::new(),
+            topic: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for a GCP `Pub/Sub` `publish` action.
+    #[derive(Debug)]
+    pub struct PubSubPublishBuilder {
+        namespace: String,
+        tenant: String,
+        data: Option<String>,
+        data_base64: Option<String>,
+        attributes: Option<HashMap<String, String>>,
+        ordering_key: Option<String>,
+        topic: Option<String>,
+        dedup_key: Option<String>,
+    }
+
+    impl PubSubPublishBuilder {
+        /// Set the message data as a UTF-8 string.
+        #[must_use]
+        pub fn data(mut self, data: impl Into<String>) -> Self {
+            self.data = Some(data.into());
+            self
+        }
+
+        /// Set the message data as base64-encoded bytes.
+        #[must_use]
+        pub fn data_base64(mut self, data: impl Into<String>) -> Self {
+            self.data_base64 = Some(data.into());
+            self
+        }
+
+        /// Set message attributes as key-value string pairs.
+        #[must_use]
+        pub fn attributes(mut self, attributes: HashMap<String, String>) -> Self {
+            self.attributes = Some(attributes);
+            self
+        }
+
+        /// Set the ordering key for ordered delivery.
+        #[must_use]
+        pub fn ordering_key(mut self, key: impl Into<String>) -> Self {
+            self.ordering_key = Some(key.into());
+            self
+        }
+
+        /// Override the topic name configured on the provider.
+        #[must_use]
+        pub fn topic(mut self, topic: impl Into<String>) -> Self {
+            self.topic = Some(topic.into());
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the GCP `Pub/Sub` `publish` Action.
+        pub fn build(self) -> Action {
+            let mut payload = serde_json::Map::new();
+
+            if let Some(v) = self.data {
+                payload.insert("data".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.data_base64 {
+                payload.insert("data_base64".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.attributes {
+                payload.insert(
+                    "attributes".to_string(),
+                    serde_json::to_value(v)
+                        .expect("HashMap<String, String> serialization cannot fail"),
+                );
+            }
+            if let Some(v) = self.ordering_key {
+                payload.insert("ordering_key".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.topic {
+                payload.insert("topic".to_string(), serde_json::Value::String(v));
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "gcp-pubsub",
+                "publish",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Builder for a GCP `Pub/Sub` `publish_batch` action.
+    #[derive(Debug)]
+    pub struct PubSubPublishBatchBuilder {
+        namespace: String,
+        tenant: String,
+        messages: Vec<serde_json::Value>,
+        topic: Option<String>,
+        dedup_key: Option<String>,
+    }
+
+    impl PubSubPublishBatchBuilder {
+        /// Set the list of messages to publish as a batch.
+        #[must_use]
+        pub fn messages(mut self, messages: Vec<serde_json::Value>) -> Self {
+            self.messages = messages;
+            self
+        }
+
+        /// Override the topic name configured on the provider.
+        #[must_use]
+        pub fn topic(mut self, topic: impl Into<String>) -> Self {
+            self.topic = Some(topic.into());
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the GCP `Pub/Sub` `publish_batch` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `messages` is empty.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.messages.is_empty(),
+                "Pub/Sub messages must not be empty"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "messages".to_string(),
+                serde_json::to_value(&self.messages).expect("Vec<Value> serialization cannot fail"),
+            );
+
+            if let Some(v) = self.topic {
+                payload.insert("topic".to_string(), serde_json::Value::String(v));
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "gcp-pubsub",
+                "publish_batch",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+}
+
+// =============================================================================
+// Cloud Storage
+// =============================================================================
+
+/// Helpers for creating GCP Cloud Storage actions.
+pub mod storage {
+    use acteon_core::Action;
+    use std::collections::HashMap;
+
+    /// Create a builder for a GCP Cloud Storage `upload_object` action.
+    pub fn upload(namespace: impl Into<String>, tenant: impl Into<String>) -> StorageUploadBuilder {
+        StorageUploadBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            object_name: String::new(),
+            bucket: None,
+            body: None,
+            body_base64: None,
+            content_type: None,
+            metadata: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Create a builder for a GCP Cloud Storage `download_object` action.
+    pub fn download(
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> StorageDownloadBuilder {
+        StorageDownloadBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            object_name: String::new(),
+            bucket: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Create a builder for a GCP Cloud Storage `delete_object` action.
+    pub fn delete(namespace: impl Into<String>, tenant: impl Into<String>) -> StorageDeleteBuilder {
+        StorageDeleteBuilder {
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            object_name: String::new(),
+            bucket: None,
+            dedup_key: None,
+        }
+    }
+
+    /// Builder for a GCP Cloud Storage `upload_object` action.
+    #[derive(Debug)]
+    pub struct StorageUploadBuilder {
+        namespace: String,
+        tenant: String,
+        object_name: String,
+        bucket: Option<String>,
+        body: Option<String>,
+        body_base64: Option<String>,
+        content_type: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+        dedup_key: Option<String>,
+    }
+
+    impl StorageUploadBuilder {
+        /// Set the object name.
+        #[must_use]
+        pub fn object_name(mut self, name: impl Into<String>) -> Self {
+            self.object_name = name.into();
+            self
+        }
+
+        /// Override the bucket name configured on the provider.
+        #[must_use]
+        pub fn bucket(mut self, bucket: impl Into<String>) -> Self {
+            self.bucket = Some(bucket.into());
+            self
+        }
+
+        /// Set the object body as a UTF-8 string.
+        #[must_use]
+        pub fn body(mut self, body: impl Into<String>) -> Self {
+            self.body = Some(body.into());
+            self
+        }
+
+        /// Set the object body as base64-encoded bytes.
+        #[must_use]
+        pub fn body_base64(mut self, data: impl Into<String>) -> Self {
+            self.body_base64 = Some(data.into());
+            self
+        }
+
+        /// Set the content type (e.g., `"application/json"`).
+        #[must_use]
+        pub fn content_type(mut self, ct: impl Into<String>) -> Self {
+            self.content_type = Some(ct.into());
+            self
+        }
+
+        /// Set object metadata as key-value string pairs.
+        #[must_use]
+        pub fn metadata(mut self, metadata: HashMap<String, String>) -> Self {
+            self.metadata = Some(metadata);
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the GCP Cloud Storage `upload_object` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `object_name` has not been set.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.object_name.is_empty(),
+                "GCP Storage object_name must be set"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "object_name".to_string(),
+                serde_json::Value::String(self.object_name),
+            );
+
+            if let Some(v) = self.bucket {
+                payload.insert("bucket".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.body {
+                payload.insert("body".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.body_base64 {
+                payload.insert("body_base64".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.content_type {
+                payload.insert("content_type".to_string(), serde_json::Value::String(v));
+            }
+            if let Some(v) = self.metadata {
+                payload.insert(
+                    "metadata".to_string(),
+                    serde_json::to_value(v)
+                        .expect("HashMap<String, String> serialization cannot fail"),
+                );
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "gcp-storage",
+                "upload_object",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Builder for a GCP Cloud Storage `download_object` action.
+    #[derive(Debug)]
+    pub struct StorageDownloadBuilder {
+        namespace: String,
+        tenant: String,
+        object_name: String,
+        bucket: Option<String>,
+        dedup_key: Option<String>,
+    }
+
+    impl StorageDownloadBuilder {
+        /// Set the object name.
+        #[must_use]
+        pub fn object_name(mut self, name: impl Into<String>) -> Self {
+            self.object_name = name.into();
+            self
+        }
+
+        /// Override the bucket name configured on the provider.
+        #[must_use]
+        pub fn bucket(mut self, bucket: impl Into<String>) -> Self {
+            self.bucket = Some(bucket.into());
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the GCP Cloud Storage `download_object` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `object_name` has not been set.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.object_name.is_empty(),
+                "GCP Storage object_name must be set"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "object_name".to_string(),
+                serde_json::Value::String(self.object_name),
+            );
+
+            if let Some(v) = self.bucket {
+                payload.insert("bucket".to_string(), serde_json::Value::String(v));
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "gcp-storage",
+                "download_object",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+
+    /// Builder for a GCP Cloud Storage `delete_object` action.
+    #[derive(Debug)]
+    pub struct StorageDeleteBuilder {
+        namespace: String,
+        tenant: String,
+        object_name: String,
+        bucket: Option<String>,
+        dedup_key: Option<String>,
+    }
+
+    impl StorageDeleteBuilder {
+        /// Set the object name.
+        #[must_use]
+        pub fn object_name(mut self, name: impl Into<String>) -> Self {
+            self.object_name = name.into();
+            self
+        }
+
+        /// Override the bucket name configured on the provider.
+        #[must_use]
+        pub fn bucket(mut self, bucket: impl Into<String>) -> Self {
+            self.bucket = Some(bucket.into());
+            self
+        }
+
+        /// Set a deduplication key on the Action.
+        #[must_use]
+        pub fn dedup_key(mut self, key: impl Into<String>) -> Self {
+            self.dedup_key = Some(key.into());
+            self
+        }
+
+        /// Build the GCP Cloud Storage `delete_object` Action.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `object_name` has not been set.
+        pub fn build(self) -> Action {
+            assert!(
+                !self.object_name.is_empty(),
+                "GCP Storage object_name must be set"
+            );
+
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "object_name".to_string(),
+                serde_json::Value::String(self.object_name),
+            );
+
+            if let Some(v) = self.bucket {
+                payload.insert("bucket".to_string(), serde_json::Value::String(v));
+            }
+
+            let mut action = Action::new(
+                self.namespace,
+                self.tenant,
+                "gcp-storage",
+                "delete_object",
+                serde_json::Value::Object(payload),
+            );
+
+            if let Some(key) = self.dedup_key {
+                action.dedup_key = Some(key);
+            }
+
+            action
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    // =========================================================================
+    // Pub/Sub tests
+    // =========================================================================
+
+    #[test]
+    fn pubsub_publish_basic() {
+        let a = pubsub::publish("ns", "t1")
+            .data(r#"{"hello":"world"}"#)
+            .build();
+
+        assert_eq!(a.provider.as_str(), "gcp-pubsub");
+        assert_eq!(a.action_type, "publish");
+        assert_eq!(a.payload["data"], r#"{"hello":"world"}"#);
+    }
+
+    #[test]
+    fn pubsub_publish_with_all_options() {
+        let mut attrs = HashMap::new();
+        attrs.insert("env".to_string(), "staging".to_string());
+
+        let a = pubsub::publish("ns", "t1")
+            .data("hello")
+            .data_base64("SGVsbG8gV29ybGQ=")
+            .attributes(attrs)
+            .ordering_key("order-1")
+            .topic("my-topic")
+            .dedup_key("pub-dedup")
+            .build();
+
+        assert_eq!(a.payload["data"], "hello");
+        assert_eq!(a.payload["data_base64"], "SGVsbG8gV29ybGQ=");
+        assert_eq!(a.payload["attributes"]["env"], "staging");
+        assert_eq!(a.payload["ordering_key"], "order-1");
+        assert_eq!(a.payload["topic"], "my-topic");
+        assert_eq!(a.dedup_key.as_deref(), Some("pub-dedup"));
+    }
+
+    #[test]
+    fn pubsub_publish_minimal() {
+        let a = pubsub::publish("ns", "t1").build();
+
+        assert_eq!(a.provider.as_str(), "gcp-pubsub");
+        assert_eq!(a.action_type, "publish");
+    }
+
+    #[test]
+    fn pubsub_publish_batch_basic() {
+        let messages = vec![
+            serde_json::json!({"data": "msg1"}),
+            serde_json::json!({"data": "msg2"}),
+        ];
+
+        let a = pubsub::publish_batch("ns", "t1").messages(messages).build();
+
+        assert_eq!(a.provider.as_str(), "gcp-pubsub");
+        assert_eq!(a.action_type, "publish_batch");
+        assert_eq!(a.payload["messages"][0]["data"], "msg1");
+        assert_eq!(a.payload["messages"][1]["data"], "msg2");
+    }
+
+    #[test]
+    fn pubsub_publish_batch_with_topic() {
+        let messages = vec![serde_json::json!({"data": "msg1"})];
+
+        let a = pubsub::publish_batch("ns", "t1")
+            .messages(messages)
+            .topic("my-topic")
+            .dedup_key("batch-dedup")
+            .build();
+
+        assert_eq!(a.payload["topic"], "my-topic");
+        assert_eq!(a.dedup_key.as_deref(), Some("batch-dedup"));
+    }
+
+    #[test]
+    #[should_panic(expected = "Pub/Sub messages must not be empty")]
+    fn pubsub_publish_batch_panics_without_messages() {
+        pubsub::publish_batch("ns", "t1").build();
+    }
+
+    // =========================================================================
+    // Cloud Storage tests
+    // =========================================================================
+
+    #[test]
+    fn storage_upload_basic() {
+        let a = storage::upload("ns", "t1")
+            .object_name("data.json")
+            .body(r#"{"hello":"world"}"#)
+            .build();
+
+        assert_eq!(a.provider.as_str(), "gcp-storage");
+        assert_eq!(a.action_type, "upload_object");
+        assert_eq!(a.payload["object_name"], "data.json");
+        assert_eq!(a.payload["body"], r#"{"hello":"world"}"#);
+    }
+
+    #[test]
+    fn storage_upload_with_all_options() {
+        let mut meta = HashMap::new();
+        meta.insert("env".to_string(), "staging".to_string());
+
+        let a = storage::upload("ns", "t1")
+            .object_name("data.bin")
+            .bucket("my-bucket")
+            .body_base64("SGVsbG8gV29ybGQ=")
+            .content_type("application/octet-stream")
+            .metadata(meta)
+            .dedup_key("upload-dedup")
+            .build();
+
+        assert_eq!(a.payload["object_name"], "data.bin");
+        assert_eq!(a.payload["bucket"], "my-bucket");
+        assert_eq!(a.payload["body_base64"], "SGVsbG8gV29ybGQ=");
+        assert_eq!(a.payload["content_type"], "application/octet-stream");
+        assert_eq!(a.payload["metadata"]["env"], "staging");
+        assert_eq!(a.dedup_key.as_deref(), Some("upload-dedup"));
+    }
+
+    #[test]
+    fn storage_download_basic() {
+        let a = storage::download("ns", "t1")
+            .object_name("data.json")
+            .build();
+
+        assert_eq!(a.provider.as_str(), "gcp-storage");
+        assert_eq!(a.action_type, "download_object");
+        assert_eq!(a.payload["object_name"], "data.json");
+    }
+
+    #[test]
+    fn storage_download_with_bucket() {
+        let a = storage::download("ns", "t1")
+            .object_name("data.json")
+            .bucket("my-bucket")
+            .build();
+
+        assert_eq!(a.payload["bucket"], "my-bucket");
+    }
+
+    #[test]
+    fn storage_delete_basic() {
+        let a = storage::delete("ns", "t1").object_name("data.json").build();
+
+        assert_eq!(a.provider.as_str(), "gcp-storage");
+        assert_eq!(a.action_type, "delete_object");
+        assert_eq!(a.payload["object_name"], "data.json");
+    }
+
+    #[test]
+    fn storage_delete_with_bucket() {
+        let a = storage::delete("ns", "t1")
+            .object_name("data.json")
+            .bucket("my-bucket")
+            .dedup_key("del-dedup")
+            .build();
+
+        assert_eq!(a.payload["bucket"], "my-bucket");
+        assert_eq!(a.dedup_key.as_deref(), Some("del-dedup"));
+    }
+
+    #[test]
+    #[should_panic(expected = "GCP Storage object_name must be set")]
+    fn storage_upload_panics_without_object_name() {
+        storage::upload("ns", "t1").build();
+    }
+
+    #[test]
+    #[should_panic(expected = "GCP Storage object_name must be set")]
+    fn storage_download_panics_without_object_name() {
+        storage::download("ns", "t1").build();
+    }
+
+    #[test]
+    #[should_panic(expected = "GCP Storage object_name must be set")]
+    fn storage_delete_panics_without_object_name() {
+        storage::delete("ns", "t1").build();
+    }
+}

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -60,6 +60,7 @@
 pub mod aws;
 pub mod azure;
 mod error;
+pub mod gcp;
 pub mod stream;
 pub mod webhook;
 

--- a/crates/gcp/Cargo.toml
+++ b/crates/gcp/Cargo.toml
@@ -19,6 +19,7 @@ google-cloud-pubsub = { workspace = true, optional = true }
 google-cloud-storage = { workspace = true, optional = true }
 google-cloud-auth = { workspace = true }
 async-trait = { workspace = true }
+dashmap = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 serde = { workspace = true }

--- a/crates/gcp/Cargo.toml
+++ b/crates/gcp/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "acteon-gcp"
+description = "GCP service providers for Acteon (Pub/Sub, Cloud Storage)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+pubsub = ["dep:google-cloud-pubsub"]
+storage = ["dep:google-cloud-storage"]
+full = ["pubsub", "storage"]
+
+[dependencies]
+acteon-core = { workspace = true }
+acteon-provider = { workspace = true }
+google-cloud-pubsub = { workspace = true, optional = true }
+google-cloud-storage = { workspace = true, optional = true }
+google-cloud-auth = { workspace = true }
+async-trait = { workspace = true }
+base64 = { workspace = true }
+bytes = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/gcp/src/auth.rs
+++ b/crates/gcp/src/auth.rs
@@ -3,39 +3,44 @@ use tracing::info;
 
 use crate::error::GcpProviderError;
 
-/// Build GCP credentials from a service account JSON key file.
+/// Build GCP credentials from a service account JSON key file or inline JSON.
 ///
-/// If `credentials_path` is `Some`, reads the file and constructs credentials
-/// from the service account key. If `None`, returns `None` so that callers can
-/// fall back to Application Default Credentials (ADC) via the SDK default.
+/// If `credentials_json` is `Some`, it is used directly.
+/// If `credentials_path` is `Some`, the file is read and used.
+/// Otherwise, returns `None` for ADC fallback.
 ///
 /// # Errors
 ///
-/// Returns [`GcpProviderError::CredentialError`] if the file cannot be read or
-/// contains invalid JSON.
+/// Returns [`GcpProviderError::CredentialError`] if the key is invalid.
 pub async fn build_gcp_credentials(
     credentials_path: Option<&str>,
+    credentials_json: Option<&str>,
 ) -> Result<Option<Credentials>, GcpProviderError> {
-    if let Some(path) = credentials_path {
+    let content = if let Some(json) = credentials_json {
+        info!("loading GCP credentials from inline JSON");
+        json.to_owned()
+    } else if let Some(path) = credentials_path {
         info!("loading GCP credentials from service account file");
-        let content = tokio::fs::read_to_string(path).await.map_err(|e| {
+        tokio::fs::read_to_string(path).await.map_err(|e| {
             GcpProviderError::CredentialError(format!(
                 "failed to read credentials file '{path}': {e}"
             ))
-        })?;
-        let key_value: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
-            GcpProviderError::CredentialError(format!("invalid credentials JSON: {e}"))
-        })?;
-        let creds = credentials::service_account::Builder::new(key_value)
-            .build()
-            .map_err(|e| {
-                GcpProviderError::CredentialError(format!(
-                    "failed to build service account credentials: {e}"
-                ))
-            })?;
-        Ok(Some(creds))
+        })?
     } else {
         info!("using Application Default Credentials (ADC) for GCP");
-        Ok(None)
-    }
+        return Ok(None);
+    };
+
+    let key_value: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| GcpProviderError::CredentialError(format!("invalid credentials JSON: {e}")))?;
+
+    let creds = credentials::service_account::Builder::new(key_value)
+        .build()
+        .map_err(|e| {
+            GcpProviderError::CredentialError(format!(
+                "failed to build service account credentials: {e}"
+            ))
+        })?;
+
+    Ok(Some(creds))
 }

--- a/crates/gcp/src/auth.rs
+++ b/crates/gcp/src/auth.rs
@@ -1,0 +1,41 @@
+use google_cloud_auth::credentials::{self, Credentials};
+use tracing::info;
+
+use crate::error::GcpProviderError;
+
+/// Build GCP credentials from a service account JSON key file.
+///
+/// If `credentials_path` is `Some`, reads the file and constructs credentials
+/// from the service account key. If `None`, returns `None` so that callers can
+/// fall back to Application Default Credentials (ADC) via the SDK default.
+///
+/// # Errors
+///
+/// Returns [`GcpProviderError::CredentialError`] if the file cannot be read or
+/// contains invalid JSON.
+pub async fn build_gcp_credentials(
+    credentials_path: Option<&str>,
+) -> Result<Option<Credentials>, GcpProviderError> {
+    if let Some(path) = credentials_path {
+        info!("loading GCP credentials from service account file");
+        let content = tokio::fs::read_to_string(path).await.map_err(|e| {
+            GcpProviderError::CredentialError(format!(
+                "failed to read credentials file '{path}': {e}"
+            ))
+        })?;
+        let key_value: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
+            GcpProviderError::CredentialError(format!("invalid credentials JSON: {e}"))
+        })?;
+        let creds = credentials::service_account::Builder::new(key_value)
+            .build()
+            .map_err(|e| {
+                GcpProviderError::CredentialError(format!(
+                    "failed to build service account credentials: {e}"
+                ))
+            })?;
+        Ok(Some(creds))
+    } else {
+        info!("using Application Default Credentials (ADC) for GCP");
+        Ok(None)
+    }
+}

--- a/crates/gcp/src/config.rs
+++ b/crates/gcp/src/config.rs
@@ -14,6 +14,11 @@ pub struct GcpBaseConfig {
     #[serde(default)]
     pub credentials_path: Option<String>,
 
+    /// Inline service account JSON key.
+    /// Supports `ENC[...]` values.
+    #[serde(default)]
+    pub credentials_json: Option<String>,
+
     /// Optional endpoint URL override for local development
     /// (e.g. `Pub/Sub` emulator, `fake-gcs-server`).
     #[serde(default)]
@@ -28,6 +33,10 @@ impl std::fmt::Debug for GcpBaseConfig {
                 "credentials_path",
                 &self.credentials_path.as_ref().map(|_| "[REDACTED]"),
             )
+            .field(
+                "credentials_json",
+                &self.credentials_json.as_ref().map(|_| "[REDACTED]"),
+            )
             .field("endpoint_url", &self.endpoint_url)
             .finish()
     }
@@ -39,6 +48,7 @@ impl GcpBaseConfig {
         Self {
             project_id: project_id.into(),
             credentials_path: None,
+            credentials_json: None,
             endpoint_url: None,
         }
     }
@@ -47,6 +57,13 @@ impl GcpBaseConfig {
     #[must_use]
     pub fn with_credentials_path(mut self, path: impl Into<String>) -> Self {
         self.credentials_path = Some(path.into());
+        self
+    }
+
+    /// Set the inline service account JSON key.
+    #[must_use]
+    pub fn with_credentials_json(mut self, json: impl Into<String>) -> Self {
+        self.credentials_json = Some(json.into());
         self
     }
 

--- a/crates/gcp/src/config.rs
+++ b/crates/gcp/src/config.rs
@@ -1,0 +1,110 @@
+use serde::{Deserialize, Serialize};
+
+/// Shared base configuration for all GCP providers.
+///
+/// Contains common settings like project ID, service account credentials path,
+/// and an optional endpoint URL override for local development (e.g. emulators).
+#[derive(Clone, Serialize, Deserialize)]
+pub struct GcpBaseConfig {
+    /// GCP project ID.
+    pub project_id: String,
+
+    /// Path to a service account JSON key file.
+    /// If not set, Application Default Credentials (ADC) are used.
+    #[serde(default)]
+    pub credentials_path: Option<String>,
+
+    /// Optional endpoint URL override for local development
+    /// (e.g. `Pub/Sub` emulator, `fake-gcs-server`).
+    #[serde(default)]
+    pub endpoint_url: Option<String>,
+}
+
+impl std::fmt::Debug for GcpBaseConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GcpBaseConfig")
+            .field("project_id", &self.project_id)
+            .field(
+                "credentials_path",
+                &self.credentials_path.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("endpoint_url", &self.endpoint_url)
+            .finish()
+    }
+}
+
+impl GcpBaseConfig {
+    /// Create a new `GcpBaseConfig` with the given project ID.
+    pub fn new(project_id: impl Into<String>) -> Self {
+        Self {
+            project_id: project_id.into(),
+            credentials_path: None,
+            endpoint_url: None,
+        }
+    }
+
+    /// Set the path to a service account JSON key file.
+    #[must_use]
+    pub fn with_credentials_path(mut self, path: impl Into<String>) -> Self {
+        self.credentials_path = Some(path.into());
+        self
+    }
+
+    /// Set the endpoint URL override for local development.
+    #[must_use]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.endpoint_url = Some(endpoint_url.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_config_sets_project_id() {
+        let config = GcpBaseConfig::new("my-project");
+        assert_eq!(config.project_id, "my-project");
+        assert!(config.credentials_path.is_none());
+        assert!(config.endpoint_url.is_none());
+    }
+
+    #[test]
+    fn builder_chain() {
+        let config = GcpBaseConfig::new("test-project")
+            .with_credentials_path("/path/to/sa.json")
+            .with_endpoint_url("http://localhost:8085");
+        assert_eq!(config.project_id, "test-project");
+        assert_eq!(config.credentials_path.as_deref(), Some("/path/to/sa.json"));
+        assert_eq!(
+            config.endpoint_url.as_deref(),
+            Some("http://localhost:8085")
+        );
+    }
+
+    #[test]
+    fn debug_redacts_credentials_path() {
+        let config =
+            GcpBaseConfig::new("my-project").with_credentials_path("/home/user/sa-key.json");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("sa-key.json"));
+        assert!(debug.contains("my-project"));
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let config = GcpBaseConfig::new("round-trip").with_endpoint_url("http://localhost:8085");
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: GcpBaseConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.project_id, "round-trip");
+        assert_eq!(
+            deserialized.endpoint_url.as_deref(),
+            Some("http://localhost:8085")
+        );
+        assert!(deserialized.credentials_path.is_none());
+    }
+}

--- a/crates/gcp/src/error.rs
+++ b/crates/gcp/src/error.rs
@@ -1,0 +1,183 @@
+use acteon_provider::ProviderError;
+use thiserror::Error;
+
+/// Errors specific to GCP provider operations.
+#[derive(Debug, Error)]
+pub enum GcpProviderError {
+    /// The GCP service returned an error.
+    #[error("GCP service error: {0}")]
+    ServiceError(String),
+
+    /// The request was throttled by the GCP service.
+    #[error("GCP request throttled")]
+    Throttled,
+
+    /// A network or connection error occurred communicating with GCP.
+    #[error("GCP connection error: {0}")]
+    Connection(String),
+
+    /// The request timed out.
+    #[error("GCP request timed out")]
+    Timeout,
+
+    /// The action payload was invalid or missing required fields.
+    #[error("invalid payload: {0}")]
+    InvalidPayload(String),
+
+    /// GCP credential resolution failed.
+    #[error("credential error: {0}")]
+    CredentialError(String),
+
+    /// Configuration is invalid.
+    #[error("invalid configuration: {0}")]
+    Configuration(String),
+}
+
+impl From<GcpProviderError> for ProviderError {
+    fn from(err: GcpProviderError) -> Self {
+        match err {
+            GcpProviderError::ServiceError(msg) => ProviderError::ExecutionFailed(msg),
+            GcpProviderError::Throttled => ProviderError::RateLimited,
+            GcpProviderError::Connection(msg) => ProviderError::Connection(msg),
+            GcpProviderError::Timeout => ProviderError::Timeout(std::time::Duration::from_secs(30)),
+            GcpProviderError::InvalidPayload(msg) => ProviderError::Serialization(msg),
+            GcpProviderError::CredentialError(msg) | GcpProviderError::Configuration(msg) => {
+                ProviderError::Configuration(msg)
+            }
+        }
+    }
+}
+
+/// Classify a GCP error string into the appropriate [`GcpProviderError`].
+///
+/// Inspects the error message for common patterns (throttling, timeout,
+/// connection) and maps them to the correct variant.
+pub fn classify_gcp_error(error_str: &str) -> GcpProviderError {
+    let lower = error_str.to_lowercase();
+    if lower.contains("429")
+        || lower.contains("throttl")
+        || lower.contains("rate exceed")
+        || lower.contains("too many")
+        || lower.contains("resource_exhausted")
+    {
+        GcpProviderError::Throttled
+    } else if lower.contains("timeout")
+        || lower.contains("timed out")
+        || lower.contains("deadline_exceeded")
+    {
+        GcpProviderError::Timeout
+    } else if lower.contains("connection")
+        || lower.contains("connect")
+        || lower.contains("dns")
+        || lower.contains("network")
+        || lower.contains("unavailable")
+    {
+        GcpProviderError::Connection(error_str.to_owned())
+    } else {
+        GcpProviderError::ServiceError(error_str.to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn throttled_maps_to_rate_limited() {
+        let err: ProviderError = GcpProviderError::Throttled.into();
+        assert!(matches!(err, ProviderError::RateLimited));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn timeout_maps_to_timeout() {
+        let err: ProviderError = GcpProviderError::Timeout.into();
+        assert!(matches!(err, ProviderError::Timeout(_)));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn connection_maps_to_connection() {
+        let err: ProviderError = GcpProviderError::Connection("reset".into()).into();
+        assert!(matches!(err, ProviderError::Connection(_)));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn service_error_maps_to_execution_failed() {
+        let err: ProviderError = GcpProviderError::ServiceError("object not found".into()).into();
+        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn invalid_payload_maps_to_serialization() {
+        let err: ProviderError = GcpProviderError::InvalidPayload("missing field".into()).into();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn credential_error_maps_to_configuration() {
+        let err: ProviderError = GcpProviderError::CredentialError("no credentials".into()).into();
+        assert!(matches!(err, ProviderError::Configuration(_)));
+    }
+
+    #[test]
+    fn classify_throttled_429() {
+        let err = classify_gcp_error("HTTP 429: Too Many Requests");
+        assert!(matches!(err, GcpProviderError::Throttled));
+    }
+
+    #[test]
+    fn classify_resource_exhausted() {
+        let err = classify_gcp_error("RESOURCE_EXHAUSTED: quota exceeded");
+        assert!(matches!(err, GcpProviderError::Throttled));
+    }
+
+    #[test]
+    fn classify_timeout() {
+        let err = classify_gcp_error("Request timed out after 30s");
+        assert!(matches!(err, GcpProviderError::Timeout));
+    }
+
+    #[test]
+    fn classify_deadline_exceeded() {
+        let err = classify_gcp_error("DEADLINE_EXCEEDED: operation took too long");
+        assert!(matches!(err, GcpProviderError::Timeout));
+    }
+
+    #[test]
+    fn classify_connection() {
+        let err = classify_gcp_error("Connection refused: 10.0.0.1:443");
+        assert!(matches!(err, GcpProviderError::Connection(_)));
+    }
+
+    #[test]
+    fn classify_unavailable() {
+        let err = classify_gcp_error("UNAVAILABLE: service is not reachable");
+        assert!(matches!(err, GcpProviderError::Connection(_)));
+    }
+
+    #[test]
+    fn classify_generic_service_error() {
+        let err = classify_gcp_error("NOT_FOUND: The specified object does not exist");
+        assert!(matches!(err, GcpProviderError::ServiceError(_)));
+    }
+
+    #[test]
+    fn error_display() {
+        assert_eq!(
+            GcpProviderError::Throttled.to_string(),
+            "GCP request throttled"
+        );
+        assert_eq!(
+            GcpProviderError::Timeout.to_string(),
+            "GCP request timed out"
+        );
+        assert_eq!(
+            GcpProviderError::ServiceError("bad".into()).to_string(),
+            "GCP service error: bad"
+        );
+    }
+}

--- a/crates/gcp/src/lib.rs
+++ b/crates/gcp/src/lib.rs
@@ -1,0 +1,29 @@
+//! GCP service providers for the Acteon action gateway.
+//!
+//! This crate provides feature-gated integrations with Google Cloud services:
+//!
+//! - **Pub/Sub** (`pubsub` feature) — Publish messages and batches
+//! - **Cloud Storage** (`storage` feature) — Upload/download/delete objects
+//!
+//! All providers share a common [`GcpBaseConfig`] for
+//! project ID, credentials path, and optional endpoint URL override.
+
+pub mod auth;
+pub mod config;
+pub mod error;
+
+#[cfg(feature = "pubsub")]
+pub mod pubsub;
+
+#[cfg(feature = "storage")]
+pub mod storage;
+
+// Re-exports for convenience.
+pub use config::GcpBaseConfig;
+pub use error::GcpProviderError;
+
+#[cfg(feature = "pubsub")]
+pub use pubsub::{PubSubConfig, PubSubProvider};
+
+#[cfg(feature = "storage")]
+pub use storage::{StorageConfig, StorageProvider};

--- a/crates/gcp/src/pubsub.rs
+++ b/crates/gcp/src/pubsub.rs
@@ -1,0 +1,479 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::ProviderError;
+use acteon_provider::provider::Provider;
+use google_cloud_auth::credentials::Credentials;
+use google_cloud_pubsub::client::Publisher;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, instrument};
+
+use crate::auth::build_gcp_credentials;
+use crate::config::GcpBaseConfig;
+use crate::error::classify_gcp_error;
+
+/// Configuration for the GCP `Pub/Sub` provider.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct PubSubConfig {
+    /// Shared GCP configuration.
+    #[serde(flatten)]
+    pub gcp: GcpBaseConfig,
+
+    /// Default `Pub/Sub` topic name. Can be overridden per-action in the payload.
+    pub topic: Option<String>,
+}
+
+impl std::fmt::Debug for PubSubConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PubSubConfig")
+            .field("gcp", &self.gcp)
+            .field("topic", &self.topic)
+            .finish()
+    }
+}
+
+impl PubSubConfig {
+    /// Create a new `PubSubConfig` with the given GCP project ID.
+    pub fn new(project_id: impl Into<String>) -> Self {
+        Self {
+            gcp: GcpBaseConfig::new(project_id),
+            topic: None,
+        }
+    }
+
+    /// Set the default `Pub/Sub` topic name.
+    #[must_use]
+    pub fn with_topic(mut self, topic: impl Into<String>) -> Self {
+        self.topic = Some(topic.into());
+        self
+    }
+
+    /// Set the endpoint URL override (for the `Pub/Sub` emulator).
+    #[must_use]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.gcp.endpoint_url = Some(endpoint_url.into());
+        self
+    }
+
+    /// Set the path to a service account JSON key file.
+    #[must_use]
+    pub fn with_credentials_path(mut self, path: impl Into<String>) -> Self {
+        self.gcp.credentials_path = Some(path.into());
+        self
+    }
+}
+
+/// Payload for the `publish` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PubSubPublishPayload {
+    /// Message data as a UTF-8 string.
+    /// Mutually exclusive with `data_base64`.
+    pub data: Option<String>,
+
+    /// Message data as base64-encoded bytes.
+    /// Mutually exclusive with `data`.
+    pub data_base64: Option<String>,
+
+    /// Optional message attributes (key-value pairs).
+    #[serde(default)]
+    pub attributes: HashMap<String, String>,
+
+    /// Optional ordering key for message ordering.
+    pub ordering_key: Option<String>,
+
+    /// Topic name override. Overrides config default.
+    pub topic: Option<String>,
+}
+
+/// A single message within a `publish_batch` payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PubSubBatchMessage {
+    /// Message data as a UTF-8 string.
+    pub data: Option<String>,
+
+    /// Message data as base64-encoded bytes.
+    pub data_base64: Option<String>,
+
+    /// Optional message attributes.
+    #[serde(default)]
+    pub attributes: HashMap<String, String>,
+
+    /// Optional ordering key.
+    pub ordering_key: Option<String>,
+}
+
+/// Payload for the `publish_batch` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PubSubPublishBatchPayload {
+    /// Topic name override. Overrides config default.
+    pub topic: Option<String>,
+
+    /// List of messages to publish.
+    pub messages: Vec<PubSubBatchMessage>,
+}
+
+/// GCP `Pub/Sub` provider for publishing messages.
+pub struct PubSubProvider {
+    config: PubSubConfig,
+    credentials: Option<Credentials>,
+}
+
+impl std::fmt::Debug for PubSubProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PubSubProvider")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PubSubProvider {
+    /// Create a new `PubSubProvider` by resolving GCP credentials.
+    pub async fn new(config: PubSubConfig) -> Result<Self, ProviderError> {
+        let credentials = build_gcp_credentials(config.gcp.credentials_path.as_deref())
+            .await
+            .map_err(|e| ProviderError::Configuration(e.to_string()))?;
+
+        Ok(Self {
+            config,
+            credentials,
+        })
+    }
+
+    /// Build a [`Publisher`] for the given fully-qualified topic path.
+    async fn build_publisher(&self, topic_path: &str) -> Result<Publisher, ProviderError> {
+        let mut builder = Publisher::builder(topic_path);
+        if let Some(ref endpoint) = self.config.gcp.endpoint_url {
+            builder = builder.with_endpoint(endpoint);
+        }
+        if let Some(ref creds) = self.credentials {
+            builder = builder.with_credentials(creds.clone());
+        }
+        builder
+            .build()
+            .await
+            .map_err(|e| ProviderError::Configuration(format!("Pub/Sub publisher error: {e}")))
+    }
+
+    /// Resolve the topic name from the payload or config default.
+    fn resolve_topic<'a>(&'a self, payload_topic: Option<&'a str>) -> Option<&'a str> {
+        payload_topic.or(self.config.topic.as_deref())
+    }
+
+    /// Build the fully-qualified topic path from a topic name.
+    fn topic_path(&self, topic_name: &str) -> String {
+        format!(
+            "projects/{}/topics/{topic_name}",
+            self.config.gcp.project_id
+        )
+    }
+
+    /// Resolve message data from either `data` (UTF-8) or `data_base64` fields.
+    fn resolve_data(
+        data: Option<&str>,
+        data_base64: Option<&str>,
+    ) -> Result<Vec<u8>, ProviderError> {
+        if let Some(b64) = data_base64 {
+            base64::Engine::decode(&base64::engine::general_purpose::STANDARD, b64)
+                .map_err(|e| ProviderError::Serialization(format!("invalid base64 data: {e}")))
+        } else if let Some(text) = data {
+            Ok(text.as_bytes().to_vec())
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    /// Build a [`google_cloud_pubsub::model::Message`] from data fields.
+    fn build_message(
+        data_bytes: Vec<u8>,
+        attributes: &HashMap<String, String>,
+        ordering_key: Option<&str>,
+    ) -> google_cloud_pubsub::model::Message {
+        let mut msg =
+            google_cloud_pubsub::model::Message::new().set_data(bytes::Bytes::from(data_bytes));
+        if !attributes.is_empty() {
+            msg = msg.set_attributes(attributes.iter().map(|(k, v)| (k.clone(), v.clone())));
+        }
+        if let Some(key) = ordering_key {
+            msg = msg.set_ordering_key(key);
+        }
+        msg
+    }
+}
+
+impl Provider for PubSubProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "gcp-pubsub"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "gcp-pubsub"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        match action.action_type.as_str() {
+            "publish" => self.publish(action).await,
+            "publish_batch" => self.publish_batch(action).await,
+            other => Err(ProviderError::Configuration(format!(
+                "unknown Pub/Sub action type '{other}' (expected 'publish' or 'publish_batch')"
+            ))),
+        }
+    }
+
+    #[instrument(skip(self), fields(provider = "gcp-pubsub"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        debug!("performing Pub/Sub health check");
+        // Build a publisher to verify connectivity. If credentials or endpoint
+        // are invalid, this will fail.
+        if let Some(topic) = self.config.topic.as_deref() {
+            let topic_path = self.topic_path(topic);
+            let _publisher = self.build_publisher(&topic_path).await?;
+        }
+        info!("Pub/Sub health check passed");
+        Ok(())
+    }
+}
+
+impl PubSubProvider {
+    async fn publish(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing Pub/Sub publish payload");
+        let payload: PubSubPublishPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let topic_name = self
+            .resolve_topic(payload.topic.as_deref())
+            .ok_or_else(|| {
+                ProviderError::Configuration("no topic in payload or provider config".to_owned())
+            })?;
+
+        let topic_path = self.topic_path(topic_name);
+        debug!(topic = %topic_name, "publishing message to Pub/Sub");
+
+        let data_bytes =
+            Self::resolve_data(payload.data.as_deref(), payload.data_base64.as_deref())?;
+        let msg = Self::build_message(
+            data_bytes,
+            &payload.attributes,
+            payload.ordering_key.as_deref(),
+        );
+
+        let publisher = self.build_publisher(&topic_path).await?;
+        let message_id =
+            publisher
+                .publish(msg)
+                .await
+                .map_err(|e: Arc<google_cloud_pubsub::Error>| {
+                    let err_str = e.to_string();
+                    error!(error = %err_str, "Pub/Sub publish failed");
+                    let gcp_err: ProviderError = classify_gcp_error(&err_str).into();
+                    gcp_err
+                })?;
+
+        info!(topic = %topic_name, message_id = %message_id, "message published to Pub/Sub");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "topic": topic_name,
+            "message_id": message_id,
+            "status": "published"
+        })))
+    }
+
+    async fn publish_batch(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing Pub/Sub publish_batch payload");
+        let payload: PubSubPublishBatchPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let topic_name = self
+            .resolve_topic(payload.topic.as_deref())
+            .ok_or_else(|| {
+                ProviderError::Configuration("no topic in payload or provider config".to_owned())
+            })?;
+
+        let msg_count = payload.messages.len();
+        let topic_path = self.topic_path(topic_name);
+        debug!(topic = %topic_name, count = msg_count, "publishing batch to Pub/Sub");
+
+        let publisher = self.build_publisher(&topic_path).await?;
+
+        // Publish all messages and collect their futures.
+        let mut publish_futures = Vec::with_capacity(msg_count);
+        for m in &payload.messages {
+            let data_bytes = Self::resolve_data(m.data.as_deref(), m.data_base64.as_deref())?;
+            let msg = Self::build_message(data_bytes, &m.attributes, m.ordering_key.as_deref());
+            publish_futures.push(publisher.publish(msg));
+        }
+
+        // Flush to ensure all messages are sent.
+        publisher.flush().await;
+
+        // Collect message IDs.
+        let mut message_ids = Vec::with_capacity(msg_count);
+        for future in publish_futures {
+            let message_id = future.await.map_err(|e: Arc<google_cloud_pubsub::Error>| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "Pub/Sub batch publish failed");
+                let gcp_err: ProviderError = classify_gcp_error(&err_str).into();
+                gcp_err
+            })?;
+            message_ids.push(message_id);
+        }
+
+        info!(topic = %topic_name, count = msg_count, "batch published to Pub/Sub");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "topic": topic_name,
+            "message_count": msg_count,
+            "message_ids": message_ids,
+            "status": "published"
+        })))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_new_sets_project_id() {
+        let config = PubSubConfig::new("my-project");
+        assert_eq!(config.gcp.project_id, "my-project");
+        assert!(config.topic.is_none());
+    }
+
+    #[test]
+    fn config_with_topic() {
+        let config = PubSubConfig::new("my-project").with_topic("my-topic");
+        assert_eq!(config.topic.as_deref(), Some("my-topic"));
+    }
+
+    #[test]
+    fn config_builder_chain() {
+        let config = PubSubConfig::new("test-project")
+            .with_topic("events")
+            .with_endpoint_url("http://localhost:8085")
+            .with_credentials_path("/path/to/sa.json");
+        assert_eq!(config.topic.as_deref(), Some("events"));
+        assert_eq!(
+            config.gcp.endpoint_url.as_deref(),
+            Some("http://localhost:8085")
+        );
+        assert!(config.gcp.credentials_path.is_some());
+    }
+
+    #[test]
+    fn config_debug_format() {
+        let config = PubSubConfig::new("my-project")
+            .with_topic("events")
+            .with_credentials_path("/private/key.json");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("PubSubConfig"));
+        assert!(debug.contains("[REDACTED]"));
+        assert!(debug.contains("events"));
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config = PubSubConfig::new("serde-project").with_topic("telemetry");
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: PubSubConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.gcp.project_id, "serde-project");
+        assert_eq!(deserialized.topic.as_deref(), Some("telemetry"));
+    }
+
+    #[test]
+    fn deserialize_publish_payload() {
+        let json = serde_json::json!({
+            "data": "{\"temperature\": 72.5}",
+            "attributes": {
+                "source": "sensor"
+            },
+            "ordering_key": "device-001",
+            "topic": "telemetry"
+        });
+        let payload: PubSubPublishPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.data.as_deref(), Some("{\"temperature\": 72.5}"));
+        assert_eq!(payload.attributes.get("source").unwrap(), "sensor");
+        assert_eq!(payload.ordering_key.as_deref(), Some("device-001"));
+        assert_eq!(payload.topic.as_deref(), Some("telemetry"));
+    }
+
+    #[test]
+    fn deserialize_publish_payload_base64() {
+        let json = serde_json::json!({
+            "data_base64": "SGVsbG8gV29ybGQ="
+        });
+        let payload: PubSubPublishPayload = serde_json::from_value(json).unwrap();
+        assert!(payload.data.is_none());
+        assert_eq!(payload.data_base64.as_deref(), Some("SGVsbG8gV29ybGQ="));
+    }
+
+    #[test]
+    fn deserialize_minimal_publish_payload() {
+        let json = serde_json::json!({
+            "data": "hello"
+        });
+        let payload: PubSubPublishPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.data.as_deref(), Some("hello"));
+        assert!(payload.data_base64.is_none());
+        assert!(payload.topic.is_none());
+        assert!(payload.ordering_key.is_none());
+        assert!(payload.attributes.is_empty());
+    }
+
+    #[test]
+    fn deserialize_batch_payload() {
+        let json = serde_json::json!({
+            "topic": "events",
+            "messages": [
+                {"data": "event 1"},
+                {"data": "{\"key\": \"value\"}", "ordering_key": "k1"},
+                {"data_base64": "SGVsbG8="}
+            ]
+        });
+        let payload: PubSubPublishBatchPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.topic.as_deref(), Some("events"));
+        assert_eq!(payload.messages.len(), 3);
+        assert_eq!(payload.messages[0].data.as_deref(), Some("event 1"));
+        assert_eq!(payload.messages[1].ordering_key.as_deref(), Some("k1"));
+        assert_eq!(payload.messages[2].data_base64.as_deref(), Some("SGVsbG8="));
+    }
+
+    #[test]
+    fn resolve_data_text() {
+        let data = PubSubProvider::resolve_data(Some("hello"), None).unwrap();
+        assert_eq!(data, b"hello");
+    }
+
+    #[test]
+    fn resolve_data_base64() {
+        let data = PubSubProvider::resolve_data(None, Some("SGVsbG8=")).unwrap();
+        assert_eq!(data, b"Hello");
+    }
+
+    #[test]
+    fn resolve_data_empty() {
+        let data = PubSubProvider::resolve_data(None, None).unwrap();
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn resolve_data_invalid_base64() {
+        let result = PubSubProvider::resolve_data(None, Some("!!!invalid!!!"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn build_message_with_data() {
+        let msg = PubSubProvider::build_message(b"hello".to_vec(), &HashMap::new(), None);
+        assert_eq!(msg.data, bytes::Bytes::from_static(b"hello"));
+    }
+
+    #[test]
+    fn build_message_with_attributes() {
+        let mut attrs = HashMap::new();
+        attrs.insert("key".to_owned(), "value".to_owned());
+        let msg = PubSubProvider::build_message(b"data".to_vec(), &attrs, Some("ordering-key"));
+        assert_eq!(msg.attributes.get("key").unwrap(), "value");
+        assert_eq!(msg.ordering_key, "ordering-key");
+    }
+}

--- a/crates/gcp/src/storage.rs
+++ b/crates/gcp/src/storage.rs
@@ -1,0 +1,510 @@
+use std::collections::HashMap;
+
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::ProviderError;
+use acteon_provider::provider::Provider;
+use base64::Engine;
+use google_cloud_storage::client::{Storage, StorageControl};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, instrument};
+
+use crate::config::GcpBaseConfig;
+use crate::error::classify_gcp_error;
+
+/// Configuration for the GCP Cloud Storage provider.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct StorageConfig {
+    /// Shared GCP configuration.
+    #[serde(flatten)]
+    pub gcp: GcpBaseConfig,
+
+    /// Default bucket name. Can be overridden per-action in the payload.
+    pub bucket: Option<String>,
+
+    /// Default object name prefix (e.g. `"acteon/artifacts/"`).
+    pub prefix: Option<String>,
+}
+
+impl std::fmt::Debug for StorageConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StorageConfig")
+            .field("gcp", &self.gcp)
+            .field("bucket", &self.bucket)
+            .field("prefix", &self.prefix)
+            .finish()
+    }
+}
+
+impl StorageConfig {
+    /// Create a new `StorageConfig` with the given GCP project ID.
+    pub fn new(project_id: impl Into<String>) -> Self {
+        Self {
+            gcp: GcpBaseConfig::new(project_id),
+            bucket: None,
+            prefix: None,
+        }
+    }
+
+    /// Set the default bucket name.
+    #[must_use]
+    pub fn with_bucket(mut self, bucket: impl Into<String>) -> Self {
+        self.bucket = Some(bucket.into());
+        self
+    }
+
+    /// Set the default object name prefix.
+    #[must_use]
+    pub fn with_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = Some(prefix.into());
+        self
+    }
+
+    /// Set the endpoint URL override (for `fake-gcs-server`).
+    #[must_use]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.gcp.endpoint_url = Some(endpoint_url.into());
+        self
+    }
+
+    /// Set the path to a service account JSON key file.
+    #[must_use]
+    pub fn with_credentials_path(mut self, path: impl Into<String>) -> Self {
+        self.gcp.credentials_path = Some(path.into());
+        self
+    }
+}
+
+/// Payload for the `upload_object` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageUploadPayload {
+    /// Bucket name. Overrides config default.
+    pub bucket: Option<String>,
+
+    /// Object name (path within the bucket).
+    pub object_name: String,
+
+    /// Object body as a UTF-8 string.
+    /// Mutually exclusive with `body_base64`.
+    pub body: Option<String>,
+
+    /// Object body as base64-encoded bytes.
+    /// Mutually exclusive with `body`.
+    pub body_base64: Option<String>,
+
+    /// Optional `Content-Type` for the object.
+    pub content_type: Option<String>,
+
+    /// Optional metadata key-value pairs attached to the object.
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+/// Payload for the `download_object` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageDownloadPayload {
+    /// Bucket name. Overrides config default.
+    pub bucket: Option<String>,
+
+    /// Object name to download.
+    pub object_name: String,
+}
+
+/// Payload for the `delete_object` action type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageDeletePayload {
+    /// Bucket name. Overrides config default.
+    pub bucket: Option<String>,
+
+    /// Object name to delete.
+    pub object_name: String,
+}
+
+/// GCP Cloud Storage provider for storing and retrieving objects.
+pub struct StorageProvider {
+    config: StorageConfig,
+    storage: Storage,
+    control: StorageControl,
+}
+
+impl std::fmt::Debug for StorageProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StorageProvider")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
+}
+
+impl StorageProvider {
+    /// Create a new `StorageProvider` by building Cloud Storage clients.
+    pub async fn new(config: StorageConfig) -> Result<Self, ProviderError> {
+        let credentials =
+            crate::auth::build_gcp_credentials(config.gcp.credentials_path.as_deref())
+                .await
+                .map_err(|e| ProviderError::Configuration(e.to_string()))?;
+
+        // Build the Storage client (for read/write operations).
+        let mut storage_builder = Storage::builder();
+        if let Some(ref endpoint) = config.gcp.endpoint_url {
+            storage_builder = storage_builder.with_endpoint(endpoint);
+        }
+        if let Some(ref creds) = credentials {
+            storage_builder = storage_builder.with_credentials(creds.clone());
+        }
+        let storage = storage_builder.build().await.map_err(|e| {
+            ProviderError::Configuration(format!("Cloud Storage client error: {e}"))
+        })?;
+
+        // Build the StorageControl client (for delete/list operations).
+        let mut control_builder = StorageControl::builder();
+        if let Some(ref endpoint) = config.gcp.endpoint_url {
+            control_builder = control_builder.with_endpoint(endpoint);
+        }
+        if let Some(ref creds) = credentials {
+            control_builder = control_builder.with_credentials(creds.clone());
+        }
+        let control = control_builder.build().await.map_err(|e| {
+            ProviderError::Configuration(format!("Cloud Storage control client error: {e}"))
+        })?;
+
+        Ok(Self {
+            config,
+            storage,
+            control,
+        })
+    }
+
+    /// Resolve the bucket name from the payload or config default.
+    fn resolve_bucket<'a>(&'a self, payload_bucket: Option<&'a str>) -> Option<&'a str> {
+        payload_bucket.or(self.config.bucket.as_deref())
+    }
+
+    /// Format a bucket name into the Cloud Storage v2 resource path.
+    fn bucket_path(bucket: &str) -> String {
+        format!("projects/_/buckets/{bucket}")
+    }
+
+    /// Apply the configured prefix to an object name.
+    fn prefixed_name(&self, object_name: &str) -> String {
+        match &self.config.prefix {
+            Some(prefix) => format!("{prefix}{object_name}"),
+            None => object_name.to_owned(),
+        }
+    }
+}
+
+impl Provider for StorageProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "gcp-storage"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "gcp-storage"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        match action.action_type.as_str() {
+            "upload_object" => Box::pin(self.upload_object(action)).await,
+            "download_object" => self.download_object(action).await,
+            "delete_object" => self.delete_object(action).await,
+            other => Err(ProviderError::Configuration(format!(
+                "unknown Cloud Storage action type '{other}' (expected 'upload_object', 'download_object', or 'delete_object')"
+            ))),
+        }
+    }
+
+    #[instrument(skip(self), fields(provider = "gcp-storage"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        debug!("performing Cloud Storage health check");
+        // The Storage client validates connectivity on build; a lightweight
+        // check is sufficient here since we verified at construction time.
+        info!("Cloud Storage health check passed");
+        Ok(())
+    }
+}
+
+impl StorageProvider {
+    async fn upload_object(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing Cloud Storage upload_object payload");
+        let payload: StorageUploadPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let bucket = self
+            .resolve_bucket(payload.bucket.as_deref())
+            .ok_or_else(|| {
+                ProviderError::Configuration("no bucket in payload or provider config".to_owned())
+            })?;
+
+        let object_name = self.prefixed_name(&payload.object_name);
+
+        // Resolve the body from either string or base64.
+        let body_bytes: Vec<u8> = if let Some(ref b64) = payload.body_base64 {
+            base64::engine::general_purpose::STANDARD
+                .decode(b64)
+                .map_err(|e| ProviderError::Serialization(format!("invalid base64 body: {e}")))?
+        } else if let Some(ref text) = payload.body {
+            text.as_bytes().to_vec()
+        } else {
+            Vec::new()
+        };
+
+        let content_length = body_bytes.len();
+        let bucket_path = Self::bucket_path(bucket);
+        debug!(bucket = %bucket, object_name = %object_name, size = content_length, "uploading object");
+
+        Box::pin(
+            self.storage
+                .write_object(&bucket_path, &object_name, bytes::Bytes::from(body_bytes))
+                .send_buffered(),
+        )
+        .await
+        .map_err(|e| {
+            let err_str = e.to_string();
+            error!(error = %err_str, "Cloud Storage upload failed");
+            let gcp_err: ProviderError = classify_gcp_error(&err_str).into();
+            gcp_err
+        })?;
+
+        info!(bucket = %bucket, object_name = %object_name, "object uploaded");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "bucket": bucket,
+            "object_name": object_name,
+            "status": "uploaded"
+        })))
+    }
+
+    async fn download_object(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing Cloud Storage download_object payload");
+        let payload: StorageDownloadPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let bucket = self
+            .resolve_bucket(payload.bucket.as_deref())
+            .ok_or_else(|| {
+                ProviderError::Configuration("no bucket in payload or provider config".to_owned())
+            })?;
+
+        let object_name = self.prefixed_name(&payload.object_name);
+        let bucket_path = Self::bucket_path(bucket);
+
+        debug!(bucket = %bucket, object_name = %object_name, "downloading object");
+
+        let mut response = self
+            .storage
+            .read_object(&bucket_path, &object_name)
+            .send()
+            .await
+            .map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "Cloud Storage download failed");
+                let gcp_err: ProviderError = classify_gcp_error(&err_str).into();
+                gcp_err
+            })?;
+
+        // Collect all chunks into a single buffer.
+        let mut body_bytes = Vec::new();
+        while let Some(chunk) = response.next().await {
+            let chunk = chunk.map_err(|e| {
+                ProviderError::ExecutionFailed(format!("failed to read object body: {e}"))
+            })?;
+            body_bytes.extend_from_slice(&chunk);
+        }
+
+        let (body_field, body_value) = match std::str::from_utf8(&body_bytes) {
+            Ok(text) => ("body", serde_json::Value::String(text.to_owned())),
+            Err(_) => (
+                "body_base64",
+                serde_json::Value::String(
+                    base64::engine::general_purpose::STANDARD.encode(&body_bytes),
+                ),
+            ),
+        };
+
+        info!(bucket = %bucket, object_name = %object_name, size = body_bytes.len(), "object downloaded");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "bucket": bucket,
+            "object_name": object_name,
+            "content_length": body_bytes.len(),
+            body_field: body_value,
+            "status": "downloaded"
+        })))
+    }
+
+    async fn delete_object(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        debug!("deserializing Cloud Storage delete_object payload");
+        let payload: StorageDeletePayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| ProviderError::Serialization(e.to_string()))?;
+
+        let bucket = self
+            .resolve_bucket(payload.bucket.as_deref())
+            .ok_or_else(|| {
+                ProviderError::Configuration("no bucket in payload or provider config".to_owned())
+            })?;
+
+        let object_name = self.prefixed_name(&payload.object_name);
+        let bucket_path = Self::bucket_path(bucket);
+
+        debug!(bucket = %bucket, object_name = %object_name, "deleting object");
+
+        self.control
+            .delete_object()
+            .set_bucket(&bucket_path)
+            .set_object(&object_name)
+            .send()
+            .await
+            .map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "Cloud Storage delete failed");
+                let gcp_err: ProviderError = classify_gcp_error(&err_str).into();
+                gcp_err
+            })?;
+
+        info!(bucket = %bucket, object_name = %object_name, "object deleted");
+
+        Ok(ProviderResponse::success(serde_json::json!({
+            "bucket": bucket,
+            "object_name": object_name,
+            "status": "deleted"
+        })))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_new_sets_project_id() {
+        let config = StorageConfig::new("my-project");
+        assert_eq!(config.gcp.project_id, "my-project");
+        assert!(config.bucket.is_none());
+        assert!(config.prefix.is_none());
+    }
+
+    #[test]
+    fn config_with_bucket() {
+        let config = StorageConfig::new("my-project").with_bucket("my-bucket");
+        assert_eq!(config.bucket.as_deref(), Some("my-bucket"));
+    }
+
+    #[test]
+    fn config_with_prefix() {
+        let config = StorageConfig::new("my-project").with_prefix("acteon/");
+        assert_eq!(config.prefix.as_deref(), Some("acteon/"));
+    }
+
+    #[test]
+    fn config_builder_chain() {
+        let config = StorageConfig::new("test-project")
+            .with_bucket("data-lake")
+            .with_prefix("logs/")
+            .with_endpoint_url("http://localhost:4443")
+            .with_credentials_path("/path/to/sa.json");
+        assert_eq!(config.bucket.as_deref(), Some("data-lake"));
+        assert_eq!(config.prefix.as_deref(), Some("logs/"));
+        assert_eq!(
+            config.gcp.endpoint_url.as_deref(),
+            Some("http://localhost:4443")
+        );
+        assert!(config.gcp.credentials_path.is_some());
+    }
+
+    #[test]
+    fn config_debug_format() {
+        let config = StorageConfig::new("my-project")
+            .with_bucket("my-bucket")
+            .with_credentials_path("/private/key.json");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("StorageConfig"));
+        assert!(debug.contains("[REDACTED]"));
+        assert!(debug.contains("my-bucket"));
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config = StorageConfig::new("serde-project")
+            .with_bucket("archive")
+            .with_prefix("data/");
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: StorageConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.gcp.project_id, "serde-project");
+        assert_eq!(deserialized.bucket.as_deref(), Some("archive"));
+        assert_eq!(deserialized.prefix.as_deref(), Some("data/"));
+    }
+
+    #[test]
+    fn deserialize_upload_payload() {
+        let json = serde_json::json!({
+            "object_name": "reports/2026/02/daily.json",
+            "body": "{\"total\": 42}",
+            "content_type": "application/json",
+            "bucket": "data-lake",
+            "metadata": {
+                "source": "acteon"
+            }
+        });
+        let payload: StorageUploadPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.object_name, "reports/2026/02/daily.json");
+        assert_eq!(payload.body.as_deref(), Some("{\"total\": 42}"));
+        assert_eq!(payload.content_type.as_deref(), Some("application/json"));
+        assert_eq!(payload.bucket.as_deref(), Some("data-lake"));
+        assert_eq!(payload.metadata.get("source").unwrap(), "acteon");
+    }
+
+    #[test]
+    fn deserialize_upload_payload_base64() {
+        let json = serde_json::json!({
+            "object_name": "images/logo.png",
+            "body_base64": "iVBORw0KGgo=",
+            "content_type": "image/png"
+        });
+        let payload: StorageUploadPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.object_name, "images/logo.png");
+        assert!(payload.body.is_none());
+        assert_eq!(payload.body_base64.as_deref(), Some("iVBORw0KGgo="));
+    }
+
+    #[test]
+    fn deserialize_minimal_upload_payload() {
+        let json = serde_json::json!({
+            "object_name": "test.txt"
+        });
+        let payload: StorageUploadPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.object_name, "test.txt");
+        assert!(payload.body.is_none());
+        assert!(payload.body_base64.is_none());
+        assert!(payload.content_type.is_none());
+        assert!(payload.bucket.is_none());
+        assert!(payload.metadata.is_empty());
+    }
+
+    #[test]
+    fn deserialize_download_payload() {
+        let json = serde_json::json!({
+            "object_name": "reports/latest.json",
+            "bucket": "data-bucket"
+        });
+        let payload: StorageDownloadPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.object_name, "reports/latest.json");
+        assert_eq!(payload.bucket.as_deref(), Some("data-bucket"));
+    }
+
+    #[test]
+    fn deserialize_delete_payload() {
+        let json = serde_json::json!({
+            "object_name": "old/data.csv"
+        });
+        let payload: StorageDeletePayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.object_name, "old/data.csv");
+        assert!(payload.bucket.is_none());
+    }
+
+    #[test]
+    fn bucket_path_format() {
+        assert_eq!(
+            StorageProvider::bucket_path("my-bucket"),
+            "projects/_/buckets/my-bucket"
+        );
+    }
+}

--- a/crates/gcp/src/storage.rs
+++ b/crates/gcp/src/storage.rs
@@ -249,7 +249,9 @@ impl StorageProvider {
         let bucket_path = Self::bucket_path(bucket);
         debug!(bucket = %bucket, object_name = %object_name, size = content_length, "uploading object");
 
-        let mut write_request = self.storage.write_object(&bucket_path, &object_name, bytes::Bytes::from(body_bytes));
+        let mut write_request =
+            self.storage
+                .write_object(&bucket_path, &object_name, bytes::Bytes::from(body_bytes));
 
         if let Some(ref content_type) = payload.content_type {
             write_request = write_request.set_content_type(content_type);
@@ -259,9 +261,7 @@ impl StorageProvider {
             write_request = write_request.set_metadata(payload.metadata);
         }
 
-        Box::pin(write_request.send_buffered())
-            .await
-            .map_err(|e| {
+        Box::pin(write_request.send_buffered()).await.map_err(|e| {
             let err_str = e.to_string();
             error!(error = %err_str, "Cloud Storage upload failed");
             let gcp_err: ProviderError = classify_gcp_error(&err_str).into();

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -36,6 +36,10 @@ aws-all = ["aws-sns", "aws-lambda", "aws-eventbridge", "aws-sqs", "aws-ses", "aw
 azure-blob = ["acteon-azure/blob"]
 azure-eventhubs = ["acteon-azure/eventhubs"]
 azure-all = ["azure-blob", "azure-eventhubs"]
+# GCP provider features — only compile the SDKs you need
+gcp-pubsub = ["acteon-gcp/pubsub"]
+gcp-storage = ["acteon-gcp/storage"]
+gcp-all = ["gcp-pubsub", "gcp-storage"]
 
 [dependencies]
 acteon-audit = { workspace = true, features = ["openapi"] }
@@ -57,6 +61,7 @@ acteon-provider = { workspace = true, features = ["webhook"] }
 acteon-email = { workspace = true, features = ["ses"] }
 acteon-aws = { workspace = true }
 acteon-azure = { workspace = true }
+acteon-gcp = { workspace = true }
 acteon-twilio = { workspace = true }
 acteon-teams = { workspace = true }
 acteon-discord = { workspace = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -59,9 +59,9 @@ acteon-rules = { workspace = true }
 acteon-rules-yaml = { workspace = true }
 acteon-provider = { workspace = true, features = ["webhook"] }
 acteon-email = { workspace = true, features = ["ses"] }
-acteon-aws = { workspace = true }
-acteon-azure = { workspace = true }
-acteon-gcp = { workspace = true }
+acteon-aws = { workspace = true, optional = true }
+acteon-azure = { workspace = true, optional = true }
+acteon-gcp = { workspace = true, optional = true }
 acteon-twilio = { workspace = true }
 acteon-teams = { workspace = true }
 acteon-discord = { workspace = true }

--- a/crates/server/src/config/providers.rs
+++ b/crates/server/src/config/providers.rs
@@ -129,6 +129,8 @@ pub struct ProviderConfig {
     pub gcp_project_id: Option<String>,
     /// Path to GCP service account JSON key file (used by `"gcp-*"` types).
     pub gcp_credentials_path: Option<String>,
+    /// Inline GCP service account JSON key (used by `"gcp-*"` types). Supports `ENC[...]`.
+    pub gcp_credentials_json: Option<String>,
     /// GCP endpoint URL override for emulators (used by `"gcp-*"` types).
     pub gcp_endpoint_url: Option<String>,
     /// Default `Pub/Sub` topic (used by `"gcp-pubsub"` type).

--- a/crates/server/src/config/providers.rs
+++ b/crates/server/src/config/providers.rs
@@ -23,7 +23,7 @@ pub struct ProviderConfig {
     /// Provider type: `"webhook"`, `"log"`, `"twilio"`, `"teams"`, `"discord"`,
     /// `"email"`, `"aws-sns"`, `"aws-lambda"`, `"aws-eventbridge"`, `"aws-sqs"`,
     /// `"aws-s3"`, `"aws-ec2"`, `"aws-autoscaling"`, `"azure-blob"`,
-    /// or `"azure-eventhubs"`.
+    /// `"azure-eventhubs"`, `"gcp-pubsub"`, or `"gcp-storage"`.
     #[serde(rename = "type")]
     pub provider_type: String,
     /// Target URL (required for `"webhook"` type).
@@ -123,4 +123,18 @@ pub struct ProviderConfig {
     pub azure_namespace: Option<String>,
     /// Azure Event Hub name (used by `"azure-eventhubs"` type).
     pub azure_event_hub_name: Option<String>,
+
+    // ---- GCP provider fields ----
+    /// GCP project ID (used by all `"gcp-*"` types).
+    pub gcp_project_id: Option<String>,
+    /// Path to GCP service account JSON key file (used by `"gcp-*"` types).
+    pub gcp_credentials_path: Option<String>,
+    /// GCP endpoint URL override for emulators (used by `"gcp-*"` types).
+    pub gcp_endpoint_url: Option<String>,
+    /// Default `Pub/Sub` topic (used by `"gcp-pubsub"` type).
+    pub gcp_topic: Option<String>,
+    /// Default Cloud Storage bucket name (used by `"gcp-storage"` type).
+    pub gcp_bucket: Option<String>,
+    /// Cloud Storage object name prefix (used by `"gcp-storage"` type).
+    pub gcp_object_prefix: Option<String>,
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1001,6 +1001,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let decrypted = require_decrypt(path, master_key.as_ref())?;
                     ps_config = ps_config.with_credentials_path(decrypted);
                 }
+                if let Some(ref json) = provider_cfg.gcp_credentials_json {
+                    let decrypted = require_decrypt(json, master_key.as_ref())?;
+                    ps_config = ps_config.with_credentials_json(decrypted);
+                }
                 std::sync::Arc::new(
                     acteon_gcp::PubSubProvider::new(ps_config)
                         .await
@@ -1028,6 +1032,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if let Some(ref path) = provider_cfg.gcp_credentials_path {
                     let decrypted = require_decrypt(path, master_key.as_ref())?;
                     storage_config = storage_config.with_credentials_path(decrypted);
+                }
+                if let Some(ref json) = provider_cfg.gcp_credentials_json {
+                    let decrypted = require_decrypt(json, master_key.as_ref())?;
+                    storage_config = storage_config.with_credentials_json(decrypted);
                 }
                 std::sync::Arc::new(
                     acteon_gcp::StorageProvider::new(storage_config)

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -998,7 +998,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     ps_config = ps_config.with_endpoint_url(url);
                 }
                 if let Some(ref path) = provider_cfg.gcp_credentials_path {
-                    ps_config = ps_config.with_credentials_path(path);
+                    let decrypted = require_decrypt(path, master_key.as_ref())?;
+                    ps_config = ps_config.with_credentials_path(decrypted);
                 }
                 std::sync::Arc::new(
                     acteon_gcp::PubSubProvider::new(ps_config)
@@ -1025,7 +1026,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     storage_config = storage_config.with_endpoint_url(url);
                 }
                 if let Some(ref path) = provider_cfg.gcp_credentials_path {
-                    storage_config = storage_config.with_credentials_path(path);
+                    let decrypted = require_decrypt(path, master_key.as_ref())?;
+                    storage_config = storage_config.with_credentials_path(decrypted);
                 }
                 std::sync::Arc::new(
                     acteon_gcp::StorageProvider::new(storage_config)

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -190,5 +190,9 @@ name = "analytics_simulation"
 name = "azure_simulation"
 # No required-features - uses in-memory backends
 
+[[example]]
+name = "gcp_simulation"
+# No required-features - uses in-memory backends
+
 [lints]
 workspace = true

--- a/crates/simulation/examples/gcp_simulation.rs
+++ b/crates/simulation/examples/gcp_simulation.rs
@@ -1,0 +1,262 @@
+//! Simulation demonstrating GCP Cloud Storage and Pub/Sub provider action types.
+//!
+//! Covers all Cloud Storage operations (upload, upload base64, download, delete) and
+//! Pub/Sub operations (publish, publish with ordering key, publish batch).
+//!
+//! Run with:
+//! ```bash
+//! cargo run -p acteon-simulation --example gcp_simulation
+//! ```
+
+use acteon_core::{Action, ActionOutcome};
+use acteon_simulation::prelude::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("==================================================================");
+    println!("       GCP CLOUD STORAGE & PUB/SUB SIMULATION");
+    println!("==================================================================\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("gcp-storage")
+            .add_recording_provider("gcp-pubsub")
+            .build(),
+    )
+    .await?;
+
+    println!("Started simulation cluster with 1 node");
+    println!("Registered providers: gcp-storage, gcp-pubsub\n");
+
+    let mut results: Vec<(&str, ActionOutcome)> = Vec::new();
+
+    // =========================================================================
+    // 1. Storage: Upload (text body)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  1. STORAGE: UPLOAD (text body)");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "storage",
+        "acme-corp",
+        "gcp-storage",
+        "upload_object",
+        serde_json::json!({
+            "bucket": "data-lake",
+            "object_name": "reports/2026/02/daily.json",
+            "body": "{\"readings\": [72.5, 68.1, 75.3]}",
+            "content_type": "application/json",
+            "metadata": {
+                "source": "acteon",
+                "pipeline_version": "2.0"
+            }
+        }),
+    );
+
+    println!("  Dispatching upload_object with text body, content_type, and metadata...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("storage/upload_object(text)", outcome));
+    println!();
+
+    // =========================================================================
+    // 2. Storage: Upload (base64 body)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  2. STORAGE: UPLOAD (base64 body)");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "storage",
+        "acme-corp",
+        "gcp-storage",
+        "upload_object",
+        serde_json::json!({
+            "bucket": "data-lake",
+            "object_name": "images/logo.png",
+            "body_base64": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk",
+            "content_type": "image/png"
+        }),
+    );
+
+    println!("  Dispatching upload_object with base64-encoded binary body...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("storage/upload_object(base64)", outcome));
+    println!();
+
+    // =========================================================================
+    // 3. Storage: Download
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  3. STORAGE: DOWNLOAD");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "storage",
+        "acme-corp",
+        "gcp-storage",
+        "download_object",
+        serde_json::json!({
+            "bucket": "data-lake",
+            "object_name": "reports/2026/02/daily.json"
+        }),
+    );
+
+    println!("  Dispatching download_object...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("storage/download_object", outcome));
+    println!();
+
+    // =========================================================================
+    // 4. Storage: Delete
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  4. STORAGE: DELETE");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "storage",
+        "acme-corp",
+        "gcp-storage",
+        "delete_object",
+        serde_json::json!({
+            "bucket": "data-lake",
+            "object_name": "old/data.csv"
+        }),
+    );
+
+    println!("  Dispatching delete_object...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("storage/delete_object", outcome));
+    println!();
+
+    // =========================================================================
+    // 5. Pub/Sub: Publish (JSON data + attributes)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  5. PUB/SUB: PUBLISH (JSON data + attributes)");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "events",
+        "acme-corp",
+        "gcp-pubsub",
+        "publish",
+        serde_json::json!({
+            "data": "{\"device_id\": \"sensor-001\", \"temperature\": 72.5, \"unit\": \"F\"}",
+            "attributes": {
+                "source": "iot-gateway",
+                "region": "us-west1"
+            }
+        }),
+    );
+
+    println!("  Dispatching publish with JSON data string and attributes...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("pubsub/publish(json+attrs)", outcome));
+    println!();
+
+    // =========================================================================
+    // 6. Pub/Sub: Publish (with ordering key)
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  6. PUB/SUB: PUBLISH (with ordering key)");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "events",
+        "acme-corp",
+        "gcp-pubsub",
+        "publish",
+        serde_json::json!({
+            "data": "{\"device_id\": \"sensor-042\", \"temperature\": 68.1, \"unit\": \"F\"}",
+            "ordering_key": "sensor-042",
+            "topic": "telemetry"
+        }),
+    );
+
+    println!("  Dispatching publish with ordering_key and topic override...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("pubsub/publish(ordering_key)", outcome));
+    println!();
+
+    // =========================================================================
+    // 7. Pub/Sub: Publish Batch
+    // =========================================================================
+    println!("------------------------------------------------------------------");
+    println!("  7. PUB/SUB: PUBLISH BATCH");
+    println!("------------------------------------------------------------------\n");
+
+    let action = Action::new(
+        "events",
+        "acme-corp",
+        "gcp-pubsub",
+        "publish_batch",
+        serde_json::json!({
+            "topic": "telemetry",
+            "messages": [
+                {
+                    "data": "{\"device_id\": \"sensor-001\", \"temperature\": 72.5}",
+                    "attributes": {"region": "us-west1"}
+                },
+                {
+                    "data": "{\"device_id\": \"sensor-002\", \"temperature\": 68.1}",
+                    "ordering_key": "sensor-002"
+                },
+                {
+                    "data": "{\"device_id\": \"sensor-003\", \"temperature\": 75.3}"
+                }
+            ]
+        }),
+    );
+
+    println!("  Dispatching publish_batch with 3 messages (mixed attributes/ordering keys)...");
+    let outcome = harness.dispatch(&action).await?;
+    println!("  Outcome: {outcome:?}");
+    results.push(("pubsub/publish_batch", outcome));
+    println!();
+
+    // =========================================================================
+    // Summary
+    // =========================================================================
+    println!("==================================================================");
+    println!("  SUMMARY");
+    println!("==================================================================\n");
+
+    let mut all_passed = true;
+    for (name, outcome) in &results {
+        let passed = matches!(outcome, ActionOutcome::Executed(_));
+        let status = if passed { "PASS" } else { "FAIL" };
+        println!("  [{status}] {name}: {outcome:?}");
+        if !passed {
+            all_passed = false;
+        }
+    }
+
+    println!();
+    println!(
+        "  Total dispatched: {}  |  Storage calls: {}  |  Pub/Sub calls: {}",
+        results.len(),
+        harness.provider("gcp-storage").unwrap().call_count(),
+        harness.provider("gcp-pubsub").unwrap().call_count(),
+    );
+
+    harness.teardown().await?;
+    println!("\n  Simulation cluster shut down");
+
+    if all_passed {
+        println!("\n  All GCP Cloud Storage and Pub/Sub actions dispatched successfully.");
+    } else {
+        println!("\n  Some actions failed. See details above.");
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/docs/book/features/gcp-providers.md
+++ b/docs/book/features/gcp-providers.md
@@ -1,0 +1,503 @@
+# GCP Providers
+
+Acteon ships with native GCP provider integrations for **Cloud Storage** and **Pub/Sub**. Both are first-class citizens -- they implement the same `Provider` trait, participate in circuit breaking, health checks, and per-provider metrics, and require no external plugins.
+
+## Compile-Time Feature Selection
+
+GCP providers are **not compiled by default**. Each provider maps to a feature flag on `acteon-server`, so you only compile the GCP SDKs you need:
+
+```bash
+# Only Cloud Storage
+cargo build -p acteon-server --features "gcp-storage"
+
+# Only Pub/Sub
+cargo build -p acteon-server --features "gcp-pubsub"
+
+# Both GCP providers
+cargo build -p acteon-server --features gcp-all
+```
+
+| Server Feature | Provider Type | GCP Service |
+|----------------|---------------|-------------|
+| `gcp-storage` | `gcp-storage` | Cloud Storage |
+| `gcp-pubsub` | `gcp-pubsub` | Pub/Sub |
+| `gcp-all` | All of the above | All of the above |
+
+The `acteon-gcp` crate uses the same pattern internally -- each provider is behind a matching feature flag (`storage`, `pubsub`), and provider registration in `main.rs` is guarded by `#[cfg(feature = "gcp-*")]`.
+
+## Overview
+
+| Provider | GCP Service | Action Types | Use Case |
+|----------|------------|--------------|----------|
+| `gcp-storage` | Cloud Storage | `upload_object`, `download_object`, `delete_object` | Store and retrieve objects (logs, artifacts, images, archives) |
+| `gcp-pubsub` | Pub/Sub | `publish`, `publish_batch` | Publish messages for asynchronous event processing |
+
+All GCP providers:
+
+- Share a common authentication layer with service account JSON keys or Application Default Credentials (ADC) fallback
+- Support endpoint URL overrides for local emulators (Pub/Sub emulator, fake-gcs-server)
+- Report per-provider health metrics (success rate, latency percentiles, error tracking)
+- Map GCP SDK errors to the standard `ProviderError` enum for circuit breaker integration
+
+## TOML Configuration
+
+### GCP Cloud Storage
+
+```toml
+[[providers]]
+name = "archive"
+type = "gcp-storage"
+location = "us-central1"
+project_id = "my-gcp-project"
+bucket = "data-lake"
+# prefix = "acteon/artifacts/"                        # Optional key prefix
+# endpoint_url = "http://127.0.0.1:4443"              # fake-gcs-server
+# credentials_json = "/path/to/service-account.json"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used in action dispatch |
+| `type` | Yes | Must be `"gcp-storage"` |
+| `location` | Yes | GCP region (e.g. `"us-central1"`) |
+| `project_id` | Yes | GCP project ID |
+| `bucket` | No | Default bucket name. Can be overridden per-action in the payload |
+| `prefix` | No | Object name prefix prepended to all object names |
+| `endpoint_url` | No | Endpoint URL override (for `fake-gcs-server` or other emulators) |
+| `credentials_json` | No | Path to a service account JSON key file |
+
+### GCP Pub/Sub
+
+```toml
+[[providers]]
+name = "telemetry-topic"
+type = "gcp-pubsub"
+location = "us-central1"
+project_id = "my-gcp-project"
+topic = "telemetry"
+# endpoint_url = "http://localhost:8085"               # Pub/Sub emulator
+# credentials_json = "/path/to/service-account.json"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used in action dispatch |
+| `type` | Yes | Must be `"gcp-pubsub"` |
+| `location` | Yes | GCP region (e.g. `"us-central1"`) |
+| `project_id` | Yes | GCP project ID |
+| `topic` | Yes | Default Pub/Sub topic name. Can be overridden per-action in the payload |
+| `endpoint_url` | No | Endpoint URL override (for the Pub/Sub emulator) |
+| `credentials_json` | No | Path to a service account JSON key file |
+
+## Payload Formats
+
+### Cloud Storage: `upload_object`
+
+```json
+{
+  "bucket": "data-lake",
+  "object_name": "reports/2026/02/daily.json",
+  "body": "{\"readings\": [72.5, 68.1]}",
+  "content_type": "application/json",
+  "metadata": {
+    "source": "acteon",
+    "pipeline_version": "2.0"
+  }
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `object_name` | Yes | string | Object name (path within the bucket) |
+| `bucket` | No | string | Override the default bucket |
+| `body` | No | string | Object body as UTF-8 text. Mutually exclusive with `body_base64` |
+| `body_base64` | No | string | Object body as base64-encoded bytes. Mutually exclusive with `body` |
+| `content_type` | No | string | MIME type for the object |
+| `metadata` | No | object | Key-value metadata pairs attached to the object |
+
+**Response:**
+
+```json
+{
+  "bucket": "data-lake",
+  "object_name": "reports/2026/02/daily.json",
+  "status": "uploaded"
+}
+```
+
+### Cloud Storage: `download_object`
+
+```json
+{
+  "bucket": "data-lake",
+  "object_name": "reports/2026/02/daily.json"
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `object_name` | Yes | string | Object name to download |
+| `bucket` | No | string | Override the default bucket |
+
+**Response** (UTF-8 content):
+
+```json
+{
+  "bucket": "data-lake",
+  "object_name": "reports/2026/02/daily.json",
+  "content_length": 1234,
+  "body": "{\"readings\": [72.5, 68.1]}",
+  "status": "downloaded"
+}
+```
+
+**Response** (binary content):
+
+```json
+{
+  "bucket": "data-lake",
+  "object_name": "images/logo.png",
+  "content_length": 5678,
+  "body_base64": "iVBORw0KGgo...",
+  "status": "downloaded"
+}
+```
+
+### Cloud Storage: `delete_object`
+
+```json
+{
+  "bucket": "data-lake",
+  "object_name": "old/data.csv"
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `object_name` | Yes | string | Object name to delete |
+| `bucket` | No | string | Override the default bucket |
+
+**Response:**
+
+```json
+{
+  "bucket": "data-lake",
+  "object_name": "old/data.csv",
+  "status": "deleted"
+}
+```
+
+### Pub/Sub: `publish`
+
+```json
+{
+  "data": "{\"device_id\": \"sensor-001\", \"temperature\": 72.5}",
+  "topic": "telemetry",
+  "ordering_key": "sensor-001",
+  "attributes": {
+    "source": "iot-gateway"
+  }
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `data` | Yes | string | Message data (typically a JSON string) |
+| `topic` | No | string | Override the default topic name |
+| `ordering_key` | No | string | Ordering key for ordered delivery within the same key |
+| `attributes` | No | object | Message attributes (key-value string pairs) |
+
+**Response:**
+
+```json
+{
+  "topic": "telemetry",
+  "message_count": 1,
+  "status": "published"
+}
+```
+
+### Pub/Sub: `publish_batch`
+
+```json
+{
+  "topic": "telemetry",
+  "messages": [
+    {
+      "data": "{\"device_id\": \"sensor-001\", \"temperature\": 72.5}",
+      "attributes": {"region": "us-west1"}
+    },
+    {
+      "data": "{\"device_id\": \"sensor-002\", \"temperature\": 68.1}",
+      "ordering_key": "sensor-002"
+    }
+  ]
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `topic` | No | string | Override the default topic name |
+| `messages` | Yes | array | List of messages to publish |
+| `messages[].data` | Yes | string | Message data (typically a JSON string) |
+| `messages[].ordering_key` | No | string | Ordering key for this message |
+| `messages[].attributes` | No | object | Message attributes for this message |
+
+**Response:**
+
+```json
+{
+  "topic": "telemetry",
+  "message_count": 2,
+  "status": "published"
+}
+```
+
+## Authentication
+
+GCP providers share a common authentication layer in `acteon-gcp`. Credentials are resolved in this order:
+
+1. **Service account JSON key** -- if `credentials_json` is configured, loads the service account key file and uses it for authentication
+2. **Application Default Credentials** (fallback) -- if `credentials_json` is not configured, falls back to ADC which checks, in order: `GOOGLE_APPLICATION_CREDENTIALS` environment variable, gcloud CLI credentials, Compute Engine / GKE metadata server
+
+For production deployments, use one of these approaches:
+
+- **Service account JSON key** in TOML config or `GOOGLE_APPLICATION_CREDENTIALS` environment variable -- best for non-GCP hosted workloads
+- **Workload Identity** -- for workloads running on GKE; configure via Kubernetes service account annotation and omit `credentials_json` from TOML config
+- **Attached service account** -- for workloads running on Compute Engine, Cloud Run, or Cloud Functions; configure externally via the GCP console and omit `credentials_json` from TOML config
+
+### Service Account Setup
+
+```bash
+# Create a service account for Acteon
+gcloud iam service-accounts create acteon-storage-writer \
+  --display-name="Acteon Storage Writer"
+
+# Grant Cloud Storage permissions
+gcloud projects add-iam-policy-binding my-gcp-project \
+  --member="serviceAccount:acteon-storage-writer@my-gcp-project.iam.gserviceaccount.com" \
+  --role="roles/storage.objectAdmin"
+
+# Grant Pub/Sub permissions
+gcloud projects add-iam-policy-binding my-gcp-project \
+  --member="serviceAccount:acteon-storage-writer@my-gcp-project.iam.gserviceaccount.com" \
+  --role="roles/pubsub.publisher"
+
+# Create and download the key file
+gcloud iam service-accounts keys create /path/to/service-account.json \
+  --iam-account=acteon-storage-writer@my-gcp-project.iam.gserviceaccount.com
+```
+
+## Health Check Behavior
+
+| Provider | Health Check Method | Notes |
+|----------|-------------------|-------|
+| `gcp-storage` | `ListBuckets` | Verifies API connectivity and credentials |
+| `gcp-pubsub` | `GetTopic` | Verifies topic existence and permissions |
+
+All health checks are lightweight read-only operations that do not modify any resources.
+
+## Error Handling
+
+GCP SDK errors are classified into the standard `ProviderError` enum:
+
+| GCP Error Pattern | ProviderError Variant | Retryable | Circuit Breaker |
+|-------------------|----------------------|-----------|-----------------|
+| Connection / DNS / network failure | `Connection` | Yes | Counts toward trip |
+| HTTP 429 / quota exceeded / rate limited | `RateLimited` | Yes | Counts toward trip |
+| Timeout | `Timeout` | Yes | Counts toward trip |
+| Credential / permission errors | `Configuration` | No | Does not count |
+| Invalid payload | `Serialization` | No | Does not count |
+| Other service errors | `ExecutionFailed` | No | Counts toward trip |
+
+## Example: Dispatching via the API
+
+```bash
+# Upload an object
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "storage",
+    "tenant": "acme-corp",
+    "provider": "archive",
+    "action_type": "upload_object",
+    "payload": {
+      "object_name": "reports/2026/02/daily.json",
+      "body": "{\"total\": 42}",
+      "content_type": "application/json"
+    }
+  }'
+
+# Download an object
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "storage",
+    "tenant": "acme-corp",
+    "provider": "archive",
+    "action_type": "download_object",
+    "payload": {
+      "object_name": "reports/2026/02/daily.json"
+    }
+  }'
+
+# Delete an object
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "storage",
+    "tenant": "acme-corp",
+    "provider": "archive",
+    "action_type": "delete_object",
+    "payload": {
+      "object_name": "old/data.csv"
+    }
+  }'
+
+# Publish a message to Pub/Sub
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "events",
+    "tenant": "acme-corp",
+    "provider": "telemetry-topic",
+    "action_type": "publish",
+    "payload": {
+      "data": "{\"device_id\": \"sensor-001\", \"temperature\": 72.5}"
+    }
+  }'
+
+# Publish a batch of messages
+curl -X POST http://localhost:8080/v1/dispatch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "events",
+    "tenant": "acme-corp",
+    "provider": "telemetry-topic",
+    "action_type": "publish_batch",
+    "payload": {
+      "messages": [
+        {"data": "{\"device_id\": \"sensor-001\", \"temperature\": 72.5}"},
+        {"data": "{\"device_id\": \"sensor-002\", \"temperature\": 68.1}"}
+      ]
+    }
+  }'
+```
+
+## Example: Rust Client
+
+```rust
+use acteon_client::ActeonClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = ActeonClient::new("http://localhost:8080", "your-api-token")?;
+
+    // Upload an object
+    client.dispatch_action(
+        "storage", "acme-corp", "archive", "upload_object",
+        serde_json::json!({
+            "object_name": "data/report.json",
+            "body": "{\"total\": 42}",
+            "content_type": "application/json"
+        }),
+    ).await?;
+
+    // Download an object
+    client.dispatch_action(
+        "storage", "acme-corp", "archive", "download_object",
+        serde_json::json!({
+            "object_name": "data/report.json"
+        }),
+    ).await?;
+
+    // Delete an object
+    client.dispatch_action(
+        "storage", "acme-corp", "archive", "delete_object",
+        serde_json::json!({
+            "object_name": "old/data.csv"
+        }),
+    ).await?;
+
+    // Publish a message to Pub/Sub
+    client.dispatch_action(
+        "events", "acme-corp", "telemetry-topic", "publish",
+        serde_json::json!({
+            "data": "{\"device_id\": \"sensor-001\", \"temperature\": 72.5}"
+        }),
+    ).await?;
+
+    // Publish a batch of messages
+    client.dispatch_action(
+        "events", "acme-corp", "telemetry-topic", "publish_batch",
+        serde_json::json!({
+            "messages": [
+                {"data": "{\"device_id\": \"sensor-001\", \"temperature\": 72.5}"},
+                {"data": "{\"device_id\": \"sensor-002\", \"temperature\": 68.1}"}
+            ]
+        }),
+    ).await?;
+
+    Ok(())
+}
+```
+
+## Local Development with Emulators
+
+### Pub/Sub Emulator
+
+GCP provides an official [Pub/Sub emulator](https://cloud.google.com/pubsub/docs/emulator) for local development and testing:
+
+```bash
+# Install and start via gcloud CLI
+gcloud components install pubsub-emulator
+gcloud beta emulators pubsub start --project=test-project
+
+# Or start via Docker
+docker run --rm -d --name pubsub-emulator -p 8085:8085 \
+  gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators \
+  gcloud beta emulators pubsub start --host-port=0.0.0.0:8085 --project=test-project
+```
+
+Point the Pub/Sub provider at the emulator endpoint:
+
+```toml
+[[providers]]
+name = "telemetry-topic"
+type = "gcp-pubsub"
+location = "local"
+project_id = "test-project"
+topic = "telemetry"
+endpoint_url = "http://localhost:8085"
+```
+
+> **Note:** When using the Pub/Sub emulator, authentication is bypassed automatically. You must create topics and subscriptions manually via the emulator API before publishing.
+
+### Cloud Storage Emulator (fake-gcs-server)
+
+For Cloud Storage, use [fake-gcs-server](https://github.com/fsouza/fake-gcs-server), a community-maintained emulator:
+
+```bash
+# Start via Docker
+docker run --rm -d --name fake-gcs -p 4443:4443 \
+  fsouza/fake-gcs-server -scheme http -port 4443
+
+# Create a bucket
+curl -X POST http://localhost:4443/storage/v1/b \
+  -H "Content-Type: application/json" \
+  -d '{"name": "test-bucket"}'
+```
+
+Point the Cloud Storage provider at the emulator endpoint:
+
+```toml
+[[providers]]
+name = "archive"
+type = "gcp-storage"
+location = "local"
+project_id = "test-project"
+bucket = "test-bucket"
+endpoint_url = "http://127.0.0.1:4443"
+```
+
+> **Note:** `fake-gcs-server` does not enforce IAM permissions. For full integration testing with authentication, use a GCP project with a dedicated test bucket.


### PR DESCRIPTION
## Summary

- Add Google Cloud Platform as the third cloud provider (after AWS and Azure), starting with **Pub/Sub** (messaging) and **Cloud Storage** (object storage)
- Uses official Google Cloud Rust crates: `google-cloud-pubsub` 0.32, `google-cloud-storage` 1.8, `google-cloud-auth` 1.6
- Authentication supports service account JSON keys (with `ENC[...]` decryption) and Application Default Credentials (ADC)

## What's included

**New crate `crates/gcp/`** (7 files): `GcpBaseConfig`, `PubSubProvider` (publish, publish_batch), `StorageProvider` (upload_object, download_object, delete_object), error classification, credential loading

**Server integration**: Feature flags (`gcp-pubsub`, `gcp-storage`, `gcp-all`), provider config fields, registration with credential decryption

**SDKs**: Rust client helpers (16 tests), Python (5 functions), Node.js (5 interfaces + 5 functions), Go (10 functions), Java (5 classes)

**Extras**: Simulation example (7 scenarios), documentation (`gcp-providers.md`), publisher caching via `DashMap`, content-type/metadata passthrough on uploads

## Test plan

- [x] `cargo test -p acteon-gcp --features full --lib --tests` — 45 tests passing
- [x] `cargo clippy --workspace --no-deps -- -D warnings` — zero warnings
- [x] `cargo test --workspace --lib --bins --tests` — full workspace green
- [x] `cd ui && npm run lint && npm run build` — frontend unaffected


🤖 Generated with [Claude Code](https://claude.com/claude-code)