### PR TITLE
feat: add `acteon rules coverage` CLI subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,7 @@ dependencies = [
  "acteon-core",
  "acteon-ops",
  "anyhow",
+ "chrono",
  "clap",
  "serde",
  "serde_json",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,6 +16,7 @@ acteon-ops = { workspace = true }
 acteon-core = { workspace = true }
 
 tokio = { workspace = true }
+chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/cli/src/commands/rules.rs
+++ b/crates/cli/src/commands/rules.rs
@@ -1,7 +1,9 @@
 use std::fmt::Write;
 
 use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::{CoverageEntry, CoverageQuery, CoverageReport};
 use acteon_ops::test_rules::{self, TestRunSummary};
+use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand};
 use tracing::{info, warn};
 
@@ -37,6 +39,37 @@ pub enum RulesCommand {
     },
     /// Reload rules from the YAML directory.
     Reload,
+    /// Analyze rule coverage from the audit trail.
+    ///
+    /// The server aggregates audit records by `(namespace, tenant, provider,
+    /// action_type, matched_rule)` within the requested time window and
+    /// cross-references the result with the currently-loaded rule set.
+    /// No raw audit records are transferred over the wire.
+    Coverage {
+        /// Filter by namespace.
+        #[arg(long)]
+        namespace: Option<String>,
+        /// Filter by tenant.
+        #[arg(long)]
+        tenant: Option<String>,
+        /// Scan the last N hours of audit history (default: 24).
+        ///
+        /// Mutually exclusive with `--from`/`--to`.
+        #[arg(long, default_value = "24", conflicts_with_all = ["from", "to"])]
+        since_hours: u64,
+        /// Start of the time range (RFC 3339).
+        #[arg(long)]
+        from: Option<DateTime<Utc>>,
+        /// End of the time range (RFC 3339). Defaults to now.
+        #[arg(long)]
+        to: Option<DateTime<Utc>>,
+        /// Only display UNCOVERED entries.
+        #[arg(long)]
+        only_uncovered: bool,
+        /// Hide entries with fewer than N uncovered actions.
+        #[arg(long, default_value = "0")]
+        min_uncovered: u64,
+    },
 }
 
 pub async fn run(ops: &OpsClient, args: &RulesArgs, format: &OutputFormat) -> anyhow::Result<()> {
@@ -107,8 +140,181 @@ pub async fn run(ops: &OpsClient, args: &RulesArgs, format: &OutputFormat) -> an
                 }
             }
         }
+        RulesCommand::Coverage {
+            namespace,
+            tenant,
+            since_hours,
+            from,
+            to,
+            only_uncovered,
+            min_uncovered,
+        } => {
+            // Build time range: explicit from/to takes precedence; otherwise use --since-hours.
+            let (effective_from, effective_to) = if from.is_some() || to.is_some() {
+                (*from, *to)
+            } else {
+                let now = Utc::now();
+                let since = now - chrono::Duration::hours((*since_hours).cast_signed());
+                (Some(since), Some(now))
+            };
+
+            let query = CoverageQuery {
+                namespace: namespace.clone(),
+                tenant: tenant.clone(),
+                from: effective_from,
+                to: effective_to,
+            };
+
+            let report = ops.rules_coverage(&query).await?;
+
+            match format {
+                OutputFormat::Json => {
+                    info!("{}", serde_json::to_string_pretty(&report)?);
+                }
+                OutputFormat::Text => {
+                    print_coverage_report(&report, *only_uncovered, *min_uncovered);
+                }
+            }
+        }
     }
     Ok(())
+}
+
+// =========================================================================
+// Coverage display
+// =========================================================================
+
+fn print_coverage_report(report: &CoverageReport, only_uncovered: bool, min_uncovered: u64) {
+    info!(
+        scanned_from = %report.scanned_from.to_rfc3339(),
+        scanned_to = %report.scanned_to.to_rfc3339(),
+        total_actions = report.total_actions,
+        rules_loaded = report.rules_loaded,
+        "Coverage analysis (scan window)"
+    );
+    info!("");
+
+    info!(
+        combinations = report.unique_combinations,
+        fully_covered = report.fully_covered,
+        partially_covered = report.partially_covered,
+        uncovered = report.uncovered,
+        "Coverage summary"
+    );
+    info!("");
+
+    if report.entries.is_empty() {
+        info!("No audit records in the scanned window.");
+        return;
+    }
+
+    let filtered: Vec<&CoverageEntry> = report
+        .entries
+        .iter()
+        .filter(|e| {
+            if only_uncovered && e.covered > 0 {
+                return false;
+            }
+            e.uncovered >= min_uncovered
+        })
+        .collect();
+
+    if filtered.is_empty() {
+        info!("No entries match the current filters.");
+    } else {
+        print_coverage_table(&filtered);
+    }
+
+    print_unmatched_rules(report);
+}
+
+fn print_coverage_table(entries: &[&CoverageEntry]) {
+    let ns_w = entries
+        .iter()
+        .map(|e| e.key.namespace.len())
+        .max()
+        .unwrap_or(9)
+        .max(9);
+    let tenant_w = entries
+        .iter()
+        .map(|e| e.key.tenant.len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+    let prov_w = entries
+        .iter()
+        .map(|e| e.key.provider.len())
+        .max()
+        .unwrap_or(8)
+        .max(8);
+    let type_w = entries
+        .iter()
+        .map(|e| e.key.action_type.len())
+        .max()
+        .unwrap_or(11)
+        .max(11);
+
+    let mut header = String::new();
+    let _ = write!(
+        header,
+        "{:<ns_w$}  {:<tenant_w$}  {:<prov_w$}  {:<type_w$}  {:>5}  {:>5}  {:>5}  STATUS     RULES",
+        "NAMESPACE", "TENANT", "PROVIDER", "ACTION_TYPE", "TOTAL", "COVER", "MISS",
+    );
+    info!("{header}");
+    info!("{}", "-".repeat(header.len()));
+
+    for entry in entries {
+        let status = if entry.covered == 0 {
+            "UNCOVERED"
+        } else if entry.uncovered > 0 {
+            "PARTIAL"
+        } else {
+            "COVERED"
+        };
+
+        let rules_str = if entry.matched_rules.is_empty() {
+            "-".to_string()
+        } else {
+            entry.matched_rules.join(", ")
+        };
+
+        let line = format!(
+            "{:<ns_w$}  {:<tenant_w$}  {:<prov_w$}  {:<type_w$}  {:>5}  {:>5}  {:>5}  {:<9}  {}",
+            entry.key.namespace,
+            entry.key.tenant,
+            entry.key.provider,
+            entry.key.action_type,
+            entry.total,
+            entry.covered,
+            entry.uncovered,
+            status,
+            rules_str,
+        );
+
+        if entry.covered == 0 {
+            warn!("{line}");
+        } else {
+            info!("{line}");
+        }
+    }
+}
+
+fn print_unmatched_rules(report: &CoverageReport) {
+    if !report.unmatched_rules.is_empty() {
+        info!("");
+        warn!(
+            count = report.unmatched_rules.len(),
+            "Enabled rules with no matches in the scanned window"
+        );
+        info!(
+            "  NOTE: This is window-scoped — a rule listed here may still be live \
+             if it triggers rarely and simply did not fire inside the queried time range. \
+             Verify against the full audit index before deleting any rule."
+        );
+        for name in &report.unmatched_rules {
+            warn!(name = %name, "  Unmatched rule");
+        }
+    }
 }
 
 fn print_test_summary(summary: &TestRunSummary) {


### PR DESCRIPTION
## Summary
Adds the `acteon rules coverage` CLI subcommand that wraps the `GET /v1/rules/coverage` endpoint shipped in #79.

### CLI flags
- `--namespace` / `--tenant` — filters passed to the server
- `--since-hours N` (default 24) **or** explicit `--from` / `--to` (RFC 3339) — mutually exclusive
- `--only-uncovered` — hide fully-covered combinations
- `--min-uncovered N` — hide entries with fewer than N uncovered actions
- `--format json` — emit the raw `CoverageReport` for scripting

### Output
- Text mode prints `scanned_from` / `scanned_to` / `total_actions` / `rules_loaded` up front so operators see the exact window being summarized
- Entries arrive pre-sorted from the server (UNCOVERED → PARTIAL → COVERED)
- Dead-rule warning is explicitly **window-scoped** — the wording warns that a rule listed as unmatched may still be live if it triggers rarely and didn't fire inside the queried range

### What's NOT in this PR
- Aggregation logic — lives on the server (#79). The CLI is a thin wrapper over `OpsClient::rules_coverage`.
- No server, audit, SDK, or migration changes — this PR touches only the CLI crate.

## Follow-up to #79
#79 landed the server endpoint, audit backend aggregation, shared core types, Postgres covering index, and all polyglot SDK wrappers. This PR adds the CLI surface on top.

## Test plan
- [x] \`cargo clippy --workspace --no-deps -- -D warnings\`
- [x] \`cargo test -p acteon-cli --bins --tests\`
- [x] \`cd ui && npm run lint && npm run build\`
- [ ] Manual: \`acteon rules coverage\` against a running gateway with audit data
- [ ] Manual: \`acteon rules coverage --only-uncovered --since-hours 168\`
- [ ] Manual: \`acteon rules coverage --format json\` emits valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)