### PR TITLE
feat(rule-coverage): tests, docs, simulation, --sort-by flag

### DIFF
--- a/crates/cli/src/commands/rules.rs
+++ b/crates/cli/src/commands/rules.rs
@@ -4,7 +4,7 @@ use acteon_ops::OpsClient;
 use acteon_ops::acteon_client::{CoverageEntry, CoverageQuery, CoverageReport};
 use acteon_ops::test_rules::{self, TestRunSummary};
 use chrono::{DateTime, Utc};
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 use tracing::{info, warn};
 
 use crate::OutputFormat;
@@ -69,7 +69,23 @@ pub enum RulesCommand {
         /// Hide entries with fewer than N uncovered actions.
         #[arg(long, default_value = "0")]
         min_uncovered: u64,
+        /// Sort order for displayed entries.
+        #[arg(long, value_enum, default_value_t = CoverageSort::Status)]
+        sort_by: CoverageSort,
     },
+}
+
+/// Sort order for the coverage table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum CoverageSort {
+    /// UNCOVERED → PARTIAL → COVERED (server default).
+    Status,
+    /// Highest total actions first.
+    Total,
+    /// Highest uncovered count first.
+    Miss,
+    /// Alphabetical by `namespace:tenant:provider:action_type`.
+    Name,
 }
 
 pub async fn run(ops: &OpsClient, args: &RulesArgs, format: &OutputFormat) -> anyhow::Result<()> {
@@ -140,75 +156,136 @@ pub async fn run(ops: &OpsClient, args: &RulesArgs, format: &OutputFormat) -> an
                 }
             }
         }
-        RulesCommand::Coverage {
-            namespace,
-            tenant,
-            since_hours,
-            from,
-            to,
-            only_uncovered,
-            min_uncovered,
-        } => {
-            // Build time range: explicit from/to takes precedence; otherwise use --since-hours.
-            let (effective_from, effective_to) = if from.is_some() || to.is_some() {
-                (*from, *to)
-            } else {
-                let now = Utc::now();
-                let since = now - chrono::Duration::hours((*since_hours).cast_signed());
-                (Some(since), Some(now))
-            };
-
-            let query = CoverageQuery {
-                namespace: namespace.clone(),
-                tenant: tenant.clone(),
-                from: effective_from,
-                to: effective_to,
-            };
-
-            let report = ops.rules_coverage(&query).await?;
-
-            match format {
-                OutputFormat::Json => {
-                    info!("{}", serde_json::to_string_pretty(&report)?);
-                }
-                OutputFormat::Text => {
-                    print_coverage_report(&report, *only_uncovered, *min_uncovered);
-                }
-            }
+        RulesCommand::Coverage { .. } => {
+            run_coverage(ops, &args.command, format).await?;
         }
     }
     Ok(())
 }
 
-// =========================================================================
-// Coverage display
-// =========================================================================
+async fn run_coverage(
+    ops: &OpsClient,
+    command: &RulesCommand,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    let RulesCommand::Coverage {
+        namespace,
+        tenant,
+        since_hours,
+        from,
+        to,
+        only_uncovered,
+        min_uncovered,
+        sort_by,
+    } = command
+    else {
+        unreachable!("run_coverage called with non-Coverage command");
+    };
 
-fn print_coverage_report(report: &CoverageReport, only_uncovered: bool, min_uncovered: u64) {
-    info!(
-        scanned_from = %report.scanned_from.to_rfc3339(),
-        scanned_to = %report.scanned_to.to_rfc3339(),
-        total_actions = report.total_actions,
-        rules_loaded = report.rules_loaded,
-        "Coverage analysis (scan window)"
-    );
-    info!("");
+    // Build time range: explicit from/to takes precedence; otherwise use --since-hours.
+    let (effective_from, effective_to) = if from.is_some() || to.is_some() {
+        (*from, *to)
+    } else {
+        let now = Utc::now();
+        let since = now - chrono::Duration::hours((*since_hours).cast_signed());
+        (Some(since), Some(now))
+    };
 
-    info!(
-        combinations = report.unique_combinations,
-        fully_covered = report.fully_covered,
-        partially_covered = report.partially_covered,
-        uncovered = report.uncovered,
-        "Coverage summary"
-    );
-    info!("");
+    let query = CoverageQuery {
+        namespace: namespace.clone(),
+        tenant: tenant.clone(),
+        from: effective_from,
+        to: effective_to,
+    };
 
-    if report.entries.is_empty() {
-        info!("No audit records in the scanned window.");
-        return;
+    let report = ops.rules_coverage(&query).await?;
+
+    match format {
+        OutputFormat::Json => {
+            info!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        OutputFormat::Text => {
+            for line in render_coverage_report(&report, *only_uncovered, *min_uncovered, *sort_by) {
+                if line.is_warning {
+                    warn!("{}", line.text);
+                } else {
+                    info!("{}", line.text);
+                }
+            }
+        }
     }
 
-    let filtered: Vec<&CoverageEntry> = report
+    Ok(())
+}
+
+// =========================================================================
+// Coverage rendering (pure functions — testable)
+// =========================================================================
+
+/// A single line of rendered coverage output.
+///
+/// `is_warning` drives whether the line is emitted at WARN or INFO level so
+/// operators can spot trouble in terminal output, while still letting us
+/// snapshot the full rendering in unit tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderedLine {
+    pub text: String,
+    pub is_warning: bool,
+}
+
+impl RenderedLine {
+    fn info(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            is_warning: false,
+        }
+    }
+
+    fn warn(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            is_warning: true,
+        }
+    }
+}
+
+/// Render a coverage report into an ordered list of output lines.
+///
+/// Pure function — no I/O, no tracing — so it can be snapshot-tested.
+pub fn render_coverage_report(
+    report: &CoverageReport,
+    only_uncovered: bool,
+    min_uncovered: u64,
+    sort_by: CoverageSort,
+) -> Vec<RenderedLine> {
+    let mut out = Vec::new();
+
+    out.push(RenderedLine::info(format!(
+        "Coverage analysis: scanned_from={} scanned_to={} total_actions={} rules_loaded={}",
+        report.scanned_from.to_rfc3339(),
+        report.scanned_to.to_rfc3339(),
+        report.total_actions,
+        report.rules_loaded,
+    )));
+    out.push(RenderedLine::info(String::new()));
+
+    out.push(RenderedLine::info(format!(
+        "Coverage summary: combinations={} fully_covered={} partially_covered={} uncovered={}",
+        report.unique_combinations,
+        report.fully_covered,
+        report.partially_covered,
+        report.uncovered,
+    )));
+    out.push(RenderedLine::info(String::new()));
+
+    if report.entries.is_empty() {
+        out.push(RenderedLine::info(
+            "No audit records in the scanned window.",
+        ));
+        return out;
+    }
+
+    let mut filtered: Vec<&CoverageEntry> = report
         .entries
         .iter()
         .filter(|e| {
@@ -219,16 +296,44 @@ fn print_coverage_report(report: &CoverageReport, only_uncovered: bool, min_unco
         })
         .collect();
 
+    // Apply local re-sort if the user asked for something other than the
+    // server default (Status).
+    apply_sort(&mut filtered, sort_by);
+
     if filtered.is_empty() {
-        info!("No entries match the current filters.");
+        out.push(RenderedLine::info("No entries match the current filters."));
     } else {
-        print_coverage_table(&filtered);
+        out.extend(render_coverage_table(&filtered));
     }
 
-    print_unmatched_rules(report);
+    out.extend(render_unmatched_rules(report));
+    out
 }
 
-fn print_coverage_table(entries: &[&CoverageEntry]) {
+fn apply_sort(entries: &mut [&CoverageEntry], sort_by: CoverageSort) {
+    match sort_by {
+        // Server already returns entries sorted by status (UNCOVERED →
+        // PARTIAL → COVERED, ties broken by key). Nothing to do.
+        CoverageSort::Status => {}
+        CoverageSort::Total => {
+            entries.sort_by(|a, b| b.total.cmp(&a.total).then_with(|| a.key.cmp(&b.key)));
+        }
+        CoverageSort::Miss => {
+            entries.sort_by(|a, b| {
+                b.uncovered
+                    .cmp(&a.uncovered)
+                    .then_with(|| a.key.cmp(&b.key))
+            });
+        }
+        CoverageSort::Name => {
+            entries.sort_by(|a, b| a.key.cmp(&b.key));
+        }
+    }
+}
+
+fn render_coverage_table(entries: &[&CoverageEntry]) -> Vec<RenderedLine> {
+    let mut out = Vec::new();
+
     let ns_w = entries
         .iter()
         .map(|e| e.key.namespace.len())
@@ -260,8 +365,9 @@ fn print_coverage_table(entries: &[&CoverageEntry]) {
         "{:<ns_w$}  {:<tenant_w$}  {:<prov_w$}  {:<type_w$}  {:>5}  {:>5}  {:>5}  STATUS     RULES",
         "NAMESPACE", "TENANT", "PROVIDER", "ACTION_TYPE", "TOTAL", "COVER", "MISS",
     );
-    info!("{header}");
-    info!("{}", "-".repeat(header.len()));
+    let sep = "-".repeat(header.len());
+    out.push(RenderedLine::info(header));
+    out.push(RenderedLine::info(sep));
 
     for entry in entries {
         let status = if entry.covered == 0 {
@@ -292,29 +398,35 @@ fn print_coverage_table(entries: &[&CoverageEntry]) {
         );
 
         if entry.covered == 0 {
-            warn!("{line}");
+            out.push(RenderedLine::warn(line));
         } else {
-            info!("{line}");
+            out.push(RenderedLine::info(line));
         }
     }
+
+    out
 }
 
-fn print_unmatched_rules(report: &CoverageReport) {
-    if !report.unmatched_rules.is_empty() {
-        info!("");
-        warn!(
-            count = report.unmatched_rules.len(),
-            "Enabled rules with no matches in the scanned window"
-        );
-        info!(
-            "  NOTE: This is window-scoped — a rule listed here may still be live \
-             if it triggers rarely and simply did not fire inside the queried time range. \
-             Verify against the full audit index before deleting any rule."
-        );
-        for name in &report.unmatched_rules {
-            warn!(name = %name, "  Unmatched rule");
-        }
+fn render_unmatched_rules(report: &CoverageReport) -> Vec<RenderedLine> {
+    let mut out = Vec::new();
+    if report.unmatched_rules.is_empty() {
+        return out;
     }
+
+    out.push(RenderedLine::info(String::new()));
+    out.push(RenderedLine::warn(format!(
+        "{} enabled rule(s) with no matches in the scanned window",
+        report.unmatched_rules.len()
+    )));
+    out.push(RenderedLine::info(
+        "  NOTE: This is window-scoped — a rule listed here may still be live \
+         if it triggers rarely and simply did not fire inside the queried time range. \
+         Verify against the full audit index before deleting any rule.",
+    ));
+    for name in &report.unmatched_rules {
+        out.push(RenderedLine::warn(format!("  Unmatched rule: {name}")));
+    }
+    out
 }
 
 fn print_test_summary(summary: &TestRunSummary) {
@@ -347,4 +459,273 @@ fn print_test_summary(summary: &TestRunSummary) {
         duration_ms = summary.duration_ms,
         "Test result"
     );
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use acteon_ops::acteon_client::CoverageKey;
+    use chrono::TimeZone;
+
+    fn fixed_time() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 4, 9, 12, 0, 0).unwrap()
+    }
+
+    fn entry(
+        ns: &str,
+        tenant: &str,
+        provider: &str,
+        action_type: &str,
+        total: u64,
+        covered: u64,
+        rules: &[&str],
+    ) -> CoverageEntry {
+        CoverageEntry {
+            key: CoverageKey {
+                namespace: ns.into(),
+                tenant: tenant.into(),
+                provider: provider.into(),
+                action_type: action_type.into(),
+            },
+            total,
+            covered,
+            uncovered: total - covered,
+            matched_rules: rules.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    fn sample_report() -> CoverageReport {
+        CoverageReport {
+            scanned_from: fixed_time() - chrono::Duration::hours(24),
+            scanned_to: fixed_time(),
+            total_actions: 30,
+            unique_combinations: 3,
+            fully_covered: 1,
+            partially_covered: 1,
+            uncovered: 1,
+            rules_loaded: 4,
+            // Server-side order: UNCOVERED → PARTIAL → COVERED, then by key.
+            entries: vec![
+                entry("prod", "acme", "webhook", "post", 10, 0, &[]),
+                entry("prod", "acme", "sms", "send", 5, 3, &["allow-sms"]),
+                entry("prod", "acme", "email", "send", 15, 15, &["allow-email"]),
+            ],
+            unmatched_rules: vec!["dead-rule".into()],
+        }
+    }
+
+    fn text_of(lines: &[RenderedLine]) -> String {
+        lines
+            .iter()
+            .map(|l| l.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn render_includes_scan_window_header() {
+        let report = sample_report();
+        let out = render_coverage_report(&report, false, 0, CoverageSort::Status);
+        let text = text_of(&out);
+
+        assert!(
+            text.contains("scanned_from=2026-04-08T12:00:00+00:00"),
+            "scanned_from header missing: {text}"
+        );
+        assert!(
+            text.contains("scanned_to=2026-04-09T12:00:00+00:00"),
+            "scanned_to header missing: {text}"
+        );
+        assert!(
+            text.contains("total_actions=30"),
+            "total_actions missing: {text}"
+        );
+        assert!(
+            text.contains("rules_loaded=4"),
+            "rules_loaded missing: {text}"
+        );
+    }
+
+    #[test]
+    fn render_classifies_entries_into_status_labels() {
+        let report = sample_report();
+        let out = render_coverage_report(&report, false, 0, CoverageSort::Status);
+        let text = text_of(&out);
+
+        assert!(text.contains("UNCOVERED"), "missing UNCOVERED label");
+        assert!(text.contains("PARTIAL"), "missing PARTIAL label");
+        assert!(text.contains("COVERED"), "missing COVERED label");
+    }
+
+    #[test]
+    fn render_marks_uncovered_rows_as_warnings() {
+        let report = sample_report();
+        let out = render_coverage_report(&report, false, 0, CoverageSort::Status);
+
+        let warning_lines: Vec<&RenderedLine> = out.iter().filter(|l| l.is_warning).collect();
+        // At least one warning for the uncovered webhook row and the dead-rule listing.
+        assert!(warning_lines.iter().any(|l| l.text.contains("webhook")));
+        assert!(
+            warning_lines
+                .iter()
+                .any(|l| l.text.contains("Unmatched rule: dead-rule"))
+        );
+    }
+
+    #[test]
+    fn render_only_uncovered_hides_partial_and_covered() {
+        let report = sample_report();
+        let out = render_coverage_report(&report, true, 0, CoverageSort::Status);
+        let text = text_of(&out);
+
+        assert!(text.contains("webhook"), "uncovered entry should be shown");
+        assert!(!text.contains("PARTIAL"), "PARTIAL row should be hidden");
+        // COVERED data rows hidden, though the summary header still mentions the count.
+        let data_rows: Vec<&RenderedLine> = out
+            .iter()
+            .filter(|l| l.text.contains("  COVERED  "))
+            .collect();
+        assert!(data_rows.is_empty(), "COVERED row should be hidden");
+    }
+
+    #[test]
+    fn render_min_uncovered_filters_low_miss_counts() {
+        let report = sample_report();
+        // sms has 2 uncovered; webhook has 10. Only webhook should survive.
+        let out = render_coverage_report(&report, false, 5, CoverageSort::Status);
+        let text = text_of(&out);
+
+        assert!(text.contains("webhook"));
+        assert!(!text.contains("  sms  "), "sms row should be filtered out");
+    }
+
+    #[test]
+    fn render_empty_entries_prints_no_records_message() {
+        let mut report = sample_report();
+        report.entries.clear();
+        report.unmatched_rules.clear();
+
+        let out = render_coverage_report(&report, false, 0, CoverageSort::Status);
+        let text = text_of(&out);
+        assert!(text.contains("No audit records in the scanned window."));
+    }
+
+    #[test]
+    fn render_filtered_to_empty_prints_no_match_message() {
+        let report = sample_report();
+        // min_uncovered=100 filters everything out.
+        let out = render_coverage_report(&report, false, 100, CoverageSort::Status);
+        let text = text_of(&out);
+        assert!(text.contains("No entries match the current filters."));
+    }
+
+    #[test]
+    fn render_unmatched_rules_warning_is_window_scoped() {
+        let report = sample_report();
+        let out = render_coverage_report(&report, false, 0, CoverageSort::Status);
+        let text = text_of(&out);
+
+        assert!(text.contains("dead-rule"));
+        // The NOTE line explicitly calls out that the result is window-scoped.
+        assert!(
+            text.contains("window-scoped"),
+            "unmatched-rule warning should emphasize scope: {text}"
+        );
+    }
+
+    #[test]
+    fn sort_by_total_orders_by_total_descending() {
+        let report = sample_report();
+        let out = render_coverage_report(&report, false, 0, CoverageSort::Total);
+
+        // Find the data rows (those that contain the provider names).
+        let data: Vec<&str> = out
+            .iter()
+            .filter_map(|l| {
+                let t = l.text.as_str();
+                if t.contains("email") || t.contains("sms") || t.contains("webhook") {
+                    Some(t)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Expected order by total desc: email(15) > webhook(10) > sms(5)
+        let email_pos = data.iter().position(|s| s.contains("email")).unwrap();
+        let webhook_pos = data.iter().position(|s| s.contains("webhook")).unwrap();
+        let sms_pos = data.iter().position(|s| s.contains("sms")).unwrap();
+        assert!(email_pos < webhook_pos, "email should be before webhook");
+        assert!(webhook_pos < sms_pos, "webhook should be before sms");
+    }
+
+    #[test]
+    fn sort_by_miss_orders_by_uncovered_descending() {
+        let report = sample_report();
+        let out = render_coverage_report(&report, false, 0, CoverageSort::Miss);
+
+        let data: Vec<&str> = out
+            .iter()
+            .filter_map(|l| {
+                let t = l.text.as_str();
+                if t.contains("email") || t.contains("sms") || t.contains("webhook") {
+                    Some(t)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Miss counts: webhook=10, sms=2, email=0.
+        let webhook_pos = data.iter().position(|s| s.contains("webhook")).unwrap();
+        let sms_pos = data.iter().position(|s| s.contains("sms")).unwrap();
+        let email_pos = data.iter().position(|s| s.contains("email")).unwrap();
+        assert!(webhook_pos < sms_pos);
+        assert!(sms_pos < email_pos);
+    }
+
+    #[test]
+    fn sort_by_name_orders_alphabetically_by_key() {
+        let report = sample_report();
+        let out = render_coverage_report(&report, false, 0, CoverageSort::Name);
+
+        let data: Vec<&str> = out
+            .iter()
+            .filter_map(|l| {
+                let t = l.text.as_str();
+                if t.contains("email") || t.contains("sms") || t.contains("webhook") {
+                    Some(t)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Alphabetical by (provider as the discriminator within the same ns/tenant):
+        // email < sms < webhook.
+        assert!(data[0].contains("email"));
+        assert!(data[1].contains("sms"));
+        assert!(data[2].contains("webhook"));
+    }
+
+    #[test]
+    fn render_table_header_and_separator_match_width() {
+        let report = sample_report();
+        let out = render_coverage_report(&report, false, 0, CoverageSort::Status);
+
+        let header_line = out
+            .iter()
+            .find(|l| l.text.contains("NAMESPACE") && l.text.contains("STATUS"))
+            .expect("header line");
+        let sep_line = out
+            .iter()
+            .find(|l| !l.text.is_empty() && l.text.chars().all(|c| c == '-'))
+            .expect("separator line");
+
+        assert_eq!(header_line.text.len(), sep_line.text.len());
+    }
 }

--- a/crates/simulation/examples/rule_coverage_simulation.rs
+++ b/crates/simulation/examples/rule_coverage_simulation.rs
@@ -1,0 +1,278 @@
+//! Simulation of the rule coverage API in Acteon.
+//!
+//! Seeds a memory audit store with a mixed workload across several
+//! `(namespace, tenant, provider, action_type)` combinations — some fully
+//! covered by rules, some partially, some untouched — then queries the
+//! `AnalyticsStore::rule_coverage` method and renders a coverage report
+//! using `acteon_core::build_report`.
+//!
+//! The same aggregation + report builder runs behind
+//! `GET /v1/rules/coverage` in the server. This example shows the moving
+//! parts without spinning up an HTTP gateway.
+//!
+//! Run with: `cargo run -p acteon-simulation --example rule_coverage_simulation`
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use acteon_audit::InMemoryAnalytics;
+use acteon_audit::analytics::AnalyticsStore;
+use acteon_audit::record::AuditRecord;
+use acteon_audit::store::AuditStore;
+use acteon_audit_memory::MemoryAuditStore;
+use acteon_core::coverage::{CoverageQuery, CoverageReport, build_report};
+use chrono::{DateTime, Duration, Utc};
+use tracing::info;
+
+#[allow(clippy::too_many_arguments)]
+fn make_record(
+    namespace: &str,
+    tenant: &str,
+    provider: &str,
+    action_type: &str,
+    matched_rule: Option<&str>,
+    dispatched_at: DateTime<Utc>,
+) -> AuditRecord {
+    AuditRecord {
+        id: uuid::Uuid::now_v7().to_string(),
+        action_id: uuid::Uuid::now_v7().to_string(),
+        chain_id: None,
+        namespace: namespace.to_string(),
+        tenant: tenant.to_string(),
+        provider: provider.to_string(),
+        action_type: action_type.to_string(),
+        verdict: if matched_rule.is_some() {
+            "deny".to_string()
+        } else {
+            "allow".to_string()
+        },
+        matched_rule: matched_rule.map(String::from),
+        outcome: "executed".to_string(),
+        action_payload: None,
+        verdict_details: serde_json::json!({}),
+        outcome_details: serde_json::json!({}),
+        metadata: serde_json::json!({}),
+        dispatched_at,
+        completed_at: dispatched_at + Duration::milliseconds(50),
+        duration_ms: 50,
+        expires_at: None,
+        caller_id: String::new(),
+        auth_method: String::new(),
+        record_hash: None,
+        previous_hash: None,
+        sequence_number: None,
+        attachment_metadata: Vec::new(),
+    }
+}
+
+fn print_report(report: &CoverageReport) {
+    info!("\n{}", "=".repeat(72));
+    info!("  Rule Coverage Report");
+    info!("{}", "=".repeat(72));
+    info!(
+        "  Window: {} -> {}",
+        report.scanned_from.format("%Y-%m-%d %H:%M"),
+        report.scanned_to.format("%Y-%m-%d %H:%M")
+    );
+    info!(
+        "  total_actions={}  combinations={}  rules_loaded={}",
+        report.total_actions, report.unique_combinations, report.rules_loaded
+    );
+    info!(
+        "  fully_covered={}  partially_covered={}  uncovered={}",
+        report.fully_covered, report.partially_covered, report.uncovered
+    );
+    info!("");
+    info!(
+        "  {:<10} {:<8} {:<10} {:<15} {:>6} {:>6} {:>6}  STATUS     RULES",
+        "NAMESPACE", "TENANT", "PROVIDER", "ACTION_TYPE", "TOTAL", "COVER", "MISS"
+    );
+    info!("  {}", "-".repeat(90));
+
+    for entry in &report.entries {
+        let status = if entry.covered == 0 {
+            "UNCOVERED"
+        } else if entry.uncovered > 0 {
+            "PARTIAL"
+        } else {
+            "COVERED"
+        };
+        let rules = if entry.matched_rules.is_empty() {
+            "-".to_string()
+        } else {
+            entry.matched_rules.join(", ")
+        };
+        info!(
+            "  {:<10} {:<8} {:<10} {:<15} {:>6} {:>6} {:>6}  {:<9}  {}",
+            entry.key.namespace,
+            entry.key.tenant,
+            entry.key.provider,
+            entry.key.action_type,
+            entry.total,
+            entry.covered,
+            entry.uncovered,
+            status,
+            rules
+        );
+    }
+
+    if !report.unmatched_rules.is_empty() {
+        info!("");
+        info!(
+            "  {} enabled rule(s) with no matches in the scanned window:",
+            report.unmatched_rules.len()
+        );
+        for name in &report.unmatched_rules {
+            info!("    - {name}");
+        }
+        info!("  NOTE: window-scoped — widen --from/--to before deciding a rule is dead.");
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    info!("Acteon Rule Coverage Simulation");
+    info!("===============================\n");
+
+    let start = Instant::now();
+
+    // ---------------------------------------------------------------
+    // 1. Seed a mixed workload into a memory audit store.
+    // ---------------------------------------------------------------
+    //
+    // Four distinct (provider, action_type) combinations, each with a
+    // different coverage profile:
+    //
+    //  email/send   — fully covered by "block-phishing"
+    //  sms/send     — partially covered: half match "rate-limit-sms",
+    //                 the other half go through with no rule
+    //  webhook/post — completely uncovered (no rules apply here)
+    //  slack/notify — fully covered by two different rules
+    //
+    // Plus a legacy rule "dead-rule" that is loaded in the gateway but
+    // never fires inside the scanned window — the kind of rule the
+    // report surfaces so operators can investigate.
+    //
+    // Because dispatched_at is explicit, everything lands inside the
+    // default 7-day window used by `rule_coverage`.
+
+    let audit_store = Arc::new(MemoryAuditStore::new());
+    let now = Utc::now();
+
+    // email/send: 40 records, all matched by "block-phishing"
+    for i in 0..40 {
+        let ts = now - Duration::minutes(i * 2);
+        let rec = make_record("prod", "acme", "email", "send", Some("block-phishing"), ts);
+        audit_store.record(rec).await.unwrap();
+    }
+
+    // sms/send: 10 matched, 10 unmatched
+    for i in 0..20 {
+        let ts = now - Duration::minutes(i * 3);
+        let rule = if i % 2 == 0 {
+            Some("rate-limit-sms")
+        } else {
+            None
+        };
+        let rec = make_record("prod", "acme", "sms", "send", rule, ts);
+        audit_store.record(rec).await.unwrap();
+    }
+
+    // webhook/post: 15 records, all uncovered
+    for i in 0..15 {
+        let ts = now - Duration::minutes(i * 4);
+        let rec = make_record("prod", "acme", "webhook", "post", None, ts);
+        audit_store.record(rec).await.unwrap();
+    }
+
+    // slack/notify: 8 records, split between two rules
+    for i in 0..8 {
+        let ts = now - Duration::minutes(i * 5);
+        let rule = if i % 2 == 0 {
+            "team-channels-only"
+        } else {
+            "no-secrets-in-slack"
+        };
+        let rec = make_record("prod", "acme", "slack", "notify", Some(rule), ts);
+        audit_store.record(rec).await.unwrap();
+    }
+
+    info!("Populated audit store: 83 records across 4 (provider, action_type) combinations");
+
+    // ---------------------------------------------------------------
+    // 2. Query the coverage aggregates through InMemoryAnalytics.
+    // ---------------------------------------------------------------
+    //
+    // Postgres/ClickHouse would emit the same shape via native GROUP BY
+    // — the abstraction is the same.
+
+    let analytics = InMemoryAnalytics::new(Arc::clone(&audit_store) as Arc<dyn AuditStore>);
+    let query = CoverageQuery {
+        namespace: Some("prod".to_string()),
+        tenant: Some("acme".to_string()),
+        from: None, // default: last 7 days
+        to: None,
+    };
+    let aggregates = analytics.rule_coverage(&query).await.unwrap();
+
+    info!(
+        "Backend returned {} aggregate rows (one per unique \
+         (ns, tenant, provider, action_type, matched_rule) tuple)",
+        aggregates.len()
+    );
+
+    // ---------------------------------------------------------------
+    // 3. Combine aggregates with the loaded rule set.
+    // ---------------------------------------------------------------
+    //
+    // In the real server this comes from `gateway.rules()`. Here we
+    // fabricate the list to show how `build_report` classifies
+    // combinations and detects unmatched rules.
+
+    let loaded_rules: Vec<(String, bool)> = vec![
+        ("block-phishing".to_string(), true),
+        ("rate-limit-sms".to_string(), true),
+        ("team-channels-only".to_string(), true),
+        ("no-secrets-in-slack".to_string(), true),
+        // Enabled but never fires in the scanned window — surfaces as
+        // "unmatched" in the final report.
+        ("dead-rule".to_string(), true),
+        // Disabled rules are ignored by the unmatched-rule detector.
+        ("disabled-rule".to_string(), false),
+    ];
+
+    let scanned_from = now - Duration::days(7);
+    let scanned_to = now;
+    let report = build_report(&aggregates, &loaded_rules, scanned_from, scanned_to);
+
+    // ---------------------------------------------------------------
+    // 4. Render the report.
+    // ---------------------------------------------------------------
+
+    print_report(&report);
+
+    // ---------------------------------------------------------------
+    // 5. Sanity assertions — this example doubles as a smoke test.
+    // ---------------------------------------------------------------
+
+    assert_eq!(report.total_actions, 83, "expected 83 total actions");
+    assert_eq!(report.unique_combinations, 4);
+    assert_eq!(
+        report.fully_covered, 2,
+        "email and slack should be fully covered"
+    );
+    assert_eq!(
+        report.partially_covered, 1,
+        "sms should be partially covered"
+    );
+    assert_eq!(report.uncovered, 1, "webhook should be uncovered");
+    assert_eq!(
+        report.unmatched_rules,
+        vec!["dead-rule".to_string()],
+        "dead-rule should be the only unmatched rule"
+    );
+
+    info!("\nSimulation completed in {:?}", start.elapsed());
+}

--- a/docs/book/features/rule-coverage.md
+++ b/docs/book/features/rule-coverage.md
@@ -1,0 +1,270 @@
+# Rule Coverage
+
+Rule Coverage analyzes the audit trail to tell you **which combinations of
+`(namespace, tenant, provider, action_type)` were matched by a rule** within a
+time window and which slipped through without any policy applied. It is
+designed as a safety-net audit: you can spot blind spots in your rule set
+before they become incidents.
+
+The feature is server-side: the gateway aggregates audit records natively
+(with `GROUP BY` on Postgres/ClickHouse, or paged aggregation on non-SQL
+backends) and returns only the aggregated report. Clients never page through
+raw audit records — the client wire payload is bounded by the cardinality of
+your dimensions, not the size of your audit trail.
+
+## When to use it
+
+- **Blind-spot detection.** A new provider or tenant was added and you want
+  to confirm your safety rules cover it.
+- **Dead-rule triage.** You suspect some rules are no longer firing and want
+  to see what's actually matching in production.
+- **Pre-incident review.** Before a release or compliance audit, verify that
+  the rule set matches the deployed namespaces.
+- **Operational debugging.** An operator thinks an action "should have been
+  blocked" — the coverage report shows whether any rule even saw it.
+
+## Terminology
+
+| Term | Meaning |
+|------|---------|
+| **Combination** | A unique `(namespace, tenant, provider, action_type)` tuple observed in the audit trail |
+| **COVERED** | Every action in the combination matched at least one rule |
+| **PARTIAL** | Some actions matched a rule, some did not |
+| **UNCOVERED** | No action in the combination matched any rule |
+| **Unmatched rule** | An enabled rule that did not match *any* audit record inside the scanned window |
+| **Scanned window** | The `scanned_from` → `scanned_to` time range the report summarizes |
+
+## API endpoint
+
+```
+GET /v1/rules/coverage
+```
+
+### Query parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `namespace` | string | no | Filter by namespace |
+| `tenant` | string | no | Filter by tenant (enforced against caller's allowed tenants) |
+| `from` | string (RFC 3339) | no | Start of time range. Defaults to 7 days ago |
+| `to` | string (RFC 3339) | no | End of time range. Defaults to now |
+
+### Response shape
+
+```json
+{
+  "scanned_from": "2026-04-08T12:00:00Z",
+  "scanned_to": "2026-04-09T12:00:00Z",
+  "total_actions": 1284,
+  "unique_combinations": 12,
+  "fully_covered": 8,
+  "partially_covered": 2,
+  "uncovered": 2,
+  "rules_loaded": 17,
+  "entries": [
+    {
+      "namespace": "prod",
+      "tenant": "acme",
+      "provider": "webhook",
+      "action_type": "post",
+      "total": 42,
+      "covered": 0,
+      "uncovered": 42,
+      "matched_rules": []
+    },
+    {
+      "namespace": "prod",
+      "tenant": "acme",
+      "provider": "email",
+      "action_type": "send",
+      "total": 120,
+      "covered": 120,
+      "uncovered": 0,
+      "matched_rules": ["block-phishing", "rate-limit-email"]
+    }
+  ],
+  "unmatched_rules": ["legacy-throttle"]
+}
+```
+
+Entries are returned pre-sorted: **UNCOVERED → PARTIAL → COVERED**, with ties
+broken by dimension key. Clients can re-sort locally if they need a different
+order.
+
+## CLI
+
+```bash
+# Last 24 hours (default), all namespaces
+acteon rules coverage
+
+# Last 7 days for a specific namespace
+acteon rules coverage --since-hours 168 --namespace prod
+
+# Explicit time range
+acteon rules coverage \
+  --from 2026-04-01T00:00:00Z \
+  --to   2026-04-08T00:00:00Z
+
+# Only show combinations where something slipped through
+acteon rules coverage --only-uncovered
+
+# Hide low-volume noise
+acteon rules coverage --min-uncovered 10
+
+# Sort by highest miss count first
+acteon rules coverage --sort-by miss
+
+# Machine-readable
+acteon rules coverage --format json
+```
+
+### CLI flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--namespace <NS>` | — | Filter by namespace |
+| `--tenant <T>` | — | Filter by tenant |
+| `--since-hours <N>` | 24 | Scan the last N hours (mutually exclusive with `--from`/`--to`) |
+| `--from <RFC3339>` | — | Explicit start of time range |
+| `--to <RFC3339>` | — | Explicit end of time range |
+| `--only-uncovered` | false | Hide entries with any covered actions |
+| `--min-uncovered <N>` | 0 | Hide entries with fewer than N uncovered actions |
+| `--sort-by <status\|total\|miss\|name>` | `status` | Sort order for the table |
+| `--format <text\|json>` | text | Output format |
+
+### Sample output
+
+```text
+Coverage analysis: scanned_from=2026-04-08T12:00:00Z scanned_to=2026-04-09T12:00:00Z total_actions=1284 rules_loaded=17
+
+Coverage summary: combinations=12 fully_covered=8 partially_covered=2 uncovered=2
+
+NAMESPACE  TENANT  PROVIDER  ACTION_TYPE  TOTAL  COVER   MISS  STATUS     RULES
+---------------------------------------------------------------------------------------
+prod       acme    webhook   post            42      0     42  UNCOVERED  -
+prod       acme    sms       send            18      6     12  PARTIAL    allow-sms
+prod       acme    email     send           120    120      0  COVERED    block-phishing, rate-limit-email
+
+1 enabled rule(s) with no matches in the scanned window
+  NOTE: This is window-scoped — a rule listed here may still be live if
+  it triggers rarely and simply did not fire inside the queried time
+  range. Verify against the full audit index before deleting any rule.
+  Unmatched rule: legacy-throttle
+```
+
+## SDK usage
+
+All five polyglot SDKs expose the endpoint as a thin wrapper. No client-side
+aggregation — one HTTP request, one parsed report.
+
+### Rust
+
+```rust
+use acteon_client::{ActeonClient, CoverageQuery};
+use chrono::{Duration, Utc};
+
+let client = ActeonClient::new("http://localhost:8080");
+let query = CoverageQuery {
+    namespace: Some("prod".into()),
+    from: Some(Utc::now() - Duration::hours(24)),
+    ..Default::default()
+};
+let report = client.rules_coverage(&query).await?;
+println!("uncovered combinations: {}", report.uncovered);
+```
+
+### Python
+
+```python
+from acteon_client import ActeonClient, CoverageQuery
+from datetime import datetime, timezone, timedelta
+
+client = ActeonClient("http://localhost:8080")
+query = CoverageQuery(
+    namespace="prod",
+    from_time=(datetime.now(timezone.utc) - timedelta(hours=24)).isoformat(),
+)
+report = client.rules_coverage(query)
+print(f"uncovered: {report.uncovered}")
+```
+
+### Node.js
+
+```typescript
+import { ActeonClient } from "@acteon/client";
+
+const client = new ActeonClient("http://localhost:8080");
+const report = await client.rulesCoverage({
+  namespace: "prod",
+  from: new Date(Date.now() - 24 * 3600 * 1000).toISOString(),
+});
+console.log(`uncovered: ${report.uncovered}`);
+```
+
+### Go
+
+```go
+import (
+    "context"
+    "time"
+    "github.com/acteon/acteon/clients/go/acteon"
+)
+
+client := acteon.NewClient("http://localhost:8080")
+from := time.Now().Add(-24 * time.Hour)
+report, err := client.RulesCoverage(context.Background(), &acteon.CoverageQuery{
+    Namespace: "prod",
+    From:      &from,
+})
+```
+
+### Java
+
+```java
+ActeonClient client = new ActeonClient("http://localhost:8080");
+CoverageQuery query = new CoverageQuery();
+query.setNamespace("prod");
+query.setFrom(Instant.now().minus(Duration.ofHours(24)).toString());
+CoverageReport report = client.rulesCoverage(query);
+```
+
+## Backend behavior
+
+Rule coverage aggregation runs server-side in the audit backend:
+
+| Backend | Aggregation strategy | Notes |
+|---------|----------------------|-------|
+| **Postgres** | Native SQL `GROUP BY` | Uses the `idx_audit_coverage` covering index added in the rule-coverage migration. Single index-seek query, O(1) memory on the server. |
+| **ClickHouse** | Native SQL `GROUP BY` | Same pattern as Postgres but using ClickHouse's `count()` and `toUnixTimestamp64Milli` for millisecond timestamps. |
+| **Memory** | Paged in-memory fallback via `InMemoryAnalytics` | Streams audit records in 1000-record batches and accumulates into a hash map keyed by dimension tuple. Bounded server-side; non-SQL backends share this code path. |
+| **Elasticsearch** | Paged in-memory fallback | Same as Memory. |
+| **DynamoDB** | Paged in-memory fallback | Same as Memory. |
+
+For high-volume deployments on non-SQL audit backends, the paged fallback
+scales linearly with the number of audit records in the window rather than
+with dimension cardinality. This is intentional: it keeps non-SQL backends
+functional without forcing each to implement native aggregation, but it is a
+scaling bottleneck for very large scan windows. Planned work on cursor-based
+audit pagination will address this — see the
+[roadmap](../reference/roadmap.md).
+
+## The window-scoped caveat
+
+The `unmatched_rules` list shows enabled rules that did not match any action
+**inside the scanned window**. This is not the same as "the rule is dead":
+
+- A rule that fires once a week will appear unmatched in a 24-hour scan.
+- A rule gated to a specific tenant will appear unmatched when the scan is
+  scoped to a different tenant.
+- A rule behind a maintenance-window condition will appear unmatched outside
+  the maintenance window.
+
+**Always widen the scan window** before deciding a rule is dead. The CLI and
+docs emphasize this for exactly this reason: don't delete a safety rule
+based on a single-hour snapshot.
+
+## Related features
+
+- [Audit Trail](audit-trail.md) — the underlying data source
+- [Rule Playground](rule-playground.md) — dry-run a single action against the rules
+- [Analytics](analytics.md) — time-bucketed volume and outcome metrics

--- a/docs/book/reference/roadmap.md
+++ b/docs/book/reference/roadmap.md
@@ -4,13 +4,6 @@ Planned features and enhancements for Acteon, ordered by estimated value/effort 
 
 ## Quick Wins
 
-### Rule Coverage CLI
-
-`acteon rules coverage` command that analyzes loaded rules and generates a coverage matrix (namespace x tenant x provider x action_type). Identifies unmatched combinations and blind spots in safety policy. Optionally integrates with the audit trail to surface real unmatched actions.
-
-**Crates:** `acteon-cli`, `acteon-rules`
-**Complexity:** Small (~500 LOC)
-
 ### Prometheus Alerting Rules Export
 
 `acteon metrics export-alerts` command and `GET /v1/metrics/alerts/prometheus.yaml` endpoint that auto-generates Prometheus alert rules from your Acteon config — per-provider SLO thresholds, quota utilization alerts, circuit breaker trip alerts, compliance mode audit failures, and retention TTL warnings.
@@ -19,6 +12,15 @@ Planned features and enhancements for Acteon, ordered by estimated value/effort 
 **Complexity:** Small (~400 LOC)
 
 ## Medium Effort
+
+### Cursor-Based Audit Pagination
+
+`AuditQuery` currently uses offset-based pagination exclusively. This is efficient for Postgres/ClickHouse because rule coverage aggregation uses native `GROUP BY` and bypasses paging, but non-SQL audit backends (Memory, Elasticsearch, DynamoDB) fall through to `InMemoryAnalytics`, which pages with offsets internally and hits the classic linear-degradation anti-pattern on large scans.
+
+Replace offset with cursor-based pagination (`after_id` / `before_timestamp` / opaque continuation tokens) across all audit backends and their client SDKs. Unlocks efficient deep scans for rule coverage, audit replay, and compliance exports on non-SQL backends. Also eliminates pagination-drift bugs when new records land mid-scan.
+
+**Crates:** `acteon-audit`, `acteon-audit-*` (all backends), `acteon-client`, polyglot SDKs, `acteon-cli`
+**Complexity:** Medium (~1500 LOC; touches every audit backend and every SDK's query surface)
 
 ### Kafka Provider Integration
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
     - Tenant Quotas: features/tenant-quotas.md
     - Data Retention: features/data-retention.md
     - Rule Playground: features/rule-playground.md
+    - Rule Coverage: features/rule-coverage.md
     - Provider Health: features/provider-health.md
     - Grafana Dashboards: features/grafana-dashboards.md
     - WASM Plugins: features/wasm-plugins.md


### PR DESCRIPTION
## Summary
Follow-up polish on the rule coverage feature shipped in #79 and #80. No new capabilities — just test coverage, documentation, a simulation example, and the `--sort-by` flag.

### CLI
- Extracted coverage rendering into pure `render_coverage_report` / `render_coverage_table` / `render_unmatched_rules` functions returning \`Vec<RenderedLine>\`. The \`run()\` path just emits each line at WARN or INFO — all layout logic is now unit-testable.
- New \`--sort-by <status|total|miss|name>\` flag. Default remains \`status\` (server-side order).
- **12 unit tests** covering: scan window header, status classification, warning labeling, \`--only-uncovered\` and \`--min-uncovered\` filters, empty results, filter-to-empty, window-scoped warning text, each sort order, and header/separator width.

### Docs
- New \`docs/book/features/rule-coverage.md\` with endpoint reference, CLI flags, sample output, SDK snippets (all 5 languages), backend behavior table, and the window-scoped dead-rule caveat spelled out in full.
- Registered in \`mkdocs.yml\` next to Rule Playground.

### Simulation
- New \`crates/simulation/examples/rule_coverage_simulation.rs\` seeds 83 audit records across 4 distinct combinations, calls \`InMemoryAnalytics::rule_coverage\` + \`build_report\`, renders the report, and asserts the classification. Doubles as an executable smoke test.

### Roadmap
- Removed the \"Rule Coverage CLI\" quick-win (shipped in #80).
- Added **Cursor-Based Audit Pagination** under Medium Effort — the current \`AuditQuery\` is offset-based, and non-SQL audit backends (Memory, Elasticsearch, DynamoDB) fall back to \`InMemoryAnalytics\` which paginates internally with offsets. Documented as the remaining structural gap from the rule-coverage review and tracked for a follow-up.

## Test plan
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --no-deps -- -D warnings\`
- [x] \`cargo test --workspace --lib --bins --tests\` — **1989 passed, 0 failed**
- [x] \`cargo run -p acteon-simulation --example rule_coverage_simulation\` — runs clean, all assertions pass
- [x] \`cd ui && npm run lint && npm run build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)