### PR TITLE
feat: tenant-scoped API keys with provider dimension and hierarchical tenants

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -182,6 +182,12 @@ if record != nil {
 
 ## Configuration
 
+API keys are sent via the `Authorization: Bearer <key>` header. The server
+accepts both JWTs and raw API keys on that header. API keys are scoped by
+tenant, namespace, provider, and action type on the server side — see the
+[API Key Scoping](https://penserai.github.io/acteon/features/api-key-scoping/)
+documentation for the grant model and hierarchical tenant matching.
+
 ```go
 client := acteon.NewClient(
     "http://localhost:8080",

--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -194,6 +194,12 @@ record.ifPresent(r -> System.out.println("Found: " + r.getOutcome()));
 
 ## Configuration
 
+API keys are sent via the `Authorization: Bearer <key>` header. The server
+accepts both JWTs and raw API keys on that header. API keys are scoped by
+tenant, namespace, provider, and action type on the server side — see the
+[API Key Scoping](https://penserai.github.io/acteon/features/api-key-scoping/)
+documentation for the grant model and hierarchical tenant matching.
+
 ```java
 // With API key
 ActeonClient client = new ActeonClient("http://localhost:8080", "your-api-key");

--- a/clients/nodejs/README.md
+++ b/clients/nodejs/README.md
@@ -162,6 +162,12 @@ const client = new ActeonClient("http://localhost:8080", {
 });
 ```
 
+API keys are sent via the `Authorization: Bearer <key>` header. The server
+accepts both JWTs and raw API keys on that header. API keys are scoped by
+tenant, namespace, provider, and action type on the server side — see the
+[API Key Scoping](https://penserai.github.io/acteon/features/api-key-scoping/)
+documentation for the grant model and hierarchical tenant matching.
+
 ## Error Handling
 
 ```typescript

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -168,6 +168,12 @@ client = ActeonClient(
 )
 ```
 
+API keys are sent via the `Authorization: Bearer <key>` header. The server
+accepts both JWTs and raw API keys on that header. API keys are scoped by
+tenant, namespace, provider, and action type on the server side — see the
+[API Key Scoping](https://penserai.github.io/acteon/features/api-key-scoping/)
+documentation for the grant model and hierarchical tenant matching.
+
 ## Error Handling
 
 ```python

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -120,6 +120,12 @@ let client = ActeonClientBuilder::new("http://localhost:8080")
     .build()?;
 ```
 
+API keys are sent via the `Authorization: Bearer <key>` header. The server
+accepts both JWTs and raw API keys on that header. API keys are scoped by
+tenant, namespace, provider, and action type on the server side — see the
+[API Key Scoping](https://penserai.github.io/acteon/features/api-key-scoping/)
+documentation for the grant model and hierarchical tenant matching.
+
 ### Custom reqwest Client
 
 For advanced HTTP configuration (TLS, proxies, etc.):

--- a/crates/server/src/api/audit.rs
+++ b/crates/server/src/api/audit.rs
@@ -115,8 +115,13 @@ pub async fn get_audit_by_action(
 
     match audit.get_by_action_id(&action_id).await {
         Ok(Some(record)) => {
-            // Verify the caller has access to this record's tenant/namespace.
-            if !identity.is_authorized(&record.tenant, &record.namespace, &record.action_type) {
+            // Verify the caller has access to this record's tenant/namespace/provider.
+            if !identity.is_authorized(
+                &record.tenant,
+                &record.namespace,
+                &record.provider,
+                &record.action_type,
+            ) {
                 return (
                     StatusCode::FORBIDDEN,
                     Json(serde_json::json!(ErrorResponse {

--- a/crates/server/src/api/dispatch.rs
+++ b/crates/server/src/api/dispatch.rs
@@ -69,13 +69,18 @@ pub async fn dispatch(
     }
 
     // Check grant-level authorization.
-    if !identity.is_authorized(&action.tenant, &action.namespace, &action.action_type) {
+    if !identity.is_authorized(
+        &action.tenant,
+        &action.namespace,
+        &action.provider,
+        &action.action_type,
+    ) {
         return Ok((
             StatusCode::FORBIDDEN,
             Json(serde_json::json!(ErrorResponse {
                 error: format!(
-                    "forbidden: no grant covers tenant={}, namespace={}, action={}",
-                    action.tenant, action.namespace, action.action_type
+                    "forbidden: no grant covers tenant={}, namespace={}, provider={}, action={}",
+                    action.tenant, action.namespace, action.provider, action.action_type
                 ),
             })),
         ));
@@ -172,13 +177,18 @@ pub async fn dispatch_batch(
 
     // Check each action individually for grant authorization.
     for action in &actions {
-        if !identity.is_authorized(&action.tenant, &action.namespace, &action.action_type) {
+        if !identity.is_authorized(
+            &action.tenant,
+            &action.namespace,
+            &action.provider,
+            &action.action_type,
+        ) {
             return Ok((
                 StatusCode::FORBIDDEN,
                 Json(vec![serde_json::json!(ErrorResponse {
                     error: format!(
-                        "forbidden: no grant covers tenant={}, namespace={}, action={}",
-                        action.tenant, action.namespace, action.action_type
+                        "forbidden: no grant covers tenant={}, namespace={}, provider={}, action={}",
+                        action.tenant, action.namespace, action.provider, action.action_type,
                     ),
                 })]),
             ));

--- a/crates/server/src/api/replay.rs
+++ b/crates/server/src/api/replay.rs
@@ -180,8 +180,13 @@ pub async fn replay_action(
         }
     };
 
-    // Verify the caller has access to this record's tenant/namespace.
-    if !identity.is_authorized(&record.tenant, &record.namespace, &record.action_type) {
+    // Verify the caller has access to this record's tenant/namespace/provider.
+    if !identity.is_authorized(
+        &record.tenant,
+        &record.namespace,
+        &record.provider,
+        &record.action_type,
+    ) {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!(ErrorResponse {
@@ -334,7 +339,12 @@ pub async fn replay_audit(
             let caller = &caller;
             let identity = &identity;
             async move {
-                if !identity.is_authorized(&record.tenant, &record.namespace, &record.action_type) {
+                if !identity.is_authorized(
+                    &record.tenant,
+                    &record.namespace,
+                    &record.provider,
+                    &record.action_type,
+                ) {
                     return None; // skipped
                 }
 

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -42,15 +42,173 @@ pub struct UserConfig {
     pub grants: Vec<Grant>,
 }
 
-/// A resource-level grant scoped to tenants, namespaces, and action types.
+/// A resource-level grant scoped to tenants, namespaces, providers, and action types.
+///
+/// A caller is authorized for an action when **every** dimension on at least
+/// one of their grants matches the action. Each field supports the `"*"`
+/// wildcard.
+///
+/// Tenant matching is hierarchical: a grant on tenant `"acme"` also covers
+/// `"acme.us-east"`, `"acme.us-east.prod"`, and so on. This lets operators
+/// scope API keys to a parent tenant without enumerating every sub-tenant.
+/// Hierarchical matching is one-way: a grant on `"acme.us-east"` does *not*
+/// cover `"acme"`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Grant {
-    /// Tenant identifiers, or `["*"]` for all.
+    /// Tenant identifiers (or tenant prefixes), or `["*"]` for all.
     pub tenants: Vec<String>,
     /// Namespace identifiers, or `["*"]` for all.
     pub namespaces: Vec<String>,
+    /// Provider identifiers, or `["*"]` for all.
+    ///
+    /// Defaults to `["*"]` when omitted from `auth.toml` for backward
+    /// compatibility with grants written before provider scoping existed.
+    #[serde(default = "wildcard_vec")]
+    pub providers: Vec<String>,
     /// Action type identifiers, or `["*"]` for all.
     pub actions: Vec<String>,
+}
+
+fn wildcard_vec() -> Vec<String> {
+    vec!["*".to_owned()]
+}
+
+impl Grant {
+    /// Check whether this grant matches a specific
+    /// `(tenant, namespace, provider, action_type)` tuple.
+    ///
+    /// - Tenant matching is hierarchical (prefix + `.` separator) in addition
+    ///   to exact and wildcard match.
+    /// - Namespace, provider, and `action_type` support exact and wildcard
+    ///   matching only.
+    pub fn matches(
+        &self,
+        tenant: &str,
+        namespace: &str,
+        provider: &str,
+        action_type: &str,
+    ) -> bool {
+        tenant_matches(&self.tenants, tenant)
+            && dimension_matches(&self.namespaces, namespace)
+            && dimension_matches(&self.providers, provider)
+            && dimension_matches(&self.actions, action_type)
+    }
+}
+
+/// Match a dimension against a grant pattern list.
+///
+/// Returns `true` if the list contains `"*"` or an exact match for `value`.
+fn dimension_matches(patterns: &[String], value: &str) -> bool {
+    patterns.iter().any(|p| p == "*" || p == value)
+}
+
+/// Match a tenant against a grant's tenant pattern list.
+///
+/// Supports wildcard (`"*"`), exact match, and hierarchical prefix match:
+/// a pattern `"acme"` matches tenants `"acme"`, `"acme.us-east"`, and
+/// `"acme.us-east.prod"`. Prefix matching requires a `.` separator after the
+/// pattern to avoid accidentally matching `"acme-corp"` against `"acme"`.
+pub fn tenant_matches(patterns: &[String], tenant: &str) -> bool {
+    patterns.iter().any(|p| {
+        if p == "*" || p == tenant {
+            return true;
+        }
+        // Hierarchical: pattern is a strict prefix of tenant, followed by `.`.
+        tenant.len() > p.len() + 1
+            && tenant.starts_with(p.as_str())
+            && tenant.as_bytes()[p.len()] == b'.'
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grant(tenants: &[&str], namespaces: &[&str], providers: &[&str], actions: &[&str]) -> Grant {
+        Grant {
+            tenants: tenants.iter().map(|s| (*s).to_string()).collect(),
+            namespaces: namespaces.iter().map(|s| (*s).to_string()).collect(),
+            providers: providers.iter().map(|s| (*s).to_string()).collect(),
+            actions: actions.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn wildcard_grant_matches_anything() {
+        let g = grant(&["*"], &["*"], &["*"], &["*"]);
+        assert!(g.matches("acme", "prod", "email", "send"));
+        assert!(g.matches("anything", "foo", "bar", "baz"));
+    }
+
+    #[test]
+    fn exact_match_on_all_dimensions() {
+        let g = grant(&["acme"], &["prod"], &["email"], &["send"]);
+        assert!(g.matches("acme", "prod", "email", "send"));
+        assert!(!g.matches("acme", "prod", "email", "draft"));
+        assert!(!g.matches("acme", "prod", "sms", "send"));
+        assert!(!g.matches("acme", "staging", "email", "send"));
+        assert!(!g.matches("other", "prod", "email", "send"));
+    }
+
+    #[test]
+    fn hierarchical_tenant_matching() {
+        let g = grant(&["acme"], &["*"], &["*"], &["*"]);
+        assert!(g.matches("acme", "x", "y", "z"), "exact match");
+        assert!(g.matches("acme.us-east", "x", "y", "z"), "one-level child");
+        assert!(
+            g.matches("acme.us-east.prod", "x", "y", "z"),
+            "multi-level child"
+        );
+    }
+
+    #[test]
+    fn hierarchical_matching_is_not_prefix_of_unrelated_tenant() {
+        let g = grant(&["acme"], &["*"], &["*"], &["*"]);
+        // Without a `.` separator, "acme-corp" should NOT match grant "acme".
+        assert!(!g.matches("acme-corp", "x", "y", "z"));
+        assert!(!g.matches("acmecorp", "x", "y", "z"));
+    }
+
+    #[test]
+    fn hierarchical_matching_is_one_way() {
+        // A grant for a child should NOT cover the parent.
+        let g = grant(&["acme.us-east"], &["*"], &["*"], &["*"]);
+        assert!(g.matches("acme.us-east", "x", "y", "z"));
+        assert!(g.matches("acme.us-east.prod", "x", "y", "z"));
+        assert!(!g.matches("acme", "x", "y", "z"));
+        assert!(!g.matches("acme.eu-west", "x", "y", "z"));
+    }
+
+    #[test]
+    fn provider_scoping_enforced() {
+        let g = grant(&["*"], &["*"], &["email"], &["*"]);
+        assert!(g.matches("any", "any", "email", "any"));
+        assert!(!g.matches("any", "any", "sms", "any"));
+    }
+
+    #[test]
+    fn providers_defaults_to_wildcard_when_deserialized_without_field() {
+        // Backward compat: existing auth.toml without `providers` should
+        // still grant access to any provider.
+        let toml = r#"
+tenants = ["acme"]
+namespaces = ["prod"]
+actions = ["*"]
+"#;
+        let g: Grant = toml::from_str(toml).expect("parse");
+        assert_eq!(g.providers, vec!["*".to_string()]);
+        assert!(g.matches("acme", "prod", "email", "send"));
+        assert!(g.matches("acme", "prod", "sms", "send"));
+    }
+
+    #[test]
+    fn tenant_matches_helper_direct() {
+        let patterns = vec!["acme".to_string()];
+        assert!(tenant_matches(&patterns, "acme"));
+        assert!(tenant_matches(&patterns, "acme.us-east"));
+        assert!(!tenant_matches(&patterns, "acme-corp"));
+        assert!(!tenant_matches(&patterns, "acm"));
+    }
 }
 
 /// An API key principal that authenticates via `X-API-Key` header.

--- a/crates/server/src/auth/identity.rs
+++ b/crates/server/src/auth/identity.rs
@@ -25,26 +25,38 @@ impl CallerIdentity {
             grants: vec![Grant {
                 tenants: vec!["*".to_owned()],
                 namespaces: vec!["*".to_owned()],
+                providers: vec!["*".to_owned()],
                 actions: vec!["*".to_owned()],
             }],
             auth_method: "anonymous".to_owned(),
         }
     }
 
-    /// Check if this caller is authorized for a specific (tenant, namespace, `action_type`).
-    pub fn is_authorized(&self, tenant: &str, namespace: &str, action_type: &str) -> bool {
-        self.grants.iter().any(|g| {
-            (g.tenants.iter().any(|t| t == "*") || g.tenants.iter().any(|t| t == tenant))
-                && (g.namespaces.iter().any(|n| n == "*")
-                    || g.namespaces.iter().any(|n| n == namespace))
-                && (g.actions.iter().any(|a| a == "*")
-                    || g.actions.iter().any(|a| a == action_type))
-        })
+    /// Check if this caller is authorized for a specific
+    /// `(tenant, namespace, provider, action_type)` tuple.
+    ///
+    /// Tenant matching is hierarchical: a grant on `"acme"` also covers
+    /// `"acme.us-east"`. See [`Grant::matches`] for details.
+    pub fn is_authorized(
+        &self,
+        tenant: &str,
+        namespace: &str,
+        provider: &str,
+        action_type: &str,
+    ) -> bool {
+        self.grants
+            .iter()
+            .any(|g| g.matches(tenant, namespace, provider, action_type))
     }
 
-    /// Return the set of (tenant, namespace) pairs this caller has access to,
-    /// for filtering audit queries. Returns `None` if the caller has wildcard
-    /// access to all tenants.
+    /// Return the set of tenant patterns this caller has access to, for
+    /// filtering audit queries. Returns `None` if the caller has wildcard
+    /// tenant access.
+    ///
+    /// Note: the returned strings are grant *patterns*, not resolved
+    /// tenants. Because tenant grants are hierarchical, a returned value of
+    /// `"acme"` means the caller can read any tenant matching `acme` or
+    /// `acme.*`. Query-filter consumers should treat them as prefixes.
     pub fn allowed_tenants(&self) -> Option<Vec<&str>> {
         let mut tenants = Vec::new();
         for g in &self.grants {
@@ -76,11 +88,110 @@ impl CallerIdentity {
         Some(namespaces)
     }
 
+    /// Return allowed providers, or `None` if the caller has wildcard provider access.
+    pub fn allowed_providers(&self) -> Option<Vec<&str>> {
+        let mut providers = Vec::new();
+        for g in &self.grants {
+            if g.providers.iter().any(|p| p == "*") {
+                return None;
+            }
+            for p in &g.providers {
+                if !providers.contains(&p.as_str()) {
+                    providers.push(p.as_str());
+                }
+            }
+        }
+        Some(providers)
+    }
+
     /// Convert to the minimal `Caller` for audit threading.
     pub fn to_caller(&self) -> Caller {
         Caller {
             id: self.id.clone(),
             auth_method: self.auth_method.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grant(tenants: &[&str], namespaces: &[&str], providers: &[&str], actions: &[&str]) -> Grant {
+        Grant {
+            tenants: tenants.iter().map(|s| (*s).to_string()).collect(),
+            namespaces: namespaces.iter().map(|s| (*s).to_string()).collect(),
+            providers: providers.iter().map(|s| (*s).to_string()).collect(),
+            actions: actions.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    fn identity_with(grants: Vec<Grant>) -> CallerIdentity {
+        CallerIdentity {
+            id: "test".into(),
+            role: Role::Admin,
+            grants,
+            auth_method: "test".into(),
+        }
+    }
+
+    #[test]
+    fn anonymous_is_authorized_for_everything() {
+        let id = CallerIdentity::anonymous();
+        assert!(id.is_authorized("any", "any", "any", "any"));
+    }
+
+    #[test]
+    fn is_authorized_enforces_provider_dimension() {
+        let id = identity_with(vec![grant(&["acme"], &["prod"], &["email"], &["send"])]);
+        assert!(id.is_authorized("acme", "prod", "email", "send"));
+        // Provider mismatch → deny, even if everything else matches.
+        assert!(!id.is_authorized("acme", "prod", "sms", "send"));
+    }
+
+    #[test]
+    fn is_authorized_matches_hierarchical_tenants() {
+        let id = identity_with(vec![grant(&["acme"], &["*"], &["*"], &["*"])]);
+        assert!(id.is_authorized("acme", "x", "y", "z"));
+        assert!(id.is_authorized("acme.us-east", "x", "y", "z"));
+        assert!(id.is_authorized("acme.us-east.prod", "x", "y", "z"));
+        assert!(!id.is_authorized("acme-corp", "x", "y", "z"));
+        assert!(!id.is_authorized("other", "x", "y", "z"));
+    }
+
+    #[test]
+    fn multiple_grants_union() {
+        let id = identity_with(vec![
+            grant(&["acme"], &["prod"], &["email"], &["*"]),
+            grant(&["beta"], &["*"], &["*"], &["*"]),
+        ]);
+        assert!(id.is_authorized("acme", "prod", "email", "send"));
+        assert!(!id.is_authorized("acme", "prod", "sms", "send"));
+        assert!(id.is_authorized("beta", "anything", "anything", "anything"));
+    }
+
+    #[test]
+    fn allowed_providers_returns_none_for_wildcard() {
+        let id = identity_with(vec![grant(&["acme"], &["*"], &["*"], &["*"])]);
+        assert_eq!(id.allowed_providers(), None);
+    }
+
+    #[test]
+    fn allowed_providers_returns_sorted_unique_list() {
+        let id = identity_with(vec![
+            grant(&["*"], &["*"], &["email", "sms"], &["*"]),
+            grant(&["*"], &["*"], &["email", "slack"], &["*"]),
+        ]);
+        let providers = id.allowed_providers().expect("non-wildcard");
+        assert!(providers.contains(&"email"));
+        assert!(providers.contains(&"sms"));
+        assert!(providers.contains(&"slack"));
+        assert_eq!(providers.len(), 3); // deduplicated
+    }
+
+    #[test]
+    fn allowed_tenants_wildcard_returns_none() {
+        let id = identity_with(vec![grant(&["*"], &["*"], &["*"], &["*"])]);
+        assert_eq!(id.allowed_tenants(), None);
     }
 }

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -65,23 +65,41 @@ where
                 return inner.call(req).await;
             };
 
-            // Try Bearer token first.
-            if let Some(auth_header) = req.headers().get("authorization")
-                && let Ok(header_str) = auth_header.to_str()
-                && let Some(token) = header_str.strip_prefix("Bearer ")
-            {
+            // Try the Authorization: Bearer header first. JWT validation
+            // runs first; if it fails (e.g., the caller is using a raw
+            // API key instead of a JWT), fall back to treating the token
+            // as an API key. This makes API-key auth work for SDKs that
+            // send credentials via the standard Authorization header.
+            let bearer_token = req
+                .headers()
+                .get("authorization")
+                .and_then(|h| h.to_str().ok())
+                .and_then(|s| s.strip_prefix("Bearer "))
+                .map(str::to_owned);
+
+            if let Some(ref token) = bearer_token {
                 match provider.validate_jwt(token).await {
                     Ok(identity) => {
                         req.extensions_mut().insert(identity);
                         return inner.call(req).await;
                     }
-                    Err(e) => {
-                        return Ok(unauthorized(&e));
+                    Err(jwt_err) => {
+                        // JWT validation failed — try API key fallback
+                        // before returning 401.
+                        if let Some(identity) = provider.authenticate_api_key(token).await {
+                            req.extensions_mut().insert(identity);
+                            return inner.call(req).await;
+                        }
+                        // Neither JWT nor API key worked. Surface the
+                        // JWT error so Bearer-JWT callers see a useful
+                        // message (invalid signature, expired, etc.).
+                        return Ok(unauthorized(&jwt_err));
                     }
                 }
             }
 
-            // Try API key.
+            // Legacy explicit X-API-Key header path. Still supported for
+            // tools and curl examples that set the dedicated header.
             if let Some(api_key_header) = req.headers().get("x-api-key")
                 && let Ok(key_str) = api_key_header.to_str()
             {

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -17,6 +17,10 @@ use acteon_provider::{DynProvider, ProviderError};
 use acteon_rules::ir::expr::{BinaryOp, Expr};
 use acteon_rules::ir::rule::{Rule, RuleAction};
 use acteon_server::api::AppState;
+use acteon_server::auth::AuthProvider;
+use acteon_server::auth::api_key::hash_api_key;
+use acteon_server::auth::config::{ApiKeyConfig, AuthFileConfig, AuthSettings, Grant};
+use acteon_server::auth::crypto::SecretString;
 use acteon_server::config::ConfigSnapshot;
 use acteon_state::StateStore;
 use acteon_state_memory::{MemoryDistributedLock, MemoryStateStore};
@@ -109,6 +113,48 @@ fn build_test_state_with_audit_and_analytics(
         ui_enabled: false,
         cors_allowed_origins: Vec::new(),
     }
+}
+
+/// Build a test `AppState` with auth enabled. The provided grant set is
+/// bound to a single API key named `"test-key"` whose raw value is
+/// `"test-raw-key"`. Callers authenticate by sending
+/// `Authorization: Bearer test-raw-key` on requests.
+fn build_test_state_with_auth(grants: Vec<Grant>) -> AppState {
+    let mut state = build_test_state(vec![]);
+
+    let api_key_config = ApiKeyConfig {
+        name: "test-key".to_string(),
+        key_hash: SecretString::new(hash_api_key("test-raw-key")),
+        role: "admin".to_string(),
+        grants,
+    };
+    let auth_config = AuthFileConfig {
+        settings: AuthSettings {
+            jwt_secret: SecretString::new("test-jwt-secret-32-bytes-long!!!!".to_string()),
+            jwt_expiry_seconds: 3600,
+        },
+        users: vec![],
+        api_keys: vec![api_key_config],
+    };
+
+    let state_store: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+    let provider = AuthProvider::new(&auth_config, state_store).expect("auth provider");
+    state.auth = Some(Arc::new(provider));
+    state
+}
+
+/// Standard single-grant for "tenant-1, notifications, email, send_email".
+fn default_test_grant() -> Grant {
+    Grant {
+        tenants: vec!["tenant-1".to_string()],
+        namespaces: vec!["notifications".to_string()],
+        providers: vec!["email".to_string()],
+        actions: vec!["send_email".to_string()],
+    }
+}
+
+fn auth_headers() -> (http::HeaderName, &'static str) {
+    (http::header::AUTHORIZATION, "Bearer test-raw-key")
 }
 
 fn test_action() -> Action {
@@ -2036,4 +2082,229 @@ async fn rule_coverage_aggregates_dispatched_actions() {
 
     // No rules loaded -> no unmatched rules.
     assert!(json["unmatched_rules"].as_array().unwrap().is_empty());
+}
+
+// =========================================================================
+// Tenant-scoped API key dispatch enforcement
+// =========================================================================
+
+async fn dispatch_with_key(app: axum::Router, action: &Action) -> StatusCode {
+    let body = serde_json::to_string(action).unwrap();
+    let (header_name, header_val) = auth_headers();
+    app.oneshot(
+        Request::builder()
+            .method(http::Method::POST)
+            .uri("/v1/dispatch")
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .header(header_name, header_val)
+            .body(Body::from(body))
+            .unwrap(),
+    )
+    .await
+    .unwrap()
+    .status()
+}
+
+fn action_for(namespace: &str, tenant: &str, provider: &str, action_type: &str) -> Action {
+    Action::new(
+        namespace,
+        tenant,
+        provider,
+        action_type,
+        serde_json::json!({"to": "user@example.com"}),
+    )
+}
+
+#[tokio::test]
+async fn scoped_api_key_allows_in_scope_dispatch() {
+    let state = build_test_state_with_auth(vec![default_test_grant()]);
+    let app = build_app(state);
+    let action = action_for("notifications", "tenant-1", "email", "send_email");
+    assert_eq!(dispatch_with_key(app, &action).await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn scoped_api_key_denies_wrong_tenant() {
+    let state = build_test_state_with_auth(vec![default_test_grant()]);
+    let app = build_app(state);
+    let action = action_for("notifications", "tenant-2", "email", "send_email");
+    assert_eq!(dispatch_with_key(app, &action).await, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn scoped_api_key_denies_wrong_namespace() {
+    let state = build_test_state_with_auth(vec![default_test_grant()]);
+    let app = build_app(state);
+    let action = action_for("alerts", "tenant-1", "email", "send_email");
+    assert_eq!(dispatch_with_key(app, &action).await, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn scoped_api_key_denies_wrong_provider() {
+    // Provider scoping is the new dimension — verify it actually fires.
+    let state = build_test_state_with_auth(vec![default_test_grant()]);
+    let app = build_app(state);
+    let action = action_for("notifications", "tenant-1", "sms", "send_email");
+    assert_eq!(dispatch_with_key(app, &action).await, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn scoped_api_key_denies_wrong_action_type() {
+    let state = build_test_state_with_auth(vec![default_test_grant()]);
+    let app = build_app(state);
+    let action = action_for("notifications", "tenant-1", "email", "draft_email");
+    assert_eq!(dispatch_with_key(app, &action).await, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn scoped_api_key_allows_hierarchical_child_tenant() {
+    // Grant on parent tenant "tenant-1" should cover child "tenant-1.us-east".
+    let state = build_test_state_with_auth(vec![default_test_grant()]);
+    let app = build_app(state);
+    let action = action_for("notifications", "tenant-1.us-east", "email", "send_email");
+    assert_eq!(dispatch_with_key(app, &action).await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn scoped_api_key_hierarchical_matching_is_one_way() {
+    // Grant on child "tenant-1.us-east" should NOT cover parent "tenant-1".
+    let mut grant = default_test_grant();
+    grant.tenants = vec!["tenant-1.us-east".to_string()];
+    let state = build_test_state_with_auth(vec![grant]);
+    let app = build_app(state);
+    let action = action_for("notifications", "tenant-1", "email", "send_email");
+    assert_eq!(dispatch_with_key(app, &action).await, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn scoped_api_key_hierarchical_does_not_match_prefix_without_dot() {
+    // Grant on "tenant-1" should NOT match "tenant-1-corp" (no dot separator).
+    let state = build_test_state_with_auth(vec![default_test_grant()]);
+    let app = build_app(state);
+    let action = action_for("notifications", "tenant-1-corp", "email", "send_email");
+    assert_eq!(dispatch_with_key(app, &action).await, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn api_key_via_bearer_header_authenticates() {
+    // Regression: SDKs send API keys via `Authorization: Bearer`, not
+    // `x-api-key`. Previously the middleware tried JWT validation first,
+    // failed, and returned 401. It should fall back to API-key lookup.
+    let state = build_test_state_with_auth(vec![default_test_grant()]);
+    let app = build_app(state);
+    let action = action_for("notifications", "tenant-1", "email", "send_email");
+    let body = serde_json::to_string(&action).unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/v1/dispatch")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(http::header::AUTHORIZATION, "Bearer test-raw-key")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn api_key_via_x_api_key_header_still_works() {
+    // The legacy `X-API-Key` header path must remain supported for curl
+    // examples and non-SDK tooling.
+    let state = build_test_state_with_auth(vec![default_test_grant()]);
+    let app = build_app(state);
+    let action = action_for("notifications", "tenant-1", "email", "send_email");
+    let body = serde_json::to_string(&action).unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/v1/dispatch")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header("x-api-key", "test-raw-key")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn missing_credentials_returns_401() {
+    let state = build_test_state_with_auth(vec![default_test_grant()]);
+    let app = build_app(state);
+    let action = action_for("notifications", "tenant-1", "email", "send_email");
+    let body = serde_json::to_string(&action).unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/v1/dispatch")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn invalid_api_key_returns_401() {
+    let state = build_test_state_with_auth(vec![default_test_grant()]);
+    let app = build_app(state);
+    let action = action_for("notifications", "tenant-1", "email", "send_email");
+    let body = serde_json::to_string(&action).unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/v1/dispatch")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(http::header::AUTHORIZATION, "Bearer not-a-real-key")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn scoped_api_key_batch_dispatch_denies_any_out_of_scope_action() {
+    let state = build_test_state_with_auth(vec![default_test_grant()]);
+    let app = build_app(state);
+
+    let batch = vec![
+        action_for("notifications", "tenant-1", "email", "send_email"),
+        // Second action is out-of-scope on provider → whole batch rejected.
+        action_for("notifications", "tenant-1", "sms", "send_email"),
+    ];
+    let body = serde_json::to_string(&batch).unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/v1/dispatch/batch")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(http::header::AUTHORIZATION, "Bearer test-raw-key")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }

--- a/docs/book/features/api-key-scoping.md
+++ b/docs/book/features/api-key-scoping.md
@@ -1,0 +1,244 @@
+# API Key Scoping
+
+Acteon API keys and JWT users are authorized via a list of **grants**. Each
+grant specifies which tenants, namespaces, providers, and action types the
+principal is allowed to dispatch, audit, or replay. A request is allowed
+when **every** dimension on at least one of the caller's grants matches the
+action.
+
+This page covers:
+
+- The grant model (tenant / namespace / provider / action-type)
+- **Hierarchical tenant matching** — a grant on `acme` also covers `acme.us-east`
+- How to define scoped API keys in `auth.toml`
+- How SDKs and `curl` authenticate against the gateway
+
+## The grant model
+
+A grant looks like this:
+
+```toml
+[[api_keys.grants]]
+tenants    = ["acme"]
+namespaces = ["notifications"]
+providers  = ["email", "sms"]
+actions    = ["send_email", "send_sms"]
+```
+
+An action is authorized iff:
+
+1. The grant's `tenants` list contains `"*"`, an exact match for the action's
+   tenant, or a **parent tenant** (see hierarchical matching below), **and**
+2. The grant's `namespaces` list contains `"*"` or an exact match for the
+   action's namespace, **and**
+3. The grant's `providers` list contains `"*"` or an exact match for the
+   action's provider, **and**
+4. The grant's `actions` list contains `"*"` or an exact match for the
+   action's `action_type`.
+
+A caller may have multiple grants. Each action is checked against every
+grant in order, and the first one that matches authorizes the request.
+
+### The four dimensions
+
+| Dimension | Meaning | Wildcard |
+|-----------|---------|----------|
+| `tenants` | Tenant IDs (or parent-tenant prefixes for hierarchical matching) | `"*"` |
+| `namespaces` | Namespace IDs | `"*"` |
+| `providers` | Provider IDs (e.g. `"email"`, `"sms"`, `"slack"`, `"webhook"`) | `"*"` |
+| `actions` | Action type strings (e.g. `"send_email"`, `"create_ticket"`) | `"*"` |
+
+The `providers` field defaults to `["*"]` when omitted, so existing
+`auth.toml` files written before provider scoping was added continue to
+work unchanged.
+
+## Hierarchical tenant matching
+
+Tenant IDs support hierarchical scoping via dotted notation. A grant on
+tenant `"acme"` automatically covers any tenant starting with `acme.` —
+including `acme.us-east`, `acme.us-east.prod`, `acme.eu-west`, and so on.
+
+This lets operators write a single grant for a parent organization rather
+than enumerating every region or environment.
+
+### Examples
+
+| Grant pattern | Action tenant | Matches? |
+|---------------|---------------|----------|
+| `"acme"` | `"acme"` | ✅ exact |
+| `"acme"` | `"acme.us-east"` | ✅ hierarchical (child) |
+| `"acme"` | `"acme.us-east.prod"` | ✅ hierarchical (grandchild) |
+| `"acme"` | `"acme-corp"` | ❌ no dot separator |
+| `"acme"` | `"acmecorp"` | ❌ no dot separator |
+| `"acme.us-east"` | `"acme"` | ❌ child grant does not cover parent |
+| `"acme.us-east"` | `"acme.eu-west"` | ❌ siblings do not cover each other |
+
+Matching is **one-way**: a grant scoped to a child (e.g. `"acme.us-east"`)
+cannot dispatch actions for the parent (`"acme"`) or sibling regions
+(`"acme.eu-west"`).
+
+Matching is also **dot-strict**: a grant on `"acme"` will not match
+`"acme-corp"` or `"acmecorp"`. The character immediately after the pattern
+must be `.` for hierarchical matching to apply.
+
+## Defining scoped API keys
+
+Keys live in `auth.toml` (path configured via `[auth].config_path` in
+`acteon.toml`; defaults to `auth.toml` relative to `acteon.toml`):
+
+```toml
+# ─── auth.toml ────────────────────────────────────────────
+
+[settings]
+jwt_secret = "ENC[AES256-GCM,...]"    # Encrypt via `acteon-server encrypt`
+jwt_expiry_seconds = 3600
+
+# ─── Admin user with full access ─────────────────────────
+[[users]]
+username = "admin"
+password_hash = "ENC[AES256-GCM,...]"  # Argon2 hash, then encrypted
+role = "admin"
+[[users.grants]]
+tenants    = ["*"]
+namespaces = ["*"]
+providers  = ["*"]
+actions    = ["*"]
+
+# ─── Scoped API key for a single product team ────────────
+[[api_keys]]
+name = "acme-notifications-team"
+key_hash = "ENC[AES256-GCM,...]"       # SHA-256 hex of raw key, then encrypted
+role = "operator"
+
+# Team can dispatch email and sms from any sub-tenant of "acme".
+[[api_keys.grants]]
+tenants    = ["acme"]                  # Covers acme, acme.us-east, acme.eu-west, ...
+namespaces = ["notifications"]
+providers  = ["email", "sms"]
+actions    = ["send_email", "send_sms"]
+
+# ─── Scoped API key for a single region ──────────────────
+[[api_keys]]
+name = "acme-us-east-oncall"
+key_hash = "ENC[AES256-GCM,...]"
+role = "operator"
+[[api_keys.grants]]
+tenants    = ["acme.us-east"]          # Only acme.us-east and its children
+namespaces = ["alerts"]
+providers  = ["pagerduty", "slack"]
+actions    = ["*"]
+
+# ─── Read-only auditor ───────────────────────────────────
+[[api_keys]]
+name = "compliance-auditor"
+key_hash = "ENC[AES256-GCM,...]"
+role = "viewer"                         # Viewer role → no dispatch permission
+[[api_keys.grants]]
+tenants    = ["*"]
+namespaces = ["*"]
+providers  = ["*"]
+actions    = ["*"]
+```
+
+### Generating a key
+
+1. Generate a raw API key — e.g., `openssl rand -hex 32`.
+2. Compute its SHA-256 hash — e.g., `printf '%s' $KEY | sha256sum`.
+3. Encrypt the hash with `acteon-server encrypt` (reads from stdin) and paste
+   the resulting `ENC[...]` value into `key_hash`.
+4. Distribute the **raw key** to the caller (never the hash).
+
+`auth.toml` is hot-reloaded: changes to API keys and users are picked up
+without restarting the server. The JWT secret is immutable after startup
+to avoid invalidating active sessions.
+
+## Authenticating
+
+Acteon accepts API keys via two equivalent mechanisms. Both are
+recommended for operational tooling.
+
+### `Authorization: Bearer` (preferred)
+
+This is what the SDKs send by default. Gateway accepts both JWTs and raw
+API keys here — it tries JWT validation first, and falls back to API-key
+lookup on failure.
+
+```bash
+curl -H "Authorization: Bearer $ACTEON_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{"namespace":"notifications","tenant":"acme","provider":"email","action_type":"send_email","payload":{}}' \
+     https://acteon.example.com/v1/dispatch
+```
+
+### `X-API-Key` (legacy)
+
+Still supported for curl examples, scripts, and tools that reserve the
+`Authorization` header for other purposes:
+
+```bash
+curl -H "X-API-Key: $ACTEON_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '...' \
+     https://acteon.example.com/v1/dispatch
+```
+
+### SDK usage
+
+All five polyglot SDKs accept an API key and send it via the
+`Authorization: Bearer` header.
+
+```rust
+// Rust
+use acteon_client::ActeonClient;
+let client = ActeonClient::builder("http://localhost:8080")
+    .api_key("my-raw-key")
+    .build()?;
+```
+
+```python
+# Python
+from acteon_client import ActeonClient
+client = ActeonClient("http://localhost:8080", api_key="my-raw-key")
+```
+
+```typescript
+// Node.js
+import { ActeonClient } from "@acteon/client";
+const client = new ActeonClient("http://localhost:8080", { apiKey: "my-raw-key" });
+```
+
+```go
+// Go
+import "github.com/acteon/acteon/clients/go/acteon"
+client := acteon.NewClient("http://localhost:8080", acteon.WithAPIKey("my-raw-key"))
+```
+
+```java
+// Java
+ActeonClient client = new ActeonClient("http://localhost:8080", "my-raw-key");
+```
+
+## Enforcement points
+
+Grants are enforced at the server ingress on every request that mutates
+or reads scoped data:
+
+| Endpoint | What's checked |
+|----------|----------------|
+| `POST /v1/dispatch` | Each action against the full `(tenant, namespace, provider, action_type)` tuple |
+| `POST /v1/dispatch/batch` | Every action in the batch; **one failure rejects the whole batch** |
+| `GET /v1/audit/{id}` | The audit record's tenant/namespace/provider/action_type |
+| `POST /v1/audit/{id}/replay` | Same as dispatch |
+| `POST /v1/audit/replay` | Each record individually; out-of-scope records are skipped |
+| `GET /v1/analytics` | Tenant filter auto-injected for single-tenant callers |
+| `GET /v1/rules/coverage` | Tenant filter auto-injected for single-tenant callers |
+
+Role-based permissions (admin / operator / viewer) are enforced separately
+and orthogonally — a viewer cannot dispatch even with a matching grant, and
+an operator cannot reload rules even with `actions = ["*"]`.
+
+## Related features
+
+- [Compliance Mode](compliance-mode.md) — tamper-evident audit chain
+- [Audit Trail](audit-trail.md) — the scoped read surface
+- [Rule Coverage](rule-coverage.md) — tenant-scoped coverage analysis

--- a/docs/book/getting-started/configuration.md
+++ b/docs/book/getting-started/configuration.md
@@ -98,10 +98,16 @@ max_concurrent = 10                  # Max concurrent executions
 # object_prefix = "acteon/"
 
 # ─── Authentication ───────────────────────────────────────
+# Users and API keys live in auth.toml, a separate file referenced from
+# here. Each principal is authorized via a list of grants that scope them
+# to specific tenants, namespaces, providers, and action types. Tenant
+# grants support hierarchical matching — a grant on "acme" covers
+# "acme.us-east" and "acme.us-east.prod". See the "API Key Scoping"
+# feature page for the full grant model and worked examples.
 [auth]
 enabled = false                      # Enable authentication
-# config_path = "auth.toml"         # Path to auth config
-# watch = true                       # Hot-reload on file changes
+# config_path = "auth.toml"         # Path to auth config (relative to acteon.toml)
+# watch = true                       # Hot-reload auth.toml on file changes
 
 # ─── Background Processing ───────────────────────────────
 [background]

--- a/docs/book/reference/roadmap.md
+++ b/docs/book/reference/roadmap.md
@@ -29,13 +29,6 @@ Native `acteon-kafka` provider for publishing actions to Kafka topics with topic
 **Crates:** New `acteon-kafka` crate, `acteon-server`
 **Complexity:** Medium (~1500 LOC)
 
-### Tenant-Scoped API Keys
-
-Extend the auth system with `allowed_tenants`, `allowed_namespaces`, `allowed_providers`, and `allowed_action_types` fields on API keys. Validate dispatch requests against key scopes before rule evaluation. Support hierarchical tenants (e.g., `acme.us-east` inherits from `acme`).
-
-**Crates:** `acteon-server` (auth module)
-**Complexity:** Medium (~800 LOC)
-
 ### Action Signing & Tamper-Proof Dispatch
 
 Ed25519/ECDSA signing of dispatch requests with a `signature` and `signer_id` on each action. Validate incoming actions against a keyring. Provide `GET /v1/actions/{id}/verify` for cryptographic proof of action origin. Export signed audit records for downstream verification.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,7 @@ nav:
     - Data Retention: features/data-retention.md
     - Rule Playground: features/rule-playground.md
     - Rule Coverage: features/rule-coverage.md
+    - API Key Scoping: features/api-key-scoping.md
     - Provider Health: features/provider-health.md
     - Grafana Dashboards: features/grafana-dashboards.md
     - WASM Plugins: features/wasm-plugins.md


### PR DESCRIPTION
## Summary
Extends the grant-based auth system with provider scoping + hierarchical tenant matching, and fixes an SDK auth bug discovered during exploration.

### Design note
The roadmap entry said "add \`allowed_tenants\`/\`allowed_namespaces\`/\`allowed_providers\`/\`allowed_action_types\` fields to API keys", but the codebase already has all of that via the existing \`Grant\` struct (tenants, namespaces, actions), enforced in dispatch via \`is_authorized()\`. Rather than duplicating, I extended the existing pattern — **Option A** in the pre-work discussion. This keeps one consistent authorization model across users and API keys.

### What's new

**Grant struct** (\`crates/server/src/auth/config.rs\`)
- New \`providers: Vec<String>\` field with \`#[serde(default)]\` → wildcard, so existing \`auth.toml\` files keep working unchanged.
- New \`Grant::matches(tenant, namespace, provider, action_type)\` — single entry point for authorization decisions.
- **Hierarchical tenant matching**: a grant on \`\"acme\"\` covers \`\"acme.us-east\"\` and \`\"acme.us-east.prod\"\`. One-way (children don't cover parents). Dot-strict (\`\"acme\"\` does NOT match \`\"acme-corp\"\`).

**CallerIdentity** (\`crates/server/src/auth/identity.rs\`)
- \`is_authorized\` now takes 4 dimensions (was 3).
- New \`allowed_providers()\` helper mirroring \`allowed_tenants()\` / \`allowed_namespaces()\`.
- Updated all callers: dispatch (single + batch), audit, replay (single + bulk). Error messages include the rejected provider dimension.

**Middleware bug fix** (\`crates/server/src/auth/middleware.rs\`)
- **Before**: API keys only worked via the legacy \`X-API-Key\` header. SDKs send \`Authorization: Bearer <key>\`, which the middleware tried to validate as a JWT, failed, and returned 401 — **blocking SDK API-key auth entirely**.
- **After**: middleware tries JWT on Bearer tokens, falls back to API-key lookup before returning 401. Legacy \`X-API-Key\` header path retained for curl examples.

### Tests
- **15 new unit tests**: \`Grant::matches\` (wildcard, exact, hierarchical, dot-strict, one-way, provider, serde backward-compat) and \`CallerIdentity\` (provider enforcement, hierarchical, multi-grant union, allowed_providers).
- **13 new integration tests**: full HTTP roundtrip with auth enabled — allow path, each denial path (tenant/namespace/provider/action_type), hierarchical child allowed, hierarchical one-way denial, dot-strict prefix denial, Bearer API-key auth path, legacy \`X-API-Key\` path, missing credentials → 401, invalid key → 401, batch dispatch rejecting whole batch on a single out-of-scope action.

### Docs
- New \`docs/book/features/api-key-scoping.md\`: grant model, four dimensions, hierarchical tenant matching worked table, complete annotated \`auth.toml\` example (admin + scoped operator + region-scoped + viewer), key-generation workflow, both authentication headers, SDK snippets for all 5 languages, enforcement points table.
- Registered in \`mkdocs.yml\`.

## Test plan
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --no-deps -- -D warnings\`
- [x] \`cargo test --workspace --lib --bins --tests\` — **2017 passed, 0 failed** (was 1989 before)
- [x] \`cd ui && npm run lint && npm run build\`

## Follow-ups
- Roadmap entry \"Tenant-Scoped API Keys\" can be removed in a follow-up doc PR.
- The 5 SDK \`api_key\` constructor params are now functionally useful; worth a brief SDK docs sweep to mention that \`Authorization: Bearer\` is the canonical way to pass keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)