### PR TITLE
feat: per-provider tenant quotas (Phase 3 of Alertmanager parity)

### DIFF
--- a/clients/go/acteon/client.go
+++ b/clients/go/acteon/client.go
@@ -1055,14 +1055,20 @@ func (c *Client) CreateQuota(ctx context.Context, req *CreateQuotaRequest) (*Quo
 	return nil, &APIError{Code: errResp.Code, Message: errResp.Message, Retryable: errResp.Retryable}
 }
 
-// ListQuotas lists quota policies with optional namespace and tenant filters.
-func (c *Client) ListQuotas(ctx context.Context, namespace, tenant *string) (*ListQuotasResponse, error) {
+// ListQuotas lists quota policies with optional namespace, tenant,
+// and provider filters. Pass "generic" as the provider filter to
+// match only policies without a provider scope; pass a provider
+// name (e.g. "slack") to match only per-provider policies.
+func (c *Client) ListQuotas(ctx context.Context, namespace, tenant, provider *string) (*ListQuotasResponse, error) {
 	params := url.Values{}
 	if namespace != nil {
 		params.Set("namespace", *namespace)
 	}
 	if tenant != nil {
 		params.Set("tenant", *tenant)
+	}
+	if provider != nil {
+		params.Set("provider", *provider)
 	}
 
 	path := "/v1/quotas"

--- a/clients/go/acteon/models.go
+++ b/clients/go/acteon/models.go
@@ -691,9 +691,16 @@ type RecurringLifecycleRequest struct {
 // =============================================================================
 
 // CreateQuotaRequest is the request to create a quota policy.
+//
+// Provider is an optional provider scope. When empty, the policy is
+// generic and counts every dispatch for the tenant. When set, only
+// dispatches whose action.Provider equals this value count against
+// (and are enforced by) this policy. Generic and per-provider
+// policies may coexist for the same (Namespace, Tenant) pair.
 type CreateQuotaRequest struct {
 	Namespace       string            `json:"namespace"`
 	Tenant          string            `json:"tenant"`
+	Provider        string            `json:"provider,omitempty"`
 	MaxActions      int64             `json:"max_actions"`
 	Window          string            `json:"window"`
 	OverageBehavior string            `json:"overage_behavior"`
@@ -713,10 +720,15 @@ type UpdateQuotaRequest struct {
 }
 
 // QuotaPolicy represents a quota policy.
+//
+// Provider is the optional provider scope: empty ("") for generic
+// catch-all policies, or a provider name (e.g. "slack") when the
+// policy is scoped to a single provider.
 type QuotaPolicy struct {
 	ID              string            `json:"id"`
 	Namespace       string            `json:"namespace"`
 	Tenant          string            `json:"tenant"`
+	Provider        string            `json:"provider,omitempty"`
 	MaxActions      int64             `json:"max_actions"`
 	Window          string            `json:"window"`
 	OverageBehavior string            `json:"overage_behavior"`

--- a/clients/java/src/main/java/com/acteon/client/ActeonClient.java
+++ b/clients/java/src/main/java/com/acteon/client/ActeonClient.java
@@ -1216,9 +1216,12 @@ public class ActeonClient implements AutoCloseable {
     }
 
     /**
-     * Lists quota policies with optional namespace and tenant filters.
+     * Lists quota policies with optional namespace, tenant, and
+     * provider filters. Pass "generic" as the provider filter to
+     * match only policies without a provider scope, or a provider
+     * name (e.g. "slack") to match only per-provider policies.
      */
-    public ListQuotasResponse listQuotas(String namespace, String tenant) throws ActeonException {
+    public ListQuotasResponse listQuotas(String namespace, String tenant, String provider) throws ActeonException {
         try {
             List<String> params = new ArrayList<>();
             if (namespace != null) {
@@ -1226,6 +1229,9 @@ public class ActeonClient implements AutoCloseable {
             }
             if (tenant != null) {
                 params.add("tenant=" + URLEncoder.encode(tenant, StandardCharsets.UTF_8));
+            }
+            if (provider != null) {
+                params.add("provider=" + URLEncoder.encode(provider, StandardCharsets.UTF_8));
             }
 
             String path = "/v1/quotas";

--- a/clients/java/src/main/java/com/acteon/client/models/CreateQuotaRequest.java
+++ b/clients/java/src/main/java/com/acteon/client/models/CreateQuotaRequest.java
@@ -16,6 +16,16 @@ public class CreateQuotaRequest {
     @JsonProperty("tenant")
     private String tenant;
 
+    /**
+     * Optional provider scope. Null (the default) creates a generic
+     * tenant-wide policy. Setting this to a provider name (e.g.
+     * "slack") scopes the policy to dispatches targeting that
+     * provider only, so generic and per-provider policies can
+     * coexist for the same (namespace, tenant).
+     */
+    @JsonProperty("provider")
+    private String provider;
+
     @JsonProperty("max_actions")
     private long maxActions;
 
@@ -46,6 +56,9 @@ public class CreateQuotaRequest {
 
     public String getTenant() { return tenant; }
     public void setTenant(String tenant) { this.tenant = tenant; }
+
+    public String getProvider() { return provider; }
+    public void setProvider(String provider) { this.provider = provider; }
 
     public long getMaxActions() { return maxActions; }
     public void setMaxActions(long maxActions) { this.maxActions = maxActions; }

--- a/clients/java/src/main/java/com/acteon/client/models/QuotaPolicy.java
+++ b/clients/java/src/main/java/com/acteon/client/models/QuotaPolicy.java
@@ -17,6 +17,10 @@ public class QuotaPolicy {
     @JsonProperty("tenant")
     private String tenant;
 
+    /** Provider scope: null for generic catch-all policies, or a provider name. */
+    @JsonProperty("provider")
+    private String provider;
+
     @JsonProperty("max_actions")
     private long maxActions;
 
@@ -44,6 +48,7 @@ public class QuotaPolicy {
     public String getId() { return id; }
     public String getNamespace() { return namespace; }
     public String getTenant() { return tenant; }
+    public String getProvider() { return provider; }
     public long getMaxActions() { return maxActions; }
     public String getWindow() { return window; }
     public String getOverageBehavior() { return overageBehavior; }

--- a/clients/nodejs/src/client.ts
+++ b/clients/nodejs/src/client.ts
@@ -873,12 +873,20 @@ export class ActeonClient {
   }
 
   /**
-   * List quota policies.
+   * List quota policies, optionally filtered by namespace, tenant,
+   * and provider scope. Pass ``"generic"`` for ``provider`` to match
+   * only policies without a provider scope, or a provider name
+   * (e.g. ``"slack"``) to match only per-provider policies.
    */
-  async listQuotas(namespace?: string, tenant?: string): Promise<ListQuotasResponse> {
+  async listQuotas(
+    namespace?: string,
+    tenant?: string,
+    provider?: string,
+  ): Promise<ListQuotasResponse> {
     const params = new URLSearchParams();
     if (namespace !== undefined) params.set("namespace", namespace);
     if (tenant !== undefined) params.set("tenant", tenant);
+    if (provider !== undefined) params.set("provider", provider);
     const response = await this.request("GET", "/v1/quotas", { params: params.toString() ? params : undefined });
 
     if (response.ok) {

--- a/clients/nodejs/src/models.ts
+++ b/clients/nodejs/src/models.ts
@@ -1082,10 +1082,17 @@ export function updateRecurringActionToRequest(action: UpdateRecurringAction): R
 // Quota Types
 // =============================================================================
 
-/** Request to create a quota policy. */
+/** Request to create a quota policy.
+ *
+ * Omit ``provider`` (or pass ``undefined``) for a generic tenant-wide
+ * policy, or set it to a provider name such as ``"slack"`` to scope
+ * the policy to a single provider. Generic and per-provider
+ * policies may coexist for the same ``(namespace, tenant)``.
+ */
 export interface CreateQuotaRequest {
   namespace: string;
   tenant: string;
+  provider?: string;
   maxActions: number;
   window: string;
   overageBehavior: string;
@@ -1102,6 +1109,7 @@ export function createQuotaRequestToApi(req: CreateQuotaRequest): Record<string,
     window: req.window,
     overage_behavior: req.overageBehavior,
   };
+  if (req.provider !== undefined) result.provider = req.provider;
   if (req.description !== undefined) result.description = req.description;
   if (req.labels !== undefined) result.labels = req.labels;
   return result;
@@ -1137,6 +1145,8 @@ export interface QuotaPolicy {
   id: string;
   namespace: string;
   tenant: string;
+  /** Provider scope (``undefined`` for generic catch-all policies). */
+  provider?: string;
   maxActions: number;
   window: string;
   overageBehavior: string;
@@ -1153,6 +1163,7 @@ export function parseQuotaPolicy(data: Record<string, unknown>): QuotaPolicy {
     id: data.id as string,
     namespace: data.namespace as string,
     tenant: data.tenant as string,
+    provider: data.provider as string | undefined,
     maxActions: data.max_actions as number,
     window: data.window as string,
     overageBehavior: data.overage_behavior as string,

--- a/clients/python/acteon_client/client.py
+++ b/clients/python/acteon_client/client.py
@@ -1034,12 +1034,18 @@ class ActeonClient:
         self,
         namespace: Optional[str] = None,
         tenant: Optional[str] = None,
+        provider: Optional[str] = None,
     ) -> "ListQuotasResponse":
         """List quota policies.
 
         Args:
             namespace: Optional namespace filter.
             tenant: Optional tenant filter.
+            provider: Optional provider scope filter. Pass the
+                literal string ``"generic"`` to match only policies
+                without a provider scope, or a provider name (e.g.
+                ``"slack"``) to match only per-provider policies
+                for that provider.
 
         Returns:
             List of quota policies.
@@ -1053,6 +1059,8 @@ class ActeonClient:
             params["namespace"] = namespace
         if tenant is not None:
             params["tenant"] = tenant
+        if provider is not None:
+            params["provider"] = provider
         response = self._request("GET", "/v1/quotas", params=params)
 
         if response.status_code == 200:
@@ -2776,13 +2784,18 @@ class AsyncActeonClient:
         self,
         namespace: Optional[str] = None,
         tenant: Optional[str] = None,
+        provider: Optional[str] = None,
     ) -> "ListQuotasResponse":
-        """List quota policies."""
+        """List quota policies, optionally filtered by namespace,
+        tenant, and provider scope (``"generic"`` matches generic
+        policies; a provider name matches per-provider policies)."""
         params: dict = {}
         if namespace is not None:
             params["namespace"] = namespace
         if tenant is not None:
             params["tenant"] = tenant
+        if provider is not None:
+            params["provider"] = provider
         response = await self._request("GET", "/v1/quotas", params=params)
         if response.status_code == 200:
             return ListQuotasResponse.from_dict(response.json())

--- a/clients/python/acteon_client/models.py
+++ b/clients/python/acteon_client/models.py
@@ -1164,12 +1164,21 @@ class UpdateRecurringAction:
 
 @dataclass
 class CreateQuotaRequest:
-    """Request to create a quota policy."""
+    """Request to create a quota policy.
+
+    Pass ``provider=None`` (the default) for a generic tenant-wide
+    policy or ``provider="slack"`` to scope the policy to a single
+    provider so it only counts dispatches to that provider.
+    Generic and per-provider policies may coexist for the same
+    ``(namespace, tenant)`` and are evaluated together at dispatch
+    time (strictest outcome wins).
+    """
     namespace: str
     tenant: str
     max_actions: int
     window: str
     overage_behavior: str
+    provider: Optional[str] = None
     description: Optional[str] = None
     labels: Optional[dict[str, str]] = None
 
@@ -1182,6 +1191,8 @@ class CreateQuotaRequest:
             "window": self.window,
             "overage_behavior": self.overage_behavior,
         }
+        if self.provider is not None:
+            result["provider"] = self.provider
         if self.description is not None:
             result["description"] = self.description
         if self.labels is not None:
@@ -1221,7 +1232,12 @@ class UpdateQuotaRequest:
 
 @dataclass
 class QuotaPolicy:
-    """A quota policy."""
+    """A quota policy.
+
+    ``provider`` is ``None`` for generic catch-all policies and
+    a provider name (e.g. ``"slack"``) when the policy is scoped
+    to a single provider.
+    """
     id: str
     namespace: str
     tenant: str
@@ -1231,6 +1247,7 @@ class QuotaPolicy:
     enabled: bool
     created_at: str
     updated_at: str
+    provider: Optional[str] = None
     description: Optional[str] = None
     labels: Optional[dict[str, str]] = None
 
@@ -1240,6 +1257,7 @@ class QuotaPolicy:
             id=data["id"],
             namespace=data["namespace"],
             tenant=data["tenant"],
+            provider=data.get("provider"),
             max_actions=data["max_actions"],
             window=data["window"],
             overage_behavior=data["overage_behavior"],

--- a/crates/cli/src/commands/quotas.rs
+++ b/crates/cli/src/commands/quotas.rs
@@ -21,6 +21,12 @@ pub enum QuotasCommand {
         /// Filter by tenant.
         #[arg(long)]
         tenant: Option<String>,
+        /// Filter by provider scope. Pass the literal `generic`
+        /// to list only policies without a provider scope, or a
+        /// provider name (e.g. `slack`) to list only per-provider
+        /// policies for that provider.
+        #[arg(long)]
+        provider: Option<String>,
     },
     /// Get a quota policy by ID.
     Get {
@@ -70,8 +76,19 @@ fn parse_json_data(input: &str) -> anyhow::Result<serde_json::Value> {
 
 pub async fn run(ops: &OpsClient, args: &QuotasArgs, format: &OutputFormat) -> anyhow::Result<()> {
     match &args.command {
-        QuotasCommand::List { namespace, tenant } => {
-            run_list(ops, namespace.as_ref(), tenant.as_ref(), format).await
+        QuotasCommand::List {
+            namespace,
+            tenant,
+            provider,
+        } => {
+            run_list(
+                ops,
+                namespace.as_ref(),
+                tenant.as_ref(),
+                provider.as_ref(),
+                format,
+            )
+            .await
         }
         QuotasCommand::Get { id } => run_get(ops, id, format).await,
         QuotasCommand::Create { data } => run_create(ops, data, format).await,
@@ -93,10 +110,15 @@ async fn run_list(
     ops: &OpsClient,
     namespace: Option<&String>,
     tenant: Option<&String>,
+    provider: Option<&String>,
     format: &OutputFormat,
 ) -> anyhow::Result<()> {
     let resp = ops
-        .list_quotas(namespace.map(String::as_str), tenant.map(String::as_str))
+        .list_quotas(
+            namespace.map(String::as_str),
+            tenant.map(String::as_str),
+            provider.map(String::as_str),
+        )
         .await?;
     match format {
         OutputFormat::Json => {
@@ -106,11 +128,13 @@ async fn run_list(
             info!(count = resp.count, "Quotas");
             for q in &resp.quotas {
                 let enabled = if q.enabled { "ON " } else { "OFF" };
+                let scope = q.provider.as_deref().unwrap_or("*");
                 info!(
                     enabled = %enabled,
                     id = %&q.id[..8.min(q.id.len())],
                     namespace = %q.namespace,
                     tenant = %q.tenant,
+                    provider = %scope,
                     max_actions = q.max_actions,
                     window = %q.window,
                     overage_behavior = %q.overage_behavior,
@@ -133,6 +157,10 @@ async fn run_get(ops: &OpsClient, id: &str, format: &OutputFormat) -> anyhow::Re
                 info!(id = %q.id, "Quota details");
                 info!(namespace = %q.namespace, "  Namespace");
                 info!(tenant = %q.tenant, "  Tenant");
+                info!(
+                    provider = %q.provider.as_deref().unwrap_or("* (generic)"),
+                    "  Provider"
+                );
                 info!(max_actions = q.max_actions, window = %q.window, "  Max");
                 info!(overage_behavior = %q.overage_behavior, "  Behavior");
                 info!(enabled = q.enabled, "  Enabled");

--- a/crates/client/src/quotas.rs
+++ b/crates/client/src/quotas.rs
@@ -10,6 +10,13 @@ pub struct CreateQuotaRequest {
     pub namespace: String,
     /// Tenant.
     pub tenant: String,
+    /// Optional provider scope. When omitted, the policy is
+    /// generic and counts every dispatch for the tenant. When set,
+    /// only dispatches to the named provider count against this
+    /// policy — useful for stacking a tenant-wide daily cap with
+    /// per-provider burst caps.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
     /// Maximum number of actions allowed in the window.
     pub max_actions: u64,
     /// Time window (e.g., "1h", "24h", "7d").
@@ -57,6 +64,9 @@ pub struct QuotaPolicy {
     pub namespace: String,
     /// Tenant.
     pub tenant: String,
+    /// Optional provider scope (`None` = generic catch-all).
+    #[serde(default)]
+    pub provider: Option<String>,
     /// Maximum number of actions allowed in the window.
     pub max_actions: u64,
     /// Time window (e.g., "1h", "24h", "7d").
@@ -138,11 +148,15 @@ impl ActeonClient {
         }
     }
 
-    /// List quota policies filtered by optional namespace and tenant.
+    /// List quota policies filtered by optional namespace, tenant,
+    /// and provider scope. Pass `Some("generic")` as `provider` to
+    /// match only policies without a provider scope, or a provider
+    /// name to match only per-provider policies for that provider.
     pub async fn list_quotas(
         &self,
         namespace: Option<&str>,
         tenant: Option<&str>,
+        provider: Option<&str>,
     ) -> Result<ListQuotasResponse, Error> {
         let url = format!("{}/v1/quotas", self.base_url);
 
@@ -152,6 +166,9 @@ impl ActeonClient {
         }
         if let Some(t) = tenant {
             query.push(("tenant", t));
+        }
+        if let Some(p) = provider {
+            query.push(("provider", p));
         }
 
         let response = self

--- a/crates/client/src/stream.rs
+++ b/crates/client/src/stream.rs
@@ -329,8 +329,10 @@ mod tests {
 
     #[test]
     fn sse_frame_state_collects_data_lines() {
-        let mut state = SseFrameState::default();
-        state.event = Some("action_dispatched".into());
+        let mut state = SseFrameState {
+            event: Some("action_dispatched".into()),
+            ..SseFrameState::default()
+        };
         state.push_data("line1");
         state.push_data("line2");
 

--- a/crates/core/src/attachment.rs
+++ b/crates/core/src/attachment.rs
@@ -69,7 +69,7 @@ mod tests {
     #[test]
     fn empty_attachments_vec_deserializes_from_missing_field() {
         // Simulates backward compatibility: old payloads without "attachments"
-        let json = r#"[]"#;
+        let json = r"[]";
         let attachments: Vec<Attachment> = serde_json::from_str(json).unwrap();
         assert!(attachments.is_empty());
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -54,8 +54,9 @@ pub use key::ActionKey;
 pub use outcome::{ActionError, ActionOutcome, ProviderResponse, ResponseStatus};
 pub use provider_health::{ListProviderHealthResponse, ProviderHealthStatus};
 pub use quota::{
-    OverageBehavior, QuotaPolicy, QuotaUsage, QuotaWindow, compute_window_boundaries,
-    quota_counter_key,
+    MAX_POLICIES_PER_BUCKET, MAX_QUOTA_IDENTIFIER_LEN, OverageBehavior, QuotaIdentifierError,
+    QuotaPolicy, QuotaUsage, QuotaWindow, compute_window_boundaries, quota_counter_key,
+    validate_quota_scope_identifier,
 };
 pub use recurring::{
     CronValidationError, DEFAULT_MIN_INTERVAL_SECONDS, RecurringAction, RecurringActionTemplate,

--- a/crates/core/src/quota.rs
+++ b/crates/core/src/quota.rs
@@ -88,6 +88,19 @@ impl std::fmt::Display for OverageBehavior {
 }
 
 /// A quota policy defining the usage limit for a tenant.
+///
+/// A policy can be **generic** (applies to every dispatch for the
+/// `(namespace, tenant)` pair regardless of target provider) or
+/// **provider-scoped** (applies only when the action's `provider`
+/// matches this field). Multiple policies may coexist for the same
+/// `(namespace, tenant)`; all of them are evaluated in parallel and
+/// the **strictest** result wins. Typical use: stack a daily
+/// tenant-wide cap with per-provider burst caps.
+///
+/// | Policy | Matches | Counted against |
+/// |---|---|---|
+/// | `provider: None` | Any dispatch for the tenant | Generic counter bucket |
+/// | `provider: Some("slack")` | Only dispatches to the `slack` provider | Provider-scoped counter bucket |
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct QuotaPolicy {
@@ -97,6 +110,13 @@ pub struct QuotaPolicy {
     pub namespace: String,
     /// Tenant this quota applies to.
     pub tenant: String,
+    /// Optional provider this quota applies to. When `None`, the
+    /// policy is generic and applies to every dispatch for the
+    /// `(namespace, tenant)` pair. When `Some(provider)`, only
+    /// dispatches whose `action.provider` equals this value count
+    /// against (and are enforced by) this policy.
+    #[serde(default)]
+    pub provider: Option<String>,
     /// Maximum number of actions allowed per window.
     pub max_actions: u64,
     /// Time window for the quota.
@@ -120,6 +140,20 @@ pub struct QuotaPolicy {
 
 fn default_enabled() -> bool {
     true
+}
+
+impl QuotaPolicy {
+    /// Whether this policy applies to an action dispatched to the
+    /// given provider. A generic policy (`provider: None`) applies
+    /// to every dispatch; a provider-scoped policy applies only
+    /// when the provider matches exactly.
+    #[must_use]
+    pub fn applies_to_provider(&self, provider: &str) -> bool {
+        match &self.provider {
+            None => true,
+            Some(p) => p.as_str() == provider,
+        }
+    }
 }
 
 /// Current quota usage for a tenant.
@@ -172,7 +206,15 @@ pub fn compute_window_boundaries(
 
 /// Build a state key suffix for a quota usage counter.
 ///
-/// Format: `{namespace}:{tenant}:{window_label}:{window_index}`
+/// Format: `{namespace}:{tenant}:{provider_or_wildcard}:{window_label}:{window_index}`
+///
+/// The `provider` component is `"*"` for generic policies (those
+/// with `provider: None`) and the literal provider name otherwise.
+/// This ensures that a generic tenant-wide policy and one or more
+/// provider-scoped policies all maintain independent counters —
+/// a burst of `slack` dispatches does not consume the `email`
+/// policy's window, and neither provider-specific counter
+/// interferes with the tenant-wide counter.
 ///
 /// # Panics
 ///
@@ -181,6 +223,7 @@ pub fn compute_window_boundaries(
 pub fn quota_counter_key(
     namespace: &str,
     tenant: &str,
+    provider: Option<&str>,
     window: &QuotaWindow,
     now: &DateTime<Utc>,
 ) -> String {
@@ -190,7 +233,11 @@ pub fn quota_counter_key(
     let elapsed = now.signed_duration_since(epoch);
     let window_secs = secs.cast_signed();
     let window_index = elapsed.num_seconds() / window_secs;
-    format!("{namespace}:{tenant}:{}:{window_index}", window.label())
+    let provider_part = provider.unwrap_or("*");
+    format!(
+        "{namespace}:{tenant}:{provider_part}:{}:{window_index}",
+        window.label()
+    )
 }
 
 #[cfg(test)]
@@ -260,6 +307,7 @@ mod tests {
             id: "q-001".into(),
             namespace: "notifications".into(),
             tenant: "tenant-1".into(),
+            provider: None,
             max_actions: 1000,
             window: QuotaWindow::Daily,
             overage_behavior: OverageBehavior::Block,
@@ -369,18 +417,33 @@ mod tests {
         let now = chrono::DateTime::parse_from_rfc3339("2026-02-10T14:30:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        let key = quota_counter_key("ns", "tenant-1", &QuotaWindow::Hourly, &now);
-        assert!(key.starts_with("ns:tenant-1:hourly:"));
+        let key = quota_counter_key("ns", "tenant-1", None, &QuotaWindow::Hourly, &now);
+        // Generic (no provider) policies encode as "*" in the counter key.
+        assert!(key.starts_with("ns:tenant-1:*:hourly:"));
         // Same time should produce the same key.
-        let key2 = quota_counter_key("ns", "tenant-1", &QuotaWindow::Hourly, &now);
+        let key2 = quota_counter_key("ns", "tenant-1", None, &QuotaWindow::Hourly, &now);
         assert_eq!(key, key2);
+    }
+
+    #[test]
+    fn quota_counter_key_per_provider_isolation() {
+        let now = Utc::now();
+        let generic = quota_counter_key("ns", "t", None, &QuotaWindow::Hourly, &now);
+        let slack = quota_counter_key("ns", "t", Some("slack"), &QuotaWindow::Hourly, &now);
+        let email = quota_counter_key("ns", "t", Some("email"), &QuotaWindow::Hourly, &now);
+        // All three live in separate counter buckets.
+        assert_ne!(generic, slack);
+        assert_ne!(generic, email);
+        assert_ne!(slack, email);
+        assert!(slack.contains(":slack:"));
+        assert!(email.contains(":email:"));
     }
 
     #[test]
     fn quota_counter_key_different_windows() {
         let now = Utc::now();
-        let k1 = quota_counter_key("ns", "t", &QuotaWindow::Hourly, &now);
-        let k2 = quota_counter_key("ns", "t", &QuotaWindow::Daily, &now);
+        let k1 = quota_counter_key("ns", "t", None, &QuotaWindow::Hourly, &now);
+        let k2 = quota_counter_key("ns", "t", None, &QuotaWindow::Daily, &now);
         assert_ne!(k1, k2);
     }
 
@@ -401,6 +464,7 @@ mod tests {
             id: "q-full".into(),
             namespace: "ns".into(),
             tenant: "t".into(),
+            provider: Some("slack".into()),
             max_actions: 10_000,
             window: QuotaWindow::Monthly,
             overage_behavior: OverageBehavior::Degrade {
@@ -417,10 +481,59 @@ mod tests {
         let back: QuotaPolicy = serde_json::from_str(&json).unwrap();
         assert_eq!(back.max_actions, 10_000);
         assert_eq!(back.labels.get("tier"), Some(&"premium".to_string()));
+        assert_eq!(back.provider.as_deref(), Some("slack"));
         assert!(matches!(
             back.overage_behavior,
             OverageBehavior::Degrade { .. }
         ));
+    }
+
+    #[test]
+    fn quota_policy_applies_to_provider() {
+        let mut generic = QuotaPolicy {
+            id: "q-generic".into(),
+            namespace: "ns".into(),
+            tenant: "t".into(),
+            provider: None,
+            max_actions: 100,
+            window: QuotaWindow::Hourly,
+            overage_behavior: OverageBehavior::Block,
+            enabled: true,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            description: None,
+            labels: HashMap::new(),
+        };
+        // Generic policy applies to every provider.
+        assert!(generic.applies_to_provider("slack"));
+        assert!(generic.applies_to_provider("email"));
+        assert!(generic.applies_to_provider("webhook"));
+
+        // Scoping to a single provider only matches that provider.
+        generic.provider = Some("slack".into());
+        assert!(generic.applies_to_provider("slack"));
+        assert!(!generic.applies_to_provider("email"));
+        assert!(!generic.applies_to_provider("webhook"));
+    }
+
+    #[test]
+    fn quota_policy_defaults_provider_to_none() {
+        // Records written before Phase 3 don't carry the provider field;
+        // they should deserialize as generic (None) policies for
+        // backward compat.
+        let json = r#"{
+            "id": "q-legacy",
+            "namespace": "ns",
+            "tenant": "t",
+            "max_actions": 500,
+            "window": "daily",
+            "overage_behavior": "block",
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z"
+        }"#;
+        let policy: QuotaPolicy = serde_json::from_str(json).unwrap();
+        assert!(policy.provider.is_none());
+        assert!(policy.applies_to_provider("anything"));
     }
 
     #[test]
@@ -429,6 +542,7 @@ mod tests {
             id: "q-dis".into(),
             namespace: "ns".into(),
             tenant: "t".into(),
+            provider: None,
             max_actions: 100,
             window: QuotaWindow::Hourly,
             overage_behavior: OverageBehavior::Block,
@@ -455,6 +569,6 @@ mod tests {
     #[should_panic(expected = "quota window duration must be greater than 0")]
     fn quota_counter_key_panics_on_zero() {
         let now = Utc::now();
-        let _ = quota_counter_key("ns", "t", &QuotaWindow::Custom { seconds: 0 }, &now);
+        let _ = quota_counter_key("ns", "t", None, &QuotaWindow::Custom { seconds: 0 }, &now);
     }
 }

--- a/crates/core/src/quota.rs
+++ b/crates/core/src/quota.rs
@@ -142,6 +142,81 @@ fn default_enabled() -> bool {
     true
 }
 
+/// Maximum length allowed for `namespace`, `tenant`, and `provider`
+/// identifiers used in quota scopes. Prevents unbounded state-key
+/// growth and bounds validation work.
+pub const MAX_QUOTA_IDENTIFIER_LEN: usize = 128;
+
+/// Maximum number of quota policies permitted per `(namespace,
+/// tenant)` bucket. One generic plus up to 31 per-provider caps is
+/// ample for real deployments and bounds cold-path load work plus
+/// per-dispatch iteration cost (mitigating policy-explosion `DoS`).
+pub const MAX_POLICIES_PER_BUCKET: usize = 32;
+
+/// Errors reported by [`validate_quota_scope_identifier`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QuotaIdentifierError {
+    /// The identifier was empty.
+    Empty,
+    /// The identifier exceeded [`MAX_QUOTA_IDENTIFIER_LEN`].
+    TooLong(usize),
+    /// The identifier contained a reserved separator character (`:`)
+    /// that would enable state-key injection / cross-tenant counter
+    /// collisions.
+    ReservedChar(char),
+    /// The identifier contained an ASCII control character.
+    ControlChar(char),
+}
+
+impl std::fmt::Display for QuotaIdentifierError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => f.write_str("identifier must not be empty"),
+            Self::TooLong(n) => write!(
+                f,
+                "identifier length {n} exceeds maximum {MAX_QUOTA_IDENTIFIER_LEN}"
+            ),
+            Self::ReservedChar(c) => {
+                write!(f, "identifier must not contain reserved character {c:?}")
+            }
+            Self::ControlChar(c) => write!(
+                f,
+                "identifier must not contain control character U+{:04X}",
+                *c as u32
+            ),
+        }
+    }
+}
+
+impl std::error::Error for QuotaIdentifierError {}
+
+/// Validate a namespace/tenant/provider identifier used in a quota
+/// scope, rejecting values that could collide with the counter-key
+/// separator or inflate state-store keys without bound.
+///
+/// # Errors
+///
+/// Returns [`QuotaIdentifierError`] if the identifier is empty,
+/// exceeds [`MAX_QUOTA_IDENTIFIER_LEN`], contains the reserved
+/// separator `:`, or contains any ASCII control character.
+pub fn validate_quota_scope_identifier(s: &str) -> Result<(), QuotaIdentifierError> {
+    if s.is_empty() {
+        return Err(QuotaIdentifierError::Empty);
+    }
+    if s.len() > MAX_QUOTA_IDENTIFIER_LEN {
+        return Err(QuotaIdentifierError::TooLong(s.len()));
+    }
+    for c in s.chars() {
+        if c == ':' {
+            return Err(QuotaIdentifierError::ReservedChar(c));
+        }
+        if c.is_control() {
+            return Err(QuotaIdentifierError::ControlChar(c));
+        }
+    }
+    Ok(())
+}
+
 impl QuotaPolicy {
     /// Whether this policy applies to an action dispatched to the
     /// given provider. A generic policy (`provider: None`) applies
@@ -153,6 +228,35 @@ impl QuotaPolicy {
             None => true,
             Some(p) => p.as_str() == provider,
         }
+    }
+
+    /// Validate that this policy's scope identifiers are safe to
+    /// use as state-store key components and that the time window
+    /// and `max_actions` are non-zero. Callers use this both at
+    /// creation time and when loading records from the state
+    /// store, so a corrupt or legacy record is rejected before it
+    /// can produce unsafe keys or trigger a zero-window
+    /// arithmetic panic downstream.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string describing the first validation
+    /// failure encountered.
+    pub fn validate_scope(&self) -> Result<(), String> {
+        validate_quota_scope_identifier(&self.namespace)
+            .map_err(|e| format!("invalid namespace: {e}"))?;
+        validate_quota_scope_identifier(&self.tenant)
+            .map_err(|e| format!("invalid tenant: {e}"))?;
+        if let Some(ref p) = self.provider {
+            validate_quota_scope_identifier(p).map_err(|e| format!("invalid provider: {e}"))?;
+        }
+        if self.window.duration_seconds() == 0 {
+            return Err("quota window duration must be greater than 0".to_string());
+        }
+        if self.max_actions == 0 {
+            return Err("max_actions must be greater than 0".to_string());
+        }
+        Ok(())
     }
 }
 
@@ -216,9 +320,18 @@ pub fn compute_window_boundaries(
 /// policy's window, and neither provider-specific counter
 /// interferes with the tenant-wide counter.
 ///
-/// # Panics
+/// Returns `None` instead of panicking when any of these would
+/// produce an unsafe or nonsensical key:
 ///
-/// Panics if the window duration is zero.
+/// * The window duration is zero (would divide by zero).
+/// * `namespace`, `tenant`, or `provider` fails
+///   [`validate_quota_scope_identifier`] (e.g., contains the
+///   reserved `:` separator that would enable cross-tenant key
+///   collisions).
+///
+/// Callers should treat `None` as fail-closed for the affected
+/// policy — skip enforcement and log a warning so the offending
+/// record can be repaired — rather than crashing the gateway.
 #[must_use]
 pub fn quota_counter_key(
     namespace: &str,
@@ -226,18 +339,30 @@ pub fn quota_counter_key(
     provider: Option<&str>,
     window: &QuotaWindow,
     now: &DateTime<Utc>,
-) -> String {
+) -> Option<String> {
     let secs = window.duration_seconds();
-    assert!(secs > 0, "quota window duration must be greater than 0");
+    if secs == 0 {
+        return None;
+    }
+    if validate_quota_scope_identifier(namespace).is_err()
+        || validate_quota_scope_identifier(tenant).is_err()
+    {
+        return None;
+    }
+    if let Some(p) = provider
+        && validate_quota_scope_identifier(p).is_err()
+    {
+        return None;
+    }
     let epoch = DateTime::UNIX_EPOCH;
     let elapsed = now.signed_duration_since(epoch);
     let window_secs = secs.cast_signed();
     let window_index = elapsed.num_seconds() / window_secs;
     let provider_part = provider.unwrap_or("*");
-    format!(
+    Some(format!(
         "{namespace}:{tenant}:{provider_part}:{}:{window_index}",
         window.label()
-    )
+    ))
 }
 
 #[cfg(test)]
@@ -417,20 +542,22 @@ mod tests {
         let now = chrono::DateTime::parse_from_rfc3339("2026-02-10T14:30:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        let key = quota_counter_key("ns", "tenant-1", None, &QuotaWindow::Hourly, &now);
+        let key = quota_counter_key("ns", "tenant-1", None, &QuotaWindow::Hourly, &now).unwrap();
         // Generic (no provider) policies encode as "*" in the counter key.
         assert!(key.starts_with("ns:tenant-1:*:hourly:"));
         // Same time should produce the same key.
-        let key2 = quota_counter_key("ns", "tenant-1", None, &QuotaWindow::Hourly, &now);
+        let key2 = quota_counter_key("ns", "tenant-1", None, &QuotaWindow::Hourly, &now).unwrap();
         assert_eq!(key, key2);
     }
 
     #[test]
     fn quota_counter_key_per_provider_isolation() {
         let now = Utc::now();
-        let generic = quota_counter_key("ns", "t", None, &QuotaWindow::Hourly, &now);
-        let slack = quota_counter_key("ns", "t", Some("slack"), &QuotaWindow::Hourly, &now);
-        let email = quota_counter_key("ns", "t", Some("email"), &QuotaWindow::Hourly, &now);
+        let generic = quota_counter_key("ns", "t", None, &QuotaWindow::Hourly, &now).unwrap();
+        let slack =
+            quota_counter_key("ns", "t", Some("slack"), &QuotaWindow::Hourly, &now).unwrap();
+        let email =
+            quota_counter_key("ns", "t", Some("email"), &QuotaWindow::Hourly, &now).unwrap();
         // All three live in separate counter buckets.
         assert_ne!(generic, slack);
         assert_ne!(generic, email);
@@ -445,6 +572,109 @@ mod tests {
         let k1 = quota_counter_key("ns", "t", None, &QuotaWindow::Hourly, &now);
         let k2 = quota_counter_key("ns", "t", None, &QuotaWindow::Daily, &now);
         assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn quota_counter_key_returns_none_on_zero_window() {
+        let now = Utc::now();
+        assert!(
+            quota_counter_key("ns", "t", None, &QuotaWindow::Custom { seconds: 0 }, &now).is_none(),
+            "zero window must return None (fail-closed) instead of panicking"
+        );
+    }
+
+    #[test]
+    fn quota_counter_key_rejects_colon_in_identifiers() {
+        // Cross-tenant key injection attempt: a malicious provider
+        // name containing `:` must not produce a key that could
+        // collide with another tenant's counter bucket.
+        let now = Utc::now();
+        assert!(
+            quota_counter_key(
+                "acme",
+                "t",
+                Some("slack:acme:*"),
+                &QuotaWindow::Hourly,
+                &now
+            )
+            .is_none()
+        );
+        assert!(quota_counter_key("ns:rogue", "t", None, &QuotaWindow::Hourly, &now).is_none());
+        assert!(quota_counter_key("ns", "t:rogue", None, &QuotaWindow::Hourly, &now).is_none());
+    }
+
+    #[test]
+    fn validate_quota_scope_identifier_accepts_typical_names() {
+        for s in &[
+            "acme",
+            "acme-prod",
+            "acme.us-east",
+            "tenant_123",
+            "notifications",
+        ] {
+            assert!(
+                validate_quota_scope_identifier(s).is_ok(),
+                "should accept {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_quota_scope_identifier_rejects_dangerous_input() {
+        assert_eq!(
+            validate_quota_scope_identifier(""),
+            Err(QuotaIdentifierError::Empty)
+        );
+        let long = "a".repeat(MAX_QUOTA_IDENTIFIER_LEN + 1);
+        assert!(matches!(
+            validate_quota_scope_identifier(&long),
+            Err(QuotaIdentifierError::TooLong(_))
+        ));
+        assert!(matches!(
+            validate_quota_scope_identifier("foo:bar"),
+            Err(QuotaIdentifierError::ReservedChar(':'))
+        ));
+        assert!(matches!(
+            validate_quota_scope_identifier("foo\nbar"),
+            Err(QuotaIdentifierError::ControlChar(_))
+        ));
+        assert!(matches!(
+            validate_quota_scope_identifier("foo\0bar"),
+            Err(QuotaIdentifierError::ControlChar(_))
+        ));
+    }
+
+    #[test]
+    fn quota_policy_validate_scope_catches_corrupt_records() {
+        let mut policy = QuotaPolicy {
+            id: "q-1".into(),
+            namespace: "ns".into(),
+            tenant: "t".into(),
+            provider: None,
+            max_actions: 100,
+            window: QuotaWindow::Hourly,
+            overage_behavior: OverageBehavior::Block,
+            enabled: true,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            description: None,
+            labels: HashMap::new(),
+        };
+        assert!(policy.validate_scope().is_ok());
+
+        // Zero window is rejected (would panic elsewhere).
+        policy.window = QuotaWindow::Custom { seconds: 0 };
+        assert!(policy.validate_scope().is_err());
+
+        // Colon in provider is rejected (key injection).
+        policy.window = QuotaWindow::Hourly;
+        policy.provider = Some("bad:provider".into());
+        assert!(policy.validate_scope().is_err());
+
+        // Zero max_actions is rejected.
+        policy.provider = None;
+        policy.max_actions = 0;
+        assert!(policy.validate_scope().is_err());
     }
 
     #[test]
@@ -563,12 +793,5 @@ mod tests {
     fn compute_window_boundaries_panics_on_zero() {
         let now = Utc::now();
         let _ = compute_window_boundaries(&QuotaWindow::Custom { seconds: 0 }, &now);
-    }
-
-    #[test]
-    #[should_panic(expected = "quota window duration must be greater than 0")]
-    fn quota_counter_key_panics_on_zero() {
-        let now = Utc::now();
-        let _ = quota_counter_key("ns", "t", None, &QuotaWindow::Custom { seconds: 0 }, &now);
     }
 }

--- a/crates/gateway/examples/basic.rs
+++ b/crates/gateway/examples/basic.rs
@@ -140,5 +140,6 @@ fn outcome_label(outcome: &ActionOutcome) -> &'static str {
         ActionOutcome::Scheduled { .. } => "Scheduled",
         ActionOutcome::RecurringCreated { .. } => "RecurringCreated",
         ActionOutcome::QuotaExceeded { .. } => "QuotaExceeded",
+        ActionOutcome::Silenced { .. } => "Silenced",
     }
 }

--- a/crates/gateway/examples/multi_provider.rs
+++ b/crates/gateway/examples/multi_provider.rs
@@ -195,5 +195,8 @@ fn describe_outcome(outcome: &ActionOutcome) -> String {
             used,
             ..
         } => format!("QuotaExceeded (tenant: {tenant}, limit: {limit}, used: {used})"),
+        ActionOutcome::Silenced { silence_id, .. } => {
+            format!("Silenced (silence_id: {silence_id})")
+        }
     }
 }

--- a/crates/gateway/src/builder.rs
+++ b/crates/gateway/src/builder.rs
@@ -56,7 +56,7 @@ pub struct GatewayBuilder {
     circuit_breaker_default: Option<CircuitBreakerConfig>,
     circuit_breaker_overrides: HashMap<String, CircuitBreakerConfig>,
     stream_buffer_size: usize,
-    quota_policies: HashMap<String, acteon_core::QuotaPolicy>,
+    quota_policies: Vec<acteon_core::QuotaPolicy>,
     retention_policies: HashMap<String, acteon_core::RetentionPolicy>,
     payload_encryptor: Option<Arc<PayloadEncryptor>>,
     wasm_runtime: Option<Arc<dyn acteon_wasm_runtime::WasmPluginRuntime>>,
@@ -101,7 +101,7 @@ impl GatewayBuilder {
             circuit_breaker_default: None,
             circuit_breaker_overrides: HashMap::new(),
             stream_buffer_size: 1024,
-            quota_policies: HashMap::new(),
+            quota_policies: Vec::new(),
             retention_policies: HashMap::new(),
             payload_encryptor: None,
             wasm_runtime: None,
@@ -371,12 +371,18 @@ impl GatewayBuilder {
 
     /// Register a quota policy for a tenant.
     ///
-    /// The policy is keyed by `"namespace:tenant"`. Multiple policies for the
-    /// same tenant replace the previous one.
+    /// Multiple policies may coexist for the same `(namespace, tenant)`
+    /// pair as long as they target different providers (one generic
+    /// policy with `provider: None` plus any number of provider-scoped
+    /// policies). Adding a policy with the same `id` as an existing
+    /// one replaces it; otherwise it is appended.
     #[must_use]
     pub fn quota_policy(mut self, policy: acteon_core::QuotaPolicy) -> Self {
-        let key = format!("{}:{}", policy.namespace, policy.tenant);
-        self.quota_policies.insert(key, policy);
+        if let Some(slot) = self.quota_policies.iter_mut().find(|p| p.id == policy.id) {
+            *slot = policy;
+        } else {
+            self.quota_policies.push(policy);
+        }
         self
     }
 
@@ -504,10 +510,7 @@ impl GatewayBuilder {
     /// Set all quota policies at once (replaces any previously added).
     #[must_use]
     pub fn quota_policies(mut self, policies: Vec<acteon_core::QuotaPolicy>) -> Self {
-        self.quota_policies = policies
-            .into_iter()
-            .map(|p| (format!("{}:{}", p.namespace, p.tenant), p))
-            .collect();
+        self.quota_policies = policies;
         self
     }
 
@@ -522,35 +525,69 @@ impl GatewayBuilder {
         self
     }
 
-    /// Validate quota policies and wrap them in [`CachedPolicy`] for TTL tracking.
+    /// Validate quota policies and bucket them by `"namespace:tenant"`.
+    ///
+    /// Each bucket may hold a generic policy plus any number of
+    /// per-provider policies, all of which are evaluated together
+    /// per dispatch at runtime.
     fn validate_and_wrap_quota_policies(
-        policies: HashMap<String, acteon_core::QuotaPolicy>,
+        policies: Vec<acteon_core::QuotaPolicy>,
     ) -> Result<HashMap<String, crate::gateway::CachedPolicy>, GatewayError> {
-        for (key, policy) in &policies {
+        for policy in &policies {
+            let label = format!(
+                "{}:{}{}",
+                policy.namespace,
+                policy.tenant,
+                policy
+                    .provider
+                    .as_ref()
+                    .map(|p| format!(":{p}"))
+                    .unwrap_or_default()
+            );
             if policy.max_actions == 0 {
                 return Err(GatewayError::Configuration(format!(
-                    "quota policy '{key}' has max_actions = 0"
+                    "quota policy '{label}' has max_actions = 0"
                 )));
             }
             if policy.window.duration_seconds() == 0 {
                 return Err(GatewayError::Configuration(format!(
-                    "quota policy '{key}' has a zero-duration window"
+                    "quota policy '{label}' has a zero-duration window"
                 )));
             }
         }
+        // Reject duplicate (ns, tenant, provider) tuples — operators
+        // should pick exactly one policy per scope; silent override
+        // would be surprising.
+        let mut seen: HashMap<(String, String, Option<String>), String> = HashMap::new();
+        for policy in &policies {
+            let key = (
+                policy.namespace.clone(),
+                policy.tenant.clone(),
+                policy.provider.clone(),
+            );
+            if let Some(existing_id) = seen.get(&key) {
+                return Err(GatewayError::Configuration(format!(
+                    "duplicate quota policy for (namespace={}, tenant={}, provider={:?}): ids {existing_id} and {}",
+                    policy.namespace, policy.tenant, policy.provider, policy.id
+                )));
+            }
+            seen.insert(key, policy.id.clone());
+        }
+
         let now = Utc::now();
-        Ok(policies
-            .into_iter()
-            .map(|(k, p)| {
-                (
-                    k,
-                    crate::gateway::CachedPolicy {
-                        policy: p,
-                        cached_at: now,
-                    },
-                )
-            })
-            .collect())
+        let mut buckets: HashMap<String, crate::gateway::CachedPolicy> = HashMap::new();
+        for policy in policies {
+            let key = format!("{}:{}", policy.namespace, policy.tenant);
+            buckets
+                .entry(key)
+                .or_insert_with(|| crate::gateway::CachedPolicy {
+                    policies: Vec::new(),
+                    cached_at: now,
+                })
+                .policies
+                .push(policy);
+        }
+        Ok(buckets)
     }
 
     /// Build and validate the circuit breaker registry if a default config is provided.
@@ -1003,6 +1040,7 @@ mod tests {
             id: "q-bad".into(),
             namespace: "ns".into(),
             tenant: "t".into(),
+            provider: None,
             max_actions: 0,
             window: acteon_core::quota::QuotaWindow::Daily,
             overage_behavior: acteon_core::quota::OverageBehavior::Block,
@@ -1032,6 +1070,7 @@ mod tests {
             id: "q-bad2".into(),
             namespace: "ns".into(),
             tenant: "t".into(),
+            provider: None,
             max_actions: 100,
             window: acteon_core::quota::QuotaWindow::Custom { seconds: 0 },
             overage_behavior: acteon_core::quota::OverageBehavior::Block,

--- a/crates/gateway/src/builder.rs
+++ b/crates/gateway/src/builder.rs
@@ -528,8 +528,15 @@ impl GatewayBuilder {
     /// Validate quota policies and bucket them by `"namespace:tenant"`.
     ///
     /// Each bucket may hold a generic policy plus any number of
-    /// per-provider policies, all of which are evaluated together
+    /// per-provider policies (capped at
+    /// [`acteon_core::MAX_POLICIES_PER_BUCKET`] to prevent
+    /// policy-explosion `DoS`), all of which are evaluated together
     /// per dispatch at runtime.
+    ///
+    /// Every policy must pass [`acteon_core::QuotaPolicy::validate_scope`]
+    /// — this catches colon injection in identifiers, zero-duration
+    /// windows, and zero `max_actions` up front so the dispatch
+    /// path can rely on the invariants.
     fn validate_and_wrap_quota_policies(
         policies: Vec<acteon_core::QuotaPolicy>,
     ) -> Result<HashMap<String, crate::gateway::CachedPolicy>, GatewayError> {
@@ -544,16 +551,9 @@ impl GatewayBuilder {
                     .map(|p| format!(":{p}"))
                     .unwrap_or_default()
             );
-            if policy.max_actions == 0 {
-                return Err(GatewayError::Configuration(format!(
-                    "quota policy '{label}' has max_actions = 0"
-                )));
-            }
-            if policy.window.duration_seconds() == 0 {
-                return Err(GatewayError::Configuration(format!(
-                    "quota policy '{label}' has a zero-duration window"
-                )));
-            }
+            policy.validate_scope().map_err(|e| {
+                GatewayError::Configuration(format!("quota policy '{label}' invalid: {e}"))
+            })?;
         }
         // Reject duplicate (ns, tenant, provider) tuples — operators
         // should pick exactly one policy per scope; silent override
@@ -578,14 +578,20 @@ impl GatewayBuilder {
         let mut buckets: HashMap<String, crate::gateway::CachedPolicy> = HashMap::new();
         for policy in policies {
             let key = format!("{}:{}", policy.namespace, policy.tenant);
-            buckets
-                .entry(key)
-                .or_insert_with(|| crate::gateway::CachedPolicy {
-                    policies: Vec::new(),
-                    cached_at: now,
-                })
-                .policies
-                .push(policy);
+            let bucket =
+                buckets
+                    .entry(key.clone())
+                    .or_insert_with(|| crate::gateway::CachedPolicy {
+                        policies: Vec::new(),
+                        cached_at: now,
+                    });
+            if bucket.policies.len() >= acteon_core::MAX_POLICIES_PER_BUCKET {
+                return Err(GatewayError::Configuration(format!(
+                    "quota bucket '{key}' exceeds the per-tenant policy cap of {}",
+                    acteon_core::MAX_POLICIES_PER_BUCKET
+                )));
+            }
+            bucket.policies.push(policy);
         }
         Ok(buckets)
     }
@@ -1057,7 +1063,10 @@ mod tests {
             .build();
         assert!(result.is_err());
         assert!(
-            result.unwrap_err().to_string().contains("max_actions = 0"),
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("max_actions must be greater than 0"),
             "should reject quota with zero max_actions"
         );
     }
@@ -1090,7 +1099,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("zero-duration window"),
+                .contains("quota window duration must be greater than 0"),
             "should reject quota with zero-duration window"
         );
     }

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -126,10 +126,14 @@ pub struct ApprovalStatus {
     pub message: Option<String>,
 }
 
-/// Internal wrapper for quota policies cached in memory.
+/// Internal wrapper for all quota policies cached in memory for a
+/// single `(namespace, tenant)` pair. A bucket may hold one generic
+/// policy (`provider: None`) plus any number of provider-scoped
+/// policies — all of them are evaluated together per dispatch, and
+/// the strictest applicable verdict wins.
 #[derive(Debug, Clone)]
 pub(crate) struct CachedPolicy {
-    pub(crate) policy: acteon_core::QuotaPolicy,
+    pub(crate) policies: Vec<acteon_core::QuotaPolicy>,
     pub(crate) cached_at: chrono::DateTime<Utc>,
 }
 
@@ -999,33 +1003,59 @@ impl Gateway {
         self.dlq.is_some()
     }
 
-    /// Return a snapshot of the current in-memory quota policies.
-    pub fn quota_policies(&self) -> HashMap<String, acteon_core::QuotaPolicy> {
+    /// Return a flat snapshot of all in-memory quota policies.
+    ///
+    /// Since Phase 3, a single `(namespace, tenant)` pair may hold
+    /// multiple policies (one generic + several provider-scoped), so
+    /// this returns every policy across every bucket.
+    pub fn quota_policies(&self) -> Vec<acteon_core::QuotaPolicy> {
         self.quota_policies
             .read()
-            .iter()
-            .map(|(k, v)| (k.clone(), v.policy.clone()))
+            .values()
+            .flat_map(|bucket| bucket.policies.clone())
             .collect()
     }
 
-    /// Add or replace a quota policy. Keyed by `"namespace:tenant"`.
+    /// Add or replace a quota policy. Policies are bucketed by
+    /// `"namespace:tenant"`; within a bucket, existing entries with
+    /// the same `id` are replaced in place while new `id`s are
+    /// appended, allowing generic and per-provider policies to
+    /// coexist for the same tenant.
     pub fn set_quota_policy(&self, policy: acteon_core::QuotaPolicy) {
         let key = format!("{}:{}", policy.namespace, policy.tenant);
-        let cached = CachedPolicy {
-            policy,
-            cached_at: Utc::now(),
-        };
-        self.quota_policies.write().insert(key, cached);
+        let now = Utc::now();
+        let mut map = self.quota_policies.write();
+        let bucket = map.entry(key).or_insert_with(|| CachedPolicy {
+            policies: Vec::new(),
+            cached_at: now,
+        });
+        bucket.cached_at = now;
+        if let Some(slot) = bucket.policies.iter_mut().find(|p| p.id == policy.id) {
+            *slot = policy;
+        } else {
+            bucket.policies.push(policy);
+        }
     }
 
-    /// Remove a quota policy by its lookup key (`"namespace:tenant"`).
-    pub fn remove_quota_policy(
+    /// Remove a single quota policy from its `(namespace, tenant)`
+    /// bucket by its `id`. Returns the removed policy if it existed.
+    /// The enclosing bucket is dropped if it becomes empty so that
+    /// the cold-path loader re-scans on the next dispatch.
+    pub fn remove_quota_policy_by_id(
         &self,
         namespace: &str,
         tenant: &str,
+        id: &str,
     ) -> Option<acteon_core::QuotaPolicy> {
         let key = format!("{namespace}:{tenant}");
-        self.quota_policies.write().remove(&key).map(|c| c.policy)
+        let mut map = self.quota_policies.write();
+        let bucket = map.get_mut(&key)?;
+        let pos = bucket.policies.iter().position(|p| p.id == id)?;
+        let removed = bucket.policies.remove(pos);
+        if bucket.policies.is_empty() {
+            map.remove(&key);
+        }
+        Some(removed)
     }
 
     /// Return a snapshot of the current in-memory retention policies.
@@ -8704,6 +8734,7 @@ mod tests {
             id: uuid::Uuid::new_v4().to_string(),
             namespace: namespace.into(),
             tenant: tenant.into(),
+            provider: None,
             max_actions,
             window,
             overage_behavior,
@@ -8713,6 +8744,27 @@ mod tests {
             description: None,
             labels: HashMap::new(),
         }
+    }
+
+    fn make_quota_policy_for_provider(
+        namespace: &str,
+        tenant: &str,
+        provider: &str,
+        max_actions: u64,
+        window: acteon_core::QuotaWindow,
+        overage_behavior: acteon_core::OverageBehavior,
+        enabled: bool,
+    ) -> acteon_core::QuotaPolicy {
+        let mut p = make_quota_policy(
+            namespace,
+            tenant,
+            max_actions,
+            window,
+            overage_behavior,
+            enabled,
+        );
+        p.provider = Some(provider.into());
+        p
     }
 
     fn build_gateway_with_quota(
@@ -9051,6 +9103,255 @@ mod tests {
             snap.quota_exceeded, 1,
             "only the real dispatch should count"
         );
+    }
+
+    // -- Per-provider quota tests (Phase 3) ----------------------------------
+
+    fn build_gateway_with_two_providers(
+        policies: Vec<acteon_core::QuotaPolicy>,
+    ) -> crate::gateway::Gateway {
+        let store = Arc::new(MemoryStateStore::new());
+        let lock = Arc::new(MemoryDistributedLock::new());
+        GatewayBuilder::new()
+            .state(store)
+            .lock(lock)
+            .rules(vec![])
+            .provider(Arc::new(MockProvider::new("email")))
+            .provider(Arc::new(MockProvider::new("slack")))
+            .executor_config(ExecutorConfig {
+                max_retries: 0,
+                execution_timeout: Duration::from_secs(5),
+                max_concurrent: 10,
+                ..ExecutorConfig::default()
+            })
+            .quota_policies(policies)
+            .build()
+            .expect("gateway should build")
+    }
+
+    fn action_for_provider(provider: &str) -> Action {
+        Action::new(
+            "notifications",
+            "tenant-1",
+            provider,
+            "send",
+            serde_json::json!({"to": "user@example.com"}),
+        )
+    }
+
+    #[tokio::test]
+    async fn per_provider_quota_scopes_only_matching_provider() {
+        // A slack-scoped policy should not count email dispatches.
+        let slack_policy = make_quota_policy_for_provider(
+            "notifications",
+            "tenant-1",
+            "slack",
+            2,
+            acteon_core::QuotaWindow::Hourly,
+            acteon_core::OverageBehavior::Block,
+            true,
+        );
+        let gw = build_gateway_with_two_providers(vec![slack_policy]);
+
+        // 5 email dispatches — should NOT count against the slack policy.
+        for _ in 0..5 {
+            let outcome = gw
+                .dispatch(action_for_provider("email"), None)
+                .await
+                .unwrap();
+            assert!(
+                matches!(outcome, ActionOutcome::Executed(_)),
+                "email dispatches must ignore a slack-scoped policy"
+            );
+        }
+
+        // 2 slack dispatches succeed (within slack cap).
+        for _ in 0..2 {
+            let outcome = gw
+                .dispatch(action_for_provider("slack"), None)
+                .await
+                .unwrap();
+            assert!(matches!(outcome, ActionOutcome::Executed(_)));
+        }
+
+        // 3rd slack dispatch is blocked.
+        let outcome = gw
+            .dispatch(action_for_provider("slack"), None)
+            .await
+            .unwrap();
+        assert!(matches!(outcome, ActionOutcome::QuotaExceeded { .. }));
+
+        let snap = gw.metrics().snapshot();
+        assert_eq!(snap.executed, 7);
+        assert_eq!(snap.quota_exceeded, 1);
+    }
+
+    #[tokio::test]
+    async fn generic_and_provider_scoped_policies_stack() {
+        // Generic tenant cap of 10, plus an 3/hour burst cap on slack.
+        // Slack dispatches are enforced by both; other providers
+        // only by the generic cap.
+        let generic = make_quota_policy(
+            "notifications",
+            "tenant-1",
+            10,
+            acteon_core::QuotaWindow::Hourly,
+            acteon_core::OverageBehavior::Block,
+            true,
+        );
+        let slack_burst = make_quota_policy_for_provider(
+            "notifications",
+            "tenant-1",
+            "slack",
+            3,
+            acteon_core::QuotaWindow::Hourly,
+            acteon_core::OverageBehavior::Block,
+            true,
+        );
+        let gw = build_gateway_with_two_providers(vec![generic, slack_burst]);
+
+        // 3 slack dispatches ok (slack burst limit met, generic at 3/10).
+        for _ in 0..3 {
+            let outcome = gw
+                .dispatch(action_for_provider("slack"), None)
+                .await
+                .unwrap();
+            assert!(matches!(outcome, ActionOutcome::Executed(_)));
+        }
+
+        // 4th slack dispatch hits the slack burst cap — blocked.
+        let outcome = gw
+            .dispatch(action_for_provider("slack"), None)
+            .await
+            .unwrap();
+        assert!(matches!(outcome, ActionOutcome::QuotaExceeded { .. }));
+
+        // Blocked request should NOT have consumed any budget on the
+        // generic cap (rollback semantics). Email can still dispatch
+        // 7 more times before hitting the generic cap of 10.
+        for _ in 0..7 {
+            let outcome = gw
+                .dispatch(action_for_provider("email"), None)
+                .await
+                .unwrap();
+            assert!(
+                matches!(outcome, ActionOutcome::Executed(_)),
+                "generic cap should not include the blocked slack attempt"
+            );
+        }
+
+        // 11th total dispatch across any provider — generic cap blocks.
+        let outcome = gw
+            .dispatch(action_for_provider("email"), None)
+            .await
+            .unwrap();
+        assert!(
+            matches!(outcome, ActionOutcome::QuotaExceeded { .. }),
+            "generic cap should kick in after 3 slack + 7 email = 10 dispatches"
+        );
+
+        let snap = gw.metrics().snapshot();
+        assert_eq!(snap.executed, 10);
+        assert_eq!(snap.quota_exceeded, 2);
+    }
+
+    #[tokio::test]
+    async fn blocked_dispatch_rolls_back_all_applicable_counters() {
+        // When one policy blocks, every counter incremented during
+        // the call must be rolled back so the blocked dispatch does
+        // not consume any budget on the sibling policies.
+        let generic = make_quota_policy(
+            "notifications",
+            "tenant-1",
+            100,
+            acteon_core::QuotaWindow::Hourly,
+            acteon_core::OverageBehavior::Warn,
+            true,
+        );
+        let slack = make_quota_policy_for_provider(
+            "notifications",
+            "tenant-1",
+            "slack",
+            1,
+            acteon_core::QuotaWindow::Hourly,
+            acteon_core::OverageBehavior::Block,
+            true,
+        );
+        let gw = build_gateway_with_two_providers(vec![generic, slack]);
+
+        // First slack dispatch succeeds.
+        let outcome = gw
+            .dispatch(action_for_provider("slack"), None)
+            .await
+            .unwrap();
+        assert!(matches!(outcome, ActionOutcome::Executed(_)));
+
+        // Second slack dispatch hits the slack block — should roll
+        // back both the slack counter (no effect, since block fires)
+        // AND the generic counter. After this, 99 email dispatches
+        // should still fit under the generic cap of 100.
+        let outcome = gw
+            .dispatch(action_for_provider("slack"), None)
+            .await
+            .unwrap();
+        assert!(matches!(outcome, ActionOutcome::QuotaExceeded { .. }));
+
+        for _ in 0..99 {
+            let outcome = gw
+                .dispatch(action_for_provider("email"), None)
+                .await
+                .unwrap();
+            assert!(matches!(outcome, ActionOutcome::Executed(_)));
+        }
+
+        let snap = gw.metrics().snapshot();
+        // 1 slack + 99 email = 100 executed.
+        assert_eq!(snap.executed, 100);
+        assert_eq!(snap.quota_exceeded, 1, "slack block");
+    }
+
+    #[tokio::test]
+    async fn strictest_policy_wins_block_over_warn() {
+        // Generic warn cap and slack block cap. When a slack dispatch
+        // exceeds both, the block outcome must win over warn.
+        let generic = make_quota_policy(
+            "notifications",
+            "tenant-1",
+            1,
+            acteon_core::QuotaWindow::Hourly,
+            acteon_core::OverageBehavior::Warn,
+            true,
+        );
+        let slack_block = make_quota_policy_for_provider(
+            "notifications",
+            "tenant-1",
+            "slack",
+            1,
+            acteon_core::QuotaWindow::Hourly,
+            acteon_core::OverageBehavior::Block,
+            true,
+        );
+        let gw = build_gateway_with_two_providers(vec![generic, slack_block]);
+
+        // First slack dispatch succeeds.
+        let _ = gw
+            .dispatch(action_for_provider("slack"), None)
+            .await
+            .unwrap();
+
+        // Second slack dispatch exceeds both policies — block wins.
+        let outcome = gw
+            .dispatch(action_for_provider("slack"), None)
+            .await
+            .unwrap();
+        match outcome {
+            ActionOutcome::QuotaExceeded {
+                overage_behavior, ..
+            } => {
+                assert_eq!(overage_behavior, "block");
+            }
+            other => panic!("expected QuotaExceeded (block), got {other:?}"),
+        }
     }
 
     // -- Provider metrics integration test -----------------------------------

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -457,40 +457,101 @@ impl Gateway {
         }
 
         // 2b. Quota check (skip in dry-run mode).
+        //
+        // Degrade outcomes swap the action's provider and
+        // re-enter the quota check so that (a) the fallback
+        // provider's own budget is actually enforced and
+        // (b) the dispatch path continues through rule
+        // evaluation and execution on the fallback instead of
+        // returning a misleading success-like "degraded" outcome
+        // without ever sending the message. The hop limit caps
+        // how many fallbacks a single dispatch can traverse so
+        // a misconfigured chain of degrade policies cannot loop.
         let mut action = action;
-        if !dry_run && let Some(outcome) = self.check_quota(&action).await? {
-            let dummy_verdict = RuleVerdict::Allow(None);
-            if let Some(ref audit) = self.audit {
-                let record = build_audit_record(
-                    event_id.clone(),
-                    &action,
-                    &dummy_verdict,
-                    &outcome,
-                    dispatched_at,
-                    start.elapsed(),
-                    self.effective_audit_ttl(&action.namespace, &action.tenant),
-                    self.audit_store_payload,
-                    caller,
-                );
-                self.emit_audit_record(audit, record).await;
+        if !dry_run {
+            const MAX_QUOTA_DEGRADE_HOPS: usize = 3;
+            let mut hops = 0usize;
+            let mut terminal: Option<ActionOutcome> = None;
+            loop {
+                let outcome = if hops == 0 {
+                    self.check_quota(&action).await?
+                } else {
+                    // After a degrade swap, only re-evaluate
+                    // provider-scoped policies so we do not
+                    // double-charge the generic (tenant-wide)
+                    // budget that already produced the initial
+                    // degrade verdict.
+                    self.check_quota_fallback(&action).await?
+                };
+                let Some(outcome) = outcome else {
+                    break;
+                };
+                match outcome {
+                    ActionOutcome::QuotaExceeded {
+                        ref overage_behavior,
+                        ..
+                    } if overage_behavior.starts_with("degrade:") => {
+                        if hops >= MAX_QUOTA_DEGRADE_HOPS {
+                            warn!(
+                                hops,
+                                "quota degrade hop limit reached — returning QuotaExceeded instead of cascading further"
+                            );
+                            terminal = Some(outcome);
+                            break;
+                        }
+                        if let Some(fallback) = overage_behavior.strip_prefix("degrade:") {
+                            info!(
+                                from = %action.provider,
+                                to = %fallback,
+                                "quota exceeded — degrading to fallback provider"
+                            );
+                            action.provider = fallback.into();
+                            hops += 1;
+                            continue;
+                        }
+                        terminal = Some(outcome);
+                        break;
+                    }
+                    _ => {
+                        terminal = Some(outcome);
+                        break;
+                    }
+                }
             }
-            let stream_event = StreamEvent {
-                id: event_id,
-                timestamp: dispatched_at,
-                event_type: StreamEventType::ActionDispatched {
-                    outcome: sanitize_outcome(&outcome),
-                    provider: action.provider.to_string(),
-                },
-                namespace: action.namespace.to_string(),
-                tenant: action.tenant.to_string(),
-                action_type: Some(action.action_type.clone()),
-                action_id: Some(action.id.to_string()),
-            };
-            let _ = self.stream_tx.send(stream_event);
-            if let Some(g) = guard {
-                let _ = g.release().await;
+            if let Some(outcome) = terminal {
+                let dummy_verdict = RuleVerdict::Allow(None);
+                if let Some(ref audit) = self.audit {
+                    let record = build_audit_record(
+                        event_id.clone(),
+                        &action,
+                        &dummy_verdict,
+                        &outcome,
+                        dispatched_at,
+                        start.elapsed(),
+                        self.effective_audit_ttl(&action.namespace, &action.tenant),
+                        self.audit_store_payload,
+                        caller,
+                    );
+                    self.emit_audit_record(audit, record).await;
+                }
+                let stream_event = StreamEvent {
+                    id: event_id,
+                    timestamp: dispatched_at,
+                    event_type: StreamEventType::ActionDispatched {
+                        outcome: sanitize_outcome(&outcome),
+                        provider: action.provider.to_string(),
+                    },
+                    namespace: action.namespace.to_string(),
+                    tenant: action.tenant.to_string(),
+                    action_type: Some(action.action_type.clone()),
+                    action_id: Some(action.id.to_string()),
+                };
+                let _ = self.stream_tx.send(stream_event);
+                if let Some(g) = guard {
+                    let _ = g.release().await;
+                }
+                return Ok(outcome);
             }
-            return Ok(outcome);
         }
 
         // 2c. Apply pre-dispatch enrichments.
@@ -2713,68 +2774,104 @@ impl Gateway {
             return Ok(());
         }
 
-        // Enforce tenant quota for each chain step so chains cannot bypass
-        // limits.
-        if let Some(quota_outcome) = self.check_quota(&step_action).await? {
-            match quota_outcome {
-                ActionOutcome::QuotaExceeded {
-                    ref overage_behavior,
-                    ..
-                } if overage_behavior == "block" => {
-                    let now = Utc::now();
-                    chain_state.step_results[step_idx] = Some(StepResult {
-                        step_name: step_config.name.clone(),
-                        success: false,
-                        response_body: None,
-                        error: Some("quota exceeded — chain step blocked".to_string()),
-                        completed_at: now,
-                        attempt: None,
-                        started_at: None,
-                    });
-                    chain_state.status = ChainStatus::Failed;
-                    chain_state.updated_at = now;
-                    self.persist_chain_state(&chain_key, &chain_state, self.completed_chain_ttl)
-                        .await?;
-                    self.cleanup_pending_chain(namespace, tenant, chain_id)
-                        .await?;
-                    self.metrics.increment_chains_failed();
-                    if let Some(ref sr) = chain_state.step_results[step_idx] {
-                        self.emit_chain_step_audit(
-                            &chain_state,
-                            step_config,
-                            step_idx,
-                            "chain_step_quota_exceeded",
-                            sr,
-                            Duration::ZERO,
-                            None,
-                        );
+        // Enforce tenant quota for each chain step so chains cannot
+        // bypass limits. Degrade outcomes swap the provider and
+        // re-check so the fallback provider's own budget is also
+        // enforced (matching the semantics in `dispatch_inner`).
+        // The hop limit prevents a misconfigured chain of degrade
+        // policies from looping indefinitely.
+        {
+            const MAX_QUOTA_DEGRADE_HOPS: usize = 3;
+            let mut hops = 0usize;
+            let mut blocked: Option<ActionOutcome> = None;
+            loop {
+                let quota_outcome = if hops == 0 {
+                    self.check_quota(&step_action).await?
+                } else {
+                    // Fallback mode: only provider-scoped policies
+                    // are re-evaluated so the generic tenant-wide
+                    // budget is not double-charged on each degrade
+                    // hop.
+                    self.check_quota_fallback(&step_action).await?
+                };
+                let Some(quota_outcome) = quota_outcome else {
+                    break;
+                };
+                match quota_outcome {
+                    ActionOutcome::QuotaExceeded {
+                        ref overage_behavior,
+                        ..
+                    } if overage_behavior.starts_with("degrade:")
+                        && hops < MAX_QUOTA_DEGRADE_HOPS =>
+                    {
+                        if let Some(fallback) = overage_behavior.strip_prefix("degrade:") {
+                            info!(
+                                chain_id = %chain_id,
+                                step = %step_config.name,
+                                from = %step_action.provider,
+                                to = %fallback,
+                                "quota exceeded — degrading chain step to fallback provider"
+                            );
+                            step_action.provider = fallback.into();
+                            hops += 1;
+                            continue;
+                        }
+                        blocked = Some(quota_outcome);
+                        break;
                     }
-                    self.emit_chain_terminal_audit(&chain_state, "chain_failed");
-                    let _ = self.state.delete(&step_dedup_key).await;
-                    guard
-                        .release()
-                        .await
-                        .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
-                    return Ok(());
-                }
-                ActionOutcome::QuotaExceeded {
-                    ref overage_behavior,
-                    ..
-                } if overage_behavior.starts_with("degrade:") => {
-                    if let Some(fallback) = overage_behavior.strip_prefix("degrade:") {
-                        info!(
-                            chain_id = %chain_id,
-                            step = %step_config.name,
-                            fallback = %fallback,
-                            "quota exceeded — degrading chain step to fallback provider"
-                        );
-                        step_action.provider = fallback.into();
+                    ActionOutcome::QuotaExceeded {
+                        ref overage_behavior,
+                        ..
+                    } if overage_behavior == "block"
+                        || overage_behavior.starts_with("degrade:") =>
+                    {
+                        // Block, or a degrade that exhausted the hop limit.
+                        blocked = Some(quota_outcome);
+                        break;
+                    }
+                    _ => {
+                        // Warn / Notify already recorded by check_quota;
+                        // proceed with execution on the current provider.
+                        break;
                     }
                 }
-                _ => {
-                    // Warn / Notify are already recorded by check_quota;
-                    // proceed with execution on original provider.
+            }
+            if let Some(_blocked) = blocked {
+                let now = Utc::now();
+                chain_state.step_results[step_idx] = Some(StepResult {
+                    step_name: step_config.name.clone(),
+                    success: false,
+                    response_body: None,
+                    error: Some("quota exceeded — chain step blocked".to_string()),
+                    completed_at: now,
+                    attempt: None,
+                    started_at: None,
+                });
+                chain_state.status = ChainStatus::Failed;
+                chain_state.updated_at = now;
+                self.persist_chain_state(&chain_key, &chain_state, self.completed_chain_ttl)
+                    .await?;
+                self.cleanup_pending_chain(namespace, tenant, chain_id)
+                    .await?;
+                self.metrics.increment_chains_failed();
+                if let Some(ref sr) = chain_state.step_results[step_idx] {
+                    self.emit_chain_step_audit(
+                        &chain_state,
+                        step_config,
+                        step_idx,
+                        "chain_step_quota_exceeded",
+                        sr,
+                        Duration::ZERO,
+                        None,
+                    );
                 }
+                self.emit_chain_terminal_audit(&chain_state, "chain_failed");
+                let _ = self.state.delete(&step_dedup_key).await;
+                guard
+                    .release()
+                    .await
+                    .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
+                return Ok(());
             }
         }
 
@@ -9015,7 +9112,7 @@ mod tests {
             .build()
             .expect("gateway should build");
 
-        // First 2 dispatches succeed normally.
+        // First 2 dispatches succeed normally on the primary provider.
         for i in 0..2 {
             let outcome = gw.dispatch(test_action(), None).await.unwrap();
             assert!(
@@ -9024,29 +9121,27 @@ mod tests {
             );
         }
 
-        // 3rd dispatch should return QuotaExceeded with degrade behavior.
+        // 3rd dispatch: the quota is exceeded on the primary
+        // provider, but Degrade semantics re-route to the fallback
+        // and actually execute there. The caller sees a regular
+        // Executed outcome, not QuotaExceeded — the fix for the
+        // pre-Phase-3 bug where degraded dispatches were silently
+        // dropped.
         let outcome = gw.dispatch(test_action(), None).await.unwrap();
-        match outcome {
-            ActionOutcome::QuotaExceeded {
-                tenant,
-                limit,
-                used,
-                overage_behavior,
-            } => {
-                assert_eq!(tenant, "tenant-1");
-                assert_eq!(limit, 2);
-                assert_eq!(used, 3, "post-increment value after atomic increment");
-                assert_eq!(overage_behavior, "degrade:sms-fallback");
-            }
-            other => panic!("expected QuotaExceeded with degrade, got {other:?}"),
-        }
+        assert!(
+            matches!(outcome, ActionOutcome::Executed(_)),
+            "degrade should re-dispatch through the fallback provider, got {outcome:?}"
+        );
 
         let snap = gw.metrics().snapshot();
-        assert_eq!(snap.executed, 2);
-        assert_eq!(snap.quota_degraded, 1);
+        assert_eq!(
+            snap.executed, 3,
+            "2 on primary + 1 on fallback after degrade"
+        );
+        assert_eq!(snap.quota_degraded, 1, "one degrade event recorded");
         assert_eq!(
             snap.quota_exceeded, 0,
-            "Degrade uses its own counter, not exceeded"
+            "Degrade does not increment the exceeded counter"
         );
     }
 
@@ -9308,6 +9403,72 @@ mod tests {
         // 1 slack + 99 email = 100 executed.
         assert_eq!(snap.executed, 100);
         assert_eq!(snap.quota_exceeded, 1, "slack block");
+    }
+
+    #[tokio::test]
+    async fn degrade_fallback_still_enforces_fallback_provider_quota() {
+        // Primary has a degrade-to-fallback policy. The fallback
+        // provider ALSO has its own per-provider block policy.
+        // Without the fallback re-check, a degraded dispatch
+        // would silently bypass the fallback's rate limit; this
+        // test proves it does not.
+        let primary_degrade = make_quota_policy_for_provider(
+            "notifications",
+            "tenant-1",
+            "email",
+            1,
+            acteon_core::QuotaWindow::Hourly,
+            acteon_core::OverageBehavior::Degrade {
+                fallback_provider: "slack".into(),
+            },
+            true,
+        );
+        let fallback_block = make_quota_policy_for_provider(
+            "notifications",
+            "tenant-1",
+            "slack",
+            1,
+            acteon_core::QuotaWindow::Hourly,
+            acteon_core::OverageBehavior::Block,
+            true,
+        );
+        let gw = build_gateway_with_two_providers(vec![primary_degrade, fallback_block]);
+
+        // 1st email dispatch: within primary cap, executes on email.
+        let outcome = gw
+            .dispatch(action_for_provider("email"), None)
+            .await
+            .unwrap();
+        assert!(matches!(outcome, ActionOutcome::Executed(_)));
+
+        // 2nd email dispatch: exceeds primary → degrades to slack.
+        // Slack cap is 1 and has not been used, so it executes on slack.
+        let outcome = gw
+            .dispatch(action_for_provider("email"), None)
+            .await
+            .unwrap();
+        assert!(
+            matches!(outcome, ActionOutcome::Executed(_)),
+            "first degrade should succeed on fallback"
+        );
+
+        // 3rd email dispatch: exceeds primary → degrades to slack,
+        // but slack cap is now also exhausted → block wins.
+        let outcome = gw
+            .dispatch(action_for_provider("email"), None)
+            .await
+            .unwrap();
+        match outcome {
+            ActionOutcome::QuotaExceeded {
+                overage_behavior, ..
+            } => {
+                assert_eq!(
+                    overage_behavior, "block",
+                    "fallback provider's block policy must apply"
+                );
+            }
+            other => panic!("expected the fallback's block policy to fire, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/gateway/src/quota_enforcement.rs
+++ b/crates/gateway/src/quota_enforcement.rs
@@ -44,6 +44,34 @@ impl Gateway {
         &self,
         action: &Action,
     ) -> Result<Option<ActionOutcome>, GatewayError> {
+        self.check_quota_inner(action, false).await
+    }
+
+    /// Re-check quota after a degrade-driven provider swap.
+    ///
+    /// Semantics: the generic (catch-all) policy was already
+    /// charged and produced the degrade verdict on the previous
+    /// pass, so re-enforcing it here would double-charge every
+    /// degraded dispatch against the tenant-wide budget. Instead,
+    /// only provider-scoped policies targeting the new provider
+    /// are evaluated — closing the "degrade-to-bypass" hole where
+    /// a fallback provider's own rate limit would otherwise be
+    /// silently ignored.
+    #[instrument(name = "gateway.check_quota_fallback", skip_all)]
+    pub(crate) async fn check_quota_fallback(
+        &self,
+        action: &Action,
+    ) -> Result<Option<ActionOutcome>, GatewayError> {
+        self.check_quota_inner(action, true).await
+    }
+
+    async fn check_quota_inner(
+        &self,
+        action: &Action,
+        only_provider_scoped: bool,
+    ) -> Result<Option<ActionOutcome>, GatewayError> {
+        const CACHE_TTL_SECS: i64 = 60;
+
         // Skip quota for internal re-dispatches (scheduled, recurring, groups)
         // to avoid double-counting. The action was already counted when it
         // first entered the gateway.
@@ -75,8 +103,6 @@ impl Gateway {
             let map = self.quota_policies.read();
             map.get(&bucket_key).cloned()
         };
-
-        const CACHE_TTL_SECS: i64 = 60;
 
         let bucket_policies: Vec<acteon_core::QuotaPolicy> = if let Some(c) = cached
             && (now - c.cached_at).num_seconds() < CACHE_TTL_SECS
@@ -120,9 +146,17 @@ impl Gateway {
         };
 
         // Filter to policies that actually apply to this dispatch.
+        // In fallback mode (called after a degrade swap), the
+        // generic catch-all is skipped because it was already
+        // enforced on the original-provider pass — re-counting it
+        // would double-charge the tenant-wide budget.
         let applicable: Vec<acteon_core::QuotaPolicy> = bucket_policies
             .into_iter()
-            .filter(|p| p.enabled && p.applies_to_provider(&action.provider))
+            .filter(|p| {
+                p.enabled
+                    && p.applies_to_provider(&action.provider)
+                    && (!only_provider_scoped || p.provider.is_some())
+            })
             .collect();
 
         if applicable.is_empty() {
@@ -163,13 +197,27 @@ impl Gateway {
         };
 
         if is_block {
-            // Roll back every counter this call incremented so the
-            // blocked action does not consume any tenant budget.
-            for other in &incremented {
-                let _ = self
-                    .state
-                    .increment(&other.counter_key, -1, other.window_ttl)
-                    .await;
+            // Roll back every counter this call incremented, in
+            // parallel, so the blocked action does not consume any
+            // tenant budget. Rollback is best-effort:
+            // compensating decrements that fail leave the counter
+            // slightly inflated ("ghost consumption"), which can
+            // cause a tenant to be blocked earlier than strictly
+            // warranted. We log the errors but do not surface them
+            // — a transient state-store blip should not turn into
+            // a request-level failure on top of the legitimate
+            // block.
+            let rollbacks = incremented.iter().map(|other| {
+                let state = self.state.clone();
+                let key = other.counter_key.clone();
+                let ttl = other.window_ttl;
+                async move { state.increment(&key, -1, ttl).await }
+            });
+            let results = futures::future::join_all(rollbacks).await;
+            for r in results {
+                if let Err(e) = r {
+                    warn!(error = %e, "quota rollback decrement failed (ghost consumption possible)");
+                }
             }
         }
 
@@ -178,24 +226,51 @@ impl Gateway {
     }
 
     /// Increment the counter for every applicable policy, returning
-    /// the per-policy state. On any state-store failure this rolls
-    /// back everything it has already incremented and returns `Err`
-    /// so the caller can fail-open.
+    /// the per-policy state. Increments are issued concurrently via
+    /// `join_all` so latency is O(1) round-trips rather than
+    /// O(policies). On any state-store failure the helper rolls
+    /// back every counter that did succeed (also in parallel) and
+    /// returns `Err` so the caller can fail-open.
+    ///
+    /// Policies whose identifiers fail
+    /// [`acteon_core::quota_counter_key`] validation (e.g., colon
+    /// injection, zero window) are silently skipped with a warning
+    /// log — the validation layers at the API, builder, and
+    /// cold-path loader should prevent this from ever happening in
+    /// steady state, but skipping is safer than panicking on a
+    /// corrupt record.
     async fn increment_all_quota_counters(
         &self,
         action: &Action,
         policies: Vec<acteon_core::QuotaPolicy>,
         now: &chrono::DateTime<Utc>,
     ) -> Result<Vec<Incremented>, ()> {
-        let mut incremented: Vec<Incremented> = Vec::with_capacity(policies.len());
+        // Build per-policy (policy, counter_key, ttl) triples up
+        // front, skipping any whose key cannot be constructed
+        // safely. We need the triples both to issue the increments
+        // concurrently AND to know what to roll back on failure.
+        struct Prepared {
+            policy: acteon_core::QuotaPolicy,
+            counter_key: acteon_state::StateKey,
+            window_ttl: Option<std::time::Duration>,
+        }
+        let mut prepared: Vec<Prepared> = Vec::with_capacity(policies.len());
         for policy in policies {
-            let counter_id = acteon_core::quota_counter_key(
+            let Some(counter_id) = acteon_core::quota_counter_key(
                 &action.namespace,
                 &action.tenant,
                 policy.provider.as_deref(),
                 &policy.window,
                 now,
-            );
+            ) else {
+                warn!(
+                    namespace = %action.namespace,
+                    tenant = %action.tenant,
+                    policy_id = %policy.id,
+                    "skipping quota policy with invalid scope or zero window (fail-closed for this policy)"
+                );
+                continue;
+            };
             let counter_key = acteon_state::StateKey::new(
                 action.namespace.as_str(),
                 action.tenant.as_str(),
@@ -205,28 +280,58 @@ impl Gateway {
             let window_ttl = Some(std::time::Duration::from_secs(
                 policy.window.duration_seconds(),
             ));
-
-            let new_count = match self.state.increment(&counter_key, 1, window_ttl).await {
-                Ok(c) => c,
-                Err(e) => {
-                    warn!(error = %e, "quota increment failed (fail-open)");
-                    for inc in &incremented {
-                        let _ = self
-                            .state
-                            .increment(&inc.counter_key, -1, inc.window_ttl)
-                            .await;
-                    }
-                    return Err(());
-                }
-            };
-            #[allow(clippy::cast_sign_loss)]
-            let used = new_count as u64;
-            incremented.push(Incremented {
+            prepared.push(Prepared {
                 policy,
                 counter_key,
                 window_ttl,
-                used,
             });
+        }
+
+        // Issue all increments concurrently. `join_all` yields
+        // results in the same order as the input so we can zip
+        // them back against `prepared` and preserve per-policy
+        // attribution.
+        let increments = prepared.iter().map(|p| {
+            let state = self.state.clone();
+            let key = p.counter_key.clone();
+            let ttl = p.window_ttl;
+            async move { state.increment(&key, 1, ttl).await }
+        });
+        let results = futures::future::join_all(increments).await;
+
+        let mut incremented: Vec<Incremented> = Vec::with_capacity(prepared.len());
+        let mut failure: Option<String> = None;
+        for (prep, res) in prepared.into_iter().zip(results.into_iter()) {
+            match res {
+                Ok(new_count) => {
+                    #[allow(clippy::cast_sign_loss)]
+                    let used = new_count as u64;
+                    incremented.push(Incremented {
+                        policy: prep.policy,
+                        counter_key: prep.counter_key,
+                        window_ttl: prep.window_ttl,
+                        used,
+                    });
+                }
+                Err(e) => {
+                    if failure.is_none() {
+                        failure = Some(e.to_string());
+                    }
+                }
+            }
+        }
+
+        if let Some(err) = failure {
+            warn!(error = %err, "quota increment failed (fail-open)");
+            // Roll back every counter that did succeed, concurrently.
+            let rollbacks = incremented.iter().map(|inc| {
+                let state = self.state.clone();
+                let key = inc.counter_key.clone();
+                let ttl = inc.window_ttl;
+                async move { state.increment(&key, -1, ttl).await }
+            });
+            let _ = futures::future::join_all(rollbacks).await;
+            return Err(());
         }
         Ok(incremented)
     }
@@ -379,7 +484,31 @@ impl Gateway {
             if let Some(data) = self.state.get(&policy_key).await? {
                 let policy = serde_json::from_str::<acteon_core::QuotaPolicy>(&data)
                     .map_err(|e| GatewayError::Configuration(e.to_string()))?;
+                // Reject obviously-bad records (colon injection,
+                // zero window, zero max_actions) at the cold-path
+                // boundary so the enforcement path can assume
+                // well-formed policies. The defense-in-depth means
+                // a manually-inserted or pre-validation record
+                // can't crash the gateway — worst case that policy
+                // silently skips enforcement until it's repaired.
+                if let Err(e) = policy.validate_scope() {
+                    warn!(
+                        policy_id = %id,
+                        error = %e,
+                        "skipping invalid quota policy loaded from state store"
+                    );
+                    continue;
+                }
                 policies.push(policy);
+                if policies.len() >= acteon_core::MAX_POLICIES_PER_BUCKET {
+                    warn!(
+                        namespace = %namespace,
+                        tenant = %tenant,
+                        cap = acteon_core::MAX_POLICIES_PER_BUCKET,
+                        "quota bucket hit per-tenant policy cap; ignoring remaining policy IDs from the index"
+                    );
+                    break;
+                }
             }
         }
         Ok(policies)

--- a/crates/gateway/src/quota_enforcement.rs
+++ b/crates/gateway/src/quota_enforcement.rs
@@ -11,17 +11,34 @@ use acteon_core::{Action, ActionOutcome};
 use crate::error::GatewayError;
 use crate::gateway::{CachedPolicy, Gateway};
 
+/// Per-policy state tracked during a single `check_quota` call so
+/// that the winner can be picked after every counter has been
+/// incremented atomically.
+struct Incremented {
+    policy: acteon_core::QuotaPolicy,
+    counter_key: acteon_state::StateKey,
+    window_ttl: Option<std::time::Duration>,
+    used: u64,
+}
+
 impl Gateway {
-    /// Check whether the action's tenant has exceeded their quota.
+    /// Check whether the action's tenant has exceeded any applicable quota.
     ///
-    /// Uses an atomic `increment()` to avoid read-then-write races between
-    /// concurrent actions for the same tenant.  The counter is always
-    /// incremented first; if the new value exceeds the limit the configured
-    /// [`OverageBehavior`](acteon_core::OverageBehavior) determines the outcome.
+    /// Since Phase 3, a `(namespace, tenant)` pair may hold several
+    /// quota policies — one generic catch-all plus any number of
+    /// provider-scoped caps. All policies whose scope matches the
+    /// outgoing provider are evaluated; each maintains its own
+    /// counter so a burst on one provider does not consume another
+    /// provider's budget. If **any** applicable policy blocks the
+    /// action, the block wins and every counter that was incremented
+    /// during this call is rolled back so the blocked request does
+    /// not consume a slot. Non-block outcomes (warn/degrade/notify)
+    /// leave counters advanced but still surface to the caller —
+    /// degrade beats warn/notify as the strictest.
     ///
-    /// Returns `None` when the action is within quota or no policy exists.
-    /// Returns `Some(ActionOutcome::QuotaExceeded { .. })` when the action
-    /// should be blocked or degraded.
+    /// Returns `None` when the action is within quota or no policy
+    /// applies. Returns `Some(ActionOutcome::QuotaExceeded { .. })`
+    /// when the action should be blocked or degraded.
     #[instrument(name = "gateway.check_quota", skip_all)]
     pub(crate) async fn check_quota(
         &self,
@@ -49,22 +66,22 @@ impl Gateway {
             return Ok(None);
         }
 
-        let policy_key = format!("{}:{}", action.namespace, action.tenant);
+        let bucket_key = format!("{}:{}", action.namespace, action.tenant);
         let now = Utc::now();
 
         // 1. Check in-memory cache with a 60-second TTL to ensure we eventually
         //    see updates made on other instances.
         let cached = {
             let map = self.quota_policies.read();
-            map.get(&policy_key).cloned()
+            map.get(&bucket_key).cloned()
         };
 
         const CACHE_TTL_SECS: i64 = 60;
 
-        let policy = if let Some(c) = cached
+        let bucket_policies: Vec<acteon_core::QuotaPolicy> = if let Some(c) = cached
             && (now - c.cached_at).num_seconds() < CACHE_TTL_SECS
         {
-            c.policy
+            c.policies
         } else {
             // Cold path: fetch from state store. We fail-open if the store
             // is down to protect system availability.
@@ -79,89 +96,208 @@ impl Gateway {
                 }
             };
 
-            match found {
-                Some(p) => {
-                    let cached = CachedPolicy {
-                        policy: p.clone(),
+            if found.is_empty() {
+                // Empty cache entry — still mark as warmed so we don't
+                // hammer the state store for every dispatch.
+                self.quota_policies.write().insert(
+                    bucket_key.clone(),
+                    CachedPolicy {
+                        policies: Vec::new(),
                         cached_at: now,
-                    };
-                    self.quota_policies
-                        .write()
-                        .insert(policy_key.clone(), cached);
-                    p
-                }
-                None => return Ok(None),
-            }
-        };
-
-        if !policy.enabled {
-            return Ok(None);
-        }
-
-        let counter_id =
-            acteon_core::quota_counter_key(&action.namespace, &action.tenant, &policy.window, &now);
-        let counter_key = acteon_state::StateKey::new(
-            action.namespace.as_str(),
-            action.tenant.as_str(),
-            acteon_state::KeyKind::QuotaUsage,
-            &counter_id,
-        );
-
-        let window_ttl = Some(std::time::Duration::from_secs(
-            policy.window.duration_seconds(),
-        ));
-
-        // 2. Increment usage counter. Fail-open on state store errors.
-        let new_count = match self.state.increment(&counter_key, 1, window_ttl).await {
-            Ok(c) => c,
-            Err(e) => {
-                warn!(error = %e, "quota increment failed (fail-open)");
+                    },
+                );
                 return Ok(None);
             }
+
+            let cached = CachedPolicy {
+                policies: found.clone(),
+                cached_at: now,
+            };
+            self.quota_policies
+                .write()
+                .insert(bucket_key.clone(), cached);
+            found
         };
 
-        #[allow(clippy::cast_sign_loss)]
-        let used = new_count as u64;
+        // Filter to policies that actually apply to this dispatch.
+        let applicable: Vec<acteon_core::QuotaPolicy> = bucket_policies
+            .into_iter()
+            .filter(|p| p.enabled && p.applies_to_provider(&action.provider))
+            .collect();
 
-        if used <= policy.max_actions {
+        if applicable.is_empty() {
             return Ok(None);
         }
 
-        // Quota exceeded — apply behavior.
-        self.apply_overage_behavior(action, &policy, used, &counter_key, window_ttl)
+        self.enforce_quota_policies(action, applicable, &now).await
+    }
+
+    /// Evaluate every applicable quota policy for a dispatch and
+    /// return the strictest outcome.
+    ///
+    /// Each policy increments its own counter first (atomic to avoid
+    /// races). If any block, every counter touched in this call is
+    /// rolled back. Otherwise the strictest non-block outcome wins,
+    /// with counters left advanced so warn/degrade/notify still
+    /// reflect true usage.
+    async fn enforce_quota_policies(
+        &self,
+        action: &Action,
+        policies: Vec<acteon_core::QuotaPolicy>,
+        now: &chrono::DateTime<Utc>,
+    ) -> Result<Option<ActionOutcome>, GatewayError> {
+        // Fail-open: if any counter write fails the helper rolls
+        // back and returns `Err(())`; fall through to `Ok(None)`
+        // so we do not penalize dispatches during state-store
+        // outages.
+        let Ok(incremented) = self
+            .increment_all_quota_counters(action, policies, now)
             .await
+        else {
+            return Ok(None);
+        };
+
+        let winner_idx = Self::pick_winning_quota(&incremented);
+        let Some((idx, is_block)) = winner_idx else {
+            return Ok(None);
+        };
+
+        if is_block {
+            // Roll back every counter this call incremented so the
+            // blocked action does not consume any tenant budget.
+            for other in &incremented {
+                let _ = self
+                    .state
+                    .increment(&other.counter_key, -1, other.window_ttl)
+                    .await;
+            }
+        }
+
+        let inc = &incremented[idx];
+        Ok(self.apply_overage_behavior(action, &inc.policy, inc.used))
+    }
+
+    /// Increment the counter for every applicable policy, returning
+    /// the per-policy state. On any state-store failure this rolls
+    /// back everything it has already incremented and returns `Err`
+    /// so the caller can fail-open.
+    async fn increment_all_quota_counters(
+        &self,
+        action: &Action,
+        policies: Vec<acteon_core::QuotaPolicy>,
+        now: &chrono::DateTime<Utc>,
+    ) -> Result<Vec<Incremented>, ()> {
+        let mut incremented: Vec<Incremented> = Vec::with_capacity(policies.len());
+        for policy in policies {
+            let counter_id = acteon_core::quota_counter_key(
+                &action.namespace,
+                &action.tenant,
+                policy.provider.as_deref(),
+                &policy.window,
+                now,
+            );
+            let counter_key = acteon_state::StateKey::new(
+                action.namespace.as_str(),
+                action.tenant.as_str(),
+                acteon_state::KeyKind::QuotaUsage,
+                &counter_id,
+            );
+            let window_ttl = Some(std::time::Duration::from_secs(
+                policy.window.duration_seconds(),
+            ));
+
+            let new_count = match self.state.increment(&counter_key, 1, window_ttl).await {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!(error = %e, "quota increment failed (fail-open)");
+                    for inc in &incremented {
+                        let _ = self
+                            .state
+                            .increment(&inc.counter_key, -1, inc.window_ttl)
+                            .await;
+                    }
+                    return Err(());
+                }
+            };
+            #[allow(clippy::cast_sign_loss)]
+            let used = new_count as u64;
+            incremented.push(Incremented {
+                policy,
+                counter_key,
+                window_ttl,
+                used,
+            });
+        }
+        Ok(incremented)
+    }
+
+    /// Pick the index of the strictest exceeded policy, returning a
+    /// tuple of `(index, is_block)`. Precedence: Block > Degrade >
+    /// Warn > Notify. When no policy is exceeded, returns `None`.
+    fn pick_winning_quota(incremented: &[Incremented]) -> Option<(usize, bool)> {
+        let mut winning_block: Option<usize> = None;
+        let mut winning_degrade: Option<usize> = None;
+        let mut winning_warn: Option<usize> = None;
+        let mut winning_notify: Option<usize> = None;
+        for (i, inc) in incremented.iter().enumerate() {
+            if inc.used <= inc.policy.max_actions {
+                continue;
+            }
+            match &inc.policy.overage_behavior {
+                acteon_core::OverageBehavior::Block if winning_block.is_none() => {
+                    winning_block = Some(i);
+                }
+                acteon_core::OverageBehavior::Degrade { .. } if winning_degrade.is_none() => {
+                    winning_degrade = Some(i);
+                }
+                acteon_core::OverageBehavior::Warn if winning_warn.is_none() => {
+                    winning_warn = Some(i);
+                }
+                acteon_core::OverageBehavior::Notify { .. } if winning_notify.is_none() => {
+                    winning_notify = Some(i);
+                }
+                _ => {}
+            }
+        }
+        if let Some(i) = winning_block {
+            Some((i, true))
+        } else {
+            winning_degrade
+                .or(winning_warn)
+                .or(winning_notify)
+                .map(|i| (i, false))
+        }
     }
 
     /// Apply the configured overage behavior when a tenant exceeds their quota.
     ///
     /// Separated from [`check_quota`](Self::check_quota) to keep each method
-    /// under the clippy line-count limit.
-    async fn apply_overage_behavior(
+    /// under the clippy line-count limit. Counter rollback for blocked
+    /// dispatches is handled by
+    /// [`enforce_quota_policies`](Self::enforce_quota_policies) across
+    /// every applicable policy, so this helper only records metrics
+    /// and shapes the outcome.
+    fn apply_overage_behavior(
         &self,
         action: &Action,
         policy: &acteon_core::QuotaPolicy,
         used: u64,
-        counter_key: &acteon_state::StateKey,
-        window_ttl: Option<std::time::Duration>,
-    ) -> Result<Option<ActionOutcome>, GatewayError> {
+    ) -> Option<ActionOutcome> {
         match &policy.overage_behavior {
             acteon_core::OverageBehavior::Block => {
                 self.metrics.increment_quota_exceeded();
-                // Roll back the increment so the blocked request doesn't
-                // consume a slot.
-                let _ = self.state.increment(counter_key, -1, window_ttl).await;
                 info!(
                     tenant = %action.tenant,
                     limit = policy.max_actions,
                     used,
                     "quota exceeded — blocking action"
                 );
-                Ok(Some(ActionOutcome::QuotaExceeded {
+                Some(ActionOutcome::QuotaExceeded {
                     tenant: action.tenant.to_string(),
                     limit: policy.max_actions,
                     used,
                     overage_behavior: "block".into(),
-                }))
+                })
             }
             acteon_core::OverageBehavior::Warn => {
                 self.metrics.increment_quota_warned();
@@ -171,7 +307,7 @@ impl Gateway {
                     used,
                     "quota exceeded — warning, allowing action"
                 );
-                Ok(None)
+                None
             }
             acteon_core::OverageBehavior::Degrade { fallback_provider } => {
                 self.metrics.increment_quota_degraded();
@@ -180,12 +316,12 @@ impl Gateway {
                     fallback = %fallback_provider,
                     "quota exceeded — degrading to fallback provider"
                 );
-                Ok(Some(ActionOutcome::QuotaExceeded {
+                Some(ActionOutcome::QuotaExceeded {
                     tenant: action.tenant.to_string(),
                     limit: policy.max_actions,
                     used,
                     overage_behavior: format!("degrade:{fallback_provider}"),
-                }))
+                })
             }
             acteon_core::OverageBehavior::Notify { target } => {
                 self.metrics.increment_quota_notified();
@@ -194,25 +330,28 @@ impl Gateway {
                     target = %target,
                     "quota exceeded — notifying admin, allowing action"
                 );
-                Ok(None)
+                None
             }
         }
     }
 
-    /// Try to load a quota policy for `namespace:tenant` from the state store.
+    /// Load every quota policy registered for `namespace:tenant`
+    /// from the state store.
     ///
-    /// This is the cold-path fallback used by [`check_quota`](Self::check_quota)
-    /// when no in-memory policy is found, enabling cross-instance visibility
-    /// without requiring a restart.
+    /// Cold-path fallback used by [`check_quota`](Self::check_quota)
+    /// when no in-memory policies are found, enabling cross-instance
+    /// visibility without requiring a restart.
     ///
-    /// Uses a two-step O(1) lookup via the `idx:{namespace}:{tenant}` index
-    /// key written by the API layer, avoiding a full `scan_keys_by_kind`.
+    /// The index key `idx:{namespace}:{tenant}` stores a JSON array
+    /// of policy IDs so a single get + N gets loads the whole bucket
+    /// without scanning the store. For backward compatibility with
+    /// pre-Phase-3 records, a bare (non-JSON) UUID is also accepted
+    /// and treated as a single-element array.
     async fn load_quota_from_state_store(
         &self,
         namespace: &str,
         tenant: &str,
-    ) -> Result<Option<acteon_core::QuotaPolicy>, GatewayError> {
-        // Step 1: look up the index key to get the policy ID.
+    ) -> Result<Vec<acteon_core::QuotaPolicy>, GatewayError> {
         let idx_suffix = format!("idx:{namespace}:{tenant}");
         let idx_key = acteon_state::StateKey::new(
             "_system",
@@ -220,24 +359,29 @@ impl Gateway {
             acteon_state::KeyKind::Quota,
             &idx_suffix,
         );
-        let Some(policy_id) = self.state.get(&idx_key).await? else {
-            return Ok(None);
+        let Some(raw) = self.state.get(&idx_key).await? else {
+            return Ok(Vec::new());
         };
 
-        // Step 2: look up the policy by ID.
-        let policy_key = acteon_state::StateKey::new(
-            "_system",
-            "_quotas",
-            acteon_state::KeyKind::Quota,
-            &policy_id,
-        );
-        match self.state.get(&policy_key).await? {
-            Some(data) => {
+        let policy_ids: Vec<String> = match serde_json::from_str::<Vec<String>>(&raw) {
+            Ok(ids) => ids,
+            Err(_) => vec![raw], // legacy: bare policy ID
+        };
+
+        let mut policies = Vec::with_capacity(policy_ids.len());
+        for id in policy_ids {
+            let policy_key = acteon_state::StateKey::new(
+                "_system",
+                "_quotas",
+                acteon_state::KeyKind::Quota,
+                &id,
+            );
+            if let Some(data) = self.state.get(&policy_key).await? {
                 let policy = serde_json::from_str::<acteon_core::QuotaPolicy>(&data)
                     .map_err(|e| GatewayError::Configuration(e.to_string()))?;
-                Ok(Some(policy))
+                policies.push(policy);
             }
-            None => Ok(None),
         }
+        Ok(policies)
     }
 }

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -155,6 +155,7 @@ fn build_create_quota(v: &serde_json::Value) -> Result<CreateQuotaRequest, McpEr
     Ok(CreateQuotaRequest {
         namespace: val_str(v, "namespace")?,
         tenant: val_str(v, "tenant")?,
+        provider: val_opt_str(v, "provider"),
         max_actions: val_u64(v, "max_actions")?,
         window: val_str(v, "window")?,
         overage_behavior: val_str(v, "overage_behavior")?,
@@ -398,6 +399,12 @@ pub struct ListQuotasParams {
     /// Filter by tenant.
     #[serde(default)]
     pub tenant: Option<String>,
+    /// Filter by provider scope: pass `"generic"` to match only
+    /// policies with no provider scope, or a provider name (e.g.
+    /// `"slack"`) to match only per-provider policies for that
+    /// provider.
+    #[serde(default)]
+    pub provider: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -597,6 +604,11 @@ pub struct ManageQuotasParams {
     /// Tenant filter for list; required for delete.
     #[serde(default)]
     pub tenant: Option<String>,
+    /// Provider scope filter for list: `"generic"` matches
+    /// policies without a provider scope; any other value matches
+    /// only per-provider policies for that provider.
+    #[serde(default)]
+    pub provider: Option<String>,
     /// JSON data for create or update operations.
     #[serde(default)]
     pub data: Option<serde_json::Value>,
@@ -1240,7 +1252,11 @@ impl ActeonMcpServer {
     ) -> Result<CallToolResult, McpError> {
         match self
             .ops
-            .list_quotas(p.namespace.as_deref(), p.tenant.as_deref())
+            .list_quotas(
+                p.namespace.as_deref(),
+                p.tenant.as_deref(),
+                p.provider.as_deref(),
+            )
             .await
         {
             Ok(resp) => {
@@ -1540,7 +1556,11 @@ impl ActeonMcpServer {
             "list" => {
                 match self
                     .ops
-                    .list_quotas(p.namespace.as_deref(), p.tenant.as_deref())
+                    .list_quotas(
+                        p.namespace.as_deref(),
+                        p.tenant.as_deref(),
+                        p.provider.as_deref(),
+                    )
                     .await
                 {
                     Ok(resp) => {

--- a/crates/ops/src/lib.rs
+++ b/crates/ops/src/lib.rs
@@ -491,13 +491,17 @@ impl OpsClient {
         Ok(self.inner.create_quota(req).await?)
     }
 
-    /// List quota policies.
+    /// List quota policies filtered by optional namespace, tenant,
+    /// and provider scope (`Some("generic")` matches only policies
+    /// with `provider: None`; any other value matches policies with
+    /// that exact provider scope).
     pub async fn list_quotas(
         &self,
         namespace: Option<&str>,
         tenant: Option<&str>,
+        provider: Option<&str>,
     ) -> Result<ListQuotasResponse, OpsError> {
-        Ok(self.inner.list_quotas(namespace, tenant).await?)
+        Ok(self.inner.list_quotas(namespace, tenant, provider).await?)
     }
 
     /// Get a quota policy by ID.

--- a/crates/server/src/api/quotas.rs
+++ b/crates/server/src/api/quotas.rs
@@ -375,10 +375,10 @@ pub async fn create_quota(
     if let Err(e) = validate_quota_scope_identifier(&req.tenant) {
         return error_response(StatusCode::BAD_REQUEST, &format!("invalid tenant: {e}"));
     }
-    if let Some(ref p) = req.provider {
-        if let Err(e) = validate_quota_scope_identifier(p) {
-            return error_response(StatusCode::BAD_REQUEST, &format!("invalid provider: {e}"));
-        }
+    if let Some(ref p) = req.provider
+        && let Err(e) = validate_quota_scope_identifier(p)
+    {
+        return error_response(StatusCode::BAD_REQUEST, &format!("invalid provider: {e}"));
     }
     // Validate window.
     let window = match parse_window(&req.window) {
@@ -428,8 +428,7 @@ pub async fn create_quota(
             let scope = req
                 .provider
                 .as_deref()
-                .map(|p| format!("provider={p}"))
-                .unwrap_or_else(|| "generic scope".to_string());
+                .map_or_else(|| "generic scope".to_string(), |p| format!("provider={p}"));
             return error_response(
                 StatusCode::CONFLICT,
                 &format!(

--- a/crates/server/src/api/quotas.rs
+++ b/crates/server/src/api/quotas.rs
@@ -34,6 +34,13 @@ pub struct CreateQuotaRequest {
     /// Tenant this quota applies to.
     #[schema(example = "tenant-1")]
     pub tenant: String,
+    /// Optional provider scope. When omitted, the policy is
+    /// generic and counts every dispatch for the tenant. When set,
+    /// only dispatches whose `action.provider` equals this value
+    /// count against (and are enforced by) this policy.
+    #[serde(default)]
+    #[schema(example = "slack")]
+    pub provider: Option<String>,
     /// Maximum number of actions allowed per window.
     #[schema(example = 1000)]
     pub max_actions: u64,
@@ -83,6 +90,9 @@ pub struct QuotaResponse {
     pub namespace: String,
     /// Tenant.
     pub tenant: String,
+    /// Optional provider scope (`None` = generic catch-all).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
     /// Maximum actions per window.
     pub max_actions: u64,
     /// Time window.
@@ -137,6 +147,12 @@ pub struct ListQuotasParams {
     /// Filter by tenant (optional).
     #[serde(default)]
     pub tenant: Option<String>,
+    /// Filter by provider scope (optional). Pass the literal string
+    /// `generic` to match only policies without a provider scope
+    /// (`provider: None`), or a provider name to match only
+    /// per-provider policies for that provider.
+    #[serde(default)]
+    pub provider: Option<String>,
     /// Maximum number of results (default: 100).
     #[serde(default = "default_limit")]
     pub limit: usize,
@@ -179,6 +195,7 @@ fn policy_to_response(policy: &QuotaPolicy, usage: Option<QuotaUsageResponse>) -
         id: policy.id.clone(),
         namespace: policy.namespace.clone(),
         tenant: policy.tenant.clone(),
+        provider: policy.provider.clone(),
         max_actions: policy.max_actions,
         window: policy.window.clone(),
         overage_behavior: policy.overage_behavior.clone(),
@@ -201,13 +218,55 @@ fn quota_state_key(id: &str) -> StateKey {
     StateKey::new(QUOTA_STORE_NS, QUOTA_STORE_TENANT, KeyKind::Quota, id)
 }
 
-/// Build a [`StateKey`] for the `namespace:tenant` → policy-ID index.
+/// Build a [`StateKey`] for the `namespace:tenant` → policy-ID(s) index.
 ///
-/// This secondary index enables O(1) lookups by namespace+tenant in both
-/// the API (for duplicate detection) and the gateway cold path.
+/// This secondary index enables O(1) lookups by `(namespace, tenant)` in
+/// both the API (for duplicate detection) and the gateway cold path.
+/// Since Phase 3, the value is a JSON array of policy IDs so that
+/// generic + per-provider policies for the same tenant can coexist.
 fn quota_index_key(namespace: &str, tenant: &str) -> StateKey {
     let suffix = format!("idx:{namespace}:{tenant}");
     StateKey::new(QUOTA_STORE_NS, QUOTA_STORE_TENANT, KeyKind::Quota, &suffix)
+}
+
+/// Read the list of policy IDs stored at a quota index key.
+///
+/// Accepts both the current format (JSON array of IDs) and the
+/// pre-Phase-3 format (bare UUID string), returning an empty
+/// `Vec` when the index key is absent.
+async fn read_quota_index(
+    state_store: &dyn acteon_state::StateStore,
+    idx_key: &StateKey,
+) -> Result<Vec<String>, String> {
+    let raw = state_store.get(idx_key).await.map_err(|e| e.to_string())?;
+    let Some(raw) = raw else {
+        return Ok(Vec::new());
+    };
+    match serde_json::from_str::<Vec<String>>(&raw) {
+        Ok(ids) => Ok(ids),
+        Err(_) => Ok(vec![raw]), // legacy: bare UUID
+    }
+}
+
+/// Overwrite the quota index at `idx_key` with the current list of
+/// policy IDs (or delete it if empty).
+async fn write_quota_index(
+    state_store: &dyn acteon_state::StateStore,
+    idx_key: &StateKey,
+    ids: &[String],
+) -> Result<(), String> {
+    if ids.is_empty() {
+        state_store
+            .delete(idx_key)
+            .await
+            .map_err(|e| e.to_string())?;
+        return Ok(());
+    }
+    let json = serde_json::to_string(ids).map_err(|e| e.to_string())?;
+    state_store
+        .set(idx_key, &json, None)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Load a [`QuotaPolicy`] from the state store by ID via direct key lookup.
@@ -233,7 +292,13 @@ async fn read_usage(
     policy: &QuotaPolicy,
 ) -> Result<QuotaUsageResponse, String> {
     let now = Utc::now();
-    let counter_id = quota_counter_key(&policy.namespace, &policy.tenant, &policy.window, &now);
+    let counter_id = quota_counter_key(
+        &policy.namespace,
+        &policy.tenant,
+        policy.provider.as_deref(),
+        &policy.window,
+        &now,
+    );
     let counter_key = StateKey::new(
         policy.namespace.as_str(),
         policy.tenant.as_str(),
@@ -299,22 +364,34 @@ pub async fn create_quota(
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
 
-    // Check for duplicate: only one quota policy per namespace:tenant.
+    // Read the existing index bucket for this (namespace, tenant).
     let idx_key = quota_index_key(&req.namespace, &req.tenant);
-    match state_store.get(&idx_key).await {
-        Ok(Some(_)) => {
+    let mut existing_ids: Vec<String> = match read_quota_index(state_store.as_ref(), &idx_key).await
+    {
+        Ok(ids) => ids,
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e),
+    };
+
+    // Reject duplicates with the same (ns, tenant, provider) tuple:
+    // operators should pick exactly one policy per scope. Different
+    // providers (or generic vs provider-scoped) may coexist.
+    for existing_id in &existing_ids {
+        if let Ok(Some(p)) = load_quota(state_store.as_ref(), existing_id).await
+            && p.provider == req.provider
+        {
+            let scope = req
+                .provider
+                .as_deref()
+                .map(|p| format!("provider={p}"))
+                .unwrap_or_else(|| "generic scope".to_string());
             return error_response(
                 StatusCode::CONFLICT,
                 &format!(
-                    "a quota policy already exists for namespace={} tenant={}",
+                    "a quota policy already exists for namespace={} tenant={} ({scope})",
                     req.namespace, req.tenant
                 ),
             );
         }
-        Err(e) => {
-            return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string());
-        }
-        Ok(None) => {} // No existing policy — proceed.
     }
 
     let now = Utc::now();
@@ -324,6 +401,7 @@ pub async fn create_quota(
         id: id.clone(),
         namespace: req.namespace.clone(),
         tenant: req.tenant.clone(),
+        provider: req.provider.clone(),
         max_actions: req.max_actions,
         window,
         overage_behavior: req.overage_behavior,
@@ -349,9 +427,10 @@ pub async fn create_quota(
         return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string());
     }
 
-    // Write the namespace:tenant → policy-ID index key.
-    if let Err(e) = state_store.set(&idx_key, &id, None).await {
-        return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string());
+    // Append the new ID to the index bucket and rewrite.
+    existing_ids.push(id.clone());
+    if let Err(e) = write_quota_index(state_store.as_ref(), &idx_key, &existing_ids).await {
+        return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e);
     }
     drop(gw);
 
@@ -410,6 +489,20 @@ pub async fn list_quotas(
             && policy.tenant != *t
         {
             continue;
+        }
+
+        // Apply provider filter: `"generic"` matches only policies
+        // without a provider scope; any other value matches only
+        // policies with an exact provider match.
+        if let Some(ref p) = params.provider {
+            let matches = if p == "generic" {
+                policy.provider.is_none()
+            } else {
+                policy.provider.as_deref() == Some(p.as_str())
+            };
+            if !matches {
+                continue;
+            }
         }
 
         // Offset-based pagination.
@@ -590,14 +683,19 @@ pub async fn delete_quota(
         return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string());
     }
 
-    // Remove the namespace:tenant → policy-ID index key.
+    // Rewrite the index bucket without this policy ID. If the
+    // bucket becomes empty the index key itself is deleted.
     let idx_key = quota_index_key(&policy.namespace, &policy.tenant);
-    let _ = state_store.delete(&idx_key).await;
+    let mut ids = read_quota_index(state_store.as_ref(), &idx_key)
+        .await
+        .unwrap_or_default();
+    ids.retain(|candidate| candidate != &id);
+    let _ = write_quota_index(state_store.as_ref(), &idx_key, &ids).await;
     drop(gw);
 
     // Remove from gateway (uses interior mutability via RwLock).
     let gw = state.gateway.read().await;
-    gw.remove_quota_policy(&policy.namespace, &policy.tenant);
+    gw.remove_quota_policy_by_id(&policy.namespace, &policy.tenant, &id);
 
     StatusCode::NO_CONTENT.into_response()
 }
@@ -635,7 +733,13 @@ pub async fn get_quota_usage(
     };
 
     let now = Utc::now();
-    let counter_id = quota_counter_key(&policy.namespace, &policy.tenant, &policy.window, &now);
+    let counter_id = quota_counter_key(
+        &policy.namespace,
+        &policy.tenant,
+        policy.provider.as_deref(),
+        &policy.window,
+        &now,
+    );
     let counter_key = StateKey::new(
         policy.namespace.as_str(),
         policy.tenant.as_str(),

--- a/crates/server/src/api/quotas.rs
+++ b/crates/server/src/api/quotas.rs
@@ -13,8 +13,8 @@ use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
 use acteon_core::{
-    OverageBehavior, QuotaPolicy, QuotaUsage, QuotaWindow, compute_window_boundaries,
-    quota_counter_key,
+    MAX_POLICIES_PER_BUCKET, OverageBehavior, QuotaPolicy, QuotaUsage, QuotaWindow,
+    compute_window_boundaries, quota_counter_key, validate_quota_scope_identifier,
 };
 use acteon_state::{KeyKind, StateKey};
 
@@ -292,13 +292,25 @@ async fn read_usage(
     policy: &QuotaPolicy,
 ) -> Result<QuotaUsageResponse, String> {
     let now = Utc::now();
-    let counter_id = quota_counter_key(
+    // Fail-closed for corrupt/rejected policies: surface zero used
+    // and the configured limit rather than panicking. The
+    // validation layers (API + builder + cold-path loader) should
+    // keep us from reaching this branch in normal operation.
+    let Some(counter_id) = quota_counter_key(
         &policy.namespace,
         &policy.tenant,
         policy.provider.as_deref(),
         &policy.window,
         &now,
-    );
+    ) else {
+        let resets_at = now;
+        return Ok(QuotaUsageResponse {
+            used: 0,
+            limit: policy.max_actions,
+            remaining: policy.max_actions,
+            resets_at,
+        });
+    };
     let counter_key = StateKey::new(
         policy.namespace.as_str(),
         policy.tenant.as_str(),
@@ -355,11 +367,30 @@ pub async fn create_quota(
     State(state): State<AppState>,
     Json(req): Json<CreateQuotaRequest>,
 ) -> impl IntoResponse {
+    // Validate identifiers first — reject colon injection and
+    // oversized names before we touch the state store.
+    if let Err(e) = validate_quota_scope_identifier(&req.namespace) {
+        return error_response(StatusCode::BAD_REQUEST, &format!("invalid namespace: {e}"));
+    }
+    if let Err(e) = validate_quota_scope_identifier(&req.tenant) {
+        return error_response(StatusCode::BAD_REQUEST, &format!("invalid tenant: {e}"));
+    }
+    if let Some(ref p) = req.provider {
+        if let Err(e) = validate_quota_scope_identifier(p) {
+            return error_response(StatusCode::BAD_REQUEST, &format!("invalid provider: {e}"));
+        }
+    }
     // Validate window.
     let window = match parse_window(&req.window) {
         Ok(w) => w,
         Err(e) => return error_response(StatusCode::BAD_REQUEST, &e),
     };
+    if req.max_actions == 0 {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "max_actions must be greater than 0",
+        );
+    }
 
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
@@ -371,6 +402,21 @@ pub async fn create_quota(
         Ok(ids) => ids,
         Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e),
     };
+
+    // Enforce the per-bucket cap before doing any writes. This
+    // prevents a malicious or buggy caller from exploding a single
+    // tenant's policy count and DoSing the dispatch path.
+    if existing_ids.len() >= MAX_POLICIES_PER_BUCKET {
+        return error_response(
+            StatusCode::CONFLICT,
+            &format!(
+                "quota bucket (namespace={}, tenant={}) already holds {} policies — cap is {MAX_POLICIES_PER_BUCKET}",
+                req.namespace,
+                req.tenant,
+                existing_ids.len()
+            ),
+        );
+    }
 
     // Reject duplicates with the same (ns, tenant, provider) tuple:
     // operators should pick exactly one policy per scope. Different
@@ -427,9 +473,14 @@ pub async fn create_quota(
         return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string());
     }
 
-    // Append the new ID to the index bucket and rewrite.
+    // Append the new ID to the index bucket and rewrite. If the
+    // index write fails after the policy record was persisted,
+    // compensate by deleting the orphaned policy record so the
+    // store is not left with a dangling entry that is unreachable
+    // via the bucket index.
     existing_ids.push(id.clone());
     if let Err(e) = write_quota_index(state_store.as_ref(), &idx_key, &existing_ids).await {
+        let _ = state_store.delete(&key).await;
         return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e);
     }
     drop(gw);
@@ -733,13 +784,28 @@ pub async fn get_quota_usage(
     };
 
     let now = Utc::now();
-    let counter_id = quota_counter_key(
+    let Some(counter_id) = quota_counter_key(
         &policy.namespace,
         &policy.tenant,
         policy.provider.as_deref(),
         &policy.window,
         &now,
-    );
+    ) else {
+        // Corrupt or rejected policy — surface zero usage rather
+        // than return an error, so operators can still see the
+        // record while they repair it.
+        let usage = QuotaUsage {
+            tenant: policy.tenant.clone(),
+            namespace: policy.namespace.clone(),
+            used: 0,
+            limit: policy.max_actions,
+            remaining: policy.max_actions,
+            window: policy.window.clone(),
+            resets_at: now,
+            overage_behavior: policy.overage_behavior.clone(),
+        };
+        return (StatusCode::OK, Json(serde_json::json!(usage))).into_response();
+    };
     let counter_key = StateKey::new(
         policy.namespace.as_str(),
         policy.tenant.as_str(),

--- a/crates/server/src/api/stream.rs
+++ b/crates/server/src/api/stream.rs
@@ -1101,7 +1101,11 @@ mod tests {
         let store = MemoryAuditStore::new();
         let now = Utc::now();
 
-        // Create two records.
+        // Create two records. UUID v7 embeds a millisecond
+        // timestamp and sorts by it, so two IDs generated in the
+        // same tick can end up mis-ordered relative to our
+        // expectation. A brief pause guarantees strictly
+        // increasing IDs regardless of how fast CI runs.
         let id1 = uuid::Uuid::now_v7().to_string();
         let record1 = mk_audit_record(
             &id1,
@@ -1112,6 +1116,7 @@ mod tests {
             serde_json::json!({"status": "Success"}),
             now - chrono::Duration::seconds(1),
         );
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
 
         let id2 = uuid::Uuid::now_v7().to_string();
         let record2 = mk_audit_record(

--- a/crates/simulation/examples/quota_simulation.rs
+++ b/crates/simulation/examples/quota_simulation.rs
@@ -402,5 +402,6 @@ fn outcome_label(outcome: &ActionOutcome) -> &'static str {
         ActionOutcome::Scheduled { .. } => "Scheduled",
         ActionOutcome::RecurringCreated { .. } => "RecurringCreated",
         ActionOutcome::QuotaExceeded { .. } => "QuotaExceeded",
+        ActionOutcome::Silenced { .. } => "Silenced",
     }
 }

--- a/crates/simulation/examples/quota_simulation.rs
+++ b/crates/simulation/examples/quota_simulation.rs
@@ -93,6 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             id: "q-tenant-a".into(),
             namespace: "notifications".into(),
             tenant: "tenant-a".into(),
+            provider: None,
             max_actions: 10,
             window: QuotaWindow::Hourly,
             overage_behavior: OverageBehavior::Block,
@@ -178,6 +179,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             id: "q-tenant-b".into(),
             namespace: "analytics".into(),
             tenant: "tenant-b".into(),
+            provider: None,
             max_actions: 100,
             window: QuotaWindow::Daily,
             overage_behavior: OverageBehavior::Warn,
@@ -262,6 +264,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             id: "q-tenant-c".into(),
             namespace: "messaging".into(),
             tenant: "tenant-c".into(),
+            provider: None,
             max_actions: 5,
             window: QuotaWindow::Hourly,
             overage_behavior: OverageBehavior::Degrade {

--- a/crates/simulation/examples/scheduled_actions_simulation.rs
+++ b/crates/simulation/examples/scheduled_actions_simulation.rs
@@ -715,5 +715,6 @@ fn outcome_label(outcome: &ActionOutcome) -> &'static str {
         ActionOutcome::Scheduled { .. } => "Scheduled",
         ActionOutcome::RecurringCreated { .. } => "RecurringCreated",
         ActionOutcome::QuotaExceeded { .. } => "QuotaExceeded",
+        ActionOutcome::Silenced { .. } => "Silenced",
     }
 }

--- a/docs/book/features/tenant-quotas.md
+++ b/docs/book/features/tenant-quotas.md
@@ -23,10 +23,33 @@ Dispatch Pipeline:
 Each quota policy defines:
 
 - A **tenant** and **namespace** scope
+- An optional **provider** scope (`None` = generic catch-all, `Some("slack")` = per-provider)
 - A **maximum number of actions** per **time window**
 - An **overage behavior** that determines what happens when the limit is exceeded
 
 Usage counters are stored in the state backend with epoch-aligned windows, so all gateway instances agree on window boundaries without coordination.
+
+### Generic vs. per-provider policies
+
+A single `(namespace, tenant)` pair can hold **one generic catch-all
+policy plus any number of per-provider policies**. This lets
+operators stack a tenant-wide daily cap with per-provider burst
+caps — e.g. "10,000 actions/day overall **and** 50 Slack
+messages/minute." Every dispatch evaluates all policies whose
+scope matches the outgoing provider, and the **strictest**
+applicable outcome wins (Block > Degrade > Warn > Notify). Each
+policy also maintains its own counter bucket, so a burst on one
+provider cannot consume another provider's budget.
+
+| Policy (`provider` field) | Matches dispatches to | Counter bucket |
+|---|---|---|
+| `None` (generic) | Any provider for the tenant | `{ns}:{tenant}:*:{window}:{idx}` |
+| `Some("slack")` | Only `slack` | `{ns}:{tenant}:slack:{window}:{idx}` |
+| `Some("email")` | Only `email` | `{ns}:{tenant}:email:{window}:{idx}` |
+
+When any applicable policy blocks a dispatch, every counter
+incremented during that call is rolled back — the blocked
+request does not consume budget on sibling policies.
 
 ## Configuration
 
@@ -39,10 +62,12 @@ use acteon_gateway::GatewayBuilder;
 let gateway = GatewayBuilder::new()
     .state(state)
     .lock(lock)
+    // Generic tenant-wide daily cap.
     .quota_policy(QuotaPolicy {
         id: "q-001".into(),
         namespace: "notifications".into(),
         tenant: "acme".into(),
+        provider: None, // generic: counts every dispatch
         max_actions: 1000,
         window: QuotaWindow::Daily,
         overage_behavior: OverageBehavior::Block,
@@ -50,6 +75,21 @@ let gateway = GatewayBuilder::new()
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
         description: Some("Acme daily limit".into()),
+        labels: Default::default(),
+    })
+    // Per-provider burst cap on Slack — stacks with the daily cap.
+    .quota_policy(QuotaPolicy {
+        id: "q-002".into(),
+        namespace: "notifications".into(),
+        tenant: "acme".into(),
+        provider: Some("slack".into()),
+        max_actions: 50,
+        window: QuotaWindow::Custom { seconds: 60 },
+        overage_behavior: OverageBehavior::Block,
+        enabled: true,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        description: Some("Acme Slack burst cap".into()),
         labels: Default::default(),
     })
     .build()?;
@@ -66,11 +106,23 @@ Create, read, update, and delete quota policies through the `/v1/quotas` endpoin
 id = "q-acme-daily"
 namespace = "notifications"
 tenant = "acme"
+# provider field omitted → generic tenant-wide policy
 max_actions = 1000
 window = "daily"
 overage_behavior = "block"
 enabled = true
 description = "Acme daily limit"
+
+[[quotas]]
+id = "q-acme-slack-burst"
+namespace = "notifications"
+tenant = "acme"
+provider = "slack"            # per-provider burst cap
+max_actions = 50
+window = { custom = { seconds = 60 } }
+overage_behavior = "block"
+enabled = true
+description = "Acme Slack burst cap"
 ```
 
 ## Quota Windows

--- a/docs/book/features/tenant-quotas.md
+++ b/docs/book/features/tenant-quotas.md
@@ -179,7 +179,7 @@ This is useful for soft limits where you want visibility into overages without d
 
 ### Degrade
 
-The action is rejected with a `QuotaExceeded` outcome that includes the fallback provider name. The caller (or a middleware) can use this to re-route the action to a cheaper or lower-priority provider.
+The action's target provider is swapped to the configured `fallback_provider` and the gateway re-enters its dispatch pipeline through that provider. The caller sees a normal `Executed` outcome if the fallback succeeds — there is no separate "degraded" success state.
 
 ```json
 {
@@ -187,7 +187,9 @@ The action is rejected with a `QuotaExceeded` outcome that includes the fallback
 }
 ```
 
-**Outcome:** `QuotaExceeded { ..., overage_behavior: "degrade:log" }`
+**Fallback re-check semantics:** after the provider swap, the gateway re-evaluates only **provider-scoped** policies targeting the new provider. The generic (tenant-wide) policy that triggered the initial degrade is *not* double-charged, but any per-provider cap on the fallback *is* enforced. This closes the "degrade-to-bypass" hole where a fallback provider's rate limit would otherwise be silently ignored.
+
+A misconfigured chain of degrade policies (A → B → C → …) is bounded at 3 hops per dispatch; past that limit the gateway returns `QuotaExceeded` instead of cascading further.
 
 ### Notify
 
@@ -414,7 +416,11 @@ curl -X DELETE "http://localhost:8080/v1/quotas/q-001?namespace=notifications&te
 
 ## Limitations
 
-- **Single policy per namespace:tenant**: Each tenant can have at most one quota policy per namespace. Multiple overlapping policies for the same scope are not supported.
+- **Per-bucket policy cap**: Each `(namespace, tenant)` bucket may hold at most 32 policies (one generic + up to 31 per-provider caps). Creation attempts past that cap return `409 Conflict`.
+- **Identifier character set**: `namespace`, `tenant`, and `provider` identifiers must not contain `:` (the state-key separator) or ASCII control characters, and must be ≤128 bytes. This prevents cross-tenant counter-key collisions.
 - **Counter precision**: Counters are stored as strings in the state backend and incremented non-atomically (read + write). In extremely high-throughput scenarios, a small number of actions may slip through just above the limit.
+- **Hot-key contention on the generic counter**: Every dispatch for a tenant hits the single `*` (generic) counter key. In very high-throughput scenarios this can become a bottleneck in the state backend. Sharded counters are a planned follow-up — open an issue if you hit this limit in practice.
+- **`list_quotas` full scan**: The list endpoint currently scans every quota record and filters in-memory. For deployments with thousands of policies, the endpoint will become slow or timeout. A secondary index for filtered lookups is planned.
+- **Ghost consumption on rollback failure**: When a Block outcome fires, the gateway rolls back every counter it just incremented using best-effort compensating decrements. If a decrement fails (state store blip), the counter stays slightly inflated — the tenant may be blocked marginally earlier than their actual usage warrants. Reconciliation is handled implicitly by window expiry.
 - **No per-action-type quotas**: Quotas apply to all action types within a namespace:tenant scope. Use rules for action-type-level control.
 - **Window granularity**: The minimum effective window is determined by the state backend's TTL precision (typically 1 second).

--- a/docs/design-alertmanager-parity.md
+++ b/docs/design-alertmanager-parity.md
@@ -34,7 +34,7 @@ A fresh audit against Alertmanager v0.27 features found the following gaps.
 |---|---|---|---|
 | 1 | **Silences** (time-bounded label-pattern mutes) | **Missing** — no `Silence` type, no CRUD, no dispatch-path enforcement | **Critical** |
 | 2 | `group_wait` / `group_interval` / `repeat_interval` | **Shipped in Phase 2.** `group_wait` was already implemented; `group_interval` is now honored on persistent groups; `repeat_interval` is a new optional field that makes the group persistent and re-fire periodically. | ~~Medium~~ Done |
-| 3 | Per-receiver rate limits | Partial — tenant/namespace quotas exist, no provider-level enforcement | Medium |
+| 3 | Per-receiver rate limits | **Shipped in Phase 3.** Generic tenant/namespace quotas now stack with optional per-provider scoped policies; strictest outcome wins; each scope has its own counter bucket. | ~~Medium~~ Done |
 | 4 | OpsGenie receiver | Missing | Medium |
 | 5 | VictorOps receiver | Missing | Medium |
 | 6 | Pushover receiver | Missing | Low |
@@ -90,10 +90,28 @@ Implementation notes:
 - `max_group_size` is now actually enforced — `EventGroup::add_event` drops the oldest event when at capacity.
 - The background flush worker only deletes ephemeral groups; persistent groups stay alive in memory.
 
-### Phase 3 — Per-provider rate limits
+### Phase 3 — Per-provider rate limits ✅ Shipped
 **Gap**: #3
-**Scope**: ~400 LOC
-**Follow-up**: extend `QuotaPolicy` with an optional `provider: Option<String>` field; update quota matching to evaluate provider scope after tenant/namespace.
+**Status**: Shipped in PR #85.
+**Scope as built**: ~1000 LOC across core types, gateway multi-policy enforcement, server CRUD, CLI flag, polyglot SDKs, and tests.
+
+`QuotaPolicy` gained an optional `provider: Option<String>` field.
+Multiple policies may coexist for the same `(namespace, tenant)`
+pair as long as their provider scopes differ (one generic catch-all
+plus any number of per-provider policies). At dispatch time, every
+policy whose scope matches the outgoing provider is evaluated, each
+maintains its own counter bucket
+(`{ns}:{tenant}:{provider_or_*}:{window}:{idx}`), and the strictest
+applicable outcome wins (Block > Degrade > Warn > Notify). When any
+policy blocks a dispatch, every counter touched during that call is
+rolled back so the blocked request never consumes sibling budgets.
+
+Implementation notes:
+- Backward compatibility: missing `provider` field deserializes as `None` (generic) via `#[serde(default)]`; the old `idx:{ns}:{tenant}` index key value format (bare UUID) is accepted on read alongside the new JSON-array format.
+- Gateway cache changes: `quota_policies` is now `HashMap<String, CachedPolicy>` where `CachedPolicy` is a bucket of policies for a `(ns, tenant)`; cold-path loader fetches the full bucket in a single index lookup + N policy reads.
+- Server CRUD: duplicate detection now keys on `(namespace, tenant, provider)` rather than just `(namespace, tenant)`; the list endpoint accepts a `provider` query param (`generic` matches catch-alls, anything else is an exact match).
+- CLI: `acteon quotas list --provider slack` filters the listing; `acteon quotas create` accepts `provider` in the JSON payload.
+- Polyglot SDKs: Rust, Python, Node.js, Go, and Java client models all gained the `provider` field and the provider filter on `list_quotas`.
 
 ### Phase 4 — Missing receivers
 **Gaps**: #4–#8


### PR DESCRIPTION
## Summary

Phase 3 of the [Alertmanager feature parity plan](https://github.com/penserai/acteon/blob/main/docs/design-alertmanager-parity.md): closes gap #3 by extending `QuotaPolicy` with an optional provider scope so a single `(namespace, tenant)` pair can stack a generic tenant-wide cap with any number of per-provider burst caps.

## Why

Alertmanager's `route.rate_limit` lets ops teams throttle per receiver. Tenant-wide quotas alone cannot express \"10k actions/day total **and** 50 Slack messages/minute.\" This PR closes that gap with Acteon's existing quota primitive.

## Design

A single `(namespace, tenant)` pair now holds a **bucket** of policies:

- `provider: None` = generic catch-all (counts every dispatch for the tenant)
- `provider: Some(\"slack\")` = only counts dispatches whose `action.provider == \"slack\"`

Per dispatch, every applicable policy is evaluated, each maintains its own counter bucket (`{ns}:{tenant}:{provider_or_*}:{window}:{idx}`), and the **strictest** outcome wins:

> Block > Degrade > Warn > Notify

When any policy blocks, **every** counter incremented during that call is rolled back so the blocked request does not consume sibling budgets.

### Backward compatibility

- Missing `provider` field on existing state-store records deserializes as `None` via `#[serde(default)]`
- The old `idx:{ns}:{tenant}` index value format (bare UUID) is still accepted on read alongside the new JSON-array format

## What changed

**Core** — `QuotaPolicy.provider: Option<String>`, `applies_to_provider()` helper, `quota_counter_key()` now takes `Option<&str>` for the provider and encodes generic policies as `*`.

**Gateway** — cache restructured to `HashMap<String, CachedPolicy>` where `CachedPolicy` is a bucket of policies; new `enforce_quota_policies` handles multi-policy evaluation with atomic rollback on block; cold-path loader reads the full bucket via a JSON-array index; `set_quota_policy` / `remove_quota_policy_by_id` replace the old single-policy helpers.

**Server CRUD** — `CreateQuotaRequest` / `QuotaResponse` gain `provider`; duplicate detection keys on `(ns, tenant, provider)`; list endpoint supports `provider=generic` / `provider=<name>` filter; index key stores a JSON array of policy IDs per bucket.

**CLI** — `acteon quotas list --provider <scope>`; `get` output displays the provider scope (`* (generic)` for catch-alls).

**Polyglot SDKs** — Rust, Python, Node.js, Go, and Java client models all carry the new `provider` field; `list_quotas` grows a provider parameter across every SDK.

**Docs** — `docs/book/features/tenant-quotas.md` gains a \"Generic vs. per-provider policies\" section and updated code examples; `docs/design-alertmanager-parity.md` marks Phase 3 ✅ Shipped.

## Tests

Four new multi-policy gateway tests covering:

1. Per-provider scoping (slack-scoped policy does not count email dispatches)
2. Generic + scoped stacking (both are enforced simultaneously; blocked dispatches do not consume the generic budget)
3. Block rollback across sibling counters
4. Block > Warn precedence when a dispatch exceeds both

Core unit tests cover the new `applies_to_provider` helper, counter-key isolation per provider, and backward-compat deserialization of pre-Phase-3 records.

## Test plan

- [ ] CI passes (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test --workspace`)
- [ ] Verify existing quota tests still pass unchanged
- [ ] Verify new multi-policy tests pass
- [ ] Manual: create a generic quota + a per-provider quota via CRUD, confirm both show up in the list, confirm dispatches enforce both caps independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)