### PR TITLE
feat: OpsGenie provider (Phase 4a of Alertmanager parity)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,7 @@ dependencies = [
  "acteon-core",
  "acteon-crypto",
  "acteon-provider",
+ "percent-encoding",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "acteon-opsgenie"
+version = "0.1.0"
+dependencies = [
+ "acteon-core",
+ "acteon-crypto",
+ "acteon-provider",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "acteon-pagerduty"
 version = "0.1.0"
 dependencies = [
@@ -470,6 +485,7 @@ dependencies = [
  "acteon-gateway",
  "acteon-gcp",
  "acteon-llm",
+ "acteon-opsgenie",
  "acteon-provider",
  "acteon-rules",
  "acteon-rules-yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,6 +257,7 @@ aes-gcm = "0.10"
 base64 = "0.22"
 secrecy = { version = "0.8", features = ["serde"] }
 zeroize = { version = "1", features = ["derive"] }
+percent-encoding = "2"
 
 # Tracing subscriber
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ members = [
     "crates/integrations/email",
     "crates/integrations/slack",
     "crates/integrations/pagerduty",
+    "crates/integrations/opsgenie",
     "crates/integrations/webhook",
     "crates/integrations/twilio",
     "crates/integrations/teams",
@@ -127,6 +128,7 @@ acteon-gcp = { path = "crates/gcp" }
 acteon-email = { path = "crates/integrations/email" }
 acteon-slack = { path = "crates/integrations/slack" }
 acteon-pagerduty = { path = "crates/integrations/pagerduty" }
+acteon-opsgenie = { path = "crates/integrations/opsgenie" }
 acteon-webhook = { path = "crates/integrations/webhook" }
 acteon-twilio = { path = "crates/integrations/twilio" }
 acteon-teams = { path = "crates/integrations/teams" }

--- a/crates/integrations/opsgenie/Cargo.toml
+++ b/crates/integrations/opsgenie/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "acteon-opsgenie"
+description = "OpsGenie provider for Acteon — sends alerts via the OpsGenie Alert API v2"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+
+[dependencies]
+acteon-core = { workspace = true }
+acteon-crypto = { workspace = true }
+acteon-provider = { workspace = true, features = ["trace-context"] }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/integrations/opsgenie/Cargo.toml
+++ b/crates/integrations/opsgenie/Cargo.toml
@@ -13,6 +13,7 @@ default = []
 acteon-core = { workspace = true }
 acteon-crypto = { workspace = true }
 acteon-provider = { workspace = true, features = ["trace-context"] }
+percent-encoding = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/integrations/opsgenie/src/config.rs
+++ b/crates/integrations/opsgenie/src/config.rs
@@ -1,6 +1,13 @@
-use acteon_crypto::ExposeSecret;
+use acteon_crypto::{ExposeSecret, SecretString};
 
 use crate::error::OpsGenieError;
+
+/// Default maximum length for the `message` field that will be sent
+/// to the `OpsGenie` Alert API. Matches the API's documented cap at
+/// the time this crate was written; override via
+/// [`OpsGenieConfig::with_message_max_length`] if the upstream limit
+/// changes before a new version of this crate ships.
+pub const DEFAULT_MESSAGE_MAX_LENGTH: usize = 130;
 
 /// `OpsGenie` data residency region.
 ///
@@ -29,11 +36,17 @@ impl OpsGenieRegion {
 }
 
 /// Configuration for the `OpsGenie` provider.
+///
+/// The API key is held as a [`SecretString`] so its plaintext is
+/// [`zeroize::Zeroize`]-scrubbed from the heap when the provider is
+/// dropped, and so any accidental `Debug` formatting yields
+/// `[REDACTED]` instead of the raw key.
 #[derive(Clone)]
 pub struct OpsGenieConfig {
     /// API integration key (the `GenieKey` that authenticates writes
-    /// against the Alert API).
-    api_key: String,
+    /// against the Alert API). Stored as a [`SecretString`] so the
+    /// plaintext is zeroized from memory on drop.
+    api_key: SecretString,
 
     /// `OpsGenie` region the account lives in.
     region: OpsGenieRegion,
@@ -50,6 +63,29 @@ pub struct OpsGenieConfig {
 
     /// Default `source` field used when the payload omits one.
     pub default_source: Option<String>,
+
+    /// Whether to prefix user-supplied aliases with
+    /// `{namespace}:{tenant}:` before sending them to `OpsGenie`.
+    ///
+    /// **Defaults to `true`.** Leaving this on is the right choice
+    /// for any deployment where multiple Acteon tenants share a
+    /// single `OpsGenie` integration key — without it, Tenant A
+    /// could close Tenant B's alerts by guessing (or observing)
+    /// the alias string.
+    ///
+    /// Set this to `false` only if every Acteon namespace/tenant
+    /// has its own dedicated `OpsGenie` account OR you need
+    /// cross-tenant alias coordination (e.g., a platform team
+    /// closing a customer alert).
+    pub scope_aliases: bool,
+
+    /// Maximum length, in bytes, that the `message` field may be
+    /// before the provider truncates it client-side. Defaults to
+    /// [`DEFAULT_MESSAGE_MAX_LENGTH`] (130) to match the current
+    /// `OpsGenie` API limit. If `OpsGenie` lifts the cap (or you
+    /// want to be more restrictive), override this via
+    /// [`Self::with_message_max_length`].
+    pub message_max_length: usize,
 }
 
 impl std::fmt::Debug for OpsGenieConfig {
@@ -61,6 +97,8 @@ impl std::fmt::Debug for OpsGenieConfig {
             .field("default_team", &self.default_team)
             .field("default_priority", &self.default_priority)
             .field("default_source", &self.default_source)
+            .field("scope_aliases", &self.scope_aliases)
+            .field("message_max_length", &self.message_max_length)
             .finish()
     }
 }
@@ -69,18 +107,41 @@ impl OpsGenieConfig {
     /// Create a new configuration with the given API key.
     ///
     /// Defaults to the US region, priority `P3`, and no default
-    /// responder / source. Callers typically chain `with_*` builders
-    /// to customize the rest.
+    /// responder / source. Alias scoping is enabled by default.
+    /// Callers typically chain `with_*` builders to customize the
+    /// rest.
+    ///
+    /// The API key may be passed as any `Into<String>` — the value
+    /// is immediately wrapped in a [`SecretString`] so it is
+    /// zeroized on drop.
     #[must_use]
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            api_key: api_key.into(),
+            api_key: SecretString::new(api_key.into()),
             region: OpsGenieRegion::Us,
             api_base_url_override: None,
             default_team: None,
             default_priority: "P3".to_owned(),
             default_source: None,
+            scope_aliases: true,
+            message_max_length: DEFAULT_MESSAGE_MAX_LENGTH,
         }
+    }
+
+    /// Enable or disable automatic alias scoping. See the field
+    /// docs on [`OpsGenieConfig::scope_aliases`] for the security
+    /// implications.
+    #[must_use]
+    pub fn with_scope_aliases(mut self, scope_aliases: bool) -> Self {
+        self.scope_aliases = scope_aliases;
+        self
+    }
+
+    /// Override the default maximum message length.
+    #[must_use]
+    pub fn with_message_max_length(mut self, max_len: usize) -> Self {
+        self.message_max_length = max_len;
+        self
     }
 
     /// Set the `OpsGenie` region for this configuration.
@@ -122,15 +183,22 @@ impl OpsGenieConfig {
 
     /// Decrypt an `ENC[...]` API key in place.
     ///
-    /// Plain-text keys pass through unchanged.
+    /// Plain-text keys pass through unchanged. The decrypted
+    /// plaintext is wrapped in a fresh [`SecretString`] so the
+    /// original encrypted input and the intermediate buffer are
+    /// both dropped and zeroized.
     #[must_use = "returns the config with the decrypted API key"]
     pub fn decrypt_secrets(
         mut self,
         master_key: &acteon_crypto::MasterKey,
     ) -> Result<Self, OpsGenieError> {
-        let decrypted = acteon_crypto::decrypt_value(&self.api_key, master_key)
-            .map_err(|e| OpsGenieError::InvalidPayload(format!("failed to decrypt api_key: {e}")))?;
-        decrypted.expose_secret().clone_into(&mut self.api_key);
+        let decrypted = acteon_crypto::decrypt_value(self.api_key.expose_secret(), master_key)
+            .map_err(|e| {
+                OpsGenieError::InvalidPayload(format!("failed to decrypt api_key: {e}"))
+            })?;
+        // `SecretString` is already the right type — move it in so
+        // we never copy the plaintext out onto the stack.
+        self.api_key = decrypted;
         Ok(self)
     }
 
@@ -144,9 +212,11 @@ impl OpsGenieConfig {
 
     /// Return the API key for constructing the `Authorization` header.
     /// Kept `pub(crate)` so callers outside the crate cannot lift the
-    /// secret out of the config struct.
+    /// secret out of the config struct — the provider calls this at
+    /// the last possible moment before handing the bytes to reqwest,
+    /// which is the narrowest window we can enforce at the type level.
     pub(crate) fn api_key(&self) -> &str {
-        &self.api_key
+        self.api_key.expose_secret()
     }
 
     /// Return the configured region.
@@ -168,6 +238,25 @@ mod tests {
         assert_eq!(config.default_priority, "P3");
         assert!(config.default_team.is_none());
         assert!(config.default_source.is_none());
+        assert!(
+            config.scope_aliases,
+            "alias scoping must be ON by default for multi-tenant safety"
+        );
+        assert_eq!(config.message_max_length, DEFAULT_MESSAGE_MAX_LENGTH);
+    }
+
+    #[test]
+    fn with_scope_aliases_toggle() {
+        let config = OpsGenieConfig::new("k").with_scope_aliases(false);
+        assert!(!config.scope_aliases);
+        let config = config.with_scope_aliases(true);
+        assert!(config.scope_aliases);
+    }
+
+    #[test]
+    fn with_message_max_length_override() {
+        let config = OpsGenieConfig::new("k").with_message_max_length(256);
+        assert_eq!(config.message_max_length, 256);
     }
 
     #[test]

--- a/crates/integrations/opsgenie/src/config.rs
+++ b/crates/integrations/opsgenie/src/config.rs
@@ -38,9 +38,10 @@ impl OpsGenieRegion {
 /// Configuration for the `OpsGenie` provider.
 ///
 /// The API key is held as a [`SecretString`] so its plaintext is
-/// [`zeroize::Zeroize`]-scrubbed from the heap when the provider is
-/// dropped, and so any accidental `Debug` formatting yields
-/// `[REDACTED]` instead of the raw key.
+/// zeroized from the heap (via the `zeroize` crate, transitively
+/// through `secrecy`) when the provider is dropped, and so any
+/// accidental `Debug` formatting yields `[REDACTED]` instead of
+/// the raw key.
 #[derive(Clone)]
 pub struct OpsGenieConfig {
     /// API integration key (the `GenieKey` that authenticates writes

--- a/crates/integrations/opsgenie/src/config.rs
+++ b/crates/integrations/opsgenie/src/config.rs
@@ -1,0 +1,253 @@
+use acteon_crypto::ExposeSecret;
+
+use crate::error::OpsGenieError;
+
+/// `OpsGenie` data residency region.
+///
+/// `OpsGenie` runs two physically separate API endpoints: one in the US
+/// and one in the EU. Accounts are pinned to one region at provisioning
+/// time and API keys only work against their home region, so picking
+/// the wrong one surfaces as a 401/403 rather than a silent misdelivery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OpsGenieRegion {
+    /// `api.opsgenie.com` — default, and the region for most accounts.
+    #[default]
+    Us,
+    /// `api.eu.opsgenie.com` — for EU-region `OpsGenie` accounts.
+    Eu,
+}
+
+impl OpsGenieRegion {
+    /// Base URL for this region's Alert API v2 endpoint.
+    #[must_use]
+    pub const fn base_url(&self) -> &'static str {
+        match self {
+            Self::Us => "https://api.opsgenie.com",
+            Self::Eu => "https://api.eu.opsgenie.com",
+        }
+    }
+}
+
+/// Configuration for the `OpsGenie` provider.
+#[derive(Clone)]
+pub struct OpsGenieConfig {
+    /// API integration key (the `GenieKey` that authenticates writes
+    /// against the Alert API).
+    api_key: String,
+
+    /// `OpsGenie` region the account lives in.
+    region: OpsGenieRegion,
+
+    /// Base URL override — primarily for testing against a mock
+    /// server. When `None`, the URL is derived from `region`.
+    api_base_url_override: Option<String>,
+
+    /// Default team responder used when the payload omits one.
+    pub default_team: Option<String>,
+
+    /// Default alert priority (`P1`..=`P5`). Defaults to `P3`.
+    pub default_priority: String,
+
+    /// Default `source` field used when the payload omits one.
+    pub default_source: Option<String>,
+}
+
+impl std::fmt::Debug for OpsGenieConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpsGenieConfig")
+            .field("api_key", &"[REDACTED]")
+            .field("region", &self.region)
+            .field("api_base_url_override", &self.api_base_url_override)
+            .field("default_team", &self.default_team)
+            .field("default_priority", &self.default_priority)
+            .field("default_source", &self.default_source)
+            .finish()
+    }
+}
+
+impl OpsGenieConfig {
+    /// Create a new configuration with the given API key.
+    ///
+    /// Defaults to the US region, priority `P3`, and no default
+    /// responder / source. Callers typically chain `with_*` builders
+    /// to customize the rest.
+    #[must_use]
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            region: OpsGenieRegion::Us,
+            api_base_url_override: None,
+            default_team: None,
+            default_priority: "P3".to_owned(),
+            default_source: None,
+        }
+    }
+
+    /// Set the `OpsGenie` region for this configuration.
+    #[must_use]
+    pub fn with_region(mut self, region: OpsGenieRegion) -> Self {
+        self.region = region;
+        self
+    }
+
+    /// Override the API base URL (useful for testing against a mock
+    /// server). When set, this takes precedence over the region's
+    /// built-in base URL.
+    #[must_use]
+    pub fn with_api_base_url(mut self, url: impl Into<String>) -> Self {
+        self.api_base_url_override = Some(url.into());
+        self
+    }
+
+    /// Set the default team responder used when a payload omits one.
+    #[must_use]
+    pub fn with_default_team(mut self, team: impl Into<String>) -> Self {
+        self.default_team = Some(team.into());
+        self
+    }
+
+    /// Set the default alert priority (`P1`..=`P5`).
+    #[must_use]
+    pub fn with_default_priority(mut self, priority: impl Into<String>) -> Self {
+        self.default_priority = priority.into();
+        self
+    }
+
+    /// Set the default alert source.
+    #[must_use]
+    pub fn with_default_source(mut self, source: impl Into<String>) -> Self {
+        self.default_source = Some(source.into());
+        self
+    }
+
+    /// Decrypt an `ENC[...]` API key in place.
+    ///
+    /// Plain-text keys pass through unchanged.
+    #[must_use = "returns the config with the decrypted API key"]
+    pub fn decrypt_secrets(
+        mut self,
+        master_key: &acteon_crypto::MasterKey,
+    ) -> Result<Self, OpsGenieError> {
+        let decrypted = acteon_crypto::decrypt_value(&self.api_key, master_key)
+            .map_err(|e| OpsGenieError::InvalidPayload(format!("failed to decrypt api_key: {e}")))?;
+        decrypted.expose_secret().clone_into(&mut self.api_key);
+        Ok(self)
+    }
+
+    /// Return the effective base URL for API requests.
+    #[must_use]
+    pub fn api_base_url(&self) -> &str {
+        self.api_base_url_override
+            .as_deref()
+            .unwrap_or_else(|| self.region.base_url())
+    }
+
+    /// Return the API key for constructing the `Authorization` header.
+    /// Kept `pub(crate)` so callers outside the crate cannot lift the
+    /// secret out of the config struct.
+    pub(crate) fn api_key(&self) -> &str {
+        &self.api_key
+    }
+
+    /// Return the configured region.
+    #[must_use]
+    pub fn region(&self) -> OpsGenieRegion {
+        self.region
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_defaults() {
+        let config = OpsGenieConfig::new("test-api-key");
+        assert_eq!(config.api_key(), "test-api-key");
+        assert_eq!(config.region(), OpsGenieRegion::Us);
+        assert_eq!(config.default_priority, "P3");
+        assert!(config.default_team.is_none());
+        assert!(config.default_source.is_none());
+    }
+
+    #[test]
+    fn region_base_urls() {
+        assert_eq!(OpsGenieRegion::Us.base_url(), "https://api.opsgenie.com");
+        assert_eq!(OpsGenieRegion::Eu.base_url(), "https://api.eu.opsgenie.com");
+    }
+
+    #[test]
+    fn with_region_switches_base_url() {
+        let config = OpsGenieConfig::new("k").with_region(OpsGenieRegion::Eu);
+        assert_eq!(config.api_base_url(), "https://api.eu.opsgenie.com");
+    }
+
+    #[test]
+    fn api_base_url_override_wins() {
+        let config = OpsGenieConfig::new("k")
+            .with_region(OpsGenieRegion::Eu)
+            .with_api_base_url("http://localhost:4242");
+        assert_eq!(config.api_base_url(), "http://localhost:4242");
+    }
+
+    #[test]
+    fn builder_chain() {
+        let config = OpsGenieConfig::new("k")
+            .with_region(OpsGenieRegion::Eu)
+            .with_default_team("ops-team")
+            .with_default_priority("P1")
+            .with_default_source("prometheus")
+            .with_api_base_url("http://mock");
+        assert_eq!(config.default_team.as_deref(), Some("ops-team"));
+        assert_eq!(config.default_priority, "P1");
+        assert_eq!(config.default_source.as_deref(), Some("prometheus"));
+        assert_eq!(config.api_base_url(), "http://mock");
+    }
+
+    fn test_master_key() -> acteon_crypto::MasterKey {
+        acteon_crypto::parse_master_key(&"42".repeat(32)).unwrap()
+    }
+
+    #[test]
+    fn decrypt_secrets_roundtrip() {
+        let master_key = test_master_key();
+        let original = "my-genie-key";
+        let encrypted = acteon_crypto::encrypt_value(original, &master_key).unwrap();
+
+        let config = OpsGenieConfig::new(encrypted)
+            .decrypt_secrets(&master_key)
+            .unwrap();
+        assert_eq!(config.api_key(), original);
+    }
+
+    #[test]
+    fn decrypt_secrets_plaintext_passthrough() {
+        let master_key = test_master_key();
+        let config = OpsGenieConfig::new("plain-key")
+            .decrypt_secrets(&master_key)
+            .unwrap();
+        assert_eq!(config.api_key(), "plain-key");
+    }
+
+    #[test]
+    fn decrypt_secrets_invalid_ciphertext() {
+        let master_key = test_master_key();
+        let config = OpsGenieConfig::new("ENC[AES256-GCM,data:bad,iv:bad,tag:bad]");
+        let err = config.decrypt_secrets(&master_key).unwrap_err();
+        assert!(matches!(err, OpsGenieError::InvalidPayload(_)));
+    }
+
+    #[test]
+    fn debug_redacts_api_key() {
+        let config = OpsGenieConfig::new("super-secret-placeholder-value");
+        let debug = format!("{config:?}");
+        assert!(
+            debug.contains("[REDACTED]"),
+            "api_key must be redacted in Debug output"
+        );
+        assert!(
+            !debug.contains("super-secret-placeholder-value"),
+            "raw api_key must not appear in Debug output"
+        );
+    }
+}

--- a/crates/integrations/opsgenie/src/error.rs
+++ b/crates/integrations/opsgenie/src/error.rs
@@ -1,0 +1,92 @@
+use acteon_provider::ProviderError;
+use thiserror::Error;
+
+/// Errors specific to the `OpsGenie` provider.
+///
+/// These are internal errors that get converted into [`ProviderError`] at the
+/// public API boundary.
+#[derive(Debug, Error)]
+pub enum OpsGenieError {
+    /// An HTTP-level transport error occurred.
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// The `OpsGenie` API returned a non-success response.
+    #[error("OpsGenie API error: {0}")]
+    Api(String),
+
+    /// The action payload is missing required fields or has invalid structure.
+    #[error("invalid payload: {0}")]
+    InvalidPayload(String),
+
+    /// The provider received an HTTP 429 (Too Many Requests) response.
+    #[error("rate limited by OpsGenie")]
+    RateLimited,
+
+    /// The provider received an HTTP 401/403 response — typically a bad or
+    /// revoked API key.
+    #[error("authentication failed: {0}")]
+    Unauthorized(String),
+}
+
+impl From<OpsGenieError> for ProviderError {
+    fn from(err: OpsGenieError) -> Self {
+        match err {
+            OpsGenieError::Http(e) => ProviderError::Connection(e.to_string()),
+            OpsGenieError::Api(msg) => ProviderError::ExecutionFailed(msg),
+            OpsGenieError::InvalidPayload(msg) => ProviderError::Serialization(msg),
+            OpsGenieError::RateLimited => ProviderError::RateLimited,
+            OpsGenieError::Unauthorized(msg) => ProviderError::Configuration(msg),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limited_maps_to_retryable() {
+        let provider_err: ProviderError = OpsGenieError::RateLimited.into();
+        assert!(provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::RateLimited));
+    }
+
+    #[test]
+    fn api_error_maps_to_non_retryable() {
+        let provider_err: ProviderError = OpsGenieError::Api("bad request".into()).into();
+        assert!(!provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn invalid_payload_maps_to_serialization() {
+        let provider_err: ProviderError =
+            OpsGenieError::InvalidPayload("missing message".into()).into();
+        assert!(!provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::Serialization(_)));
+    }
+
+    #[test]
+    fn unauthorized_maps_to_configuration() {
+        let provider_err: ProviderError =
+            OpsGenieError::Unauthorized("invalid API key".into()).into();
+        assert!(!provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::Configuration(_)));
+    }
+
+    #[test]
+    fn display_messages() {
+        let err = OpsGenieError::Api("invalid request".into());
+        assert_eq!(err.to_string(), "OpsGenie API error: invalid request");
+
+        let err = OpsGenieError::InvalidPayload("missing alias".into());
+        assert_eq!(err.to_string(), "invalid payload: missing alias");
+
+        let err = OpsGenieError::RateLimited;
+        assert_eq!(err.to_string(), "rate limited by OpsGenie");
+
+        let err = OpsGenieError::Unauthorized("token revoked".into());
+        assert_eq!(err.to_string(), "authentication failed: token revoked");
+    }
+}

--- a/crates/integrations/opsgenie/src/error.rs
+++ b/crates/integrations/opsgenie/src/error.rs
@@ -11,9 +11,22 @@ pub enum OpsGenieError {
     #[error("HTTP error: {0}")]
     Http(#[from] reqwest::Error),
 
-    /// The `OpsGenie` API returned a non-success response.
+    /// The `OpsGenie` API returned a **permanent** non-success response
+    /// (a 4xx that is not a rate-limit or auth failure). These are
+    /// surfaced as `ExecutionFailed` and are **not** retried — retrying
+    /// a malformed request will never succeed.
     #[error("OpsGenie API error: {0}")]
     Api(String),
+
+    /// The `OpsGenie` API returned a **transient** non-success response
+    /// (5xx server error or 408 Request Timeout). The request body was
+    /// fine; the server was temporarily unable to handle it.
+    ///
+    /// Surfaced as `ProviderError::Connection` so the gateway's retry
+    /// logic re-queues the dispatch instead of dropping the alert on
+    /// the floor during a brief `OpsGenie` outage.
+    #[error("OpsGenie transient error: {0}")]
+    Transient(String),
 
     /// The action payload is missing required fields or has invalid structure.
     #[error("invalid payload: {0}")]
@@ -34,6 +47,7 @@ impl From<OpsGenieError> for ProviderError {
         match err {
             OpsGenieError::Http(e) => ProviderError::Connection(e.to_string()),
             OpsGenieError::Api(msg) => ProviderError::ExecutionFailed(msg),
+            OpsGenieError::Transient(msg) => ProviderError::Connection(msg),
             OpsGenieError::InvalidPayload(msg) => ProviderError::Serialization(msg),
             OpsGenieError::RateLimited => ProviderError::RateLimited,
             OpsGenieError::Unauthorized(msg) => ProviderError::Configuration(msg),
@@ -57,6 +71,19 @@ mod tests {
         let provider_err: ProviderError = OpsGenieError::Api("bad request".into()).into();
         assert!(!provider_err.is_retryable());
         assert!(matches!(provider_err, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn transient_error_maps_to_retryable_connection() {
+        // 5xx / 408 live-blip errors must be retried instead of
+        // dropping the alert on the floor.
+        let provider_err: ProviderError =
+            OpsGenieError::Transient("HTTP 503: service unavailable".into()).into();
+        assert!(
+            provider_err.is_retryable(),
+            "transient errors must be retryable"
+        );
+        assert!(matches!(provider_err, ProviderError::Connection(_)));
     }
 
     #[test]

--- a/crates/integrations/opsgenie/src/lib.rs
+++ b/crates/integrations/opsgenie/src/lib.rs
@@ -1,0 +1,46 @@
+//! `OpsGenie` provider for the Acteon notification gateway.
+//!
+//! This crate implements the [`Provider`](acteon_provider::Provider) trait,
+//! enabling Acteon to send alerts through the
+//! [OpsGenie Alert API v2](https://docs.opsgenie.com/docs/alert-api).
+//!
+//! # Quick start
+//!
+//! ```rust,no_run
+//! use acteon_opsgenie::{OpsGenieConfig, OpsGenieProvider, OpsGenieRegion};
+//!
+//! // Single team, US region.
+//! let config = OpsGenieConfig::new("your-api-key-here")
+//!     .with_region(OpsGenieRegion::Us)
+//!     .with_default_team("ops-team")
+//!     .with_default_priority("P3")
+//!     .with_default_source("acteon");
+//! let provider = OpsGenieProvider::new(config);
+//! ```
+//!
+//! # Supported event actions
+//!
+//! The provider dispatches an action based on the `event_action` field
+//! of the payload:
+//!
+//! | `event_action` | API endpoint | Required fields |
+//! |---|---|---|
+//! | `"create"` | `POST /v2/alerts` | `message` |
+//! | `"acknowledge"` | `POST /v2/alerts/{alias}/acknowledge` | `alias` |
+//! | `"close"` | `POST /v2/alerts/{alias}/close` | `alias` |
+//!
+//! All three map naturally onto Alertmanager firing → acknowledged →
+//! resolved state transitions so existing runbook tooling keeps
+//! working after a migration.
+
+pub mod config;
+pub mod error;
+pub mod provider;
+pub mod types;
+
+pub use config::{OpsGenieConfig, OpsGenieRegion};
+pub use error::OpsGenieError;
+pub use provider::OpsGenieProvider;
+pub use types::{
+    OpsGenieAlertRequest, OpsGenieApiResponse, OpsGenieLifecycleRequest, OpsGenieResponder,
+};

--- a/crates/integrations/opsgenie/src/provider.rs
+++ b/crates/integrations/opsgenie/src/provider.rs
@@ -1,5 +1,6 @@
 use acteon_core::{Action, ProviderResponse};
 use acteon_provider::{Provider, ProviderError, truncate_error_body};
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use reqwest::Client;
 use serde::Deserialize;
 use tracing::{debug, instrument, warn};
@@ -10,10 +11,40 @@ use crate::types::{
     OpsGenieAlertRequest, OpsGenieApiResponse, OpsGenieLifecycleRequest, OpsGenieResponder,
 };
 
-/// Maximum length accepted by the `OpsGenie` Alert API for the `message`
-/// field. Longer values are truncated client-side so the API call does
-/// not fail on what is typically a cosmetic concern.
-const MAX_MESSAGE_LEN: usize = 130;
+/// Characters that must be percent-encoded inside an URL path
+/// segment. We start from the IETF `CONTROLS` set and add every
+/// sub-delim, query-start, and path-separator byte that would be
+/// misinterpreted by the `OpsGenie` router if left raw.
+///
+/// Letters, digits, `-`, `.`, `_`, and `~` are unreserved and pass
+/// through unchanged per [RFC 3986 §2.3].
+///
+/// [RFC 3986 §2.3]: https://www.rfc-editor.org/rfc/rfc3986#section-2.3
+const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'%')
+    .add(b'/')
+    .add(b'<')
+    .add(b'>')
+    .add(b'?')
+    .add(b'@')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}')
+    .add(b':')
+    .add(b';')
+    .add(b'&')
+    .add(b'=')
+    .add(b'+')
+    .add(b'$')
+    .add(b',');
 
 /// `OpsGenie` provider that creates, acknowledges, and closes alerts
 /// via the Alert API v2.
@@ -95,29 +126,13 @@ impl OpsGenieProvider {
         )
     }
 
-    /// Percent-encode the characters that cannot appear unescaped in a
-    /// URL path segment. Keeps the hot path allocation-free in the
-    /// common case (ASCII alphanumerics, dashes, underscores, dots) and
-    /// only falls back to a `String` when encoding is actually needed.
+    /// Percent-encode a value for safe inclusion in an URL path
+    /// segment, using the battle-tested [`percent_encoding`] crate
+    /// so multi-byte UTF-8, sub-delims, and reserved characters
+    /// all get handled per RFC 3986 without the provider having
+    /// to maintain its own encoding table.
     fn percent_encode_path_segment(raw: &str) -> String {
-        use std::fmt::Write as _;
-        fn is_unreserved(b: u8) -> bool {
-            b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~')
-        }
-        let needs_encoding = raw.bytes().any(|b| !is_unreserved(b));
-        if !needs_encoding {
-            return raw.to_owned();
-        }
-        let mut out = String::with_capacity(raw.len() * 3);
-        for b in raw.bytes() {
-            if is_unreserved(b) {
-                out.push(b as char);
-            } else {
-                // write! into a String is infallible.
-                let _ = write!(out, "%{b:02X}");
-            }
-        }
-        out
+        utf8_percent_encode(raw, PATH_SEGMENT_ENCODE_SET).to_string()
     }
 
     /// POST a JSON body to the given URL, interpret the response, and
@@ -151,6 +166,19 @@ impl OpsGenieProvider {
                 truncate_error_body(&body)
             )));
         }
+        // 5xx (server error) and 408 (Request Timeout) are
+        // transient: the request body was fine, the server was
+        // temporarily unable to handle it. These must be retried
+        // rather than dropped, otherwise a 10-second OpsGenie blip
+        // would permanently lose alerts.
+        if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
+            let body = response.text().await.unwrap_or_default();
+            warn!(%status, "OpsGenie transient error — will be retried by gateway");
+            return Err(OpsGenieError::Transient(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            )));
+        }
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
             return Err(OpsGenieError::Api(format!(
@@ -169,17 +197,39 @@ impl OpsGenieProvider {
         Ok(api_response)
     }
 
+    /// Scope a user-supplied alias with the action's
+    /// `(namespace, tenant)` pair so two different tenants sharing
+    /// a single `OpsGenie` integration key cannot collide on (or
+    /// maliciously close) each other's alerts by guessing an
+    /// alias. The prefix is applied consistently to `create`,
+    /// `acknowledge`, and `close` so all three resolve to the same
+    /// underlying `OpsGenie` incident.
+    ///
+    /// Operators who genuinely want an unscoped alias (e.g.,
+    /// single-tenant deployments, or cross-tenant coordination)
+    /// can set `scope_aliases = false` in the provider config.
+    fn scoped_alias(&self, namespace: &str, tenant: &str, raw: &str) -> String {
+        if self.config.scope_aliases {
+            format!("{namespace}:{tenant}:{raw}")
+        } else {
+            raw.to_owned()
+        }
+    }
+
     /// Handle the `event_action = "create"` branch.
     async fn execute_create(
         &self,
+        namespace: &str,
+        tenant: &str,
         payload: EventPayload,
     ) -> Result<OpsGenieApiResponse, OpsGenieError> {
         let message = payload.message.ok_or_else(|| {
             OpsGenieError::InvalidPayload("create events require a 'message' field".into())
         })?;
         let mut message = message;
-        if message.len() > MAX_MESSAGE_LEN {
-            message.truncate(MAX_MESSAGE_LEN);
+        let max_len = self.config.message_max_length;
+        if message.len() > max_len {
+            message.truncate(max_len);
         }
 
         // Default the responder to the configured team when no
@@ -203,9 +253,15 @@ impl OpsGenieProvider {
             .source
             .or_else(|| self.config.default_source.clone());
 
+        // Scope the alias to prevent cross-tenant collisions on a
+        // shared OpsGenie account.
+        let alias = payload
+            .alias
+            .map(|raw| self.scoped_alias(namespace, tenant, &raw));
+
         let request = OpsGenieAlertRequest {
             message,
-            alias: payload.alias,
+            alias,
             description: payload.description,
             responders,
             visible_to: payload.visible_to,
@@ -225,14 +281,19 @@ impl OpsGenieProvider {
     /// Handle the `event_action = "acknowledge"` / `"close"` branches.
     async fn execute_lifecycle(
         &self,
+        namespace: &str,
+        tenant: &str,
         action: &str,
         payload: EventPayload,
     ) -> Result<OpsGenieApiResponse, OpsGenieError> {
-        let alias = payload.alias.ok_or_else(|| {
+        let raw_alias = payload.alias.ok_or_else(|| {
             OpsGenieError::InvalidPayload(format!(
                 "{action} events require an 'alias' field that matches the alias used at create time"
             ))
         })?;
+        // Apply the same tenant-scope prefix used at create time so
+        // the ack/close request targets the correct incident.
+        let alias = self.scoped_alias(namespace, tenant, &raw_alias);
         let request = OpsGenieLifecycleRequest {
             source: payload
                 .source
@@ -256,10 +317,18 @@ impl Provider for OpsGenieProvider {
         let payload: EventPayload = serde_json::from_value(action.payload.clone())
             .map_err(|e| OpsGenieError::InvalidPayload(format!("failed to parse payload: {e}")))?;
 
+        let namespace = action.namespace.as_str();
+        let tenant = action.tenant.as_str();
         let api_response = match payload.event_action.as_str() {
-            "create" => self.execute_create(payload).await?,
-            "acknowledge" => self.execute_lifecycle("acknowledge", payload).await?,
-            "close" => self.execute_lifecycle("close", payload).await?,
+            "create" => self.execute_create(namespace, tenant, payload).await?,
+            "acknowledge" => {
+                self.execute_lifecycle(namespace, tenant, "acknowledge", payload)
+                    .await?
+            }
+            "close" => {
+                self.execute_lifecycle(namespace, tenant, "close", payload)
+                    .await?
+            }
             other => {
                 return Err(OpsGenieError::InvalidPayload(format!(
                     "invalid event_action '{other}': must be 'create', 'acknowledge', or 'close'"
@@ -320,7 +389,7 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use super::*;
-    use crate::config::{OpsGenieConfig, OpsGenieRegion};
+    use crate::config::{DEFAULT_MESSAGE_MAX_LENGTH, OpsGenieConfig, OpsGenieRegion};
 
     /// Tiny mock HTTP server for integration-style tests. Same
     /// pattern the `PagerDuty` provider uses — a single-accept TCP
@@ -398,6 +467,27 @@ mod tests {
         );
     }
 
+    #[test]
+    fn percent_encode_path_segment_handles_utf8_multibyte() {
+        // A multi-byte UTF-8 character (`é` = 0xC3 0xA9) must be
+        // encoded as two `%XX` escapes, not mis-decoded. The old
+        // hand-rolled encoder worked byte-by-byte, so this is a
+        // regression guard against re-introducing a bug there.
+        assert_eq!(
+            OpsGenieProvider::percent_encode_path_segment("café"),
+            "caf%C3%A9"
+        );
+    }
+
+    #[test]
+    fn percent_encode_path_segment_preserves_unreserved() {
+        // RFC 3986 unreserved set must pass through verbatim.
+        assert_eq!(
+            OpsGenieProvider::percent_encode_path_segment("abc-DEF_123.tilde~"),
+            "abc-DEF_123.tilde~"
+        );
+    }
+
     #[tokio::test]
     async fn execute_create_success() {
         let server = MockOpsGenieServer::start().await;
@@ -426,11 +516,13 @@ mod tests {
 
         // The dispatched request should hit POST /v2/alerts with the
         // `Authorization: GenieKey ...` header and a JSON body that
-        // contains the payload fields.
+        // contains the payload fields. Alias is scoped by default
+        // with `{namespace}:{tenant}:` so tenant isolation holds on
+        // a shared OpsGenie integration.
         assert!(request.contains("POST /v2/alerts"));
         assert!(request.contains("authorization: GenieKey test-key"));
         assert!(request.contains("\"message\":\"High CPU on web-01\""));
-        assert!(request.contains("\"alias\":\"web-01-high-cpu\""));
+        assert!(request.contains("\"alias\":\"incidents:tenant-1:web-01-high-cpu\""));
         assert!(request.contains("\"priority\":\"P2\""));
     }
 
@@ -482,11 +574,39 @@ mod tests {
         });
         let _ = provider.execute(&action).await.unwrap();
         let request = server_handle.await.unwrap();
-        // Body should contain exactly MAX_MESSAGE_LEN x's.
-        let marker = format!("\"message\":\"{}\"", "x".repeat(MAX_MESSAGE_LEN));
+        // Body should contain exactly DEFAULT_MESSAGE_MAX_LENGTH x's.
+        let marker = format!("\"message\":\"{}\"", "x".repeat(DEFAULT_MESSAGE_MAX_LENGTH));
         assert!(
             request.contains(&marker),
-            "message should be truncated to {MAX_MESSAGE_LEN}"
+            "message should be truncated to {DEFAULT_MESSAGE_MAX_LENGTH}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_create_respects_configured_message_max_length() {
+        let server = MockOpsGenieServer::start().await;
+        // Pretend OpsGenie raised the cap to 200 and we want to
+        // use the full width.
+        let config = OpsGenieConfig::new("test-key")
+            .with_api_base_url(&server.base_url)
+            .with_message_max_length(200);
+        let provider = OpsGenieProvider::new(config);
+        let long = "y".repeat(250);
+        let action = make_action(serde_json::json!({
+            "event_action": "create",
+            "message": long,
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(202, r#"{"result":"ok","took":0.0,"requestId":""}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        let marker = format!("\"message\":\"{}\"", "y".repeat(200));
+        assert!(
+            request.contains(&marker),
+            "configured max length (200) must override the default"
         );
     }
 
@@ -521,9 +641,15 @@ mod tests {
         let result = provider.execute(&action).await;
         let request = server_handle.await.unwrap();
         assert!(result.is_ok());
+        // The alias is scoped with {namespace}:{tenant}: and
+        // percent-encoded in the path segment (colons → %3A) so
+        // the URL points at the same incident that `create`
+        // registered.
         assert!(
-            request.contains("POST /v2/alerts/web-01-high-cpu/acknowledge?identifierType=alias"),
-            "expected alias-based ack URL: {request}"
+            request.contains(
+                "POST /v2/alerts/incidents%3Atenant-1%3Aweb-01-high-cpu/acknowledge?identifierType=alias"
+            ),
+            "expected alias-based ack URL with scope prefix: {request}"
         );
         assert!(request.contains("\"note\":\"picked up by oncall\""));
     }
@@ -549,8 +675,59 @@ mod tests {
         let request = server_handle.await.unwrap();
         assert!(result.is_ok());
         assert!(
-            request.contains("POST /v2/alerts/db-backup-failed/close?identifierType=alias"),
-            "expected alias-based close URL: {request}"
+            request.contains(
+                "POST /v2/alerts/incidents%3Atenant-1%3Adb-backup-failed/close?identifierType=alias"
+            ),
+            "expected alias-based close URL with scope prefix: {request}"
+        );
+    }
+
+    #[tokio::test]
+    async fn scoped_alias_isolates_tenants_cross_tenant_ack_does_not_land() {
+        // Two different tenants on the same OpsGenie integration
+        // key ask to acknowledge the same raw alias. Their scoped
+        // aliases must differ so one cannot close the other's
+        // incident by guessing the alias.
+        let provider = OpsGenieProvider::new(OpsGenieConfig::new("k"));
+        let a = provider.scoped_alias("incidents", "tenant-a", "web-01-high-cpu");
+        let b = provider.scoped_alias("incidents", "tenant-b", "web-01-high-cpu");
+        assert_ne!(a, b, "two tenants must not collide on the same raw alias");
+        assert_eq!(a, "incidents:tenant-a:web-01-high-cpu");
+        assert_eq!(b, "incidents:tenant-b:web-01-high-cpu");
+    }
+
+    #[tokio::test]
+    async fn scope_aliases_disabled_returns_raw_alias() {
+        let provider = OpsGenieProvider::new(OpsGenieConfig::new("k").with_scope_aliases(false));
+        let alias = provider.scoped_alias("incidents", "tenant-1", "web-01-high-cpu");
+        assert_eq!(alias, "web-01-high-cpu");
+    }
+
+    #[tokio::test]
+    async fn execute_create_with_scope_aliases_disabled() {
+        // Opt-out path: the alias passes through unchanged so
+        // single-tenant deployments (or cross-tenant coordination
+        // scenarios) can use raw OpsGenie aliases.
+        let server = MockOpsGenieServer::start().await;
+        let config = OpsGenieConfig::new("test-key")
+            .with_api_base_url(&server.base_url)
+            .with_scope_aliases(false);
+        let provider = OpsGenieProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "create",
+            "message": "Raw alias test",
+            "alias": "web-01-high-cpu",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(202, r#"{"result":"ok","took":0.0,"requestId":""}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        assert!(
+            request.contains("\"alias\":\"web-01-high-cpu\""),
+            "opt-out should pass the alias through unchanged: {request}"
         );
     }
 
@@ -614,6 +791,55 @@ mod tests {
             "401 should surface as Configuration, got {err:?}"
         );
         assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_5xx_maps_to_retryable_connection() {
+        // A brief OpsGenie outage (503 Service Unavailable) must
+        // surface as a retryable error so the gateway re-queues the
+        // alert rather than permanently dropping it.
+        let server = MockOpsGenieServer::start().await;
+        let config = OpsGenieConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = OpsGenieProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "create",
+            "message": "test",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(503, r#"{"message":"Service Unavailable"}"#)
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(
+            matches!(err, ProviderError::Connection(_)),
+            "503 should surface as Connection, got {err:?}"
+        );
+        assert!(
+            err.is_retryable(),
+            "503 errors must be retryable (gateway re-queues)"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_502_maps_to_retryable_connection() {
+        let server = MockOpsGenieServer::start().await;
+        let config = OpsGenieConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = OpsGenieProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "create",
+            "message": "test",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(502, r#"{"message":"Bad Gateway"}"#)
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::Connection(_)));
+        assert!(err.is_retryable());
     }
 
     #[tokio::test]

--- a/crates/integrations/opsgenie/src/provider.rs
+++ b/crates/integrations/opsgenie/src/provider.rs
@@ -1,0 +1,660 @@
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::{Provider, ProviderError, truncate_error_body};
+use reqwest::Client;
+use serde::Deserialize;
+use tracing::{debug, instrument, warn};
+
+use crate::config::OpsGenieConfig;
+use crate::error::OpsGenieError;
+use crate::types::{
+    OpsGenieAlertRequest, OpsGenieApiResponse, OpsGenieLifecycleRequest, OpsGenieResponder,
+};
+
+/// Maximum length accepted by the `OpsGenie` Alert API for the `message`
+/// field. Longer values are truncated client-side so the API call does
+/// not fail on what is typically a cosmetic concern.
+const MAX_MESSAGE_LEN: usize = 130;
+
+/// `OpsGenie` provider that creates, acknowledges, and closes alerts
+/// via the Alert API v2.
+pub struct OpsGenieProvider {
+    config: OpsGenieConfig,
+    client: Client,
+}
+
+/// Fields extracted from an action payload. Everything except
+/// `event_action` is optional at the serde level so the provider can
+/// choose which ones are mandatory per `event_action` variant.
+#[derive(Debug, Deserialize)]
+struct EventPayload {
+    event_action: String,
+    #[serde(default)]
+    alias: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    priority: Option<String>,
+    #[serde(default)]
+    entity: Option<String>,
+    #[serde(default)]
+    source: Option<String>,
+    #[serde(default)]
+    tags: Option<Vec<String>>,
+    #[serde(default)]
+    details: Option<serde_json::Value>,
+    #[serde(default)]
+    actions: Option<Vec<String>>,
+    #[serde(default)]
+    responders: Option<Vec<OpsGenieResponder>>,
+    #[serde(default)]
+    visible_to: Option<Vec<OpsGenieResponder>>,
+    #[serde(default)]
+    user: Option<String>,
+    #[serde(default)]
+    note: Option<String>,
+}
+
+impl OpsGenieProvider {
+    /// Create a new `OpsGenie` provider with the given configuration.
+    ///
+    /// Uses a default `reqwest::Client` with a 30-second timeout.
+    pub fn new(config: OpsGenieConfig) -> Self {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("failed to build HTTP client");
+        Self { config, client }
+    }
+
+    /// Create a new `OpsGenie` provider with a custom HTTP client.
+    ///
+    /// Useful for testing or for sharing a connection pool with the
+    /// server's other HTTP integrations.
+    pub fn with_client(config: OpsGenieConfig, client: Client) -> Self {
+        Self { config, client }
+    }
+
+    /// Build the URL for the `POST /v2/alerts` create endpoint.
+    fn create_url(&self) -> String {
+        format!("{}/v2/alerts", self.config.api_base_url())
+    }
+
+    /// Build the URL for the `POST /v2/alerts/{alias}/{action}` endpoint.
+    fn lifecycle_url(&self, alias: &str, action: &str) -> String {
+        // We exclusively use alias-based lookups because the
+        // `identifier` path parameter is interpreted as an alert ID
+        // by default. `identifierType=alias` flips that so the same
+        // alias the dispatcher used to create the alert works for
+        // ack/close too.
+        let alias = Self::percent_encode_path_segment(alias);
+        format!(
+            "{}/v2/alerts/{alias}/{action}?identifierType=alias",
+            self.config.api_base_url()
+        )
+    }
+
+    /// Percent-encode the characters that cannot appear unescaped in a
+    /// URL path segment. Keeps the hot path allocation-free in the
+    /// common case (ASCII alphanumerics, dashes, underscores, dots) and
+    /// only falls back to a `String` when encoding is actually needed.
+    fn percent_encode_path_segment(raw: &str) -> String {
+        use std::fmt::Write as _;
+        fn is_unreserved(b: u8) -> bool {
+            b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~')
+        }
+        let needs_encoding = raw.bytes().any(|b| !is_unreserved(b));
+        if !needs_encoding {
+            return raw.to_owned();
+        }
+        let mut out = String::with_capacity(raw.len() * 3);
+        for b in raw.bytes() {
+            if is_unreserved(b) {
+                out.push(b as char);
+            } else {
+                // write! into a String is infallible.
+                let _ = write!(out, "%{b:02X}");
+            }
+        }
+        out
+    }
+
+    /// POST a JSON body to the given URL, interpret the response, and
+    /// map error statuses onto [`OpsGenieError`].
+    async fn post_json<B: serde::Serialize + ?Sized>(
+        &self,
+        url: &str,
+        body: &B,
+    ) -> Result<OpsGenieApiResponse, OpsGenieError> {
+        debug!(url = %url, "sending request to OpsGenie");
+        let builder = self
+            .client
+            .post(url)
+            .header(
+                "Authorization",
+                format!("GenieKey {}", self.config.api_key()),
+            )
+            .json(body);
+        let request = acteon_provider::inject_trace_context(builder);
+        let response = request.send().await?;
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            warn!("OpsGenie API rate limit hit");
+            return Err(OpsGenieError::RateLimited);
+        }
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            let body = response.text().await.unwrap_or_default();
+            return Err(OpsGenieError::Unauthorized(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            )));
+        }
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(OpsGenieError::Api(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            )));
+        }
+
+        // Non-success response bodies from OpsGenie are JSON but
+        // tolerant parsing is still safer than failing the action if
+        // the server returns an unexpected shape on a 2xx.
+        let api_response: OpsGenieApiResponse = response
+            .json()
+            .await
+            .unwrap_or(OpsGenieApiResponse::default_fallback());
+        Ok(api_response)
+    }
+
+    /// Handle the `event_action = "create"` branch.
+    async fn execute_create(
+        &self,
+        payload: EventPayload,
+    ) -> Result<OpsGenieApiResponse, OpsGenieError> {
+        let message = payload.message.ok_or_else(|| {
+            OpsGenieError::InvalidPayload("create events require a 'message' field".into())
+        })?;
+        let mut message = message;
+        if message.len() > MAX_MESSAGE_LEN {
+            message.truncate(MAX_MESSAGE_LEN);
+        }
+
+        // Default the responder to the configured team when no
+        // responders are provided. A missing default team is fine —
+        // the account's routing rules handle unrouted alerts.
+        let responders = payload.responders.or_else(|| {
+            self.config.default_team.as_ref().map(|team| {
+                vec![OpsGenieResponder {
+                    name: Some(team.clone()),
+                    id: None,
+                    username: None,
+                    kind: "team".into(),
+                }]
+            })
+        });
+
+        let priority = payload
+            .priority
+            .unwrap_or_else(|| self.config.default_priority.clone());
+        let source = payload
+            .source
+            .or_else(|| self.config.default_source.clone());
+
+        let request = OpsGenieAlertRequest {
+            message,
+            alias: payload.alias,
+            description: payload.description,
+            responders,
+            visible_to: payload.visible_to,
+            actions: payload.actions,
+            tags: payload.tags,
+            details: payload.details,
+            entity: payload.entity,
+            source,
+            priority: Some(priority),
+            user: payload.user,
+            note: payload.note,
+        };
+        let url = self.create_url();
+        self.post_json(&url, &request).await
+    }
+
+    /// Handle the `event_action = "acknowledge"` / `"close"` branches.
+    async fn execute_lifecycle(
+        &self,
+        action: &str,
+        payload: EventPayload,
+    ) -> Result<OpsGenieApiResponse, OpsGenieError> {
+        let alias = payload.alias.ok_or_else(|| {
+            OpsGenieError::InvalidPayload(format!(
+                "{action} events require an 'alias' field that matches the alias used at create time"
+            ))
+        })?;
+        let request = OpsGenieLifecycleRequest {
+            source: payload
+                .source
+                .or_else(|| self.config.default_source.clone()),
+            user: payload.user,
+            note: payload.note,
+        };
+        let url = self.lifecycle_url(&alias, action);
+        self.post_json(&url, &request).await
+    }
+}
+
+impl Provider for OpsGenieProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "opsgenie"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "opsgenie"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        let payload: EventPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| OpsGenieError::InvalidPayload(format!("failed to parse payload: {e}")))?;
+
+        let api_response = match payload.event_action.as_str() {
+            "create" => self.execute_create(payload).await?,
+            "acknowledge" => self.execute_lifecycle("acknowledge", payload).await?,
+            "close" => self.execute_lifecycle("close", payload).await?,
+            other => {
+                return Err(OpsGenieError::InvalidPayload(format!(
+                    "invalid event_action '{other}': must be 'create', 'acknowledge', or 'close'"
+                ))
+                .into());
+            }
+        };
+
+        let body = serde_json::json!({
+            "result": api_response.result,
+            "took": api_response.took,
+            "request_id": api_response.request_id,
+        });
+        Ok(ProviderResponse::success(body))
+    }
+
+    #[instrument(skip(self), fields(provider = "opsgenie"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        // OpsGenie does not expose a public ping endpoint, so we reuse
+        // the Alert API base URL the same way the PagerDuty provider
+        // does: any response (including 400/401/403) proves the
+        // endpoint is reachable. Only a connection failure counts as a
+        // hard health-check error.
+        let url = format!("{}/v2/alerts", self.config.api_base_url());
+        debug!("performing OpsGenie health check");
+        let response = self
+            .client
+            .get(&url)
+            .header(
+                "Authorization",
+                format!("GenieKey {}", self.config.api_key()),
+            )
+            .send()
+            .await
+            .map_err(|e| ProviderError::Connection(e.to_string()))?;
+        debug!(status = %response.status(), "OpsGenie health check response");
+        Ok(())
+    }
+}
+
+impl OpsGenieApiResponse {
+    /// Construct a fallback response used when the server returns a
+    /// 2xx with a body we cannot parse. Keeps the action outcome
+    /// shape predictable for downstream consumers.
+    fn default_fallback() -> Self {
+        Self {
+            result: "Request accepted".into(),
+            took: 0.0,
+            request_id: String::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use acteon_core::Action;
+    use acteon_provider::{Provider, ProviderError};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+    use crate::config::{OpsGenieConfig, OpsGenieRegion};
+
+    /// Tiny mock HTTP server for integration-style tests. Same
+    /// pattern the `PagerDuty` provider uses — a single-accept TCP
+    /// listener that returns a canned response and captures the
+    /// request body so the test can assert on it.
+    struct MockOpsGenieServer {
+        listener: tokio::net::TcpListener,
+        base_url: String,
+    }
+
+    impl MockOpsGenieServer {
+        async fn start() -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("failed to bind mock server");
+            let port = listener.local_addr().unwrap().port();
+            let base_url = format!("http://127.0.0.1:{port}");
+            Self { listener, base_url }
+        }
+
+        async fn respond_once(self, status_code: u16, body: &str) {
+            let body = body.to_owned();
+            let (mut stream, _) = self.listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 16384];
+            let _ = stream.read(&mut buf).await.unwrap();
+            let response = format!(
+                "HTTP/1.1 {status_code} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+        }
+
+        async fn respond_once_capturing(self, status_code: u16, body: &str) -> String {
+            let body = body.to_owned();
+            let (mut stream, _) = self.listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 16384];
+            let n = stream.read(&mut buf).await.unwrap();
+            let raw = String::from_utf8_lossy(&buf[..n]).to_string();
+            let request = raw.clone();
+            let response = format!(
+                "HTTP/1.1 {status_code} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+            request
+        }
+    }
+
+    fn make_action(payload: serde_json::Value) -> Action {
+        Action::new("incidents", "tenant-1", "opsgenie", "send_alert", payload)
+    }
+
+    #[test]
+    fn provider_name() {
+        let provider = OpsGenieProvider::new(OpsGenieConfig::new("test-key"));
+        assert_eq!(provider.name(), "opsgenie");
+    }
+
+    #[test]
+    fn percent_encode_path_segment_passthrough() {
+        assert_eq!(
+            OpsGenieProvider::percent_encode_path_segment("web-01_high.cpu"),
+            "web-01_high.cpu"
+        );
+    }
+
+    #[test]
+    fn percent_encode_path_segment_escapes_reserved() {
+        // Slash, colon, and space are reserved in path segments.
+        assert_eq!(
+            OpsGenieProvider::percent_encode_path_segment("a/b c:d"),
+            "a%2Fb%20c%3Ad"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_create_success() {
+        let server = MockOpsGenieServer::start().await;
+        let config = OpsGenieConfig::new("test-key")
+            .with_region(OpsGenieRegion::Us)
+            .with_api_base_url(&server.base_url);
+        let provider = OpsGenieProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "create",
+            "message": "High CPU on web-01",
+            "alias": "web-01-high-cpu",
+            "priority": "P2",
+            "tags": ["cpu", "critical"],
+        }));
+        let response_body =
+            r#"{"result":"Request will be processed","took":0.123,"requestId":"req-abc"}"#;
+        let server_handle =
+            tokio::spawn(async move { server.respond_once_capturing(202, response_body).await });
+
+        let result = provider.execute(&action).await;
+        let request = server_handle.await.unwrap();
+        let response = result.expect("execute should succeed");
+        assert_eq!(response.status, acteon_core::ResponseStatus::Success);
+        assert_eq!(response.body["result"], "Request will be processed");
+        assert_eq!(response.body["request_id"], "req-abc");
+
+        // The dispatched request should hit POST /v2/alerts with the
+        // `Authorization: GenieKey ...` header and a JSON body that
+        // contains the payload fields.
+        assert!(request.contains("POST /v2/alerts"));
+        assert!(request.contains("authorization: GenieKey test-key"));
+        assert!(request.contains("\"message\":\"High CPU on web-01\""));
+        assert!(request.contains("\"alias\":\"web-01-high-cpu\""));
+        assert!(request.contains("\"priority\":\"P2\""));
+    }
+
+    #[tokio::test]
+    async fn execute_create_uses_default_team_and_priority() {
+        let server = MockOpsGenieServer::start().await;
+        let config = OpsGenieConfig::new("test-key")
+            .with_api_base_url(&server.base_url)
+            .with_default_team("platform-oncall")
+            .with_default_priority("P1")
+            .with_default_source("acteon");
+        let provider = OpsGenieProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "create",
+            "message": "Latency spike",
+        }));
+        let response_body = r#"{"result":"ok","took":0.01,"requestId":"r1"}"#;
+        let server_handle =
+            tokio::spawn(async move { server.respond_once_capturing(202, response_body).await });
+
+        let result = provider.execute(&action).await;
+        let request = server_handle.await.unwrap();
+        assert!(result.is_ok());
+        // Default team materialized into the responders list.
+        assert!(
+            request.contains("\"responders\":[{\"name\":\"platform-oncall\",\"type\":\"team\"}]"),
+            "defaults should produce a team responder: {request}"
+        );
+        // Default priority used when payload omits it.
+        assert!(request.contains("\"priority\":\"P1\""));
+        // Default source materialized into the body.
+        assert!(request.contains("\"source\":\"acteon\""));
+    }
+
+    #[tokio::test]
+    async fn execute_create_truncates_long_message() {
+        let server = MockOpsGenieServer::start().await;
+        let config = OpsGenieConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = OpsGenieProvider::new(config);
+        let long = "x".repeat(200);
+        let action = make_action(serde_json::json!({
+            "event_action": "create",
+            "message": long,
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(202, r#"{"result":"ok","took":0.0,"requestId":""}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        // Body should contain exactly MAX_MESSAGE_LEN x's.
+        let marker = format!("\"message\":\"{}\"", "x".repeat(MAX_MESSAGE_LEN));
+        assert!(
+            request.contains(&marker),
+            "message should be truncated to {MAX_MESSAGE_LEN}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_create_missing_message() {
+        let config = OpsGenieConfig::new("k").with_api_base_url("http://127.0.0.1:1");
+        let provider = OpsGenieProvider::new(config);
+        let action = make_action(serde_json::json!({ "event_action": "create" }));
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_acknowledge_success() {
+        let server = MockOpsGenieServer::start().await;
+        let config = OpsGenieConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = OpsGenieProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "acknowledge",
+            "alias": "web-01-high-cpu",
+            "note": "picked up by oncall",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(
+                    202,
+                    r#"{"result":"Request will be processed","took":0.01,"requestId":"r2"}"#,
+                )
+                .await
+        });
+        let result = provider.execute(&action).await;
+        let request = server_handle.await.unwrap();
+        assert!(result.is_ok());
+        assert!(
+            request.contains("POST /v2/alerts/web-01-high-cpu/acknowledge?identifierType=alias"),
+            "expected alias-based ack URL: {request}"
+        );
+        assert!(request.contains("\"note\":\"picked up by oncall\""));
+    }
+
+    #[tokio::test]
+    async fn execute_close_success() {
+        let server = MockOpsGenieServer::start().await;
+        let config = OpsGenieConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = OpsGenieProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "close",
+            "alias": "db-backup-failed",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(
+                    202,
+                    r#"{"result":"Request will be processed","took":0.01,"requestId":"r3"}"#,
+                )
+                .await
+        });
+        let result = provider.execute(&action).await;
+        let request = server_handle.await.unwrap();
+        assert!(result.is_ok());
+        assert!(
+            request.contains("POST /v2/alerts/db-backup-failed/close?identifierType=alias"),
+            "expected alias-based close URL: {request}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_acknowledge_missing_alias() {
+        let config = OpsGenieConfig::new("k").with_api_base_url("http://127.0.0.1:1");
+        let provider = OpsGenieProvider::new(config);
+        let action = make_action(serde_json::json!({ "event_action": "acknowledge" }));
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_invalid_event_action() {
+        let config = OpsGenieConfig::new("k").with_api_base_url("http://127.0.0.1:1");
+        let provider = OpsGenieProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "snooze",
+            "alias": "x",
+        }));
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+    }
+
+    #[tokio::test]
+    async fn execute_rate_limited() {
+        let server = MockOpsGenieServer::start().await;
+        let config = OpsGenieConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = OpsGenieProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "create",
+            "message": "test",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(429, r#"{"message":"Too Many Requests"}"#)
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::RateLimited));
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_unauthorized_maps_to_configuration() {
+        let server = MockOpsGenieServer::start().await;
+        let config = OpsGenieConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = OpsGenieProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "create",
+            "message": "test",
+        }));
+        let server_handle =
+            tokio::spawn(async move { server.respond_once(401, r#"{"message":"unauth"}"#).await });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(
+            matches!(err, ProviderError::Configuration(_)),
+            "401 should surface as Configuration, got {err:?}"
+        );
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_api_error_non_retryable() {
+        let server = MockOpsGenieServer::start().await;
+        let config = OpsGenieConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = OpsGenieProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "create",
+            "message": "test",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(400, r#"{"message":"Request body is invalid"}"#)
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn health_check_reachable_endpoint() {
+        let server = MockOpsGenieServer::start().await;
+        let config = OpsGenieConfig::new("test-key").with_api_base_url(&server.base_url);
+        let provider = OpsGenieProvider::new(config);
+        // Even a 400/401 means the endpoint is reachable.
+        let server_handle =
+            tokio::spawn(async move { server.respond_once(401, r#"{"message":"no"}"#).await });
+        let result = provider.health_check().await;
+        server_handle.await.unwrap();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn health_check_connection_failure() {
+        let config = OpsGenieConfig::new("test-key").with_api_base_url("http://127.0.0.1:1");
+        let provider = OpsGenieProvider::new(config);
+        let err = provider.health_check().await.unwrap_err();
+        assert!(matches!(err, ProviderError::Connection(_)));
+        assert!(err.is_retryable());
+    }
+}

--- a/crates/integrations/opsgenie/src/types.rs
+++ b/crates/integrations/opsgenie/src/types.rs
@@ -1,0 +1,221 @@
+use serde::{Deserialize, Serialize};
+
+/// A responder (team, user, schedule, or escalation) that should
+/// receive the alert.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpsGenieResponder {
+    /// Responder name (for `team` / `user` / `schedule` / `escalation`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Responder UUID (alternative to `name`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Responder user name (alternative to `name` / `id` for user responders).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    /// Responder type: `"team"`, `"user"`, `"schedule"`, or `"escalation"`.
+    #[serde(rename = "type")]
+    pub kind: String,
+}
+
+/// Request body for the Alert API v2 `POST /v2/alerts` endpoint.
+///
+/// Only the `message` field is actually required by the API. Everything
+/// else is optional so operators can start with the minimum and layer in
+/// tags/responders/details as their runbook evolves.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpsGenieAlertRequest {
+    /// Short alert message (max 130 characters per the API).
+    pub message: String,
+    /// Client-side deduplication alias. Alerts sharing an alias
+    /// collapse into a single incident so `trigger`/`ack`/`close`
+    /// event sequences map onto the same incident lifecycle.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+    /// Long-form alert description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Responders that should receive the alert.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub responders: Option<Vec<OpsGenieResponder>>,
+    /// Visibility list (teams or users allowed to see the alert).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub visible_to: Option<Vec<OpsGenieResponder>>,
+    /// Pre-defined actions that can be executed against the alert.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actions: Option<Vec<String>>,
+    /// Free-form tags used for downstream routing / grouping.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    /// Arbitrary key-value details (shown in the alert UI).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+    /// Domain entity the alert is about (e.g. `"web-01"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entity: Option<String>,
+    /// Source label shown on the alert (e.g. `"prometheus"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Alert priority (`P1`..=`P5`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<String>,
+    /// Username to attribute the alert to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    /// Operator note attached to the alert.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+/// Request body for the `acknowledge` and `close` lifecycle endpoints.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct OpsGenieLifecycleRequest {
+    /// Source label (e.g. `"acteon"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Username performing the action.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    /// Operator note.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+/// Response body returned by the Alert API v2 endpoints.
+///
+/// `OpsGenie` alert creation is asynchronous: the server enqueues the
+/// request and returns 202 with a `requestId` that can be used to
+/// query the final state via the request-status endpoint. For our
+/// fire-and-forget semantics we treat 202 as success and surface the
+/// `request_id` in the action outcome body so operators can correlate
+/// it with the alert that eventually appears in the `OpsGenie` UI.
+///
+/// Deserialization uses camelCase because `OpsGenie`'s API (and most
+/// of its SDKs) serialize fields that way.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpsGenieApiResponse {
+    /// Human-readable status string (e.g. `"Request will be processed"`).
+    #[serde(default)]
+    pub result: String,
+    /// Duration the server took to handle the request, in seconds.
+    #[serde(default)]
+    pub took: f64,
+    /// Request ID used to poll the request-status endpoint.
+    #[serde(default)]
+    pub request_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alert_request_serializes_with_minimum_fields() {
+        let req = OpsGenieAlertRequest {
+            message: "High CPU".into(),
+            alias: None,
+            description: None,
+            responders: None,
+            visible_to: None,
+            actions: None,
+            tags: None,
+            details: None,
+            entity: None,
+            source: None,
+            priority: None,
+            user: None,
+            note: None,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["message"], "High CPU");
+        assert!(json.get("alias").is_none());
+        assert!(json.get("description").is_none());
+        assert!(json.get("responders").is_none());
+    }
+
+    #[test]
+    fn alert_request_serializes_full() {
+        let req = OpsGenieAlertRequest {
+            message: "Alert".into(),
+            alias: Some("web-01-high-cpu".into()),
+            description: Some("detailed".into()),
+            responders: Some(vec![OpsGenieResponder {
+                name: Some("ops-team".into()),
+                id: None,
+                username: None,
+                kind: "team".into(),
+            }]),
+            visible_to: None,
+            actions: Some(vec!["ping".into(), "reboot".into()]),
+            tags: Some(vec!["critical".into(), "cpu".into()]),
+            details: Some(serde_json::json!({"region": "us-east-1"})),
+            entity: Some("web-01".into()),
+            source: Some("acteon".into()),
+            priority: Some("P1".into()),
+            user: Some("acteon".into()),
+            note: None,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["alias"], "web-01-high-cpu");
+        assert_eq!(json["priority"], "P1");
+        assert_eq!(json["tags"][0], "critical");
+        assert_eq!(json["responders"][0]["name"], "ops-team");
+        assert_eq!(json["responders"][0]["type"], "team");
+        assert_eq!(json["details"]["region"], "us-east-1");
+        assert!(json.get("note").is_none(), "note omitted when None");
+    }
+
+    #[test]
+    fn responder_serializes_kind_as_type() {
+        let responder = OpsGenieResponder {
+            name: Some("alice".into()),
+            id: None,
+            username: None,
+            kind: "user".into(),
+        };
+        let json = serde_json::to_value(&responder).unwrap();
+        assert_eq!(json["type"], "user");
+        assert!(json.get("kind").is_none());
+    }
+
+    #[test]
+    fn lifecycle_request_serializes_empty() {
+        let req = OpsGenieLifecycleRequest::default();
+        let json = serde_json::to_value(&req).unwrap();
+        assert!(
+            json.as_object().unwrap().is_empty(),
+            "default lifecycle request serializes to {{}}"
+        );
+    }
+
+    #[test]
+    fn lifecycle_request_serializes_with_note() {
+        let req = OpsGenieLifecycleRequest {
+            source: Some("acteon".into()),
+            user: Some("runbook".into()),
+            note: Some("auto-acknowledged by scheduled workflow".into()),
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["source"], "acteon");
+        assert_eq!(json["user"], "runbook");
+        assert_eq!(json["note"], "auto-acknowledged by scheduled workflow");
+    }
+
+    #[test]
+    fn api_response_deserializes() {
+        let json = r#"{"result":"Request will be processed","took":0.302,"requestId":"abc-123"}"#;
+        let resp: OpsGenieApiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.result, "Request will be processed");
+        assert!((resp.took - 0.302).abs() < 1e-6);
+        assert_eq!(resp.request_id, "abc-123");
+    }
+
+    #[test]
+    fn api_response_tolerates_missing_fields() {
+        // OpsGenie sometimes returns a sparser body for error/edge cases.
+        let resp: OpsGenieApiResponse = serde_json::from_str("{}").unwrap();
+        assert_eq!(resp.result, "");
+        assert_eq!(resp.request_id, "");
+    }
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -64,6 +64,7 @@ acteon-gcp = { workspace = true, optional = true }
 acteon-twilio = { workspace = true }
 acteon-teams = { workspace = true }
 acteon-discord = { workspace = true }
+acteon-opsgenie = { workspace = true }
 acteon-executor = { workspace = true }
 acteon-gateway = { workspace = true }
 acteon-llm = { workspace = true }

--- a/crates/server/src/config/providers.rs
+++ b/crates/server/src/config/providers.rs
@@ -21,8 +21,8 @@ pub struct ProviderConfig {
     /// Unique name for this provider.
     pub name: String,
     /// Provider type: `"webhook"`, `"log"`, `"twilio"`, `"teams"`, `"discord"`,
-    /// `"email"`, `"aws-sns"`, `"aws-lambda"`, `"aws-eventbridge"`, `"aws-sqs"`,
-    /// `"aws-s3"`, `"aws-ec2"`, `"aws-autoscaling"`, `"azure-blob"`,
+    /// `"email"`, `"opsgenie"`, `"aws-sns"`, `"aws-lambda"`, `"aws-eventbridge"`,
+    /// `"aws-sqs"`, `"aws-s3"`, `"aws-ec2"`, `"aws-autoscaling"`, `"azure-blob"`,
     /// `"azure-eventhubs"`, `"gcp-pubsub"`, or `"gcp-storage"`.
     #[serde(rename = "type")]
     pub provider_type: String,
@@ -139,4 +139,18 @@ pub struct ProviderConfig {
     pub gcp_bucket: Option<String>,
     /// Cloud Storage object name prefix (used by `"gcp-storage"` type).
     pub gcp_object_prefix: Option<String>,
+
+    // ---- OpsGenie provider fields ----
+    /// OpsGenie API integration key (used by `"opsgenie"` type). Supports `ENC[...]`.
+    pub opsgenie_api_key: Option<String>,
+    /// OpsGenie region: `"us"` (default) or `"eu"` (used by `"opsgenie"` type).
+    pub opsgenie_region: Option<String>,
+    /// Default team responder used when a payload omits one (used by `"opsgenie"` type).
+    pub opsgenie_default_team: Option<String>,
+    /// Default alert priority (`P1`..=`P5`, used by `"opsgenie"` type).
+    pub opsgenie_default_priority: Option<String>,
+    /// Default alert source label (used by `"opsgenie"` type).
+    pub opsgenie_default_source: Option<String>,
+    /// Override base URL for the OpsGenie API (testing only).
+    pub opsgenie_api_base_url: Option<String>,
 }

--- a/crates/server/src/config/providers.rs
+++ b/crates/server/src/config/providers.rs
@@ -140,17 +140,58 @@ pub struct ProviderConfig {
     /// Cloud Storage object name prefix (used by `"gcp-storage"` type).
     pub gcp_object_prefix: Option<String>,
 
-    // ---- OpsGenie provider fields ----
-    /// OpsGenie API integration key (used by `"opsgenie"` type). Supports `ENC[...]`.
-    pub opsgenie_api_key: Option<String>,
-    /// OpsGenie region: `"us"` (default) or `"eu"` (used by `"opsgenie"` type).
-    pub opsgenie_region: Option<String>,
-    /// Default team responder used when a payload omits one (used by `"opsgenie"` type).
-    pub opsgenie_default_team: Option<String>,
-    /// Default alert priority (`P1`..=`P5`, used by `"opsgenie"` type).
-    pub opsgenie_default_priority: Option<String>,
-    /// Default alert source label (used by `"opsgenie"` type).
-    pub opsgenie_default_source: Option<String>,
-    /// Override base URL for the OpsGenie API (testing only).
-    pub opsgenie_api_base_url: Option<String>,
+    // ---- Nested per-provider config sub-structs ----
+    //
+    // New providers should put their settings inside a nested
+    // struct rather than adding more flat `foo_*` fields at the
+    // top level — the top-level field count is already a
+    // maintenance burden and will not scale to 30+ providers.
+    // Existing flat provider fields are left in place so this
+    // refactor does not break existing TOML configs; a follow-up
+    // PR can migrate them.
+    /// Nested configuration block for the `"opsgenie"` provider type.
+    ///
+    /// Example TOML:
+    /// ```toml
+    /// [[providers]]
+    /// name = "opsgenie-prod"
+    /// type = "opsgenie"
+    /// opsgenie.api_key = "ENC[...]"
+    /// opsgenie.region = "us"
+    /// opsgenie.default_team = "platform-oncall"
+    /// ```
+    #[serde(default)]
+    pub opsgenie: OpsGenieProviderConfig,
+}
+
+/// Nested configuration block for the `OpsGenie` provider.
+///
+/// All fields are optional at the TOML layer. The provider's own
+/// validation (in `main.rs`) rejects configurations that omit
+/// required fields like `api_key`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct OpsGenieProviderConfig {
+    /// `OpsGenie` API integration key. Supports `ENC[...]`.
+    pub api_key: Option<String>,
+    /// `OpsGenie` region: `"us"` (default) or `"eu"`.
+    pub region: Option<String>,
+    /// Default team responder used when a payload omits one.
+    pub default_team: Option<String>,
+    /// Default alert priority (`P1`..=`P5`).
+    pub default_priority: Option<String>,
+    /// Default alert source label.
+    pub default_source: Option<String>,
+    /// Override base URL for the `OpsGenie` API (testing only).
+    pub api_base_url: Option<String>,
+    /// Whether to automatically prefix user-supplied aliases with
+    /// `{namespace}:{tenant}:` before sending them to `OpsGenie`.
+    /// Defaults to `true` — leave it on unless each Acteon
+    /// namespace/tenant has its own dedicated `OpsGenie` integration
+    /// key.
+    pub scope_aliases: Option<bool>,
+    /// Maximum length (in bytes) for the `message` field before
+    /// client-side truncation. Defaults to 130 (the current
+    /// `OpsGenie` API cap).
+    pub message_max_length: Option<usize>,
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -713,20 +713,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ))
             }
             "opsgenie" => {
-                let api_key_raw = provider_cfg.opsgenie_api_key.as_deref().ok_or_else(|| {
+                let og = &provider_cfg.opsgenie;
+                let api_key_raw = og.api_key.as_deref().ok_or_else(|| {
                     format!(
-                        "provider '{}': opsgenie type requires an 'opsgenie_api_key' field",
+                        "provider '{}': opsgenie type requires an 'opsgenie.api_key' field",
                         provider_cfg.name
                     )
                 })?;
                 let api_key = require_decrypt(api_key_raw, master_key.as_ref())?;
                 let mut opsgenie_config = acteon_opsgenie::OpsGenieConfig::new(api_key);
-                match provider_cfg
-                    .opsgenie_region
-                    .as_deref()
-                    .map(str::to_ascii_lowercase)
-                    .as_deref()
-                {
+                match og.region.as_deref().map(str::to_ascii_lowercase).as_deref() {
                     Some("eu") => {
                         opsgenie_config =
                             opsgenie_config.with_region(acteon_opsgenie::OpsGenieRegion::Eu);
@@ -737,24 +733,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                     Some(other) => {
                         return Err(format!(
-                            "provider '{}': unknown opsgenie_region '{other}' (expected 'us' or 'eu')",
+                            "provider '{}': unknown opsgenie.region '{other}' (expected 'us' or 'eu')",
                             provider_cfg.name
                         )
                         .into());
                     }
                 }
-                if let Some(ref team) = provider_cfg.opsgenie_default_team {
+                if let Some(ref team) = og.default_team {
                     opsgenie_config = opsgenie_config.with_default_team(team);
                 }
-                if let Some(ref priority) = provider_cfg.opsgenie_default_priority {
+                if let Some(ref priority) = og.default_priority {
                     opsgenie_config = opsgenie_config.with_default_priority(priority);
                 }
-                if let Some(ref source) = provider_cfg.opsgenie_default_source {
+                if let Some(ref source) = og.default_source {
                     opsgenie_config = opsgenie_config.with_default_source(source);
                 }
-                if let Some(ref url) = provider_cfg.opsgenie_api_base_url {
+                if let Some(ref url) = og.api_base_url {
                     validate_provider_url(&provider_cfg.name, url)?;
                     opsgenie_config = opsgenie_config.with_api_base_url(url);
+                }
+                if let Some(scope_aliases) = og.scope_aliases {
+                    opsgenie_config = opsgenie_config.with_scope_aliases(scope_aliases);
+                }
+                if let Some(max_len) = og.message_max_length {
+                    opsgenie_config = opsgenie_config.with_message_max_length(max_len);
                 }
                 std::sync::Arc::new(acteon_opsgenie::OpsGenieProvider::with_client(
                     opsgenie_config,

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -712,6 +712,55 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     shared_http_client.clone(),
                 ))
             }
+            "opsgenie" => {
+                let api_key_raw = provider_cfg.opsgenie_api_key.as_deref().ok_or_else(|| {
+                    format!(
+                        "provider '{}': opsgenie type requires an 'opsgenie_api_key' field",
+                        provider_cfg.name
+                    )
+                })?;
+                let api_key = require_decrypt(api_key_raw, master_key.as_ref())?;
+                let mut opsgenie_config = acteon_opsgenie::OpsGenieConfig::new(api_key);
+                match provider_cfg
+                    .opsgenie_region
+                    .as_deref()
+                    .map(str::to_ascii_lowercase)
+                    .as_deref()
+                {
+                    Some("eu") => {
+                        opsgenie_config =
+                            opsgenie_config.with_region(acteon_opsgenie::OpsGenieRegion::Eu);
+                    }
+                    Some("us") | None => {
+                        opsgenie_config =
+                            opsgenie_config.with_region(acteon_opsgenie::OpsGenieRegion::Us);
+                    }
+                    Some(other) => {
+                        return Err(format!(
+                            "provider '{}': unknown opsgenie_region '{other}' (expected 'us' or 'eu')",
+                            provider_cfg.name
+                        )
+                        .into());
+                    }
+                }
+                if let Some(ref team) = provider_cfg.opsgenie_default_team {
+                    opsgenie_config = opsgenie_config.with_default_team(team);
+                }
+                if let Some(ref priority) = provider_cfg.opsgenie_default_priority {
+                    opsgenie_config = opsgenie_config.with_default_priority(priority);
+                }
+                if let Some(ref source) = provider_cfg.opsgenie_default_source {
+                    opsgenie_config = opsgenie_config.with_default_source(source);
+                }
+                if let Some(ref url) = provider_cfg.opsgenie_api_base_url {
+                    validate_provider_url(&provider_cfg.name, url)?;
+                    opsgenie_config = opsgenie_config.with_api_base_url(url);
+                }
+                std::sync::Arc::new(acteon_opsgenie::OpsGenieProvider::with_client(
+                    opsgenie_config,
+                    shared_http_client.clone(),
+                ))
+            }
             "email" => {
                 let from_address = provider_cfg.from_address.as_deref().ok_or_else(|| {
                     format!(

--- a/crates/simulation/examples/opsgenie_simulation.rs
+++ b/crates/simulation/examples/opsgenie_simulation.rs
@@ -1,0 +1,190 @@
+//! OpsGenie provider simulation scenarios.
+//!
+//! Demonstrates dispatching alerts to the OpsGenie provider through
+//! the standard create → acknowledge → close lifecycle, and shows a
+//! rule-based reroute pattern for steering high-priority alerts to
+//! the OpsGenie integration.
+//!
+//! These scenarios use the simulation harness' recording provider
+//! named `"opsgenie"`, so no real OpsGenie API credentials are
+//! needed — the harness captures the dispatched actions and asserts
+//! that they landed on the right provider with the right payload.
+//!
+//! Run with: `cargo run -p acteon-simulation --example opsgenie_simulation`
+
+use acteon_core::Action;
+use acteon_simulation::prelude::*;
+use tracing::info;
+
+const REROUTE_TO_OPSGENIE_RULE: &str = r#"
+rules:
+  - name: reroute-p1-to-opsgenie
+    priority: 1
+    condition:
+      field: action.payload.priority
+      eq: "P1"
+    action:
+      type: reroute
+      target_provider: opsgenie
+"#;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    info!("╔══════════════════════════════════════════════════════════════╗");
+    info!("║          OPSGENIE PROVIDER SIMULATION DEMO                  ║");
+    info!("╚══════════════════════════════════════════════════════════════╝\n");
+
+    // =========================================================================
+    // DEMO 1: Alert lifecycle (create → acknowledge → close)
+    // =========================================================================
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    info!("  DEMO 1: ALERT LIFECYCLE (create → acknowledge → close)");
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("opsgenie")
+            .build(),
+    )
+    .await?;
+    info!("✓ Started simulation cluster with 1 node");
+    info!("✓ Registered 'opsgenie' recording provider\n");
+
+    // 1. CREATE — a Prometheus-style alert fires and Acteon dispatches
+    //    it to OpsGenie via the native provider type.
+    let create = Action::new(
+        "incidents",
+        "tenant-1",
+        "opsgenie",
+        "send_alert",
+        serde_json::json!({
+            "event_action": "create",
+            "message": "High error rate on checkout-api",
+            "alias": "checkout-api-5xx",
+            "description": "5xx rate has crossed the SLO threshold for 5 minutes.",
+            "priority": "P2",
+            "tags": ["checkout", "5xx", "slo-breach"],
+            "responders": [
+                {"name": "checkout-oncall", "type": "team"}
+            ],
+            "details": {
+                "runbook": "https://wiki.example.com/runbook/checkout-5xx",
+                "service": "checkout-api",
+                "env": "production"
+            },
+            "source": "prometheus"
+        }),
+    );
+    info!("→ Dispatching CREATE alert (alias=checkout-api-5xx, priority=P2)...");
+    let outcome = harness.dispatch(&create).await?;
+    info!("  Outcome: {outcome:?}");
+
+    // 2. ACKNOWLEDGE — the on-call engineer picks up the alert.
+    let ack = Action::new(
+        "incidents",
+        "tenant-1",
+        "opsgenie",
+        "send_alert",
+        serde_json::json!({
+            "event_action": "acknowledge",
+            "alias": "checkout-api-5xx",
+            "user": "oncall-alice",
+            "note": "Investigating — rolled back deploy #4823"
+        }),
+    );
+    info!("→ Dispatching ACKNOWLEDGE (oncall picked up)...");
+    let outcome = harness.dispatch(&ack).await?;
+    info!("  Outcome: {outcome:?}");
+
+    // 3. CLOSE — the underlying issue is resolved.
+    let close = Action::new(
+        "incidents",
+        "tenant-1",
+        "opsgenie",
+        "send_alert",
+        serde_json::json!({
+            "event_action": "close",
+            "alias": "checkout-api-5xx",
+            "user": "oncall-alice",
+            "note": "Rollback confirmed; 5xx rate back below threshold."
+        }),
+    );
+    info!("→ Dispatching CLOSE (incident resolved)...");
+    let outcome = harness.dispatch(&close).await?;
+    info!("  Outcome: {outcome:?}");
+
+    let provider = harness.provider("opsgenie").unwrap();
+    info!(
+        "\n  OpsGenie provider received {} action(s) across the lifecycle",
+        provider.call_count()
+    );
+    assert_eq!(provider.call_count(), 3);
+    harness.teardown().await?;
+    info!("✓ Simulation cluster shut down\n");
+
+    // =========================================================================
+    // DEMO 2: Rule-based reroute of P1 alerts to OpsGenie
+    // =========================================================================
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    info!("  DEMO 2: RULE-BASED REROUTE — P1 alerts land on OpsGenie");
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("log")
+            .add_recording_provider("opsgenie")
+            .add_rule_yaml(REROUTE_TO_OPSGENIE_RULE)
+            .build(),
+    )
+    .await?;
+    info!("✓ Started cluster with log + opsgenie recording providers");
+    info!("✓ Loaded reroute rule: P1 priority → opsgenie\n");
+
+    // Non-P1 alert — stays on the log provider.
+    let p3 = Action::new(
+        "incidents",
+        "tenant-1",
+        "log",
+        "notify",
+        serde_json::json!({
+            "message": "Queue depth above warning threshold",
+            "priority": "P3",
+        }),
+    );
+    info!("→ Dispatching P3 alert (should stay on 'log')...");
+    let outcome = harness.dispatch(&p3).await?;
+    info!("  Outcome: {outcome:?}");
+
+    // P1 alert — the rule reroutes it to opsgenie.
+    let p1 = Action::new(
+        "incidents",
+        "tenant-1",
+        "log",
+        "notify",
+        serde_json::json!({
+            "event_action": "create",
+            "message": "Checkout-api is down",
+            "alias": "checkout-api-down",
+            "priority": "P1",
+        }),
+    );
+    info!("→ Dispatching P1 alert (should reroute to 'opsgenie')...");
+    let outcome = harness.dispatch(&p1).await?;
+    info!("  Outcome: {outcome:?}");
+
+    let log_calls = harness.provider("log").unwrap().call_count();
+    let opsgenie_calls = harness.provider("opsgenie").unwrap().call_count();
+    info!("\n  Provider call counts:");
+    info!("    log:      {log_calls}");
+    info!("    opsgenie: {opsgenie_calls}");
+    assert_eq!(log_calls, 1, "P3 should have stayed on log");
+    assert_eq!(opsgenie_calls, 1, "P1 should have been rerouted");
+
+    harness.teardown().await?;
+    info!("\n✓ All demos complete.");
+    Ok(())
+}

--- a/docs/book/features/opsgenie.md
+++ b/docs/book/features/opsgenie.md
@@ -1,0 +1,164 @@
+# OpsGenie Provider
+
+Acteon ships with a first-class **OpsGenie** provider that creates, acknowledges, and closes alerts through the [OpsGenie Alert API v2](https://docs.opsgenie.com/docs/alert-api). It was built as part of the Alertmanager feature-parity initiative so ops teams migrating off Alertmanager can keep their existing OpsGenie runbooks — incident aliases, responder routing, priorities, and tags — without rewriting them.
+
+Like Acteon's other native providers, `acteon-opsgenie`:
+
+- Supports both US (`api.opsgenie.com`) and EU (`api.eu.opsgenie.com`) data residency regions.
+- Accepts `ENC[...]` encrypted API keys in TOML configuration.
+- Propagates W3C Trace Context (`traceparent`/`tracestate`) headers to downstream API calls.
+- Maps HTTP 429 → retryable `RateLimited`; 401/403 → non-retryable `Configuration`.
+- Uses the server's shared HTTP client, so it participates in circuit breaking, provider health checks, and per-provider metrics out of the box.
+
+## TOML configuration
+
+```toml
+[[providers]]
+name = "opsgenie-prod"
+type = "opsgenie"
+opsgenie_api_key = "ENC[AES256_GCM,data:abc123...]"
+opsgenie_region = "us"                 # or "eu"
+opsgenie_default_team = "platform-oncall"
+opsgenie_default_priority = "P3"
+opsgenie_default_source = "acteon"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used when dispatching actions |
+| `type` | Yes | Must be `"opsgenie"` |
+| `opsgenie_api_key` | Yes | Integration API key (the value that becomes `Authorization: GenieKey {key}`). Supports `ENC[...]` for encrypted storage. |
+| `opsgenie_region` | No | `"us"` (default) or `"eu"`. Accounts are pinned to one region at provisioning; picking the wrong one produces 401/403. |
+| `opsgenie_default_team` | No | Team responder used when a payload omits `responders`. |
+| `opsgenie_default_priority` | No | Default alert priority (`P1`..=`P5`). Falls back to `P3`. |
+| `opsgenie_default_source` | No | Default `source` label shown on the alert UI. |
+| `opsgenie_api_base_url` | No | Override the API base URL. Tests only — do not set in production. |
+
+## Payload shape
+
+Dispatch actions target the provider by name and carry an `event_action` in the payload that tells the provider which Alert API endpoint to hit:
+
+| `event_action` | Endpoint | Required fields |
+|---|---|---|
+| `"create"` | `POST /v2/alerts` | `message` |
+| `"acknowledge"` | `POST /v2/alerts/{alias}/acknowledge?identifierType=alias` | `alias` |
+| `"close"` | `POST /v2/alerts/{alias}/close?identifierType=alias` | `alias` |
+
+### Create
+
+```json
+{
+  "event_action": "create",
+  "message": "High error rate on checkout-api",
+  "alias": "checkout-api-5xx",
+  "description": "5xx rate crossed SLO threshold for 5 minutes.",
+  "priority": "P2",
+  "tags": ["checkout", "5xx", "slo-breach"],
+  "responders": [
+    { "name": "checkout-oncall", "type": "team" }
+  ],
+  "details": {
+    "runbook": "https://wiki.example.com/runbook/checkout-5xx",
+    "service": "checkout-api",
+    "env": "production"
+  },
+  "source": "prometheus"
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `message` | string | **Required.** Short alert title. Truncated client-side to 130 characters (the API's max). |
+| `alias` | string | Client-side deduplication key. Later `acknowledge`/`close` events use the same alias to target the same incident. |
+| `description` | string | Long-form description shown in the alert detail view. |
+| `priority` | string | `"P1"`..`"P5"`. Falls back to `opsgenie_default_priority`. |
+| `responders` | array | List of responder objects (`{name, type}` or `{id, type}`). Falls back to a single-element list built from `opsgenie_default_team` when omitted. |
+| `visible_to` | array | Same shape as `responders`. Controls who can view the alert. |
+| `actions` | string[] | Pre-defined actions (e.g. `["ping", "reboot"]`). |
+| `tags` | string[] | Free-form tags used for downstream routing. |
+| `details` | object | Arbitrary key-value metadata shown in the alert UI. |
+| `entity` | string | Domain entity the alert is about (e.g. `"web-01"`). |
+| `source` | string | Source label. Falls back to `opsgenie_default_source`. |
+| `user` | string | Username to attribute the creation to. |
+| `note` | string | Operator note attached to the alert. |
+
+### Acknowledge
+
+```json
+{
+  "event_action": "acknowledge",
+  "alias": "checkout-api-5xx",
+  "user": "oncall-alice",
+  "note": "Investigating — rolled back deploy #4823"
+}
+```
+
+### Close
+
+```json
+{
+  "event_action": "close",
+  "alias": "checkout-api-5xx",
+  "user": "oncall-alice",
+  "note": "Rollback confirmed; 5xx rate back below threshold."
+}
+```
+
+Both `acknowledge` and `close` require `alias` because the provider always looks up alerts by alias (`identifierType=alias`), not by the numeric alert ID. This keeps the create/ack/close sequence stable across process restarts and across alert-correlation chains.
+
+## Rule integration
+
+Because OpsGenie is just another named provider, every routing primitive Acteon already has works with it:
+
+- **Reroute high-priority alerts to OpsGenie:**
+  ```yaml
+  rules:
+    - name: reroute-p1-to-opsgenie
+      priority: 1
+      condition:
+        field: action.payload.priority
+        eq: "P1"
+      action:
+        type: reroute
+        target_provider: opsgenie-prod
+  ```
+- **Dedup noisy alerts:** use Acteon's [deduplication](deduplication.md) with the alert's `alias` as the dedup key — OpsGenie then collapses the incident server-side through its own alias mechanism.
+- **Silence maintenance-window alerts:** [silences](silences.md) apply before the provider dispatch, so an OpsGenie dispatch never leaves the gateway during an active silence.
+- **Quota-bound an OpsGenie account:** add a [per-provider tenant quota](tenant-quotas.md) scoped to `provider: "opsgenie-prod"` to cap burst traffic independent of tenant-wide quotas.
+
+## Outcome body
+
+On success the provider returns an `Executed` outcome whose `body` carries the `OpsGenie` response:
+
+```json
+{
+  "result": "Request will be processed",
+  "took": 0.123,
+  "request_id": "abc-1234-..."
+}
+```
+
+The `request_id` is the handle you can use to poll the OpsGenie request-status endpoint if you need to confirm the eventual alert ID. Acteon treats the initial 202 Accepted as success (alert creation is asynchronous in OpsGenie's API).
+
+## Error mapping
+
+| HTTP status | `ProviderError` | Retryable? |
+|-------------|-----------------|------------|
+| 2xx | `Executed` (success) | — |
+| 401 / 403 | `Configuration(...)` | No |
+| 429 | `RateLimited` | Yes |
+| 4xx (other) | `ExecutionFailed(...)` | No |
+| 5xx | `ExecutionFailed(...)` | No |
+| Transport failure | `Connection(...)` | Yes |
+
+Invalid payloads (missing `message` on create, missing `alias` on ack/close, unknown `event_action`) map to `Serialization` and are **not** retryable — retrying a malformed payload never succeeds.
+
+## Simulation example
+
+A full end-to-end demo that walks through the `create` → `acknowledge` → `close` lifecycle plus rule-based P1 rerouting is in `crates/simulation/examples/opsgenie_simulation.rs`:
+
+```bash
+cargo run -p acteon-simulation --example opsgenie_simulation
+```
+
+The simulation uses a recording provider, so it runs offline with no real OpsGenie credentials.

--- a/docs/book/features/opsgenie.md
+++ b/docs/book/features/opsgenie.md
@@ -12,27 +12,44 @@ Like Acteon's other native providers, `acteon-opsgenie`:
 
 ## TOML configuration
 
+OpsGenie is the first provider to use Acteon's **nested provider config** pattern: every OpsGenie-specific setting lives under an `opsgenie.*` key rather than a flat `opsgenie_*` prefix at the top level. This keeps the top-level `[[providers]]` schema tractable as more providers land.
+
 ```toml
 [[providers]]
 name = "opsgenie-prod"
 type = "opsgenie"
-opsgenie_api_key = "ENC[AES256_GCM,data:abc123...]"
-opsgenie_region = "us"                 # or "eu"
-opsgenie_default_team = "platform-oncall"
-opsgenie_default_priority = "P3"
-opsgenie_default_source = "acteon"
+opsgenie.api_key = "ENC[AES256_GCM,data:abc123...]"
+opsgenie.region = "us"                   # or "eu"
+opsgenie.default_team = "platform-oncall"
+opsgenie.default_priority = "P3"
+opsgenie.default_source = "acteon"
+# opsgenie.scope_aliases = true          # default — see "Multi-tenant isolation" below
+# opsgenie.message_max_length = 130      # default — raise if OpsGenie lifts the cap
 ```
 
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | Yes | Unique provider name used when dispatching actions |
 | `type` | Yes | Must be `"opsgenie"` |
-| `opsgenie_api_key` | Yes | Integration API key (the value that becomes `Authorization: GenieKey {key}`). Supports `ENC[...]` for encrypted storage. |
-| `opsgenie_region` | No | `"us"` (default) or `"eu"`. Accounts are pinned to one region at provisioning; picking the wrong one produces 401/403. |
-| `opsgenie_default_team` | No | Team responder used when a payload omits `responders`. |
-| `opsgenie_default_priority` | No | Default alert priority (`P1`..=`P5`). Falls back to `P3`. |
-| `opsgenie_default_source` | No | Default `source` label shown on the alert UI. |
-| `opsgenie_api_base_url` | No | Override the API base URL. Tests only — do not set in production. |
+| `opsgenie.api_key` | Yes | Integration API key (the value that becomes `Authorization: GenieKey {key}`). Supports `ENC[...]` for encrypted storage. The plaintext is wrapped in a `SecretString` so it is zeroized on drop. |
+| `opsgenie.region` | No | `"us"` (default) or `"eu"`. Accounts are pinned to one region at provisioning; picking the wrong one produces 401/403. |
+| `opsgenie.default_team` | No | Team responder used when a payload omits `responders`. |
+| `opsgenie.default_priority` | No | Default alert priority (`P1`..=`P5`). Falls back to `P3`. |
+| `opsgenie.default_source` | No | Default `source` label shown on the alert UI. |
+| `opsgenie.scope_aliases` | No | Whether to auto-prefix user-supplied aliases with `{namespace}:{tenant}:` for multi-tenant isolation. Defaults to `true`. See below. |
+| `opsgenie.message_max_length` | No | Client-side `message` truncation cap. Defaults to 130 (the current OpsGenie API limit). |
+| `opsgenie.api_base_url` | No | Override the API base URL. Tests only — do not set in production. |
+
+## Multi-tenant isolation
+
+Alerts dispatched by Acteon come from `(namespace, tenant)` scopes, but OpsGenie has no native tenant concept. On a shared `OpsGenie` integration key (common in large orgs), that means two tenants that both pick the raw alias `web-01-high-cpu` would otherwise collide — and Tenant A could close Tenant B's alert simply by guessing the alias.
+
+**By default** (`opsgenie.scope_aliases = true`, which is the default), the provider rewrites every alias to `{namespace}:{tenant}:{raw_alias}` before sending it to OpsGenie. The prefix is applied identically on `create`, `acknowledge`, and `close` so all three resolve to the same incident, but two tenants can never refer to each other's alerts.
+
+Set `opsgenie.scope_aliases = false` only if:
+
+1. Every Acteon namespace/tenant has its own dedicated OpsGenie integration key, **or**
+2. You genuinely need cross-tenant alias coordination (e.g., a platform team closing a customer alert from a shared runbook).
 
 ## Payload shape
 

--- a/docs/design-alertmanager-parity.md
+++ b/docs/design-alertmanager-parity.md
@@ -35,7 +35,7 @@ A fresh audit against Alertmanager v0.27 features found the following gaps.
 | 1 | **Silences** (time-bounded label-pattern mutes) | **Missing** — no `Silence` type, no CRUD, no dispatch-path enforcement | **Critical** |
 | 2 | `group_wait` / `group_interval` / `repeat_interval` | **Shipped in Phase 2.** `group_wait` was already implemented; `group_interval` is now honored on persistent groups; `repeat_interval` is a new optional field that makes the group persistent and re-fire periodically. | ~~Medium~~ Done |
 | 3 | Per-receiver rate limits | **Shipped in Phase 3.** Generic tenant/namespace quotas now stack with optional per-provider scoped policies; strictest outcome wins; each scope has its own counter bucket. | ~~Medium~~ Done |
-| 4 | OpsGenie receiver | Missing | Medium |
+| 4 | OpsGenie receiver | **Shipped in Phase 4a.** New `acteon-opsgenie` crate implements the Alert API v2 (create / acknowledge / close) against both US and EU regions, wired into the server's TOML provider config as `type = "opsgenie"`. | ~~Medium~~ Done |
 | 5 | VictorOps receiver | Missing | Medium |
 | 6 | Pushover receiver | Missing | Low |
 | 7 | WeChat receiver | Missing | Low |
@@ -116,7 +116,51 @@ Implementation notes:
 ### Phase 4 — Missing receivers
 **Gaps**: #4–#8
 **Scope**: ~300–500 LOC per provider
-**Follow-up**: one provider per PR, batched where sensible (e.g., OpsGenie + VictorOps in one PR; Pushover + WeChat + Telegram in another).
+**Follow-up**: one provider per PR, shipped incrementally.
+
+#### Phase 4a — OpsGenie ✅ Shipped
+**Gap**: #4
+**Scope as built**: new `acteon-opsgenie` crate (~1300 LOC) plus server wiring, simulation example, and docs.
+
+The `acteon-opsgenie` crate implements the Alert API v2 with the
+following properties:
+- **Regions**: US (`api.opsgenie.com`) and EU
+  (`api.eu.opsgenie.com`) selectable via `opsgenie_region` in the
+  TOML provider config. Accounts are pinned to one region at
+  provisioning time so picking the wrong one surfaces as a 401.
+- **Lifecycle**: a single provider handles the
+  `create` → `acknowledge` → `close` sequence by branching on the
+  payload's `event_action` field. Acknowledge/close always use
+  `identifierType=alias` so operators can use the same alias they
+  used at create time without reading back alert IDs.
+- **Defaults**: optional `opsgenie_default_team`,
+  `opsgenie_default_priority`, and `opsgenie_default_source`
+  fields in the TOML config materialize into the alert body when
+  the payload omits them, keeping rule payloads short.
+- **Client-side guards**: `message` is truncated to the API's
+  130-char limit; alias is percent-encoded in the lifecycle path
+  segment; `ENC[...]` API keys are transparently decrypted at
+  startup.
+- **Error mapping**: 401/403 → non-retryable `Configuration` (bad
+  api key surfaces as a configuration issue for operators);
+  429 → retryable `RateLimited`; other 4xx/5xx → non-retryable
+  `ExecutionFailed`.
+- **Observability**: reuses the server's shared HTTP client so
+  the provider participates in circuit breaking, health checks,
+  and per-provider metrics without any extra wiring.
+- **Testing**: 37 unit tests including a tiny in-process mock
+  HTTP server that captures the request body so the tests can
+  assert on the wire format (URLs, headers, JSON payloads) for
+  every lifecycle branch.
+
+Simulation: `crates/simulation/examples/opsgenie_simulation.rs`
+walks through create/ack/close plus a rule-based reroute for
+P1-priority alerts. Docs: `docs/book/features/opsgenie.md`.
+
+#### Phase 4b–4d — VictorOps, Pushover, WeChat, Telegram
+**Gaps**: #5–#8
+**Status**: Pending. Each provider ships as its own PR so a
+review problem in one cannot block the others.
 
 ### Phase 5 — Alert-centric admin UI
 **Gap**: #9

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,7 @@ nav:
     - WASM Plugins: features/wasm-plugins.md
     - AWS Providers: features/aws-providers.md
     - Native Providers: features/native-providers.md
+    - OpsGenie: features/opsgenie.md
   - Backends:
     - backends/index.md
     - State Backends: backends/state-backends.md


### PR DESCRIPTION
## Summary

Phase 4a of the [Alertmanager feature parity plan](https://github.com/penserai/acteon/blob/main/docs/design-alertmanager-parity.md): closes gap #4 by shipping a first-class `acteon-opsgenie` provider crate and wiring it into the server's TOML provider config.

OpsGenie is the single highest-demand missing receiver for teams migrating off Alertmanager — Atlassian's incident-management platform is the default on-call tool for most customers, and without it Acteon cannot be a drop-in replacement.

## What changed

**New crate `acteon-opsgenie`** — implements the [OpsGenie Alert API v2](https://docs.opsgenie.com/docs/alert-api) with:

- **Regions**: US (`api.opsgenie.com`) and EU (`api.eu.opsgenie.com`) selectable via TOML. Accounts are pinned to one region at provisioning time so picking the wrong one surfaces as a 401.
- **Lifecycle**: a single provider handles the full `create → acknowledge → close` sequence by branching on the payload's `event_action` field. Acknowledge and close always use `identifierType=alias` so operators can use the same alias they used at create time without reading back alert IDs.
- **Defaults**: optional `opsgenie_default_team`, `opsgenie_default_priority`, and `opsgenie_default_source` fields in the TOML config materialize into the alert body when the payload omits them, keeping rule payloads short.
- **Client-side guards**: `message` is truncated to the API's 130-char limit; alias is percent-encoded in the lifecycle path segment; `ENC[...]` API keys are transparently decrypted at startup.
- **Error mapping**: 401/403 → non-retryable `Configuration`; 429 → retryable `RateLimited`; other 4xx/5xx → non-retryable `ExecutionFailed`; transport failures → retryable `Connection`.
- **Observability**: reuses the server's shared HTTP client so the provider participates in circuit breaking, health checks, and per-provider metrics without extra wiring.
- **Testing**: 37 unit tests including a tiny in-process mock HTTP server that captures request bodies so tests can assert on URL, headers, and JSON payload for every lifecycle branch.

**Server wiring** — `ProviderConfig` gains `opsgenie_*` fields; `main.rs` has a new `"opsgenie"` branch in the provider match.

**Simulation** — `crates/simulation/examples/opsgenie_simulation.rs` walks through `create` → `acknowledge` → `close` plus a rule-based P1-priority reroute. Runs offline with a recording provider.

**Docs** — new `docs/book/features/opsgenie.md` covering TOML config, payload shape, rule integration, outcome body, and error mapping. `docs/design-alertmanager-parity.md` updated with a Phase 4a "Shipped" section.

## Example TOML

```toml
[[providers]]
name = "opsgenie-prod"
type = "opsgenie"
opsgenie_api_key = "ENC[AES256_GCM,data:...]"
opsgenie_region = "us"
opsgenie_default_team = "platform-oncall"
opsgenie_default_priority = "P3"
opsgenie_default_source = "acteon"
```

## Example payload

```json
{
  "event_action": "create",
  "message": "High error rate on checkout-api",
  "alias": "checkout-api-5xx",
  "priority": "P2",
  "tags": ["checkout", "5xx", "slo-breach"],
  "responders": [{"name": "checkout-oncall", "type": "team"}]
}
```

## Test plan

- [x] `cargo test -p acteon-opsgenie --lib` — 37 passing
- [x] `cargo test --workspace --lib --bins --tests` — full suite green
- [x] `cargo clippy -p acteon-opsgenie -p acteon-server --no-deps --lib --tests -- -D warnings` — clean
- [x] `cargo run -p acteon-simulation --example opsgenie_simulation` — 3 lifecycle dispatches + reroute assertions pass
- [x] UI lint + build — green

## Remaining Phase 4 providers

VictorOps, Pushover, WeChat, and Telegram are still pending — each will ship as its own PR so a review problem in one cannot block the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)