### PR TITLE
feat: VictorOps / Splunk On-Call provider (Phase 4b of Alertmanager parity)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "acteon-state-redis",
  "acteon-teams",
  "acteon-twilio",
+ "acteon-victorops",
  "acteon-wasm-runtime",
  "argon2",
  "async-trait",
@@ -719,6 +720,22 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "acteon-victorops"
+version = "0.1.0"
+dependencies = [
+ "acteon-core",
+ "acteon-crypto",
+ "acteon-provider",
+ "percent-encoding",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
     "crates/integrations/slack",
     "crates/integrations/pagerduty",
     "crates/integrations/opsgenie",
+    "crates/integrations/victorops",
     "crates/integrations/webhook",
     "crates/integrations/twilio",
     "crates/integrations/teams",
@@ -129,6 +130,7 @@ acteon-email = { path = "crates/integrations/email" }
 acteon-slack = { path = "crates/integrations/slack" }
 acteon-pagerduty = { path = "crates/integrations/pagerduty" }
 acteon-opsgenie = { path = "crates/integrations/opsgenie" }
+acteon-victorops = { path = "crates/integrations/victorops" }
 acteon-webhook = { path = "crates/integrations/webhook" }
 acteon-twilio = { path = "crates/integrations/twilio" }
 acteon-teams = { path = "crates/integrations/teams" }

--- a/crates/integrations/victorops/Cargo.toml
+++ b/crates/integrations/victorops/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "acteon-victorops"
+description = "VictorOps / Splunk On-Call provider for Acteon — posts alerts to the REST endpoint integration"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+
+[dependencies]
+acteon-core = { workspace = true }
+acteon-crypto = { workspace = true }
+acteon-provider = { workspace = true, features = ["trace-context"] }
+percent-encoding = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/integrations/victorops/src/config.rs
+++ b/crates/integrations/victorops/src/config.rs
@@ -1,0 +1,387 @@
+use std::collections::HashMap;
+
+use acteon_crypto::{ExposeSecret, SecretString};
+
+use crate::error::VictorOpsError;
+
+/// Default value reported in the `monitoring_tool` field of every
+/// alert body. Can be overridden via
+/// [`VictorOpsConfig::with_monitoring_tool`].
+pub const DEFAULT_MONITORING_TOOL: &str = "acteon";
+
+/// Configuration for the `VictorOps` / Splunk On-Call provider.
+///
+/// The `VictorOps` REST endpoint integration embeds **two** secrets
+/// in the request URL: an organization-level `api_key` and a
+/// per-route `routing_key`. Both are held as [`SecretString`] so
+/// the plaintexts are zeroized on drop (via the `zeroize` crate,
+/// transitively through `secrecy`) and any accidental `Debug`
+/// formatting yields `[REDACTED]` instead of the raw values.
+///
+/// Multiple routing keys can be registered via [`Self::with_route`]
+/// so one provider instance can fan alerts out to several
+/// `VictorOps` teams based on the dispatch payload's `routing_key`
+/// field. A single-route convenience constructor is available for
+/// the common case.
+#[derive(Clone)]
+pub struct VictorOpsConfig {
+    /// Organization-level REST integration key (embedded in the
+    /// URL path alongside the routing key).
+    api_key: SecretString,
+
+    /// Map of logical route name → per-route routing key. The
+    /// dispatch payload can select an entry via its `routing_key`
+    /// field; if absent, the `default_route_name` is used, and if
+    /// there is only one entry it is used implicitly.
+    routing_keys: HashMap<String, SecretString>,
+
+    /// Name of the default entry in `routing_keys` used when the
+    /// payload omits an explicit `routing_key`.
+    default_route_name: Option<String>,
+
+    /// Base URL for the `VictorOps` REST endpoint integration.
+    /// Override this to point tests at a mock server.
+    api_base_url: String,
+
+    /// Value reported in the `monitoring_tool` field of every alert.
+    pub monitoring_tool: String,
+
+    /// Whether to auto-prefix the `entity_id` with
+    /// `{namespace}:{tenant}:` before sending it to `VictorOps`.
+    ///
+    /// **Defaults to `true`.** Leaving this on is the right choice
+    /// for deployments where multiple Acteon tenants share a
+    /// single `VictorOps` integration key — without it, Tenant A
+    /// could resolve Tenant B's alerts by guessing (or observing)
+    /// the `entity_id` string. The prefix is applied identically
+    /// across trigger / acknowledge / resolve so all three
+    /// lifecycle events resolve to the same `VictorOps` incident.
+    ///
+    /// Set to `false` only if every Acteon namespace/tenant has
+    /// its own dedicated `VictorOps` integration key, or you
+    /// genuinely need cross-tenant `entity_id` coordination.
+    pub scope_entity_ids: bool,
+}
+
+impl std::fmt::Debug for VictorOpsConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Debug-format the routing-key map as just the route names;
+        // the actual keys are redacted.
+        struct RedactedRoutes<'a>(&'a HashMap<String, SecretString>);
+        impl std::fmt::Debug for RedactedRoutes<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let mut map = f.debug_map();
+                for name in self.0.keys() {
+                    map.entry(name, &"[REDACTED]");
+                }
+                map.finish()
+            }
+        }
+
+        f.debug_struct("VictorOpsConfig")
+            .field("api_key", &"[REDACTED]")
+            .field("routing_keys", &RedactedRoutes(&self.routing_keys))
+            .field("default_route_name", &self.default_route_name)
+            .field("api_base_url", &self.api_base_url)
+            .field("monitoring_tool", &self.monitoring_tool)
+            .field("scope_entity_ids", &self.scope_entity_ids)
+            .finish()
+    }
+}
+
+impl VictorOpsConfig {
+    /// Create an empty configuration with the given organization
+    /// API key. Callers typically chain [`Self::with_route`] to
+    /// register at least one routing key before building a
+    /// provider.
+    #[must_use]
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            api_key: SecretString::new(api_key.into()),
+            routing_keys: HashMap::new(),
+            default_route_name: None,
+            api_base_url: "https://alert.victorops.com".to_owned(),
+            monitoring_tool: DEFAULT_MONITORING_TOOL.to_owned(),
+            scope_entity_ids: true,
+        }
+    }
+
+    /// Convenience shorthand for the single-route case — registers
+    /// one routing key under the given name and marks it as the
+    /// default.
+    #[must_use]
+    pub fn single_route(
+        api_key: impl Into<String>,
+        route_name: impl Into<String>,
+        routing_key: impl Into<String>,
+    ) -> Self {
+        let route_name = route_name.into();
+        let mut config = Self::new(api_key);
+        config
+            .routing_keys
+            .insert(route_name.clone(), SecretString::new(routing_key.into()));
+        config.default_route_name = Some(route_name);
+        config
+    }
+
+    /// Register an additional routing key under a logical name.
+    /// The name is what dispatch payloads refer to via their
+    /// `routing_key` field.
+    #[must_use]
+    pub fn with_route(
+        mut self,
+        route_name: impl Into<String>,
+        routing_key: impl Into<String>,
+    ) -> Self {
+        self.routing_keys
+            .insert(route_name.into(), SecretString::new(routing_key.into()));
+        self
+    }
+
+    /// Set the default route used when the payload omits an
+    /// explicit `routing_key`.
+    #[must_use]
+    pub fn with_default_route(mut self, route_name: impl Into<String>) -> Self {
+        self.default_route_name = Some(route_name.into());
+        self
+    }
+
+    /// Override the API base URL (primarily for tests against a
+    /// mock server).
+    #[must_use]
+    pub fn with_api_base_url(mut self, url: impl Into<String>) -> Self {
+        self.api_base_url = url.into();
+        self
+    }
+
+    /// Override the value reported in the alert body's
+    /// `monitoring_tool` field.
+    #[must_use]
+    pub fn with_monitoring_tool(mut self, tool: impl Into<String>) -> Self {
+        self.monitoring_tool = tool.into();
+        self
+    }
+
+    /// Enable or disable automatic `entity_id` scoping. See the
+    /// field docs on [`Self::scope_entity_ids`] for the security
+    /// implications.
+    #[must_use]
+    pub fn with_scope_entity_ids(mut self, scope: bool) -> Self {
+        self.scope_entity_ids = scope;
+        self
+    }
+
+    /// Decrypt any `ENC[...]` secrets in the config in place.
+    ///
+    /// Plain-text values pass through unchanged. Both the
+    /// organization `api_key` and every entry in `routing_keys`
+    /// are processed so operators can mix-and-match encrypted and
+    /// plain values without breaking the provider build.
+    #[must_use = "returns the config with decrypted secrets"]
+    pub fn decrypt_secrets(
+        mut self,
+        master_key: &acteon_crypto::MasterKey,
+    ) -> Result<Self, VictorOpsError> {
+        self.api_key = acteon_crypto::decrypt_value(self.api_key.expose_secret(), master_key)
+            .map_err(|e| {
+                VictorOpsError::InvalidPayload(format!("failed to decrypt api_key: {e}"))
+            })?;
+        let mut decrypted: HashMap<String, SecretString> =
+            HashMap::with_capacity(self.routing_keys.len());
+        for (name, value) in &self.routing_keys {
+            let decrypted_value = acteon_crypto::decrypt_value(value.expose_secret(), master_key)
+                .map_err(|e| {
+                VictorOpsError::InvalidPayload(format!(
+                    "failed to decrypt routing_key '{name}': {e}"
+                ))
+            })?;
+            decrypted.insert(name.clone(), decrypted_value);
+        }
+        self.routing_keys = decrypted;
+        Ok(self)
+    }
+
+    /// Return the API base URL (used by the provider to build
+    /// request URLs and by tests to assert routing).
+    #[must_use]
+    pub fn api_base_url(&self) -> &str {
+        &self.api_base_url
+    }
+
+    /// Return the organization API key for URL construction.
+    /// Kept `pub(crate)` so the secret cannot leak out of this crate.
+    pub(crate) fn api_key(&self) -> &str {
+        self.api_key.expose_secret()
+    }
+
+    /// Resolve a routing key name to its secret value, honoring
+    /// the default-route fallback and the single-entry implicit
+    /// fallback.
+    ///
+    /// # Errors
+    ///
+    /// - [`VictorOpsError::UnknownRoutingKey`] if the named route is not registered
+    /// - [`VictorOpsError::NoDefaultRoutingKey`] if no name was provided and no default is set
+    pub(crate) fn resolve_routing_key(&self, name: Option<&str>) -> Result<&str, VictorOpsError> {
+        match name {
+            Some(n) => self
+                .routing_keys
+                .get(n)
+                .map(|s| s.expose_secret().as_str())
+                .ok_or_else(|| VictorOpsError::UnknownRoutingKey(n.to_owned())),
+            None => {
+                if let Some(default_name) = &self.default_route_name {
+                    self.routing_keys
+                        .get(default_name.as_str())
+                        .map(|s| s.expose_secret().as_str())
+                        .ok_or_else(|| VictorOpsError::UnknownRoutingKey(default_name.clone()))
+                } else if self.routing_keys.len() == 1 {
+                    Ok(self
+                        .routing_keys
+                        .values()
+                        .next()
+                        .unwrap()
+                        .expose_secret()
+                        .as_str())
+                } else {
+                    Err(VictorOpsError::NoDefaultRoutingKey)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_defaults() {
+        let config = VictorOpsConfig::new("api");
+        assert_eq!(config.api_key(), "api");
+        assert_eq!(config.api_base_url(), "https://alert.victorops.com");
+        assert_eq!(config.monitoring_tool, DEFAULT_MONITORING_TOOL);
+        assert!(config.scope_entity_ids);
+        assert!(config.routing_keys.is_empty());
+        assert!(config.default_route_name.is_none());
+    }
+
+    #[test]
+    fn single_route_constructor() {
+        let config = VictorOpsConfig::single_route("api", "team-ops", "rk-ops");
+        assert_eq!(config.resolve_routing_key(None).unwrap(), "rk-ops");
+        assert_eq!(
+            config.resolve_routing_key(Some("team-ops")).unwrap(),
+            "rk-ops"
+        );
+    }
+
+    #[test]
+    fn builder_chain() {
+        let config = VictorOpsConfig::new("api")
+            .with_route("team-a", "rk-a")
+            .with_route("team-b", "rk-b")
+            .with_default_route("team-a")
+            .with_api_base_url("http://mock")
+            .with_monitoring_tool("prometheus")
+            .with_scope_entity_ids(false);
+        assert_eq!(config.monitoring_tool, "prometheus");
+        assert_eq!(config.api_base_url(), "http://mock");
+        assert!(!config.scope_entity_ids);
+        assert_eq!(config.routing_keys.len(), 2);
+        assert_eq!(config.resolve_routing_key(None).unwrap(), "rk-a");
+        assert_eq!(config.resolve_routing_key(Some("team-b")).unwrap(), "rk-b");
+    }
+
+    #[test]
+    fn resolve_explicit() {
+        let config = VictorOpsConfig::new("api")
+            .with_route("team-a", "rk-a")
+            .with_route("team-b", "rk-b");
+        assert_eq!(config.resolve_routing_key(Some("team-a")).unwrap(), "rk-a");
+    }
+
+    #[test]
+    fn resolve_implicit_single() {
+        let config = VictorOpsConfig::new("api").with_route("only-team", "rk-only");
+        assert_eq!(config.resolve_routing_key(None).unwrap(), "rk-only");
+    }
+
+    #[test]
+    fn resolve_unknown_route() {
+        let config = VictorOpsConfig::single_route("api", "team-a", "rk-a");
+        let err = config.resolve_routing_key(Some("team-gone")).unwrap_err();
+        assert!(matches!(err, VictorOpsError::UnknownRoutingKey(ref n) if n == "team-gone"));
+    }
+
+    #[test]
+    fn resolve_no_default_multi() {
+        let config = VictorOpsConfig::new("api")
+            .with_route("team-a", "rk-a")
+            .with_route("team-b", "rk-b");
+        let err = config.resolve_routing_key(None).unwrap_err();
+        assert!(matches!(err, VictorOpsError::NoDefaultRoutingKey));
+    }
+
+    fn test_master_key() -> acteon_crypto::MasterKey {
+        acteon_crypto::parse_master_key(&"42".repeat(32)).unwrap()
+    }
+
+    #[test]
+    fn decrypt_secrets_roundtrip() {
+        let master_key = test_master_key();
+        let api_plain = "org-api-key";
+        let route_plain = "team-ops-routing-key";
+        let api_enc = acteon_crypto::encrypt_value(api_plain, &master_key).unwrap();
+        let route_enc = acteon_crypto::encrypt_value(route_plain, &master_key).unwrap();
+
+        let config = VictorOpsConfig::new(api_enc)
+            .with_route("team-ops", route_enc)
+            .decrypt_secrets(&master_key)
+            .unwrap();
+        assert_eq!(config.api_key(), api_plain);
+        assert_eq!(
+            config.resolve_routing_key(Some("team-ops")).unwrap(),
+            route_plain
+        );
+    }
+
+    #[test]
+    fn decrypt_secrets_passthrough_plaintext() {
+        let master_key = test_master_key();
+        let config = VictorOpsConfig::single_route("plain-api", "team-ops", "plain-route")
+            .decrypt_secrets(&master_key)
+            .unwrap();
+        assert_eq!(config.api_key(), "plain-api");
+        assert_eq!(
+            config.resolve_routing_key(Some("team-ops")).unwrap(),
+            "plain-route"
+        );
+    }
+
+    #[test]
+    fn decrypt_secrets_invalid_api_key() {
+        let master_key = test_master_key();
+        let config = VictorOpsConfig::new("ENC[AES256-GCM,data:bad,iv:bad,tag:bad]");
+        let err = config.decrypt_secrets(&master_key).unwrap_err();
+        assert!(matches!(err, VictorOpsError::InvalidPayload(_)));
+    }
+
+    #[test]
+    fn debug_redacts_secrets() {
+        let config = VictorOpsConfig::new("super-secret-api-placeholder")
+            .with_route("team-ops", "super-secret-route-placeholder");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("[REDACTED]"), "secrets must be redacted");
+        assert!(
+            !debug.contains("super-secret-api-placeholder"),
+            "api key must not appear in debug output"
+        );
+        assert!(
+            !debug.contains("super-secret-route-placeholder"),
+            "routing key must not appear in debug output"
+        );
+        // Route names themselves should still be visible for debugging.
+        assert!(debug.contains("team-ops"));
+    }
+}

--- a/crates/integrations/victorops/src/error.rs
+++ b/crates/integrations/victorops/src/error.rs
@@ -1,0 +1,152 @@
+use acteon_provider::ProviderError;
+use thiserror::Error;
+
+/// Errors specific to the `VictorOps` provider.
+///
+/// These are internal errors that get converted into [`ProviderError`]
+/// at the public API boundary. The variants deliberately mirror
+/// `acteon-opsgenie` so operators see the same retry semantics across
+/// on-call receivers.
+#[derive(Debug, Error)]
+pub enum VictorOpsError {
+    /// An HTTP-level transport error occurred.
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// The `VictorOps` API returned a **permanent** non-success
+    /// response (a 4xx that is not a rate-limit or auth failure).
+    /// Surfaced as `ExecutionFailed` and **not** retried — retrying
+    /// a malformed request will never succeed.
+    #[error("VictorOps API error: {0}")]
+    Api(String),
+
+    /// The `VictorOps` API returned a **transient** non-success
+    /// response (5xx server error or 408 Request Timeout). The
+    /// request body was fine; the server was temporarily unable to
+    /// handle it.
+    ///
+    /// Surfaced as `ProviderError::Connection` so the gateway's
+    /// retry logic re-queues the dispatch instead of dropping the
+    /// alert on the floor during a brief `VictorOps` outage.
+    #[error("VictorOps transient error: {0}")]
+    Transient(String),
+
+    /// The action payload is missing required fields or has invalid structure.
+    #[error("invalid payload: {0}")]
+    InvalidPayload(String),
+
+    /// The provider received an HTTP 429 (Too Many Requests) response.
+    #[error("rate limited by VictorOps")]
+    RateLimited,
+
+    /// The provider received an HTTP 401/403 response — typically a
+    /// bad or revoked api key / routing key.
+    #[error("authentication failed: {0}")]
+    Unauthorized(String),
+
+    /// The payload referenced a routing key that is not present in
+    /// the configured routing-key map.
+    #[error("unknown VictorOps routing key: {0}")]
+    UnknownRoutingKey(String),
+
+    /// No routing key was provided in the payload and none of the
+    /// config's fallbacks apply (no default routing key, and the
+    /// routing-key map is not a single-entry map).
+    #[error("no routing_key in payload and no default routing key configured")]
+    NoDefaultRoutingKey,
+}
+
+impl From<VictorOpsError> for ProviderError {
+    fn from(err: VictorOpsError) -> Self {
+        match err {
+            VictorOpsError::Http(e) => ProviderError::Connection(e.to_string()),
+            VictorOpsError::Api(msg) => ProviderError::ExecutionFailed(msg),
+            VictorOpsError::Transient(msg) => ProviderError::Connection(msg),
+            VictorOpsError::InvalidPayload(msg) => ProviderError::Serialization(msg),
+            VictorOpsError::RateLimited => ProviderError::RateLimited,
+            VictorOpsError::Unauthorized(msg) => ProviderError::Configuration(msg),
+            VictorOpsError::UnknownRoutingKey(name) => {
+                ProviderError::Configuration(format!("unknown VictorOps routing key: {name}"))
+            }
+            VictorOpsError::NoDefaultRoutingKey => ProviderError::Configuration(
+                "no routing_key in payload and no default routing key configured".into(),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limited_maps_to_retryable() {
+        let provider_err: ProviderError = VictorOpsError::RateLimited.into();
+        assert!(provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::RateLimited));
+    }
+
+    #[test]
+    fn api_error_maps_to_non_retryable() {
+        let provider_err: ProviderError = VictorOpsError::Api("bad request".into()).into();
+        assert!(!provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn transient_error_maps_to_retryable_connection() {
+        // 5xx/408 live-blip errors must be retried instead of
+        // dropping the alert on the floor.
+        let provider_err: ProviderError =
+            VictorOpsError::Transient("HTTP 503: service unavailable".into()).into();
+        assert!(provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::Connection(_)));
+    }
+
+    #[test]
+    fn invalid_payload_maps_to_serialization() {
+        let provider_err: ProviderError =
+            VictorOpsError::InvalidPayload("missing entity_id".into()).into();
+        assert!(!provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::Serialization(_)));
+    }
+
+    #[test]
+    fn unauthorized_maps_to_configuration() {
+        let provider_err: ProviderError = VictorOpsError::Unauthorized("bad key".into()).into();
+        assert!(!provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::Configuration(_)));
+    }
+
+    #[test]
+    fn unknown_routing_key_maps_to_configuration() {
+        let provider_err: ProviderError =
+            VictorOpsError::UnknownRoutingKey("team-gone".into()).into();
+        assert!(!provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::Configuration(_)));
+    }
+
+    #[test]
+    fn display_messages() {
+        assert_eq!(
+            VictorOpsError::Api("bad".into()).to_string(),
+            "VictorOps API error: bad"
+        );
+        assert_eq!(
+            VictorOpsError::Transient("503".into()).to_string(),
+            "VictorOps transient error: 503"
+        );
+        assert_eq!(
+            VictorOpsError::RateLimited.to_string(),
+            "rate limited by VictorOps"
+        );
+        assert_eq!(
+            VictorOpsError::UnknownRoutingKey("team-x".into()).to_string(),
+            "unknown VictorOps routing key: team-x"
+        );
+        assert_eq!(
+            VictorOpsError::NoDefaultRoutingKey.to_string(),
+            "no routing_key in payload and no default routing key configured"
+        );
+    }
+}

--- a/crates/integrations/victorops/src/lib.rs
+++ b/crates/integrations/victorops/src/lib.rs
@@ -1,0 +1,54 @@
+//! `VictorOps` / Splunk On-Call provider for the Acteon notification gateway.
+//!
+//! This crate implements the [`Provider`](acteon_provider::Provider) trait
+//! against the [`VictorOps` REST endpoint integration][integration] — the
+//! same endpoint Alertmanager targets via its `victorops_configs`, so a
+//! migration is a matter of re-authoring the routing, not re-plumbing
+//! the receiver.
+//!
+//! # Quick start
+//!
+//! ```rust,no_run
+//! use acteon_victorops::{VictorOpsConfig, VictorOpsProvider};
+//!
+//! // Single routing key (the common case).
+//! let config = VictorOpsConfig::single_route(
+//!     "organization-api-key",
+//!     "team-ops",
+//!     "team-ops-routing-key",
+//! )
+//! .with_monitoring_tool("acteon");
+//! let provider = VictorOpsProvider::new(config);
+//! ```
+//!
+//! Multiple routing keys are supported for deployments that fan alerts
+//! out to different `VictorOps` teams based on the payload's
+//! `routing_key` field.
+//!
+//! # Supported event actions
+//!
+//! The provider selects a `VictorOps` `message_type` based on the
+//! payload's `event_action` field:
+//!
+//! | `event_action` | `VictorOps` `message_type` | Purpose |
+//! |---|---|---|
+//! | `"trigger"` | `CRITICAL` | Firing alert |
+//! | `"warn"` | `WARNING` | Lower-priority alert |
+//! | `"info"` | `INFO` | Informational (does not page) |
+//! | `"acknowledge"` | `ACKNOWLEDGEMENT` | Oncall picked up |
+//! | `"resolve"` | `RECOVERY` | Incident closed |
+//!
+//! All five map naturally onto Alertmanager firing → acknowledged →
+//! resolved state transitions.
+//!
+//! [integration]: https://help.victorops.com/knowledge-base/rest-endpoint-integration-guide/
+
+pub mod config;
+pub mod error;
+pub mod provider;
+pub mod types;
+
+pub use config::{DEFAULT_MONITORING_TOOL, VictorOpsConfig};
+pub use error::VictorOpsError;
+pub use provider::VictorOpsProvider;
+pub use types::{VictorOpsAlertRequest, VictorOpsApiResponse, VictorOpsMessageType};

--- a/crates/integrations/victorops/src/provider.rs
+++ b/crates/integrations/victorops/src/provider.rs
@@ -1,0 +1,788 @@
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::{Provider, ProviderError, truncate_error_body};
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
+use reqwest::Client;
+use serde::Deserialize;
+use tracing::{debug, instrument, warn};
+
+use crate::config::VictorOpsConfig;
+use crate::error::VictorOpsError;
+use crate::types::{VictorOpsAlertRequest, VictorOpsApiResponse, VictorOpsMessageType};
+
+/// Characters that must be percent-encoded inside an URL path
+/// segment. Start from the IETF `CONTROLS` set and add every
+/// sub-delim, query-start, and path-separator byte that would be
+/// misinterpreted by the `VictorOps` router if left raw.
+///
+/// Letters, digits, `-`, `.`, `_`, and `~` are unreserved and pass
+/// through unchanged per [RFC 3986 §2.3].
+///
+/// [RFC 3986 §2.3]: https://www.rfc-editor.org/rfc/rfc3986#section-2.3
+const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'%')
+    .add(b'/')
+    .add(b'<')
+    .add(b'>')
+    .add(b'?')
+    .add(b'@')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}')
+    .add(b':')
+    .add(b';')
+    .add(b'&')
+    .add(b'=')
+    .add(b'+')
+    .add(b'$')
+    .add(b',');
+
+/// `VictorOps` / Splunk On-Call provider that posts alerts to the
+/// REST endpoint integration.
+pub struct VictorOpsProvider {
+    config: VictorOpsConfig,
+    client: Client,
+}
+
+/// Fields extracted from an action payload. Everything except
+/// `event_action` is optional at the serde level so the provider
+/// can enforce per-branch requirements (e.g., `entity_id` required
+/// for `acknowledge` / `resolve`).
+#[derive(Debug, Deserialize)]
+struct EventPayload {
+    event_action: String,
+    #[serde(default)]
+    routing_key: Option<String>,
+    #[serde(default)]
+    entity_id: Option<String>,
+    #[serde(default)]
+    entity_display_name: Option<String>,
+    #[serde(default)]
+    state_message: Option<String>,
+    #[serde(default)]
+    host_name: Option<String>,
+    #[serde(default)]
+    state_start_time: Option<i64>,
+    #[serde(default)]
+    monitoring_tool: Option<String>,
+}
+
+impl VictorOpsProvider {
+    /// Create a new `VictorOps` provider with the given configuration.
+    ///
+    /// Uses a default `reqwest::Client` with a 30-second timeout.
+    pub fn new(config: VictorOpsConfig) -> Self {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("failed to build HTTP client");
+        Self { config, client }
+    }
+
+    /// Create a new `VictorOps` provider with a custom HTTP client.
+    /// Useful for tests and for sharing a connection pool with the
+    /// server's other HTTP integrations.
+    pub fn with_client(config: VictorOpsConfig, client: Client) -> Self {
+        Self { config, client }
+    }
+
+    /// Percent-encode a value for safe inclusion in an URL path
+    /// segment using the [`percent_encoding`] crate so multi-byte
+    /// UTF-8, sub-delims, and reserved characters all get handled
+    /// per RFC 3986.
+    fn percent_encode_path_segment(raw: &str) -> String {
+        utf8_percent_encode(raw, PATH_SEGMENT_ENCODE_SET).to_string()
+    }
+
+    /// Build the URL for a given routing key.
+    ///
+    /// Both the `api_key` and the `routing_key` live in the URL
+    /// path — the REST endpoint integration's only
+    /// authentication mechanism. Both segments are
+    /// percent-encoded so an accidentally-special character in
+    /// either cannot produce an injection or 404.
+    fn integration_url(&self, routing_key: &str) -> String {
+        let api_key_seg = Self::percent_encode_path_segment(self.config.api_key());
+        let route_seg = Self::percent_encode_path_segment(routing_key);
+        format!(
+            "{}/integrations/generic/20131114/alert/{api_key_seg}/{route_seg}",
+            self.config.api_base_url()
+        )
+    }
+
+    /// Scope the `entity_id` with `{namespace}:{tenant}:` so two
+    /// tenants sharing one `VictorOps` integration key cannot
+    /// collide on (or maliciously resolve) each other's alerts.
+    /// Matches the `scoped_alias` semantics in `acteon-opsgenie`.
+    fn scoped_entity_id(&self, namespace: &str, tenant: &str, raw: &str) -> String {
+        if self.config.scope_entity_ids {
+            format!("{namespace}:{tenant}:{raw}")
+        } else {
+            raw.to_owned()
+        }
+    }
+
+    /// POST a JSON body to the given URL, interpret the response,
+    /// and map error statuses onto [`VictorOpsError`].
+    async fn post_json<B: serde::Serialize + ?Sized>(
+        &self,
+        url: &str,
+        body: &B,
+    ) -> Result<VictorOpsApiResponse, VictorOpsError> {
+        // NOTE: do not include the full URL in debug/error output —
+        // it contains the api_key and routing_key as path segments.
+        debug!("sending request to VictorOps");
+        let builder = self.client.post(url).json(body);
+        let request = acteon_provider::inject_trace_context(builder);
+        let response = request.send().await?;
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            warn!("VictorOps API rate limit hit");
+            return Err(VictorOpsError::RateLimited);
+        }
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            let body = response.text().await.unwrap_or_default();
+            return Err(VictorOpsError::Unauthorized(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            )));
+        }
+        if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
+            let body = response.text().await.unwrap_or_default();
+            warn!(%status, "VictorOps transient error — will be retried by gateway");
+            return Err(VictorOpsError::Transient(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            )));
+        }
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(VictorOpsError::Api(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            )));
+        }
+
+        // Non-success response bodies sometimes come back with a
+        // sparser JSON shape — fall back to an empty response so
+        // the action outcome stays predictable.
+        let api_response: VictorOpsApiResponse = response
+            .json()
+            .await
+            .unwrap_or_else(|_| VictorOpsApiResponse::default_fallback());
+        Ok(api_response)
+    }
+
+    /// Build and send a single alert.
+    async fn send_alert(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        payload: EventPayload,
+    ) -> Result<VictorOpsApiResponse, VictorOpsError> {
+        let message_type = VictorOpsMessageType::parse(&payload.event_action)
+            .map_err(VictorOpsError::InvalidPayload)?;
+
+        // ack and resolve require an explicit entity_id so the
+        // lifecycle event correlates with the original trigger.
+        // trigger, warn, and info accept a missing entity_id (the
+        // VictorOps server will auto-assign).
+        let needs_entity_id = matches!(
+            message_type,
+            VictorOpsMessageType::Acknowledgement | VictorOpsMessageType::Recovery
+        );
+        if needs_entity_id && payload.entity_id.is_none() {
+            return Err(VictorOpsError::InvalidPayload(format!(
+                "{} events require an 'entity_id' field matching the one used at trigger time",
+                payload.event_action
+            )));
+        }
+
+        // Scope the entity_id to prevent cross-tenant collisions on a shared
+        // VictorOps integration key.
+        let entity_id = payload
+            .entity_id
+            .map(|raw| self.scoped_entity_id(namespace, tenant, &raw));
+
+        let monitoring_tool = payload
+            .monitoring_tool
+            .unwrap_or_else(|| self.config.monitoring_tool.clone());
+
+        let routing_key = self
+            .config
+            .resolve_routing_key(payload.routing_key.as_deref())?
+            .to_owned();
+
+        let request = VictorOpsAlertRequest {
+            message_type,
+            entity_id,
+            entity_display_name: payload.entity_display_name,
+            state_message: payload.state_message,
+            monitoring_tool,
+            host_name: payload.host_name,
+            state_start_time: payload.state_start_time,
+        };
+        let url = self.integration_url(&routing_key);
+        self.post_json(&url, &request).await
+    }
+}
+
+impl Provider for VictorOpsProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "victorops"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "victorops"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        let payload: EventPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| VictorOpsError::InvalidPayload(format!("failed to parse payload: {e}")))?;
+        let namespace = action.namespace.as_str();
+        let tenant = action.tenant.as_str();
+        let api_response = self.send_alert(namespace, tenant, payload).await?;
+        let body = serde_json::json!({
+            "result": api_response.result,
+            "entity_id": api_response.entity_id,
+        });
+        Ok(ProviderResponse::success(body))
+    }
+
+    #[instrument(skip(self), fields(provider = "victorops"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        // VictorOps does not expose a no-op ping. We issue a GET
+        // against the base URL — any response (including 404 or
+        // 405) means the endpoint is reachable. Only a connection
+        // failure counts as a hard health-check error.
+        let url = format!(
+            "{}/integrations/generic/20131114/alert",
+            self.config.api_base_url()
+        );
+        debug!("performing VictorOps health check");
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| ProviderError::Connection(e.to_string()))?;
+        debug!(status = %response.status(), "VictorOps health check response");
+        Ok(())
+    }
+}
+
+impl VictorOpsApiResponse {
+    /// Construct a fallback response used when the server returns
+    /// a 2xx with a body we cannot parse. Keeps the action outcome
+    /// shape predictable for downstream consumers.
+    fn default_fallback() -> Self {
+        Self {
+            result: "success".into(),
+            entity_id: String::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use acteon_core::Action;
+    use acteon_provider::{Provider, ProviderError};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+    use crate::config::VictorOpsConfig;
+
+    /// Tiny mock HTTP server for integration-style tests. Same
+    /// pattern the `OpsGenie` provider uses — a single-accept TCP
+    /// listener that returns a canned response and captures the
+    /// request body so the test can assert on it.
+    struct MockVictorOpsServer {
+        listener: tokio::net::TcpListener,
+        base_url: String,
+    }
+
+    impl MockVictorOpsServer {
+        async fn start() -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("failed to bind mock server");
+            let port = listener.local_addr().unwrap().port();
+            let base_url = format!("http://127.0.0.1:{port}");
+            Self { listener, base_url }
+        }
+
+        async fn respond_once(self, status_code: u16, body: &str) {
+            let body = body.to_owned();
+            let (mut stream, _) = self.listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 16384];
+            let _ = stream.read(&mut buf).await.unwrap();
+            let response = format!(
+                "HTTP/1.1 {status_code} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+        }
+
+        async fn respond_once_capturing(self, status_code: u16, body: &str) -> String {
+            let body = body.to_owned();
+            let (mut stream, _) = self.listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 16384];
+            let n = stream.read(&mut buf).await.unwrap();
+            let raw = String::from_utf8_lossy(&buf[..n]).to_string();
+            let response = format!(
+                "HTTP/1.1 {status_code} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+            raw
+        }
+    }
+
+    fn make_action(payload: serde_json::Value) -> Action {
+        Action::new("incidents", "tenant-1", "victorops", "send_alert", payload)
+    }
+
+    #[test]
+    fn provider_name() {
+        let provider =
+            VictorOpsProvider::new(VictorOpsConfig::single_route("api", "team-ops", "rk-ops"));
+        assert_eq!(provider.name(), "victorops");
+    }
+
+    #[test]
+    fn percent_encode_path_segment_escapes_reserved() {
+        assert_eq!(
+            VictorOpsProvider::percent_encode_path_segment("a/b c:d"),
+            "a%2Fb%20c%3Ad"
+        );
+    }
+
+    #[test]
+    fn percent_encode_path_segment_utf8() {
+        assert_eq!(
+            VictorOpsProvider::percent_encode_path_segment("café"),
+            "caf%C3%A9"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_trigger_success() {
+        let server = MockVictorOpsServer::start().await;
+        let config = VictorOpsConfig::single_route("test-api", "team-ops", "rk-ops")
+            .with_api_base_url(&server.base_url);
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "entity_id": "web-01-high-cpu",
+            "entity_display_name": "High CPU on web-01",
+            "state_message": "CPU > 90% for 5 minutes.",
+            "host_name": "web-01",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(
+                    200,
+                    r#"{"result":"success","entity_id":"web-01-high-cpu"}"#,
+                )
+                .await
+        });
+        let result = provider.execute(&action).await;
+        let request = server_handle.await.unwrap();
+        let response = result.expect("execute should succeed");
+        assert_eq!(response.status, acteon_core::ResponseStatus::Success);
+
+        // URL embeds the api_key and routing_key segments, and the
+        // entity_id is scoped with {namespace}:{tenant}:.
+        assert!(
+            request.contains("POST /integrations/generic/20131114/alert/test-api/rk-ops"),
+            "URL should embed api_key and routing_key: {request}"
+        );
+        assert!(request.contains("\"message_type\":\"CRITICAL\""));
+        assert!(request.contains("\"entity_id\":\"incidents:tenant-1:web-01-high-cpu\""));
+        assert!(request.contains("\"entity_display_name\":\"High CPU on web-01\""));
+        assert!(request.contains("\"state_message\":\"CPU > 90% for 5 minutes.\""));
+        assert!(request.contains("\"monitoring_tool\":\"acteon\""));
+        assert!(request.contains("\"host_name\":\"web-01\""));
+    }
+
+    #[tokio::test]
+    async fn execute_acknowledge_success() {
+        let server = MockVictorOpsServer::start().await;
+        let config = VictorOpsConfig::single_route("test-api", "team-ops", "rk-ops")
+            .with_api_base_url(&server.base_url);
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "acknowledge",
+            "entity_id": "web-01-high-cpu",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"result":"success","entity_id":""}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        assert!(request.contains("\"message_type\":\"ACKNOWLEDGEMENT\""));
+        assert!(request.contains("\"entity_id\":\"incidents:tenant-1:web-01-high-cpu\""));
+    }
+
+    #[tokio::test]
+    async fn execute_resolve_success() {
+        let server = MockVictorOpsServer::start().await;
+        let config = VictorOpsConfig::single_route("test-api", "team-ops", "rk-ops")
+            .with_api_base_url(&server.base_url);
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "resolve",
+            "entity_id": "web-01-high-cpu",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"result":"success","entity_id":""}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        assert!(request.contains("\"message_type\":\"RECOVERY\""));
+    }
+
+    #[tokio::test]
+    async fn execute_warn_and_info_message_types() {
+        // Single server call per test; `warn` first.
+        let server = MockVictorOpsServer::start().await;
+        let config = VictorOpsConfig::single_route("api", "team-ops", "rk-ops")
+            .with_api_base_url(&server.base_url);
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "warn",
+            "entity_id": "disk-warn",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"result":"success"}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        assert!(request.contains("\"message_type\":\"WARNING\""));
+
+        // Fresh server for the info path.
+        let server = MockVictorOpsServer::start().await;
+        let config = VictorOpsConfig::single_route("api", "team-ops", "rk-ops")
+            .with_api_base_url(&server.base_url);
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "info",
+            "entity_id": "informational",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"result":"success"}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        assert!(request.contains("\"message_type\":\"INFO\""));
+    }
+
+    #[tokio::test]
+    async fn execute_acknowledge_missing_entity_id() {
+        let config = VictorOpsConfig::single_route("api", "team-ops", "rk")
+            .with_api_base_url("http://127.0.0.1:1");
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({ "event_action": "acknowledge" }));
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_invalid_event_action() {
+        let config = VictorOpsConfig::single_route("api", "team-ops", "rk")
+            .with_api_base_url("http://127.0.0.1:1");
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "snooze",
+            "entity_id": "x",
+        }));
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+    }
+
+    #[tokio::test]
+    async fn execute_rate_limited() {
+        let server = MockVictorOpsServer::start().await;
+        let config = VictorOpsConfig::single_route("api", "team-ops", "rk")
+            .with_api_base_url(&server.base_url);
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "entity_id": "x",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(429, r#"{"message":"Too Many Requests"}"#)
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::RateLimited));
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_503_retryable_connection() {
+        let server = MockVictorOpsServer::start().await;
+        let config = VictorOpsConfig::single_route("api", "team-ops", "rk")
+            .with_api_base_url(&server.base_url);
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "entity_id": "x",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(503, r#"{"message":"Service Unavailable"}"#)
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::Connection(_)));
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_unauthorized_maps_to_configuration() {
+        let server = MockVictorOpsServer::start().await;
+        let config = VictorOpsConfig::single_route("api", "team-ops", "rk")
+            .with_api_base_url(&server.base_url);
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "entity_id": "x",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(401, r#"{"message":"Unauthorized"}"#)
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::Configuration(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_api_error_non_retryable() {
+        let server = MockVictorOpsServer::start().await;
+        let config = VictorOpsConfig::single_route("api", "team-ops", "rk")
+            .with_api_base_url(&server.base_url);
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "entity_id": "x",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(400, r#"{"message":"Bad Request"}"#)
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_with_explicit_routing_key() {
+        let server = MockVictorOpsServer::start().await;
+        let config = VictorOpsConfig::new("api")
+            .with_route("team-a", "rk-a")
+            .with_route("team-b", "rk-b")
+            .with_default_route("team-a")
+            .with_api_base_url(&server.base_url);
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "entity_id": "x",
+            "routing_key": "team-b",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"result":"success"}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        assert!(
+            request.contains("POST /integrations/generic/20131114/alert/api/rk-b"),
+            "explicit routing_key should pick rk-b: {request}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_with_unknown_routing_key_returns_configuration() {
+        let config = VictorOpsConfig::single_route("api", "team-ops", "rk")
+            .with_api_base_url("http://127.0.0.1:1");
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "entity_id": "x",
+            "routing_key": "team-gone",
+        }));
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Configuration(_)));
+    }
+
+    #[tokio::test]
+    async fn scoped_entity_id_isolates_tenants() {
+        // Two different tenants on the same VictorOps integration
+        // key ask to resolve the same raw entity_id. The scoped
+        // ids must differ so cross-tenant interference is impossible.
+        let provider = VictorOpsProvider::new(VictorOpsConfig::single_route("api", "team", "rk"));
+        let a = provider.scoped_entity_id("incidents", "tenant-a", "web-01-high-cpu");
+        let b = provider.scoped_entity_id("incidents", "tenant-b", "web-01-high-cpu");
+        assert_ne!(a, b);
+        assert_eq!(a, "incidents:tenant-a:web-01-high-cpu");
+        assert_eq!(b, "incidents:tenant-b:web-01-high-cpu");
+    }
+
+    #[tokio::test]
+    async fn scope_disabled_passes_through() {
+        let config =
+            VictorOpsConfig::single_route("api", "team", "rk").with_scope_entity_ids(false);
+        let provider = VictorOpsProvider::new(config);
+        assert_eq!(
+            provider.scoped_entity_id("incidents", "tenant-1", "raw-id"),
+            "raw-id"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_with_scope_entity_ids_disabled() {
+        let server = MockVictorOpsServer::start().await;
+        let config = VictorOpsConfig::single_route("api", "team-ops", "rk")
+            .with_api_base_url(&server.base_url)
+            .with_scope_entity_ids(false);
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "entity_id": "raw-id",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"result":"success"}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        assert!(
+            request.contains("\"entity_id\":\"raw-id\""),
+            "opt-out should pass entity_id through unchanged: {request}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_override_monitoring_tool() {
+        let server = MockVictorOpsServer::start().await;
+        let config = VictorOpsConfig::single_route("api", "team-ops", "rk")
+            .with_api_base_url(&server.base_url)
+            .with_monitoring_tool("acteon-test");
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "entity_id": "x",
+            "monitoring_tool": "prometheus",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"result":"success"}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        // Payload override wins over config default.
+        assert!(request.contains("\"monitoring_tool\":\"prometheus\""));
+    }
+
+    #[tokio::test]
+    async fn execute_trigger_allows_missing_entity_id() {
+        let server = MockVictorOpsServer::start().await;
+        let config = VictorOpsConfig::single_route("api", "team-ops", "rk")
+            .with_api_base_url(&server.base_url);
+        let provider = VictorOpsProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "trigger",
+            "entity_display_name": "Quick alert",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"result":"success","entity_id":"auto"}"#)
+                .await
+        });
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn integration_url_embeds_both_secrets() {
+        let provider = VictorOpsProvider::new(VictorOpsConfig::single_route(
+            "org-api-secret",
+            "team-ops",
+            "route-secret",
+        ));
+        let url = provider.integration_url("route-secret");
+        assert_eq!(
+            url,
+            "https://alert.victorops.com/integrations/generic/20131114/alert/org-api-secret/route-secret"
+        );
+    }
+
+    #[tokio::test]
+    async fn integration_url_percent_encodes_segments() {
+        let provider = VictorOpsProvider::new(VictorOpsConfig::single_route(
+            "org/api",
+            "team",
+            "route key",
+        ));
+        // Both path segments get encoded independently so neither
+        // can inject an additional path component.
+        let url = provider.integration_url("route key");
+        assert_eq!(
+            url,
+            "https://alert.victorops.com/integrations/generic/20131114/alert/org%2Fapi/route%20key"
+        );
+    }
+
+    #[tokio::test]
+    async fn health_check_reachable_endpoint() {
+        let server = MockVictorOpsServer::start().await;
+        let config =
+            VictorOpsConfig::single_route("api", "team", "rk").with_api_base_url(&server.base_url);
+        let provider = VictorOpsProvider::new(config);
+        // Even a 404 means the endpoint is reachable.
+        let server_handle = tokio::spawn(async move { server.respond_once(404, "{}").await });
+        let result = provider.health_check().await;
+        server_handle.await.unwrap();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn health_check_connection_failure() {
+        let config = VictorOpsConfig::single_route("api", "team", "rk")
+            .with_api_base_url("http://127.0.0.1:1");
+        let provider = VictorOpsProvider::new(config);
+        let err = provider.health_check().await.unwrap_err();
+        assert!(matches!(err, ProviderError::Connection(_)));
+        assert!(err.is_retryable());
+    }
+}

--- a/crates/integrations/victorops/src/types.rs
+++ b/crates/integrations/victorops/src/types.rs
@@ -1,0 +1,201 @@
+use serde::{Deserialize, Serialize};
+
+/// `VictorOps` alert state. Maps one-to-one onto the strings
+/// accepted by the `message_type` field of the REST endpoint
+/// integration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum VictorOpsMessageType {
+    /// Firing alert — pages the on-call.
+    Critical,
+    /// Lower-priority alert. Still visible but does not page.
+    Warning,
+    /// Informational alert. Appears in the timeline but does not page.
+    Info,
+    /// Oncall acknowledged the incident.
+    Acknowledgement,
+    /// Incident is resolved.
+    Recovery,
+}
+
+impl VictorOpsMessageType {
+    /// Parse an Acteon `event_action` string into the corresponding
+    /// `VictorOps` message type.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` with the unrecognized input wrapped in a
+    /// static string when the action does not map to a known
+    /// `VictorOps` state.
+    pub fn parse(event_action: &str) -> Result<Self, String> {
+        match event_action {
+            "trigger" => Ok(Self::Critical),
+            "warn" => Ok(Self::Warning),
+            "info" => Ok(Self::Info),
+            "acknowledge" => Ok(Self::Acknowledgement),
+            "resolve" => Ok(Self::Recovery),
+            other => Err(format!(
+                "invalid event_action '{other}': must be one of 'trigger', 'warn', 'info', 'acknowledge', or 'resolve'"
+            )),
+        }
+    }
+
+    /// Return the wire-format string used in the `message_type`
+    /// field of the JSON body.
+    #[must_use]
+    pub const fn as_wire(&self) -> &'static str {
+        match self {
+            Self::Critical => "CRITICAL",
+            Self::Warning => "WARNING",
+            Self::Info => "INFO",
+            Self::Acknowledgement => "ACKNOWLEDGEMENT",
+            Self::Recovery => "RECOVERY",
+        }
+    }
+}
+
+/// Request body for the `VictorOps` REST endpoint integration.
+///
+/// Only `message_type` is strictly required by the API; everything
+/// else is optional so operators can start with the minimum and
+/// layer in details as their runbook evolves.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VictorOpsAlertRequest {
+    /// Alert state (`CRITICAL`, `WARNING`, `INFO`,
+    /// `ACKNOWLEDGEMENT`, or `RECOVERY`).
+    pub message_type: VictorOpsMessageType,
+    /// Client-side deduplication identifier. `VictorOps` correlates
+    /// trigger / ack / resolve events that share an `entity_id`
+    /// into a single incident.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entity_id: Option<String>,
+    /// Human-readable short display name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entity_display_name: Option<String>,
+    /// Long-form alert body.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_message: Option<String>,
+    /// Value reported in the `monitoring_tool` field (defaults to
+    /// the config's `monitoring_tool`, typically `"acteon"`).
+    pub monitoring_tool: String,
+    /// Optional host name the alert is about.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host_name: Option<String>,
+    /// Unix timestamp (seconds) of when the alerting condition started.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_start_time: Option<i64>,
+}
+
+/// Response body returned by the `VictorOps` REST endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct VictorOpsApiResponse {
+    /// Result status (`"success"` on happy path).
+    #[serde(default)]
+    pub result: String,
+    /// Echoed `entity_id` from the request body.
+    #[serde(default)]
+    pub entity_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_type_parse_valid() {
+        assert_eq!(
+            VictorOpsMessageType::parse("trigger").unwrap(),
+            VictorOpsMessageType::Critical
+        );
+        assert_eq!(
+            VictorOpsMessageType::parse("warn").unwrap(),
+            VictorOpsMessageType::Warning
+        );
+        assert_eq!(
+            VictorOpsMessageType::parse("info").unwrap(),
+            VictorOpsMessageType::Info
+        );
+        assert_eq!(
+            VictorOpsMessageType::parse("acknowledge").unwrap(),
+            VictorOpsMessageType::Acknowledgement
+        );
+        assert_eq!(
+            VictorOpsMessageType::parse("resolve").unwrap(),
+            VictorOpsMessageType::Recovery
+        );
+    }
+
+    #[test]
+    fn message_type_parse_invalid() {
+        let err = VictorOpsMessageType::parse("snooze").unwrap_err();
+        assert!(err.contains("snooze"));
+    }
+
+    #[test]
+    fn message_type_wire_format() {
+        assert_eq!(VictorOpsMessageType::Critical.as_wire(), "CRITICAL");
+        assert_eq!(VictorOpsMessageType::Warning.as_wire(), "WARNING");
+        assert_eq!(VictorOpsMessageType::Info.as_wire(), "INFO");
+        assert_eq!(
+            VictorOpsMessageType::Acknowledgement.as_wire(),
+            "ACKNOWLEDGEMENT"
+        );
+        assert_eq!(VictorOpsMessageType::Recovery.as_wire(), "RECOVERY");
+    }
+
+    #[test]
+    fn alert_request_serializes_minimum() {
+        let req = VictorOpsAlertRequest {
+            message_type: VictorOpsMessageType::Critical,
+            entity_id: None,
+            entity_display_name: None,
+            state_message: None,
+            monitoring_tool: "acteon".into(),
+            host_name: None,
+            state_start_time: None,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["message_type"], "CRITICAL");
+        assert_eq!(json["monitoring_tool"], "acteon");
+        assert!(json.get("entity_id").is_none());
+        assert!(json.get("entity_display_name").is_none());
+        assert!(json.get("state_message").is_none());
+        assert!(json.get("host_name").is_none());
+    }
+
+    #[test]
+    fn alert_request_serializes_full() {
+        let req = VictorOpsAlertRequest {
+            message_type: VictorOpsMessageType::Recovery,
+            entity_id: Some("web-01-high-cpu".into()),
+            entity_display_name: Some("High CPU on web-01".into()),
+            state_message: Some("CPU > 90% for 5 minutes.".into()),
+            monitoring_tool: "prometheus".into(),
+            host_name: Some("web-01".into()),
+            state_start_time: Some(1_713_897_600),
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["message_type"], "RECOVERY");
+        assert_eq!(json["entity_id"], "web-01-high-cpu");
+        assert_eq!(json["entity_display_name"], "High CPU on web-01");
+        assert_eq!(json["state_message"], "CPU > 90% for 5 minutes.");
+        assert_eq!(json["monitoring_tool"], "prometheus");
+        assert_eq!(json["host_name"], "web-01");
+        assert_eq!(json["state_start_time"], 1_713_897_600);
+    }
+
+    #[test]
+    fn api_response_deserializes() {
+        let json = r#"{"result":"success","entity_id":"web-01-high-cpu"}"#;
+        let resp: VictorOpsApiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.result, "success");
+        assert_eq!(resp.entity_id, "web-01-high-cpu");
+    }
+
+    #[test]
+    fn api_response_tolerates_missing_fields() {
+        let resp: VictorOpsApiResponse = serde_json::from_str("{}").unwrap();
+        assert_eq!(resp.result, "");
+        assert_eq!(resp.entity_id, "");
+    }
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -65,6 +65,7 @@ acteon-twilio = { workspace = true }
 acteon-teams = { workspace = true }
 acteon-discord = { workspace = true }
 acteon-opsgenie = { workspace = true }
+acteon-victorops = { workspace = true }
 acteon-executor = { workspace = true }
 acteon-gateway = { workspace = true }
 acteon-llm = { workspace = true }

--- a/crates/server/src/config/providers.rs
+++ b/crates/server/src/config/providers.rs
@@ -21,9 +21,10 @@ pub struct ProviderConfig {
     /// Unique name for this provider.
     pub name: String,
     /// Provider type: `"webhook"`, `"log"`, `"twilio"`, `"teams"`, `"discord"`,
-    /// `"email"`, `"opsgenie"`, `"aws-sns"`, `"aws-lambda"`, `"aws-eventbridge"`,
-    /// `"aws-sqs"`, `"aws-s3"`, `"aws-ec2"`, `"aws-autoscaling"`, `"azure-blob"`,
-    /// `"azure-eventhubs"`, `"gcp-pubsub"`, or `"gcp-storage"`.
+    /// `"email"`, `"opsgenie"`, `"victorops"`, `"aws-sns"`, `"aws-lambda"`,
+    /// `"aws-eventbridge"`, `"aws-sqs"`, `"aws-s3"`, `"aws-ec2"`,
+    /// `"aws-autoscaling"`, `"azure-blob"`, `"azure-eventhubs"`, `"gcp-pubsub"`,
+    /// or `"gcp-storage"`.
     #[serde(rename = "type")]
     pub provider_type: String,
     /// Target URL (required for `"webhook"` type).
@@ -162,6 +163,20 @@ pub struct ProviderConfig {
     /// ```
     #[serde(default)]
     pub opsgenie: OpsGenieProviderConfig,
+
+    /// Nested configuration block for the `"victorops"` provider type.
+    ///
+    /// Example TOML:
+    /// ```toml
+    /// [[providers]]
+    /// name = "victorops-prod"
+    /// type = "victorops"
+    /// victorops.api_key = "ENC[...]"
+    /// victorops.default_route = "team-ops"
+    /// victorops.routes = { team-ops = "ENC[...]", team-infra = "ENC[...]" }
+    /// ```
+    #[serde(default)]
+    pub victorops: VictorOpsProviderConfig,
 }
 
 /// Nested configuration block for the `OpsGenie` provider.
@@ -194,4 +209,28 @@ pub struct OpsGenieProviderConfig {
     /// client-side truncation. Defaults to 130 (the current
     /// `OpsGenie` API cap).
     pub message_max_length: Option<usize>,
+}
+
+/// Nested configuration block for the `VictorOps` (Splunk On-Call) provider.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct VictorOpsProviderConfig {
+    /// Organization-level REST integration key. Supports `ENC[...]`.
+    pub api_key: Option<String>,
+    /// Map of logical route name → per-route routing key. Values
+    /// support `ENC[...]`.
+    pub routes: HashMap<String, String>,
+    /// Name of the default route used when the payload omits
+    /// `routing_key`.
+    pub default_route: Option<String>,
+    /// Override base URL for the `VictorOps` REST endpoint
+    /// integration (testing only).
+    pub api_base_url: Option<String>,
+    /// Value reported in the alert body's `monitoring_tool` field.
+    /// Defaults to `"acteon"` at the provider layer.
+    pub monitoring_tool: Option<String>,
+    /// Whether to auto-prefix `entity_id` with
+    /// `{namespace}:{tenant}:` for multi-tenant isolation. Defaults
+    /// to `true`.
+    pub scope_entity_ids: Option<bool>,
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -763,6 +763,45 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     shared_http_client.clone(),
                 ))
             }
+            "victorops" => {
+                let vo = &provider_cfg.victorops;
+                let api_key_raw = vo.api_key.as_deref().ok_or_else(|| {
+                    format!(
+                        "provider '{}': victorops type requires a 'victorops.api_key' field",
+                        provider_cfg.name
+                    )
+                })?;
+                if vo.routes.is_empty() {
+                    return Err(format!(
+                        "provider '{}': victorops type requires at least one entry in 'victorops.routes'",
+                        provider_cfg.name
+                    )
+                    .into());
+                }
+                let api_key = require_decrypt(api_key_raw, master_key.as_ref())?;
+                let mut victorops_config = acteon_victorops::VictorOpsConfig::new(api_key);
+                for (route_name, routing_key_raw) in &vo.routes {
+                    let routing_key = require_decrypt(routing_key_raw, master_key.as_ref())?;
+                    victorops_config = victorops_config.with_route(route_name, routing_key);
+                }
+                if let Some(ref default_route) = vo.default_route {
+                    victorops_config = victorops_config.with_default_route(default_route);
+                }
+                if let Some(ref url) = vo.api_base_url {
+                    validate_provider_url(&provider_cfg.name, url)?;
+                    victorops_config = victorops_config.with_api_base_url(url);
+                }
+                if let Some(ref tool) = vo.monitoring_tool {
+                    victorops_config = victorops_config.with_monitoring_tool(tool);
+                }
+                if let Some(scope) = vo.scope_entity_ids {
+                    victorops_config = victorops_config.with_scope_entity_ids(scope);
+                }
+                std::sync::Arc::new(acteon_victorops::VictorOpsProvider::with_client(
+                    victorops_config,
+                    shared_http_client.clone(),
+                ))
+            }
             "email" => {
                 let from_address = provider_cfg.from_address.as_deref().ok_or_else(|| {
                     format!(

--- a/crates/simulation/examples/victorops_simulation.rs
+++ b/crates/simulation/examples/victorops_simulation.rs
@@ -1,0 +1,180 @@
+//! VictorOps (Splunk On-Call) provider simulation scenarios.
+//!
+//! Demonstrates dispatching alerts through the full trigger → ack
+//! → resolve lifecycle and a rule-based CRITICAL reroute pattern.
+//!
+//! The scenarios use the simulation harness' recording provider
+//! named `"victorops"`, so no real VictorOps API credentials are
+//! needed — the harness captures the dispatched actions and
+//! asserts that they landed on the right provider.
+//!
+//! Run with: `cargo run -p acteon-simulation --example victorops_simulation`
+
+use acteon_core::Action;
+use acteon_simulation::prelude::*;
+use tracing::info;
+
+const REROUTE_TO_VICTOROPS_RULE: &str = r#"
+rules:
+  - name: reroute-critical-to-victorops
+    priority: 1
+    condition:
+      field: action.payload.severity
+      eq: "critical"
+    action:
+      type: reroute
+      target_provider: victorops
+"#;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    info!("╔══════════════════════════════════════════════════════════════╗");
+    info!("║         VICTOROPS PROVIDER SIMULATION DEMO                  ║");
+    info!("╚══════════════════════════════════════════════════════════════╝\n");
+
+    // =========================================================================
+    // DEMO 1: Alert lifecycle (trigger → acknowledge → resolve)
+    // =========================================================================
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    info!("  DEMO 1: ALERT LIFECYCLE (trigger → acknowledge → resolve)");
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("victorops")
+            .build(),
+    )
+    .await?;
+    info!("✓ Started simulation cluster with 1 node");
+    info!("✓ Registered 'victorops' recording provider\n");
+
+    // 1. TRIGGER — a Prometheus-style alert fires and Acteon
+    //    dispatches it to VictorOps with message_type=CRITICAL.
+    let trigger = Action::new(
+        "incidents",
+        "tenant-1",
+        "victorops",
+        "send_alert",
+        serde_json::json!({
+            "event_action": "trigger",
+            "entity_id": "checkout-api-5xx",
+            "entity_display_name": "Checkout API 5xx rate above SLO",
+            "state_message": "5xx rate crossed SLO threshold for 5 minutes.",
+            "host_name": "checkout-api",
+            "routing_key": "team-ops",
+        }),
+    );
+    info!("→ Dispatching TRIGGER (entity_id=checkout-api-5xx, CRITICAL)...");
+    let outcome = harness.dispatch(&trigger).await?;
+    info!("  Outcome: {outcome:?}");
+
+    // 2. ACKNOWLEDGE — the on-call engineer picks up the alert.
+    let ack = Action::new(
+        "incidents",
+        "tenant-1",
+        "victorops",
+        "send_alert",
+        serde_json::json!({
+            "event_action": "acknowledge",
+            "entity_id": "checkout-api-5xx",
+            "state_message": "Investigating — rolling back deploy #4823.",
+        }),
+    );
+    info!("→ Dispatching ACKNOWLEDGE (oncall picked up)...");
+    let outcome = harness.dispatch(&ack).await?;
+    info!("  Outcome: {outcome:?}");
+
+    // 3. RESOLVE — the underlying issue is cleared.
+    let resolve = Action::new(
+        "incidents",
+        "tenant-1",
+        "victorops",
+        "send_alert",
+        serde_json::json!({
+            "event_action": "resolve",
+            "entity_id": "checkout-api-5xx",
+            "state_message": "Rollback confirmed; error rate back below threshold.",
+        }),
+    );
+    info!("→ Dispatching RESOLVE (incident closed)...");
+    let outcome = harness.dispatch(&resolve).await?;
+    info!("  Outcome: {outcome:?}");
+
+    let provider = harness.provider("victorops").unwrap();
+    info!(
+        "\n  VictorOps provider received {} action(s) across the lifecycle",
+        provider.call_count()
+    );
+    assert_eq!(provider.call_count(), 3);
+    harness.teardown().await?;
+    info!("✓ Simulation cluster shut down\n");
+
+    // =========================================================================
+    // DEMO 2: Rule-based reroute of critical alerts to VictorOps
+    // =========================================================================
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    info!("  DEMO 2: RULE-BASED REROUTE — critical alerts → VictorOps");
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("log")
+            .add_recording_provider("victorops")
+            .add_rule_yaml(REROUTE_TO_VICTOROPS_RULE)
+            .build(),
+    )
+    .await?;
+    info!("✓ Started cluster with log + victorops recording providers");
+    info!("✓ Loaded reroute rule: severity=critical → victorops\n");
+
+    // Non-critical alert — stays on the log provider.
+    let warn = Action::new(
+        "incidents",
+        "tenant-1",
+        "log",
+        "notify",
+        serde_json::json!({
+            "severity": "warning",
+            "message": "Queue depth above warning threshold",
+        }),
+    );
+    info!("→ Dispatching WARN alert (should stay on 'log')...");
+    let outcome = harness.dispatch(&warn).await?;
+    info!("  Outcome: {outcome:?}");
+
+    // Critical alert — the rule reroutes it to victorops.
+    let critical = Action::new(
+        "incidents",
+        "tenant-1",
+        "log",
+        "notify",
+        serde_json::json!({
+            "event_action": "trigger",
+            "entity_id": "checkout-api-down",
+            "severity": "critical",
+            "entity_display_name": "Checkout API is down",
+        }),
+    );
+    info!("→ Dispatching CRITICAL alert (should reroute to 'victorops')...");
+    let outcome = harness.dispatch(&critical).await?;
+    info!("  Outcome: {outcome:?}");
+
+    let log_calls = harness.provider("log").unwrap().call_count();
+    let victorops_calls = harness.provider("victorops").unwrap().call_count();
+    info!("\n  Provider call counts:");
+    info!("    log:       {log_calls}");
+    info!("    victorops: {victorops_calls}");
+    assert_eq!(log_calls, 1, "warn alert should have stayed on log");
+    assert_eq!(
+        victorops_calls, 1,
+        "critical alert should have been rerouted"
+    );
+
+    harness.teardown().await?;
+    info!("\n✓ All demos complete.");
+    Ok(())
+}

--- a/docs/book/features/victorops.md
+++ b/docs/book/features/victorops.md
@@ -1,0 +1,159 @@
+# VictorOps / Splunk On-Call Provider
+
+Acteon ships with a first-class **VictorOps** (now Splunk On-Call) provider that posts alerts to the [REST endpoint integration][integration] — the same endpoint Alertmanager targets via its `victorops_configs`. It was built as part of Phase 4b of the Alertmanager feature-parity initiative so ops teams migrating off Alertmanager can reuse their existing VictorOps routing without rewriting runbooks.
+
+[integration]: https://help.victorops.com/knowledge-base/rest-endpoint-integration-guide/
+
+Like Acteon's other native providers, `acteon-victorops`:
+
+- Supports multiple routing keys per provider instance so one config can fan alerts out to several VictorOps teams.
+- Stores both the organization API key and every routing key as `SecretString`, zeroizing the plaintexts on drop.
+- Auto-scopes `entity_id` with `{namespace}:{tenant}:` for multi-tenant isolation on shared integration keys (opt-out available).
+- Propagates W3C Trace Context (`traceparent`/`tracestate`) headers.
+- Maps 5xx / 408 → retryable `Connection`; 429 → retryable `RateLimited`; 401/403 → non-retryable `Configuration`; other 4xx → non-retryable `ExecutionFailed`.
+- Reuses the server's shared HTTP client, so it participates in circuit breaking, provider health checks, and per-provider metrics automatically.
+
+## TOML configuration
+
+VictorOps uses Acteon's **nested provider config** pattern: every VictorOps-specific setting lives under a `victorops.*` key rather than at the top level of the `[[providers]]` entry.
+
+```toml
+[[providers]]
+name = "victorops-prod"
+type = "victorops"
+victorops.api_key = "ENC[AES256_GCM,data:abc123...]"
+victorops.default_route = "team-ops"
+victorops.monitoring_tool = "acteon"     # default
+# victorops.scope_entity_ids = true      # default — see "Multi-tenant isolation" below
+# victorops.api_base_url = "..."         # testing only
+
+[providers.victorops.routes]
+team-ops   = "ENC[AES256_GCM,data:def456...]"
+team-infra = "ENC[AES256_GCM,data:ghi789...]"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used when dispatching actions |
+| `type` | Yes | Must be `"victorops"` |
+| `victorops.api_key` | Yes | Organization-level REST integration key. Supports `ENC[...]`. |
+| `victorops.routes` | Yes (≥1) | Map of logical route name → per-route routing key. Values support `ENC[...]`. |
+| `victorops.default_route` | No | Name of the default route used when the dispatch payload omits `routing_key`. If there is only one route, it is used implicitly. |
+| `victorops.monitoring_tool` | No | Value reported in the alert body's `monitoring_tool` field. Defaults to `"acteon"`. |
+| `victorops.scope_entity_ids` | No | Whether to auto-prefix `entity_id` with `{namespace}:{tenant}:` for multi-tenant isolation. Defaults to `true`. See below. |
+| `victorops.api_base_url` | No | Override the REST endpoint base URL. Tests only — do not set in production. |
+
+Both the `api_key` and every value in `routes` get embedded as **URL path segments** in the final request (`POST /integrations/generic/20131114/alert/{api_key}/{routing_key}`). Both segments are percent-encoded using the `percent-encoding` crate so a stray character in either cannot inject an extra path component.
+
+## Multi-tenant isolation
+
+Alerts dispatched by Acteon come from `(namespace, tenant)` scopes, but VictorOps has no native tenant concept. On a shared integration key (common in large orgs), that means two tenants that both pick the raw `entity_id` `web-01-high-cpu` would otherwise collide — and Tenant A could resolve Tenant B's incident simply by guessing the `entity_id`.
+
+**By default** (`victorops.scope_entity_ids = true`, which is the default), the provider rewrites every `entity_id` to `{namespace}:{tenant}:{raw_entity_id}` before sending it to VictorOps. The prefix is applied identically on `trigger`, `acknowledge`, and `resolve` so all three map to the same VictorOps incident, but two tenants can never refer to each other's alerts.
+
+Set `victorops.scope_entity_ids = false` only if:
+
+1. Every Acteon namespace/tenant has its own dedicated VictorOps integration key, **or**
+2. You genuinely need cross-tenant `entity_id` coordination (e.g., a platform team resolving a customer alert from a shared runbook).
+
+## Payload shape
+
+Dispatch actions target the provider by name and carry an `event_action` in the payload. The provider maps `event_action` to a VictorOps `message_type`:
+
+| `event_action` | VictorOps `message_type` | Purpose |
+|---|---|---|
+| `"trigger"` | `CRITICAL` | Firing alert — pages the on-call |
+| `"warn"` | `WARNING` | Lower-priority alert, visible but does not page |
+| `"info"` | `INFO` | Informational — does not page |
+| `"acknowledge"` | `ACKNOWLEDGEMENT` | Oncall picked up the incident |
+| `"resolve"` | `RECOVERY` | Incident resolved |
+
+### Trigger
+
+```json
+{
+  "event_action": "trigger",
+  "entity_id": "checkout-api-5xx",
+  "entity_display_name": "Checkout API 5xx rate above SLO",
+  "state_message": "5xx rate crossed SLO threshold for 5 minutes.",
+  "host_name": "checkout-api",
+  "routing_key": "team-ops",
+  "state_start_time": 1713897600
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `event_action` | string | **Required.** See the message-type table above. |
+| `entity_id` | string | Deduplication key. **Required for `acknowledge` / `resolve`** so the lifecycle events correlate with the original trigger. Optional on `trigger` / `warn` / `info` (VictorOps will auto-assign). |
+| `entity_display_name` | string | Short human-readable title. |
+| `state_message` | string | Long-form body. |
+| `host_name` | string | Domain entity the alert is about. |
+| `routing_key` | string | Logical route name (matching a key in `victorops.routes`). Falls back to `victorops.default_route` or the single-entry implicit default. |
+| `state_start_time` | int | Unix timestamp (seconds) of when the alerting condition started. |
+| `monitoring_tool` | string | Overrides the provider's configured default. |
+
+### Acknowledge
+
+```json
+{
+  "event_action": "acknowledge",
+  "entity_id": "checkout-api-5xx",
+  "state_message": "Investigating — rolling back deploy #4823."
+}
+```
+
+### Resolve
+
+```json
+{
+  "event_action": "resolve",
+  "entity_id": "checkout-api-5xx",
+  "state_message": "Rollback confirmed; error rate back below threshold."
+}
+```
+
+## Rule integration
+
+Because VictorOps is just another named provider, every routing primitive Acteon already has works with it:
+
+- **Reroute critical alerts** to the VictorOps integration by matching on `action.payload.severity == "critical"` with a `reroute` rule.
+- **Silence maintenance windows** with [silences](silences.md) — silences apply before the provider dispatch, so a VictorOps alert never leaves the gateway during an active silence.
+- **Quota-bound a VictorOps account** via a [per-provider tenant quota](tenant-quotas.md) scoped to `provider: "victorops-prod"` to cap burst traffic.
+- **Dedup noisy alerts** with Acteon's [deduplication](deduplication.md) using the VictorOps `entity_id` as the dedup key — VictorOps then collapses the incident server-side through its own entity-id correlation.
+
+## Outcome body
+
+On success the provider returns an `Executed` outcome whose `body` carries the VictorOps response:
+
+```json
+{
+  "result": "success",
+  "entity_id": "incidents:tenant-1:checkout-api-5xx"
+}
+```
+
+The returned `entity_id` is the **scoped** form that the provider actually sent (i.e., it includes the `{namespace}:{tenant}:` prefix when `scope_entity_ids` is on). Operators resolving incidents through the VictorOps UI should reference this exact value.
+
+## Error mapping
+
+| HTTP status | `ProviderError` | Retryable? |
+|-------------|-----------------|------------|
+| 2xx | `Executed` (success) | — |
+| 401 / 403 | `Configuration(...)` | No |
+| 429 | `RateLimited` | Yes |
+| 408, 5xx | `Connection(...)` (via `Transient`) | **Yes** — a brief VictorOps outage re-queues the alert |
+| Other 4xx | `ExecutionFailed(...)` | No |
+| Transport failure | `Connection(...)` | Yes |
+
+Invalid payloads (missing `entity_id` on ack/resolve, unknown `event_action`, unknown routing key) map to `Serialization` / `Configuration` and are **not** retryable.
+
+## Simulation example
+
+A full end-to-end demo that walks through the `trigger → acknowledge → resolve` lifecycle plus a rule-based critical reroute is in `crates/simulation/examples/victorops_simulation.rs`:
+
+```bash
+cargo run -p acteon-simulation --example victorops_simulation
+```
+
+The simulation uses a recording provider, so it runs offline with no real VictorOps credentials.

--- a/docs/design-alertmanager-parity.md
+++ b/docs/design-alertmanager-parity.md
@@ -36,7 +36,7 @@ A fresh audit against Alertmanager v0.27 features found the following gaps.
 | 2 | `group_wait` / `group_interval` / `repeat_interval` | **Shipped in Phase 2.** `group_wait` was already implemented; `group_interval` is now honored on persistent groups; `repeat_interval` is a new optional field that makes the group persistent and re-fire periodically. | ~~Medium~~ Done |
 | 3 | Per-receiver rate limits | **Shipped in Phase 3.** Generic tenant/namespace quotas now stack with optional per-provider scoped policies; strictest outcome wins; each scope has its own counter bucket. | ~~Medium~~ Done |
 | 4 | OpsGenie receiver | **Shipped in Phase 4a.** New `acteon-opsgenie` crate implements the Alert API v2 (create / acknowledge / close) against both US and EU regions, wired into the server's TOML provider config as `type = "opsgenie"`. | ~~Medium~~ Done |
-| 5 | VictorOps receiver | Missing | Medium |
+| 5 | VictorOps receiver | **Shipped in Phase 4b.** New `acteon-victorops` crate implements the REST endpoint integration (trigger / warn / info / acknowledge / resolve) with routing-key fan-out, auto-scoped `entity_id` for multi-tenant safety, and retryable 5xx/408. | ~~Medium~~ Done |
 | 6 | Pushover receiver | Missing | Low |
 | 7 | WeChat receiver | Missing | Low |
 | 8 | Telegram receiver | Missing | Low |
@@ -157,8 +157,60 @@ Simulation: `crates/simulation/examples/opsgenie_simulation.rs`
 walks through create/ack/close plus a rule-based reroute for
 P1-priority alerts. Docs: `docs/book/features/opsgenie.md`.
 
-#### Phase 4b–4d — VictorOps, Pushover, WeChat, Telegram
-**Gaps**: #5–#8
+#### Phase 4b — VictorOps ✅ Shipped
+**Gap**: #5
+**Status**: Shipped in PR (feat/victorops-provider).
+**Scope as built**: new `acteon-victorops` crate (~1600 LOC with tests) plus server wiring, simulation example, and docs.
+
+The `acteon-victorops` crate implements the
+[REST endpoint integration](https://help.victorops.com/knowledge-base/rest-endpoint-integration-guide/)
+— the same endpoint Alertmanager targets via its
+`victorops_configs` — with the following properties:
+- **Lifecycle**: a single provider handles the
+  `trigger` → `acknowledge` → `resolve` sequence plus `warn` and
+  `info` variants by branching on the payload's `event_action`
+  field. The branch is mapped to `VictorOps`'s `message_type`
+  (`CRITICAL` / `WARNING` / `INFO` / `ACKNOWLEDGEMENT` /
+  `RECOVERY`).
+- **Routing fan-out**: the `VictorOps` REST integration encodes
+  both an organization-level api key and a per-route routing key
+  in the URL. The provider supports registering multiple routing
+  keys under logical names and lets dispatch payloads pick
+  between them via a `routing_key` field, falling back to a
+  configured default or a single-entry implicit default.
+- **Multi-tenant safety**: `entity_id` (the `VictorOps` dedup
+  key) is auto-prefixed with `{namespace}:{tenant}:` by default,
+  matching the `acteon-opsgenie` alias-scoping pattern. An
+  opt-out (`scope_entity_ids = false`) is documented for
+  single-tenant deployments or cross-tenant coordination.
+- **Secret hygiene**: `api_key` and every routing key live in
+  `SecretString`, zeroized on drop. The `Debug` impl redacts
+  both. Neither appears in log messages or URL debug output.
+- **Percent-encoding**: uses the `percent-encoding` crate (added
+  to the workspace in PR #86) with an explicit RFC 3986
+  path-segment `AsciiSet` so multi-byte UTF-8 and reserved
+  characters in the api key or routing key cannot inject extra
+  path components.
+- **Error mapping**: 401/403 → non-retryable `Configuration`;
+  429 → retryable `RateLimited`; 5xx/408 → retryable `Connection`
+  (via the same `Transient` variant pattern established in PR #86
+  for `OpsGenie`); other 4xx → non-retryable `ExecutionFailed`.
+- **Testing**: 49 unit tests including a tiny in-process mock
+  HTTP server that captures the request body so tests assert on
+  the full wire format — URL shape, path segments, JSON payload
+  — for every lifecycle branch.
+
+Config uses the same nested provider sub-struct pattern as
+`OpsGenie`: `victorops.api_key`, `victorops.routes`,
+`victorops.default_route`, `victorops.monitoring_tool`,
+`victorops.scope_entity_ids`. Both secrets support `ENC[...]`.
+
+Simulation: `crates/simulation/examples/victorops_simulation.rs`
+walks the full lifecycle plus a severity-based reroute. Docs:
+`docs/book/features/victorops.md`.
+
+#### Phase 4c–4d — Pushover, WeChat, Telegram
+**Gaps**: #6–#8
 **Status**: Pending. Each provider ships as its own PR so a
 review problem in one cannot block the others.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,7 @@ nav:
     - AWS Providers: features/aws-providers.md
     - Native Providers: features/native-providers.md
     - OpsGenie: features/opsgenie.md
+    - VictorOps: features/victorops.md
   - Backends:
     - backends/index.md
     - State Backends: backends/state-backends.md


### PR DESCRIPTION
## Summary

Phase 4b of the [Alertmanager feature parity plan](https://github.com/penserai/acteon/blob/main/docs/design-alertmanager-parity.md): closes gap #5 by shipping a first-class `acteon-victorops` provider crate for VictorOps / Splunk On-Call, targeting the same REST endpoint integration Alertmanager uses via its `victorops_configs`.

VictorOps is the second-most-requested missing receiver after OpsGenie for teams migrating off Alertmanager. Shipping these two back-to-back covers the vast majority of real-world on-call migrations.

## Design

**Lifecycle** — a single provider handles the full lifecycle by branching on the payload's `event_action`:

| `event_action` | VictorOps `message_type` | Purpose |
|---|---|---|
| `"trigger"` | `CRITICAL` | Firing alert |
| `"warn"` | `WARNING` | Lower-priority alert |
| `"info"` | `INFO` | Informational |
| `"acknowledge"` | `ACKNOWLEDGEMENT` | Oncall picked up |
| `"resolve"` | `RECOVERY` | Incident closed |

**Routing fan-out** — the VictorOps REST integration encodes both an organization-level `api_key` and a per-route `routing_key` in the URL path. The provider supports registering multiple routing keys under logical names and lets dispatch payloads pick between them via a `routing_key` field, falling back to a configured default or single-entry implicit default.

**Multi-tenant safety** — `entity_id` (the VictorOps dedup key) is auto-prefixed with `{namespace}:{tenant}:` by default, matching the `acteon-opsgenie` alias-scoping pattern (PR #86). Opt-out available for single-tenant deployments.

**Secret hygiene** — both `api_key` and every routing key are `SecretString`, zeroized on drop. The `Debug` impl redacts both. Neither appears in log messages or URL debug output.

**Percent-encoding** — uses the `percent-encoding` crate (added to the workspace in PR #86) with an explicit RFC 3986 path-segment `AsciiSet` so multi-byte UTF-8 and reserved characters in either the api key or routing key cannot inject extra path components.

**Retry map** — mirrors opsgenie so operators see consistent semantics across on-call receivers:
- 401/403 → non-retryable `Configuration`
- 429 → retryable `RateLimited`
- 5xx/408 → retryable `Connection` (via `Transient`)
- Other 4xx → non-retryable `ExecutionFailed`

## Example TOML

```toml
[[providers]]
name = "victorops-prod"
type = "victorops"
victorops.api_key = "ENC[AES256_GCM,data:...]"
victorops.default_route = "team-ops"
victorops.monitoring_tool = "acteon"

[providers.victorops.routes]
team-ops   = "ENC[AES256_GCM,data:...]"
team-infra = "ENC[AES256_GCM,data:...]"
```

## Example payload

```json
{
  "event_action": "trigger",
  "entity_id": "checkout-api-5xx",
  "entity_display_name": "Checkout API 5xx rate above SLO",
  "state_message": "5xx rate crossed SLO threshold for 5 minutes.",
  "host_name": "checkout-api",
  "routing_key": "team-ops"
}
```

## Test plan

- [x] `cargo test -p acteon-victorops --lib` — 49 passing
- [x] `cargo test --workspace --lib --bins --tests` — full suite green
- [x] `cargo clippy -p acteon-victorops --no-deps --lib --tests -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p acteon-victorops --no-deps` — clean
- [x] `cargo run -p acteon-simulation --example victorops_simulation` — lifecycle + reroute assertions pass
- [x] UI lint + build — green

## Remaining Phase 4 providers

Pushover, WeChat, and Telegram are still pending — each will ship as its own PR so a review problem in one cannot block the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)