### PR TITLE
feat: Pushover provider (Phase 4c of Alertmanager parity)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "acteon-pushover"
+version = "0.1.0"
+dependencies = [
+ "acteon-core",
+ "acteon-crypto",
+ "acteon-provider",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "acteon-rules"
 version = "0.1.0"
 dependencies = [
@@ -488,6 +504,7 @@ dependencies = [
  "acteon-llm",
  "acteon-opsgenie",
  "acteon-provider",
+ "acteon-pushover",
  "acteon-rules",
  "acteon-rules-yaml",
  "acteon-state",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
     "crates/integrations/pagerduty",
     "crates/integrations/opsgenie",
     "crates/integrations/victorops",
+    "crates/integrations/pushover",
     "crates/integrations/webhook",
     "crates/integrations/twilio",
     "crates/integrations/teams",
@@ -131,6 +132,7 @@ acteon-slack = { path = "crates/integrations/slack" }
 acteon-pagerduty = { path = "crates/integrations/pagerduty" }
 acteon-opsgenie = { path = "crates/integrations/opsgenie" }
 acteon-victorops = { path = "crates/integrations/victorops" }
+acteon-pushover = { path = "crates/integrations/pushover" }
 acteon-webhook = { path = "crates/integrations/webhook" }
 acteon-twilio = { path = "crates/integrations/twilio" }
 acteon-teams = { path = "crates/integrations/teams" }

--- a/crates/integrations/pushover/Cargo.toml
+++ b/crates/integrations/pushover/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "acteon-pushover"
+description = "Pushover provider for Acteon — sends push notifications via the Pushover Messages API"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+
+[dependencies]
+acteon-core = { workspace = true }
+acteon-crypto = { workspace = true }
+acteon-provider = { workspace = true, features = ["trace-context"] }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+serde_urlencoded = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/integrations/pushover/src/config.rs
+++ b/crates/integrations/pushover/src/config.rs
@@ -1,0 +1,288 @@
+use std::collections::HashMap;
+
+use acteon_crypto::{ExposeSecret, SecretString};
+
+use crate::error::PushoverError;
+
+/// Configuration for the `Pushover` provider.
+///
+/// Pushover authenticates every request with two secrets: an
+/// application-level `app_token` and a per-recipient `user_key`
+/// (which can be either an individual user key or a group key).
+/// Both live in [`SecretString`] so the plaintexts are zeroized on
+/// drop (via the `zeroize` crate, transitively through `secrecy`)
+/// and the `Debug` impl redacts them to `[REDACTED]`.
+///
+/// Multiple user keys can be registered so one provider instance
+/// can fan notifications out to several recipients (or groups)
+/// based on the dispatch payload's `user_key` field.
+#[derive(Clone)]
+pub struct PushoverConfig {
+    /// Application token (the `T...` key that identifies the
+    /// Pushover app registered for Acteon).
+    app_token: SecretString,
+
+    /// Map of logical recipient name → user or group key
+    /// (`U...` / `G...`). The dispatch payload selects an entry
+    /// via its `user_key` field.
+    user_keys: HashMap<String, SecretString>,
+
+    /// Name of the default entry in `user_keys` used when the
+    /// payload omits an explicit `user_key`.
+    default_recipient: Option<String>,
+
+    /// Base URL for the Pushover Messages API. Override this to
+    /// point tests at a mock server.
+    api_base_url: String,
+}
+
+impl std::fmt::Debug for PushoverConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        struct RedactedRecipients<'a>(&'a HashMap<String, SecretString>);
+        impl std::fmt::Debug for RedactedRecipients<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let mut map = f.debug_map();
+                for name in self.0.keys() {
+                    map.entry(name, &"[REDACTED]");
+                }
+                map.finish()
+            }
+        }
+        f.debug_struct("PushoverConfig")
+            .field("app_token", &"[REDACTED]")
+            .field("user_keys", &RedactedRecipients(&self.user_keys))
+            .field("default_recipient", &self.default_recipient)
+            .field("api_base_url", &self.api_base_url)
+            .finish()
+    }
+}
+
+impl PushoverConfig {
+    /// Create an empty configuration with the given app token.
+    /// Callers typically chain [`Self::with_recipient`] to register
+    /// at least one user key before building a provider.
+    #[must_use]
+    pub fn new(app_token: impl Into<String>) -> Self {
+        Self {
+            app_token: SecretString::new(app_token.into()),
+            user_keys: HashMap::new(),
+            default_recipient: None,
+            api_base_url: "https://api.pushover.net".to_owned(),
+        }
+    }
+
+    /// Convenience shorthand for the single-recipient case.
+    #[must_use]
+    pub fn single_recipient(
+        app_token: impl Into<String>,
+        recipient_name: impl Into<String>,
+        user_key: impl Into<String>,
+    ) -> Self {
+        let recipient_name = recipient_name.into();
+        let mut config = Self::new(app_token);
+        config
+            .user_keys
+            .insert(recipient_name.clone(), SecretString::new(user_key.into()));
+        config.default_recipient = Some(recipient_name);
+        config
+    }
+
+    /// Register an additional user or group key under a logical name.
+    #[must_use]
+    pub fn with_recipient(mut self, name: impl Into<String>, user_key: impl Into<String>) -> Self {
+        self.user_keys
+            .insert(name.into(), SecretString::new(user_key.into()));
+        self
+    }
+
+    /// Set the default recipient used when the payload omits an
+    /// explicit `user_key`.
+    #[must_use]
+    pub fn with_default_recipient(mut self, name: impl Into<String>) -> Self {
+        self.default_recipient = Some(name.into());
+        self
+    }
+
+    /// Override the API base URL (primarily for tests).
+    #[must_use]
+    pub fn with_api_base_url(mut self, url: impl Into<String>) -> Self {
+        self.api_base_url = url.into();
+        self
+    }
+
+    /// Decrypt any `ENC[...]` secrets in place.
+    #[must_use = "returns the config with decrypted secrets"]
+    pub fn decrypt_secrets(
+        mut self,
+        master_key: &acteon_crypto::MasterKey,
+    ) -> Result<Self, PushoverError> {
+        self.app_token = acteon_crypto::decrypt_value(self.app_token.expose_secret(), master_key)
+            .map_err(|e| {
+            PushoverError::InvalidPayload(format!("failed to decrypt app_token: {e}"))
+        })?;
+        let mut decrypted: HashMap<String, SecretString> =
+            HashMap::with_capacity(self.user_keys.len());
+        for (name, value) in &self.user_keys {
+            let v =
+                acteon_crypto::decrypt_value(value.expose_secret(), master_key).map_err(|e| {
+                    PushoverError::InvalidPayload(format!(
+                        "failed to decrypt user_key '{name}': {e}"
+                    ))
+                })?;
+            decrypted.insert(name.clone(), v);
+        }
+        self.user_keys = decrypted;
+        Ok(self)
+    }
+
+    /// Return the API base URL.
+    #[must_use]
+    pub fn api_base_url(&self) -> &str {
+        &self.api_base_url
+    }
+
+    /// Return the app token (kept `pub(crate)` so the secret stays
+    /// inside this crate).
+    pub(crate) fn app_token(&self) -> &str {
+        self.app_token.expose_secret()
+    }
+
+    /// Resolve a recipient name to its user/group key, honoring the
+    /// default-recipient fallback and the single-entry implicit
+    /// fallback.
+    pub(crate) fn resolve_user_key(&self, name: Option<&str>) -> Result<&str, PushoverError> {
+        match name {
+            Some(n) => self
+                .user_keys
+                .get(n)
+                .map(|s| s.expose_secret().as_str())
+                .ok_or_else(|| PushoverError::UnknownRecipient(n.to_owned())),
+            None => {
+                if let Some(default_name) = &self.default_recipient {
+                    self.user_keys
+                        .get(default_name.as_str())
+                        .map(|s| s.expose_secret().as_str())
+                        .ok_or_else(|| PushoverError::UnknownRecipient(default_name.clone()))
+                } else if self.user_keys.len() == 1 {
+                    Ok(self
+                        .user_keys
+                        .values()
+                        .next()
+                        .unwrap()
+                        .expose_secret()
+                        .as_str())
+                } else {
+                    Err(PushoverError::NoDefaultRecipient)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_defaults() {
+        let config = PushoverConfig::new("app");
+        assert_eq!(config.app_token(), "app");
+        assert_eq!(config.api_base_url(), "https://api.pushover.net");
+        assert!(config.user_keys.is_empty());
+        assert!(config.default_recipient.is_none());
+    }
+
+    #[test]
+    fn single_recipient_constructor() {
+        let config = PushoverConfig::single_recipient("app", "ops-oncall", "u-ops");
+        assert_eq!(config.resolve_user_key(None).unwrap(), "u-ops");
+        assert_eq!(
+            config.resolve_user_key(Some("ops-oncall")).unwrap(),
+            "u-ops"
+        );
+    }
+
+    #[test]
+    fn builder_chain() {
+        let config = PushoverConfig::new("app")
+            .with_recipient("ops", "u-ops")
+            .with_recipient("dev", "u-dev")
+            .with_default_recipient("ops")
+            .with_api_base_url("http://mock");
+        assert_eq!(config.api_base_url(), "http://mock");
+        assert_eq!(config.resolve_user_key(None).unwrap(), "u-ops");
+        assert_eq!(config.resolve_user_key(Some("dev")).unwrap(), "u-dev");
+    }
+
+    #[test]
+    fn resolve_unknown_recipient() {
+        let config = PushoverConfig::single_recipient("app", "ops", "u-ops");
+        let err = config.resolve_user_key(Some("dev")).unwrap_err();
+        assert!(matches!(err, PushoverError::UnknownRecipient(ref n) if n == "dev"));
+    }
+
+    #[test]
+    fn resolve_no_default_multi() {
+        let config = PushoverConfig::new("app")
+            .with_recipient("ops", "u-ops")
+            .with_recipient("dev", "u-dev");
+        let err = config.resolve_user_key(None).unwrap_err();
+        assert!(matches!(err, PushoverError::NoDefaultRecipient));
+    }
+
+    #[test]
+    fn resolve_implicit_single() {
+        let config = PushoverConfig::new("app").with_recipient("ops", "u-ops");
+        assert_eq!(config.resolve_user_key(None).unwrap(), "u-ops");
+    }
+
+    fn test_master_key() -> acteon_crypto::MasterKey {
+        acteon_crypto::parse_master_key(&"42".repeat(32)).unwrap()
+    }
+
+    #[test]
+    fn decrypt_secrets_roundtrip() {
+        let master_key = test_master_key();
+        let app_plain = "app-token-plain";
+        let user_plain = "user-key-plain";
+        let app_enc = acteon_crypto::encrypt_value(app_plain, &master_key).unwrap();
+        let user_enc = acteon_crypto::encrypt_value(user_plain, &master_key).unwrap();
+
+        let config = PushoverConfig::new(app_enc)
+            .with_recipient("ops", user_enc)
+            .decrypt_secrets(&master_key)
+            .unwrap();
+        assert_eq!(config.app_token(), app_plain);
+        assert_eq!(config.resolve_user_key(Some("ops")).unwrap(), user_plain);
+    }
+
+    #[test]
+    fn decrypt_secrets_plaintext_passthrough() {
+        let master_key = test_master_key();
+        let config = PushoverConfig::single_recipient("plain-app", "ops", "plain-user")
+            .decrypt_secrets(&master_key)
+            .unwrap();
+        assert_eq!(config.app_token(), "plain-app");
+        assert_eq!(config.resolve_user_key(Some("ops")).unwrap(), "plain-user");
+    }
+
+    #[test]
+    fn decrypt_secrets_invalid_app_token() {
+        let master_key = test_master_key();
+        let config = PushoverConfig::new("ENC[AES256-GCM,data:bad,iv:bad,tag:bad]");
+        let err = config.decrypt_secrets(&master_key).unwrap_err();
+        assert!(matches!(err, PushoverError::InvalidPayload(_)));
+    }
+
+    #[test]
+    fn debug_redacts_secrets() {
+        let config = PushoverConfig::new("super-secret-app-token-placeholder")
+            .with_recipient("ops", "super-secret-user-key-placeholder");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("super-secret-app-token-placeholder"));
+        assert!(!debug.contains("super-secret-user-key-placeholder"));
+        // Logical names should still be visible for operators.
+        assert!(debug.contains("ops"));
+    }
+}

--- a/crates/integrations/pushover/src/error.rs
+++ b/crates/integrations/pushover/src/error.rs
@@ -1,0 +1,137 @@
+use acteon_provider::ProviderError;
+use thiserror::Error;
+
+/// Errors specific to the `Pushover` provider.
+///
+/// These are internal errors that get converted into [`ProviderError`]
+/// at the public API boundary. The variants deliberately mirror the
+/// other on-call receiver crates so operators see the same retry
+/// semantics across the Alertmanager parity set.
+#[derive(Debug, Error)]
+pub enum PushoverError {
+    /// An HTTP-level transport error occurred.
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// The Pushover API returned a **permanent** non-success response
+    /// (a 4xx that is not a rate-limit or auth failure).
+    #[error("Pushover API error: {0}")]
+    Api(String),
+
+    /// The Pushover API returned a **transient** non-success response
+    /// (5xx server error or 408 Request Timeout). Surfaced as
+    /// `ProviderError::Connection` so the gateway's retry logic
+    /// re-queues the dispatch instead of dropping the notification.
+    #[error("Pushover transient error: {0}")]
+    Transient(String),
+
+    /// The action payload is missing required fields or has invalid structure.
+    #[error("invalid payload: {0}")]
+    InvalidPayload(String),
+
+    /// The provider received an HTTP 429 (Too Many Requests) response.
+    #[error("rate limited by Pushover")]
+    RateLimited,
+
+    /// The provider received an HTTP 401/403 response — typically a bad
+    /// app token or user key.
+    #[error("authentication failed: {0}")]
+    Unauthorized(String),
+
+    /// The payload referenced a `user_key` that is not present in the
+    /// configured recipients map.
+    #[error("unknown Pushover recipient: {0}")]
+    UnknownRecipient(String),
+
+    /// No `user_key` was provided in the payload and no fallback applies
+    /// (no default recipient, and the recipient map is not a single-entry map).
+    #[error("no user_key in payload and no default recipient configured")]
+    NoDefaultRecipient,
+}
+
+impl From<PushoverError> for ProviderError {
+    fn from(err: PushoverError) -> Self {
+        match err {
+            PushoverError::Http(e) => ProviderError::Connection(e.to_string()),
+            PushoverError::Api(msg) => ProviderError::ExecutionFailed(msg),
+            PushoverError::Transient(msg) => ProviderError::Connection(msg),
+            PushoverError::InvalidPayload(msg) => ProviderError::Serialization(msg),
+            PushoverError::RateLimited => ProviderError::RateLimited,
+            PushoverError::Unauthorized(msg) => ProviderError::Configuration(msg),
+            PushoverError::UnknownRecipient(name) => {
+                ProviderError::Configuration(format!("unknown Pushover recipient: {name}"))
+            }
+            PushoverError::NoDefaultRecipient => ProviderError::Configuration(
+                "no user_key in payload and no default recipient configured".into(),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limited_is_retryable() {
+        let e: ProviderError = PushoverError::RateLimited.into();
+        assert!(e.is_retryable());
+        assert!(matches!(e, ProviderError::RateLimited));
+    }
+
+    #[test]
+    fn transient_maps_to_retryable_connection() {
+        let e: ProviderError =
+            PushoverError::Transient("HTTP 503: Service Unavailable".into()).into();
+        assert!(e.is_retryable());
+        assert!(matches!(e, ProviderError::Connection(_)));
+    }
+
+    #[test]
+    fn api_is_non_retryable() {
+        let e: ProviderError = PushoverError::Api("bad request".into()).into();
+        assert!(!e.is_retryable());
+        assert!(matches!(e, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn unauthorized_is_configuration() {
+        let e: ProviderError = PushoverError::Unauthorized("bad token".into()).into();
+        assert!(!e.is_retryable());
+        assert!(matches!(e, ProviderError::Configuration(_)));
+    }
+
+    #[test]
+    fn unknown_recipient_is_configuration() {
+        let e: ProviderError = PushoverError::UnknownRecipient("ops-gone".into()).into();
+        assert!(!e.is_retryable());
+        assert!(matches!(e, ProviderError::Configuration(_)));
+    }
+
+    #[test]
+    fn invalid_payload_is_serialization() {
+        let e: ProviderError = PushoverError::InvalidPayload("missing message".into()).into();
+        assert!(!e.is_retryable());
+        assert!(matches!(e, ProviderError::Serialization(_)));
+    }
+
+    #[test]
+    fn display_messages() {
+        assert_eq!(
+            PushoverError::Api("bad".into()).to_string(),
+            "Pushover API error: bad"
+        );
+        assert_eq!(
+            PushoverError::Transient("503".into()).to_string(),
+            "Pushover transient error: 503"
+        );
+        assert_eq!(
+            PushoverError::RateLimited.to_string(),
+            "rate limited by Pushover"
+        );
+        assert_eq!(
+            PushoverError::UnknownRecipient("ops".into()).to_string(),
+            "unknown Pushover recipient: ops"
+        );
+    }
+}

--- a/crates/integrations/pushover/src/lib.rs
+++ b/crates/integrations/pushover/src/lib.rs
@@ -1,0 +1,63 @@
+//! Pushover provider for the Acteon notification gateway.
+//!
+//! This crate implements the [`Provider`](acteon_provider::Provider)
+//! trait against the [Pushover Messages API][api], a lightweight
+//! push-notification service for mobile devices and desktops.
+//! `Pushover` is the lowest-ceremony receiver in the Alertmanager
+//! parity set — it has no lifecycle (just fire-and-forget sends)
+//! and no client-side deduplication, so the provider is thin on
+//! purpose.
+//!
+//! # Quick start
+//!
+//! ```rust,no_run
+//! use acteon_pushover::{PushoverConfig, PushoverProvider};
+//!
+//! // Single user key (the common case).
+//! let config = PushoverConfig::single_recipient(
+//!     "your-app-token",
+//!     "ops-oncall",
+//!     "the-user-or-group-key",
+//! );
+//! let provider = PushoverProvider::new(config);
+//! ```
+//!
+//! Multiple recipients are supported for deployments that fan
+//! notifications out to different Pushover user or group keys
+//! based on the payload's `user_key` field.
+//!
+//! # Payload shape
+//!
+//! The provider accepts one `event_action`, `"send"` (also the
+//! default when omitted). `message` is the only required field;
+//! everything else passes through to the Pushover API optionally.
+//!
+//! ```text
+//! event_action  "send" (default, optional)
+//! message       required — body of the notification
+//! user_key      logical recipient name (matches a key in `user_keys`)
+//! title         notification title
+//! priority      -2..=2 (emergency = 2, requires retry + expire)
+//! retry         seconds between re-notifications (emergency only, ≥30)
+//! expire        seconds until giving up re-notifying (emergency only, ≤10800)
+//! sound         notification sound name
+//! url           supplementary URL to display
+//! url_title     label for `url`
+//! device        target device name (default: all devices on the user's account)
+//! html          render message as HTML (bool)
+//! monospace     render message as monospace (bool, exclusive with html)
+//! ttl           auto-delete after N seconds
+//! timestamp     unix timestamp of the originating event
+//! ```
+//!
+//! [api]: https://pushover.net/api
+
+pub mod config;
+pub mod error;
+pub mod provider;
+pub mod types;
+
+pub use config::PushoverConfig;
+pub use error::PushoverError;
+pub use provider::PushoverProvider;
+pub use types::{PushoverApiResponse, PushoverPriority, PushoverRequest};

--- a/crates/integrations/pushover/src/provider.rs
+++ b/crates/integrations/pushover/src/provider.rs
@@ -1,0 +1,785 @@
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::{Provider, ProviderError, truncate_error_body};
+use reqwest::Client;
+use serde::Deserialize;
+use tracing::{debug, instrument, warn};
+
+use crate::config::PushoverConfig;
+use crate::error::PushoverError;
+use crate::types::{PushoverApiResponse, PushoverPriority, PushoverRequest};
+
+/// Maximum length of the `message` field accepted by the Pushover
+/// API as of the time this crate was written (1024 UTF-8 bytes).
+/// Longer messages are truncated client-side — we'd rather ship
+/// a slightly shortened notification than have the API reject the
+/// whole call.
+const MESSAGE_MAX_BYTES: usize = 1024;
+
+/// Maximum length of the `title` field (250 UTF-8 bytes).
+const TITLE_MAX_BYTES: usize = 250;
+
+/// Maximum length of the `url` field (512 UTF-8 bytes).
+const URL_MAX_BYTES: usize = 512;
+
+/// Maximum length of the `url_title` field (100 UTF-8 bytes).
+const URL_TITLE_MAX_BYTES: usize = 100;
+
+/// Pushover provider that posts messages to the Messages API.
+pub struct PushoverProvider {
+    config: PushoverConfig,
+    client: Client,
+}
+
+/// Fields extracted from an action payload.
+#[derive(Debug, Deserialize)]
+struct EventPayload {
+    /// Optional — defaults to `"send"`. Present for symmetry with the
+    /// other receivers that have a real lifecycle; Pushover itself has
+    /// only one action (deliver a notification).
+    #[serde(default)]
+    event_action: Option<String>,
+    #[serde(default)]
+    user_key: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    priority: Option<i32>,
+    #[serde(default)]
+    retry: Option<u32>,
+    #[serde(default)]
+    expire: Option<u32>,
+    #[serde(default)]
+    sound: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    url_title: Option<String>,
+    #[serde(default)]
+    device: Option<String>,
+    #[serde(default)]
+    html: Option<bool>,
+    #[serde(default)]
+    monospace: Option<bool>,
+    #[serde(default)]
+    timestamp: Option<i64>,
+    #[serde(default)]
+    ttl: Option<u32>,
+}
+
+impl PushoverProvider {
+    /// Create a new `Pushover` provider with a default HTTP client
+    /// (30-second timeout).
+    pub fn new(config: PushoverConfig) -> Self {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("failed to build HTTP client");
+        Self { config, client }
+    }
+
+    /// Create a new provider with a custom HTTP client — useful for
+    /// tests and for sharing a connection pool across providers.
+    pub fn with_client(config: PushoverConfig, client: Client) -> Self {
+        Self { config, client }
+    }
+
+    fn messages_url(&self) -> String {
+        format!("{}/1/messages.json", self.config.api_base_url())
+    }
+
+    /// Truncate a string to `max_bytes` UTF-8 bytes without splitting
+    /// a multi-byte character. Returns the input unchanged when it
+    /// already fits.
+    fn truncate_utf8(s: String, max_bytes: usize) -> String {
+        if s.len() <= max_bytes {
+            return s;
+        }
+        let mut cut = max_bytes;
+        // Walk backwards to the nearest UTF-8 char boundary so we
+        // never hand the API a partially-cut multi-byte character.
+        while cut > 0 && !s.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        let mut out = s;
+        out.truncate(cut);
+        out
+    }
+
+    /// Build a [`PushoverRequest`] from the payload, applying
+    /// config defaults and client-side validation.
+    fn build_request(&self, payload: EventPayload) -> Result<PushoverRequest, PushoverError> {
+        // event_action is optional and defaults to "send"; any
+        // other value is an explicit caller error so operators
+        // notice quickly when they've mistyped a rule.
+        match payload.event_action.as_deref() {
+            None | Some("send") => {}
+            Some(other) => {
+                return Err(PushoverError::InvalidPayload(format!(
+                    "invalid event_action '{other}': Pushover only supports 'send' (or no event_action)"
+                )));
+            }
+        }
+
+        let message = payload
+            .message
+            .ok_or_else(|| PushoverError::InvalidPayload("missing 'message' field".into()))?;
+        let message = Self::truncate_utf8(message, MESSAGE_MAX_BYTES);
+
+        let user = self
+            .config
+            .resolve_user_key(payload.user_key.as_deref())?
+            .to_owned();
+
+        let priority = if let Some(raw) = payload.priority {
+            Some(
+                PushoverPriority::from_i32(raw)
+                    .map_err(PushoverError::InvalidPayload)?
+                    .as_i32(),
+            )
+        } else {
+            None
+        };
+
+        // Emergency priority (2) requires retry + expire. Reject at
+        // build time so we never send the API a request that is
+        // guaranteed to fail.
+        if priority == Some(2) && (payload.retry.is_none() || payload.expire.is_none()) {
+            return Err(PushoverError::InvalidPayload(
+                "priority=2 (emergency) requires both 'retry' and 'expire' fields".into(),
+            ));
+        }
+        // Validate retry/expire bounds per the Pushover API docs.
+        if let Some(retry) = payload.retry
+            && retry < 30
+        {
+            return Err(PushoverError::InvalidPayload(format!(
+                "retry must be >= 30 seconds (got {retry})"
+            )));
+        }
+        if let Some(expire) = payload.expire
+            && expire > 10_800
+        {
+            return Err(PushoverError::InvalidPayload(format!(
+                "expire must be <= 10800 seconds (got {expire})"
+            )));
+        }
+
+        // html and monospace are mutually exclusive.
+        if payload.html == Some(true) && payload.monospace == Some(true) {
+            return Err(PushoverError::InvalidPayload(
+                "html and monospace are mutually exclusive".into(),
+            ));
+        }
+
+        let title = payload
+            .title
+            .map(|t| Self::truncate_utf8(t, TITLE_MAX_BYTES));
+        let url = payload.url.map(|u| Self::truncate_utf8(u, URL_MAX_BYTES));
+        let url_title = payload
+            .url_title
+            .map(|t| Self::truncate_utf8(t, URL_TITLE_MAX_BYTES));
+
+        Ok(PushoverRequest {
+            token: self.config.app_token().to_owned(),
+            user,
+            message,
+            title,
+            priority,
+            retry: payload.retry,
+            expire: payload.expire,
+            sound: payload.sound,
+            url,
+            url_title,
+            device: payload.device,
+            html: payload.html.map(u8::from),
+            monospace: payload.monospace.map(u8::from),
+            timestamp: payload.timestamp,
+            ttl: payload.ttl,
+        })
+    }
+
+    /// POST a form body to the Pushover Messages API and classify
+    /// the response into a [`PushoverError`] or a success.
+    async fn send_message(
+        &self,
+        request: &PushoverRequest,
+    ) -> Result<PushoverApiResponse, PushoverError> {
+        let url = self.messages_url();
+        // NOTE: do not include the form body in debug/error output;
+        // it contains both secrets (token and user key).
+        debug!("sending message to Pushover");
+        let builder = self.client.post(&url).form(request);
+        let request = acteon_provider::inject_trace_context(builder);
+        let response = request.send().await?;
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            warn!("Pushover API rate limit hit");
+            return Err(PushoverError::RateLimited);
+        }
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            let body = response.text().await.unwrap_or_default();
+            return Err(PushoverError::Unauthorized(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            )));
+        }
+        if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
+            let body = response.text().await.unwrap_or_default();
+            warn!(%status, "Pushover transient error — will be retried by gateway");
+            return Err(PushoverError::Transient(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            )));
+        }
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(PushoverError::Api(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            )));
+        }
+
+        // 2xx — parse the body and respect the Pushover-layer
+        // `status` field. Most 2xx responses include `status: 1`,
+        // but if for some reason the server returns 200 with
+        // `status: 0` and an errors array we still surface it as
+        // a permanent API error rather than silently passing.
+        let api_response: PushoverApiResponse = response
+            .json()
+            .await
+            .map_err(|e| PushoverError::Api(format!("failed to parse Pushover response: {e}")))?;
+        if api_response.status != 1 {
+            return Err(PushoverError::Api(format!(
+                "Pushover returned status={} errors={:?}",
+                api_response.status, api_response.errors
+            )));
+        }
+        Ok(api_response)
+    }
+}
+
+impl Provider for PushoverProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "pushover"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "pushover"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        let payload: EventPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| PushoverError::InvalidPayload(format!("failed to parse payload: {e}")))?;
+        let request = self.build_request(payload)?;
+        let api_response = self.send_message(&request).await?;
+        let body = serde_json::json!({
+            "status": api_response.status,
+            "request": api_response.request,
+            "receipt": api_response.receipt,
+        });
+        Ok(ProviderResponse::success(body))
+    }
+
+    #[instrument(skip(self), fields(provider = "pushover"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        // Pushover doesn't have a public ping endpoint, so we issue
+        // a GET against the Messages URL. A 405 Method Not Allowed
+        // proves the endpoint is reachable; only a transport
+        // failure counts as a hard health-check error.
+        let url = self.messages_url();
+        debug!("performing Pushover health check");
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| ProviderError::Connection(e.to_string()))?;
+        debug!(status = %response.status(), "Pushover health check response");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use acteon_core::Action;
+    use acteon_provider::{Provider, ProviderError};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+    use crate::config::PushoverConfig;
+
+    /// Tiny mock HTTP server that accepts one connection, returns
+    /// a canned response, and captures the request body for
+    /// assertions.
+    struct MockPushoverServer {
+        listener: tokio::net::TcpListener,
+        base_url: String,
+    }
+
+    impl MockPushoverServer {
+        async fn start() -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("failed to bind mock server");
+            let port = listener.local_addr().unwrap().port();
+            let base_url = format!("http://127.0.0.1:{port}");
+            Self { listener, base_url }
+        }
+
+        async fn respond_once(self, status_code: u16, body: &str) {
+            let body = body.to_owned();
+            let (mut stream, _) = self.listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 16384];
+            let _ = stream.read(&mut buf).await.unwrap();
+            let response = format!(
+                "HTTP/1.1 {status_code} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+        }
+
+        async fn respond_once_capturing(self, status_code: u16, body: &str) -> String {
+            let body = body.to_owned();
+            let (mut stream, _) = self.listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 16384];
+            let n = stream.read(&mut buf).await.unwrap();
+            let raw = String::from_utf8_lossy(&buf[..n]).to_string();
+            let response = format!(
+                "HTTP/1.1 {status_code} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+            raw
+        }
+    }
+
+    fn make_action(payload: serde_json::Value) -> Action {
+        Action::new("notifications", "tenant-1", "pushover", "notify", payload)
+    }
+
+    #[test]
+    fn provider_name() {
+        let provider =
+            PushoverProvider::new(PushoverConfig::single_recipient("app", "ops", "u-ops"));
+        assert_eq!(provider.name(), "pushover");
+    }
+
+    #[test]
+    fn truncate_utf8_passthrough() {
+        assert_eq!(
+            PushoverProvider::truncate_utf8("short".into(), 100),
+            "short"
+        );
+    }
+
+    #[test]
+    fn truncate_utf8_cuts_on_boundary() {
+        // 5 bytes, we only allow 4 — the cut should land between
+        // whole ASCII characters.
+        assert_eq!(PushoverProvider::truncate_utf8("abcde".into(), 4), "abcd");
+    }
+
+    #[test]
+    fn truncate_utf8_respects_char_boundaries() {
+        // "café" is 5 bytes (`c`, `a`, `f`, 0xC3, 0xA9). A naive
+        // truncate to 4 bytes would split the `é` in half; our
+        // helper must back up to the last UTF-8 boundary.
+        let out = PushoverProvider::truncate_utf8("café".into(), 4);
+        // Cut should land between `f` and `é`, so we get "caf".
+        assert_eq!(out, "caf");
+    }
+
+    #[tokio::test]
+    async fn execute_send_success() {
+        let server = MockPushoverServer::start().await;
+        let config = PushoverConfig::single_recipient("test-app", "ops", "u-ops")
+            .with_api_base_url(&server.base_url);
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "message": "Deploy complete",
+            "title": "CI/CD",
+            "priority": 0,
+            "url": "https://ci.example.com/build/1234",
+            "url_title": "View build",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"status":1,"request":"req-xyz"}"#)
+                .await
+        });
+        let result = provider.execute(&action).await;
+        let request = server_handle.await.unwrap();
+        let response = result.expect("execute should succeed");
+        assert_eq!(response.status, acteon_core::ResponseStatus::Success);
+        assert_eq!(response.body["status"], 1);
+        assert_eq!(response.body["request"], "req-xyz");
+
+        // Form-encoded POST against /1/messages.json.
+        assert!(request.contains("POST /1/messages.json"));
+        assert!(request.contains("content-type: application/x-www-form-urlencoded"));
+        // Body carries the form-encoded fields.
+        assert!(request.contains("token=test-app"));
+        assert!(request.contains("user=u-ops"));
+        assert!(request.contains("message=Deploy+complete"));
+        assert!(request.contains("title=CI%2FCD"));
+        assert!(request.contains("priority=0"));
+        assert!(request.contains("url_title=View+build"));
+    }
+
+    #[tokio::test]
+    async fn execute_send_event_action_default() {
+        // event_action omitted — should default to "send".
+        let server = MockPushoverServer::start().await;
+        let config =
+            PushoverConfig::single_recipient("t", "ops", "u").with_api_base_url(&server.base_url);
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({ "message": "hi" }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(200, r#"{"status":1,"request":"r"}"#)
+                .await;
+        });
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn execute_send_event_action_explicit() {
+        let server = MockPushoverServer::start().await;
+        let config =
+            PushoverConfig::single_recipient("t", "ops", "u").with_api_base_url(&server.base_url);
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "send",
+            "message": "hi",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(200, r#"{"status":1,"request":"r"}"#)
+                .await;
+        });
+        let result = provider.execute(&action).await;
+        server_handle.await.unwrap();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn execute_invalid_event_action() {
+        let config = PushoverConfig::single_recipient("t", "ops", "u")
+            .with_api_base_url("http://127.0.0.1:1");
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "acknowledge",
+            "message": "hi",
+        }));
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+    }
+
+    #[tokio::test]
+    async fn execute_missing_message() {
+        let config = PushoverConfig::single_recipient("t", "ops", "u")
+            .with_api_base_url("http://127.0.0.1:1");
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({ "title": "oops" }));
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+    }
+
+    #[tokio::test]
+    async fn execute_truncates_long_message() {
+        let server = MockPushoverServer::start().await;
+        let config =
+            PushoverConfig::single_recipient("t", "ops", "u").with_api_base_url(&server.base_url);
+        let provider = PushoverProvider::new(config);
+        let long = "x".repeat(2000);
+        let action = make_action(serde_json::json!({ "message": long }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"status":1,"request":"r"}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        // The body should contain exactly MESSAGE_MAX_BYTES x's,
+        // not 2000.
+        let marker = format!("message={}", "x".repeat(MESSAGE_MAX_BYTES));
+        assert!(
+            request.contains(&marker),
+            "message should be truncated to {MESSAGE_MAX_BYTES} bytes"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_priority_out_of_range() {
+        let config = PushoverConfig::single_recipient("t", "ops", "u")
+            .with_api_base_url("http://127.0.0.1:1");
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "message": "hi",
+            "priority": 5,
+        }));
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+    }
+
+    #[tokio::test]
+    async fn execute_emergency_priority_requires_retry_and_expire() {
+        let config = PushoverConfig::single_recipient("t", "ops", "u")
+            .with_api_base_url("http://127.0.0.1:1");
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "message": "pageme",
+            "priority": 2,
+        }));
+        let err = provider.execute(&action).await.unwrap_err();
+        let msg = match err {
+            ProviderError::Serialization(m) => m,
+            other => panic!("expected Serialization, got {other:?}"),
+        };
+        assert!(msg.contains("retry") && msg.contains("expire"));
+    }
+
+    #[tokio::test]
+    async fn execute_emergency_priority_with_retry_and_expire() {
+        let server = MockPushoverServer::start().await;
+        let config =
+            PushoverConfig::single_recipient("t", "ops", "u").with_api_base_url(&server.base_url);
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "message": "pageme",
+            "priority": 2,
+            "retry": 60,
+            "expire": 3600,
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(
+                    200,
+                    r#"{"status":1,"request":"r","receipt":"rec-emergency"}"#,
+                )
+                .await
+        });
+        let result = provider.execute(&action).await;
+        let request = server_handle.await.unwrap();
+        let response = result.expect("execute should succeed");
+        assert!(request.contains("priority=2"));
+        assert!(request.contains("retry=60"));
+        assert!(request.contains("expire=3600"));
+        // Receipt makes it through to the outcome body.
+        assert_eq!(response.body["receipt"], "rec-emergency");
+    }
+
+    #[tokio::test]
+    async fn execute_retry_below_minimum() {
+        let config = PushoverConfig::single_recipient("t", "ops", "u")
+            .with_api_base_url("http://127.0.0.1:1");
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "message": "pageme",
+            "priority": 2,
+            "retry": 15,     // < 30
+            "expire": 600,
+        }));
+        let err = provider.execute(&action).await.unwrap_err();
+        let msg = match err {
+            ProviderError::Serialization(m) => m,
+            other => panic!("expected Serialization, got {other:?}"),
+        };
+        assert!(msg.contains("retry"));
+    }
+
+    #[tokio::test]
+    async fn execute_expire_above_maximum() {
+        let config = PushoverConfig::single_recipient("t", "ops", "u")
+            .with_api_base_url("http://127.0.0.1:1");
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "message": "pageme",
+            "priority": 2,
+            "retry": 60,
+            "expire": 99_999, // > 10800
+        }));
+        let err = provider.execute(&action).await.unwrap_err();
+        let msg = match err {
+            ProviderError::Serialization(m) => m,
+            other => panic!("expected Serialization, got {other:?}"),
+        };
+        assert!(msg.contains("expire"));
+    }
+
+    #[tokio::test]
+    async fn execute_html_and_monospace_mutually_exclusive() {
+        let config = PushoverConfig::single_recipient("t", "ops", "u")
+            .with_api_base_url("http://127.0.0.1:1");
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "message": "hi",
+            "html": true,
+            "monospace": true,
+        }));
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+    }
+
+    #[tokio::test]
+    async fn execute_with_explicit_user_key() {
+        let server = MockPushoverServer::start().await;
+        let config = PushoverConfig::new("t")
+            .with_recipient("ops", "u-ops")
+            .with_recipient("dev", "u-dev")
+            .with_default_recipient("ops")
+            .with_api_base_url(&server.base_url);
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "message": "hi",
+            "user_key": "dev",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"status":1,"request":"r"}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        assert!(
+            request.contains("user=u-dev"),
+            "explicit user_key should pick u-dev: {request}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_unknown_user_key_is_configuration() {
+        let config = PushoverConfig::single_recipient("t", "ops", "u-ops")
+            .with_api_base_url("http://127.0.0.1:1");
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "message": "hi",
+            "user_key": "nope",
+        }));
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Configuration(_)));
+    }
+
+    #[tokio::test]
+    async fn execute_rate_limited() {
+        let server = MockPushoverServer::start().await;
+        let config =
+            PushoverConfig::single_recipient("t", "ops", "u").with_api_base_url(&server.base_url);
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({ "message": "hi" }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(429, r#"{"status":0,"errors":["rate limited"]}"#)
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::RateLimited));
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_503_retryable_connection() {
+        let server = MockPushoverServer::start().await;
+        let config =
+            PushoverConfig::single_recipient("t", "ops", "u").with_api_base_url(&server.base_url);
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({ "message": "hi" }));
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(503, r#"{"status":0}"#).await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::Connection(_)));
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_401_maps_to_configuration() {
+        let server = MockPushoverServer::start().await;
+        let config =
+            PushoverConfig::single_recipient("t", "ops", "u").with_api_base_url(&server.base_url);
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({ "message": "hi" }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(401, r#"{"status":0,"errors":["bad token"]}"#)
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::Configuration(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_400_non_retryable() {
+        let server = MockPushoverServer::start().await;
+        let config =
+            PushoverConfig::single_recipient("t", "ops", "u").with_api_base_url(&server.base_url);
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({ "message": "hi" }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(
+                    400,
+                    r#"{"status":0,"errors":["user identifier is invalid"]}"#,
+                )
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_200_but_status_zero_is_api_error() {
+        // Pushover sometimes returns HTTP 200 with a body that
+        // contains `status: 0`. The provider must still classify
+        // this as a permanent API error rather than silently
+        // succeeding.
+        let server = MockPushoverServer::start().await;
+        let config =
+            PushoverConfig::single_recipient("t", "ops", "u").with_api_base_url(&server.base_url);
+        let provider = PushoverProvider::new(config);
+        let action = make_action(serde_json::json!({ "message": "hi" }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(200, r#"{"status":0,"request":"r","errors":["nope"]}"#)
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn health_check_reachable_endpoint() {
+        let server = MockPushoverServer::start().await;
+        let config =
+            PushoverConfig::single_recipient("t", "ops", "u").with_api_base_url(&server.base_url);
+        let provider = PushoverProvider::new(config);
+        // A 405 Method Not Allowed still means reachable.
+        let server_handle = tokio::spawn(async move { server.respond_once(405, "{}").await });
+        let result = provider.health_check().await;
+        server_handle.await.unwrap();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn health_check_connection_failure() {
+        let config = PushoverConfig::single_recipient("t", "ops", "u")
+            .with_api_base_url("http://127.0.0.1:1");
+        let provider = PushoverProvider::new(config);
+        let err = provider.health_check().await.unwrap_err();
+        assert!(matches!(err, ProviderError::Connection(_)));
+        assert!(err.is_retryable());
+    }
+}

--- a/crates/integrations/pushover/src/types.rs
+++ b/crates/integrations/pushover/src/types.rs
@@ -1,0 +1,290 @@
+use serde::{Deserialize, Serialize};
+
+/// Pushover priority level.
+///
+/// `Emergency` notifications bypass the recipient's quiet hours
+/// **and** require `retry` + `expire` parameters — the server keeps
+/// re-notifying the user every `retry` seconds until they
+/// acknowledge the alert (by tapping it), or `expire` seconds
+/// elapse, whichever comes first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PushoverPriority {
+    /// `-2`: no notification at all, the message appears silently
+    /// in the history.
+    Lowest,
+    /// `-1`: deliver silently (no sound, no vibration).
+    Low,
+    /// `0`: normal priority — the default.
+    #[default]
+    Normal,
+    /// `1`: high priority — bypasses the user's quiet hours.
+    High,
+    /// `2`: emergency priority — bypasses quiet hours **and**
+    /// requires acknowledgment. Must be paired with `retry` and
+    /// `expire` fields.
+    Emergency,
+}
+
+impl PushoverPriority {
+    /// Parse an integer priority value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error message when `raw` is outside the
+    /// `-2..=2` range.
+    pub fn from_i32(raw: i32) -> Result<Self, String> {
+        match raw {
+            -2 => Ok(Self::Lowest),
+            -1 => Ok(Self::Low),
+            0 => Ok(Self::Normal),
+            1 => Ok(Self::High),
+            2 => Ok(Self::Emergency),
+            other => Err(format!(
+                "invalid Pushover priority {other}: must be in -2..=2"
+            )),
+        }
+    }
+
+    /// Convert back to the wire integer representation.
+    #[must_use]
+    pub const fn as_i32(self) -> i32 {
+        match self {
+            Self::Lowest => -2,
+            Self::Low => -1,
+            Self::Normal => 0,
+            Self::High => 1,
+            Self::Emergency => 2,
+        }
+    }
+}
+
+/// Serialized form of a Pushover message request.
+///
+/// Pushover's API is form-encoded (`application/x-www-form-urlencoded`),
+/// **not** JSON, so this struct is deliberately flat — no nested
+/// objects, no arrays. `serde_urlencoded` (which reqwest's `.form()`
+/// helper uses under the hood) can't serialize anything that needs
+/// indirection beyond a single level.
+///
+/// `None` fields are skipped so the Pushover API sees only the
+/// parameters the caller actually provided.
+#[derive(Debug, Clone, Serialize)]
+pub struct PushoverRequest {
+    /// Application token (`T...`) — the app identifier.
+    pub token: String,
+    /// User or group key (`U...` / `G...`) — the recipient.
+    pub user: String,
+    /// Body of the notification.
+    pub message: String,
+
+    /// Optional notification title shown above the message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Priority level as the wire integer (`-2..=2`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<i32>,
+    /// Seconds between re-notifications when `priority == 2`
+    /// (minimum 30).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry: Option<u32>,
+    /// Seconds until the server gives up re-notifying when
+    /// `priority == 2` (maximum 10800).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expire: Option<u32>,
+    /// Notification sound name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sound: Option<String>,
+    /// Supplementary URL attached to the notification.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Label for `url`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url_title: Option<String>,
+    /// Specific device name to deliver to (overrides the default
+    /// of every device on the recipient's account).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device: Option<String>,
+    /// Render the message body as HTML (`1` = yes, omitted = no).
+    /// Mutually exclusive with `monospace`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub html: Option<u8>,
+    /// Render the message body as monospace. Mutually exclusive
+    /// with `html`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub monospace: Option<u8>,
+    /// Unix timestamp (seconds) of the originating event — the
+    /// Pushover app shows this instead of the receive time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<i64>,
+    /// Auto-delete the message from the client after `ttl`
+    /// seconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<u32>,
+}
+
+/// Response body from the Pushover Messages API.
+///
+/// `status` is `1` on success and `0` on failure. Error responses
+/// additionally populate the `errors` array with one or more
+/// human-readable strings describing what went wrong.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PushoverApiResponse {
+    /// `1` on success, `0` on failure. This is the Pushover-layer
+    /// status, independent of the HTTP status.
+    #[serde(default)]
+    pub status: i32,
+    /// Request ID assigned by the Pushover server (UUID).
+    #[serde(default)]
+    pub request: String,
+    /// Optional `receipt` ID, present for emergency-priority
+    /// notifications so clients can poll acknowledgment state.
+    #[serde(default)]
+    pub receipt: String,
+    /// Array of error strings when `status == 0`.
+    #[serde(default)]
+    pub errors: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn priority_parse_valid() {
+        assert_eq!(
+            PushoverPriority::from_i32(-2).unwrap(),
+            PushoverPriority::Lowest
+        );
+        assert_eq!(
+            PushoverPriority::from_i32(-1).unwrap(),
+            PushoverPriority::Low
+        );
+        assert_eq!(
+            PushoverPriority::from_i32(0).unwrap(),
+            PushoverPriority::Normal
+        );
+        assert_eq!(
+            PushoverPriority::from_i32(1).unwrap(),
+            PushoverPriority::High
+        );
+        assert_eq!(
+            PushoverPriority::from_i32(2).unwrap(),
+            PushoverPriority::Emergency
+        );
+    }
+
+    #[test]
+    fn priority_parse_out_of_range() {
+        assert!(PushoverPriority::from_i32(3).is_err());
+        assert!(PushoverPriority::from_i32(-3).is_err());
+    }
+
+    #[test]
+    fn priority_roundtrip_i32() {
+        for raw in -2..=2 {
+            let p = PushoverPriority::from_i32(raw).unwrap();
+            assert_eq!(p.as_i32(), raw);
+        }
+    }
+
+    #[test]
+    fn priority_default_is_normal() {
+        assert_eq!(PushoverPriority::default(), PushoverPriority::Normal);
+    }
+
+    #[test]
+    fn request_serializes_form_minimum() {
+        // The form-encoded output is what goes on the wire.
+        let req = PushoverRequest {
+            token: "app-token".into(),
+            user: "user-key".into(),
+            message: "Deploy complete".into(),
+            title: None,
+            priority: None,
+            retry: None,
+            expire: None,
+            sound: None,
+            url: None,
+            url_title: None,
+            device: None,
+            html: None,
+            monospace: None,
+            timestamp: None,
+            ttl: None,
+        };
+        let form = serde_urlencoded::to_string(&req).unwrap();
+        // Field order may vary, so test with `contains`.
+        assert!(form.contains("token=app-token"));
+        assert!(form.contains("user=user-key"));
+        assert!(form.contains("message=Deploy+complete"));
+        // Skipped fields must not appear on the wire.
+        assert!(!form.contains("title="));
+        assert!(!form.contains("priority="));
+        assert!(!form.contains("retry="));
+    }
+
+    #[test]
+    fn request_serializes_form_full() {
+        let req = PushoverRequest {
+            token: "t".into(),
+            user: "u".into(),
+            message: "CPU >90% on web-01".into(),
+            title: Some("High CPU".into()),
+            priority: Some(2),
+            retry: Some(60),
+            expire: Some(3600),
+            sound: Some("cashregister".into()),
+            url: Some("https://runbook.example.com/cpu".into()),
+            url_title: Some("Runbook".into()),
+            device: None,
+            html: Some(0),
+            monospace: None,
+            timestamp: Some(1_713_897_600),
+            ttl: Some(7200),
+        };
+        let form = serde_urlencoded::to_string(&req).unwrap();
+        assert!(form.contains("message=CPU+%3E90%25+on+web-01"));
+        assert!(form.contains("priority=2"));
+        assert!(form.contains("retry=60"));
+        assert!(form.contains("expire=3600"));
+        assert!(form.contains("sound=cashregister"));
+        assert!(form.contains("url_title=Runbook"));
+        assert!(form.contains("timestamp=1713897600"));
+        assert!(form.contains("ttl=7200"));
+        assert!(form.contains("html=0"));
+    }
+
+    #[test]
+    fn api_response_deserializes_success() {
+        let json = r#"{"status":1,"request":"abc-123"}"#;
+        let resp: PushoverApiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.status, 1);
+        assert_eq!(resp.request, "abc-123");
+        assert!(resp.errors.is_empty());
+    }
+
+    #[test]
+    fn api_response_deserializes_error() {
+        let json = r#"{"status":0,"request":"abc","errors":["user identifier is invalid"]}"#;
+        let resp: PushoverApiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.status, 0);
+        assert_eq!(resp.errors.len(), 1);
+        assert_eq!(resp.errors[0], "user identifier is invalid");
+    }
+
+    #[test]
+    fn api_response_deserializes_with_receipt() {
+        // Emergency-priority (priority=2) notifications come back
+        // with a receipt so clients can poll acknowledgment state.
+        let json = r#"{"status":1,"request":"abc","receipt":"rec-xyz"}"#;
+        let resp: PushoverApiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.receipt, "rec-xyz");
+    }
+
+    #[test]
+    fn api_response_tolerates_missing_fields() {
+        let resp: PushoverApiResponse = serde_json::from_str("{}").unwrap();
+        assert_eq!(resp.status, 0);
+        assert!(resp.errors.is_empty());
+    }
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -66,6 +66,7 @@ acteon-teams = { workspace = true }
 acteon-discord = { workspace = true }
 acteon-opsgenie = { workspace = true }
 acteon-victorops = { workspace = true }
+acteon-pushover = { workspace = true }
 acteon-executor = { workspace = true }
 acteon-gateway = { workspace = true }
 acteon-llm = { workspace = true }

--- a/crates/server/src/config/providers.rs
+++ b/crates/server/src/config/providers.rs
@@ -21,8 +21,8 @@ pub struct ProviderConfig {
     /// Unique name for this provider.
     pub name: String,
     /// Provider type: `"webhook"`, `"log"`, `"twilio"`, `"teams"`, `"discord"`,
-    /// `"email"`, `"opsgenie"`, `"victorops"`, `"aws-sns"`, `"aws-lambda"`,
-    /// `"aws-eventbridge"`, `"aws-sqs"`, `"aws-s3"`, `"aws-ec2"`,
+    /// `"email"`, `"opsgenie"`, `"victorops"`, `"pushover"`, `"aws-sns"`,
+    /// `"aws-lambda"`, `"aws-eventbridge"`, `"aws-sqs"`, `"aws-s3"`, `"aws-ec2"`,
     /// `"aws-autoscaling"`, `"azure-blob"`, `"azure-eventhubs"`, `"gcp-pubsub"`,
     /// or `"gcp-storage"`.
     #[serde(rename = "type")]
@@ -177,6 +177,20 @@ pub struct ProviderConfig {
     /// ```
     #[serde(default)]
     pub victorops: VictorOpsProviderConfig,
+
+    /// Nested configuration block for the `"pushover"` provider type.
+    ///
+    /// Example TOML:
+    /// ```toml
+    /// [[providers]]
+    /// name = "pushover-ops"
+    /// type = "pushover"
+    /// pushover.app_token = "ENC[...]"
+    /// pushover.default_recipient = "ops-oncall"
+    /// pushover.recipients = { ops-oncall = "ENC[...]", dev = "ENC[...]" }
+    /// ```
+    #[serde(default)]
+    pub pushover: PushoverProviderConfig,
 }
 
 /// Nested configuration block for the `OpsGenie` provider.
@@ -233,4 +247,20 @@ pub struct VictorOpsProviderConfig {
     /// `{namespace}:{tenant}:` for multi-tenant isolation. Defaults
     /// to `true`.
     pub scope_entity_ids: Option<bool>,
+}
+
+/// Nested configuration block for the `Pushover` provider.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct PushoverProviderConfig {
+    /// Pushover application token (the `T...` key). Supports `ENC[...]`.
+    pub app_token: Option<String>,
+    /// Map of logical recipient name → Pushover user or group key
+    /// (`U...` / `G...`). Values support `ENC[...]`.
+    pub recipients: HashMap<String, String>,
+    /// Name of the default recipient used when the dispatch payload
+    /// omits `user_key`.
+    pub default_recipient: Option<String>,
+    /// Override base URL for the Pushover Messages API (testing only).
+    pub api_base_url: Option<String>,
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -802,6 +802,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     shared_http_client.clone(),
                 ))
             }
+            "pushover" => {
+                let po = &provider_cfg.pushover;
+                let app_token_raw = po.app_token.as_deref().ok_or_else(|| {
+                    format!(
+                        "provider '{}': pushover type requires a 'pushover.app_token' field",
+                        provider_cfg.name
+                    )
+                })?;
+                if po.recipients.is_empty() {
+                    return Err(format!(
+                        "provider '{}': pushover type requires at least one entry in 'pushover.recipients'",
+                        provider_cfg.name
+                    )
+                    .into());
+                }
+                let app_token = require_decrypt(app_token_raw, master_key.as_ref())?;
+                let mut pushover_config = acteon_pushover::PushoverConfig::new(app_token);
+                for (name, user_key_raw) in &po.recipients {
+                    let user_key = require_decrypt(user_key_raw, master_key.as_ref())?;
+                    pushover_config = pushover_config.with_recipient(name, user_key);
+                }
+                if let Some(ref default_recipient) = po.default_recipient {
+                    pushover_config = pushover_config.with_default_recipient(default_recipient);
+                }
+                if let Some(ref url) = po.api_base_url {
+                    validate_provider_url(&provider_cfg.name, url)?;
+                    pushover_config = pushover_config.with_api_base_url(url);
+                }
+                std::sync::Arc::new(acteon_pushover::PushoverProvider::with_client(
+                    pushover_config,
+                    shared_http_client.clone(),
+                ))
+            }
             "email" => {
                 let from_address = provider_cfg.from_address.as_deref().ok_or_else(|| {
                     format!(

--- a/crates/simulation/examples/pushover_simulation.rs
+++ b/crates/simulation/examples/pushover_simulation.rs
@@ -1,0 +1,168 @@
+//! Pushover provider simulation scenarios.
+//!
+//! Demonstrates dispatching push notifications through the
+//! Pushover provider: a normal-priority deploy notification, an
+//! emergency-priority alert that includes `retry`/`expire`, and a
+//! rule-based reroute sending high-priority events to Pushover.
+//!
+//! The scenarios use the simulation harness' recording provider
+//! named `"pushover"`, so no real Pushover credentials are needed.
+//!
+//! Run with: `cargo run -p acteon-simulation --example pushover_simulation`
+
+use acteon_core::Action;
+use acteon_simulation::prelude::*;
+use tracing::info;
+
+const REROUTE_HIGH_TO_PUSHOVER_RULE: &str = r#"
+rules:
+  - name: reroute-high-to-pushover
+    priority: 1
+    condition:
+      field: action.payload.priority
+      gte: 1
+    action:
+      type: reroute
+      target_provider: pushover
+"#;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    info!("╔══════════════════════════════════════════════════════════════╗");
+    info!("║          PUSHOVER PROVIDER SIMULATION DEMO                  ║");
+    info!("╚══════════════════════════════════════════════════════════════╝\n");
+
+    // =========================================================================
+    // DEMO 1: Normal-priority notification
+    // =========================================================================
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    info!("  DEMO 1: NORMAL-PRIORITY NOTIFICATION");
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("pushover")
+            .build(),
+    )
+    .await?;
+    info!("✓ Started simulation cluster with 1 node");
+    info!("✓ Registered 'pushover' recording provider\n");
+
+    let deploy = Action::new(
+        "notifications",
+        "tenant-1",
+        "pushover",
+        "notify",
+        serde_json::json!({
+            "message": "Deploy #4823 completed successfully.",
+            "title": "CI/CD — production",
+            "priority": 0,
+            "url": "https://ci.example.com/build/4823",
+            "url_title": "View build",
+        }),
+    );
+    info!("→ Dispatching normal-priority deploy notification...");
+    let outcome = harness.dispatch(&deploy).await?;
+    info!("  Outcome: {outcome:?}\n");
+
+    // =========================================================================
+    // DEMO 2: Emergency-priority alert (requires retry + expire)
+    // =========================================================================
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    info!("  DEMO 2: EMERGENCY PRIORITY (pages until acknowledged)");
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let emergency = Action::new(
+        "incidents",
+        "tenant-1",
+        "pushover",
+        "notify",
+        serde_json::json!({
+            "message": "Checkout API is returning 5xx for >50% of traffic.",
+            "title": "CRITICAL: checkout-api down",
+            "priority": 2,
+            "retry": 60,       // re-notify every 60s...
+            "expire": 3600,    // ...for up to 1 hour or until ack
+            "sound": "siren",
+            "url": "https://wiki.example.com/runbook/checkout-5xx",
+            "url_title": "Open runbook",
+        }),
+    );
+    info!("→ Dispatching emergency-priority alert (retry=60s, expire=1h)...");
+    let outcome = harness.dispatch(&emergency).await?;
+    info!("  Outcome: {outcome:?}");
+
+    let provider = harness.provider("pushover").unwrap();
+    info!(
+        "\n  Pushover provider received {} notification(s)",
+        provider.call_count()
+    );
+    assert_eq!(provider.call_count(), 2);
+    harness.teardown().await?;
+    info!("✓ Simulation cluster shut down\n");
+
+    // =========================================================================
+    // DEMO 3: Rule-based reroute — high-priority events go to Pushover
+    // =========================================================================
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    info!("  DEMO 3: RULE-BASED REROUTE — priority>=1 → Pushover");
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("log")
+            .add_recording_provider("pushover")
+            .add_rule_yaml(REROUTE_HIGH_TO_PUSHOVER_RULE)
+            .build(),
+    )
+    .await?;
+    info!("✓ Started cluster with log + pushover recording providers");
+    info!("✓ Loaded reroute rule: priority>=1 → pushover\n");
+
+    // Low-priority — stays on log.
+    let low = Action::new(
+        "notifications",
+        "tenant-1",
+        "log",
+        "notify",
+        serde_json::json!({
+            "message": "Nightly index rebuild started.",
+            "priority": 0,
+        }),
+    );
+    info!("→ Dispatching priority=0 (should stay on 'log')...");
+    let outcome = harness.dispatch(&low).await?;
+    info!("  Outcome: {outcome:?}");
+
+    // High-priority — routed to pushover.
+    let high = Action::new(
+        "notifications",
+        "tenant-1",
+        "log",
+        "notify",
+        serde_json::json!({
+            "message": "Disk usage above 85% on db-primary-01.",
+            "title": "Disk pressure",
+            "priority": 1,
+        }),
+    );
+    info!("→ Dispatching priority=1 (should reroute to 'pushover')...");
+    let outcome = harness.dispatch(&high).await?;
+    info!("  Outcome: {outcome:?}");
+
+    let log_calls = harness.provider("log").unwrap().call_count();
+    let pushover_calls = harness.provider("pushover").unwrap().call_count();
+    info!("\n  Provider call counts:");
+    info!("    log:      {log_calls}");
+    info!("    pushover: {pushover_calls}");
+    assert_eq!(log_calls, 1);
+    assert_eq!(pushover_calls, 1);
+
+    harness.teardown().await?;
+    info!("\n✓ All demos complete.");
+    Ok(())
+}

--- a/docs/book/features/pushover.md
+++ b/docs/book/features/pushover.md
@@ -1,0 +1,146 @@
+# Pushover Provider
+
+Acteon ships with a first-class **Pushover** provider that sends push notifications to mobile devices via the [Pushover Messages API][api]. It was built as part of Phase 4c of the Alertmanager feature-parity initiative so teams migrating off Alertmanager can re-use their existing Pushover receivers.
+
+[api]: https://pushover.net/api
+
+Pushover is the lowest-ceremony receiver in the set: it has no lifecycle (just fire-and-forget sends) and no client-side deduplication, so the provider is deliberately thin. Like the other native providers, `acteon-pushover`:
+
+- Holds the application token and every user/group key as `SecretString`, zeroized on drop.
+- Supports multiple recipients per provider instance so one config can fan notifications out to several Pushover users or groups.
+- Maps 5xx / 408 → retryable `Connection` (via a `Transient` variant); 429 → retryable `RateLimited`; 401/403 → non-retryable `Configuration`; other 4xx → non-retryable `ExecutionFailed`.
+- Handles the Pushover-specific quirk of **200 OK with `status: 0`** — a successful HTTP round-trip with a Pushover-layer failure in the body. The provider classifies those as permanent `ExecutionFailed` so rules don't silently succeed when the API actually rejected the call.
+- Reuses the server's shared HTTP client, so it participates in circuit breaking, provider health checks, and per-provider metrics automatically.
+- Propagates W3C Trace Context headers.
+
+## TOML configuration
+
+Pushover uses Acteon's **nested provider config** pattern. Every Pushover-specific setting lives under a `pushover.*` key.
+
+```toml
+[[providers]]
+name = "pushover-ops"
+type = "pushover"
+pushover.app_token = "ENC[AES256_GCM,data:abc123...]"
+pushover.default_recipient = "ops-oncall"
+
+[providers.pushover.recipients]
+ops-oncall = "ENC[AES256_GCM,data:def456...]"  # a user key (U...) or group key (G...)
+dev-team   = "ENC[AES256_GCM,data:ghi789...]"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used when dispatching actions |
+| `type` | Yes | Must be `"pushover"` |
+| `pushover.app_token` | Yes | Application token (the `T...` key). Supports `ENC[...]`. |
+| `pushover.recipients` | Yes (≥1) | Map of logical recipient name → user or group key (`U...` / `G...`). Values support `ENC[...]`. |
+| `pushover.default_recipient` | No | Name of the default recipient used when the dispatch payload omits `user_key`. If there is only one recipient, it is used implicitly. |
+| `pushover.api_base_url` | No | Override the Messages API base URL. Tests only. |
+
+## Payload shape
+
+Pushover accepts one `event_action`, `"send"` (also the default when omitted). The only required payload field is `message`; everything else is optional.
+
+### Normal-priority notification
+
+```json
+{
+  "message": "Deploy #4823 completed successfully.",
+  "title": "CI/CD — production",
+  "priority": 0,
+  "url": "https://ci.example.com/build/4823",
+  "url_title": "View build"
+}
+```
+
+### Emergency-priority alert (requires `retry` + `expire`)
+
+Emergency notifications bypass the recipient's quiet hours **and** require acknowledgment. The server re-notifies the user every `retry` seconds until they tap the notification, or `expire` seconds elapse:
+
+```json
+{
+  "message": "Checkout API returning 5xx for >50% of traffic.",
+  "title": "CRITICAL: checkout-api down",
+  "priority": 2,
+  "retry": 60,
+  "expire": 3600,
+  "sound": "siren",
+  "url": "https://wiki.example.com/runbook/checkout-5xx",
+  "url_title": "Open runbook"
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `message` | string | **Required.** Body of the notification. Truncated client-side to 1024 UTF-8 bytes (the API cap) — multi-byte characters are never split. |
+| `title` | string | Title shown above the message. Truncated to 250 bytes. |
+| `user_key` | string | Logical recipient name (matching a key in `pushover.recipients`). Falls back to `pushover.default_recipient` or the single-entry implicit default. |
+| `priority` | int | `-2..=2`. `2` is emergency and requires `retry` + `expire`. |
+| `retry` | int (seconds) | Seconds between re-notifications for emergency priority. **Minimum 30.** |
+| `expire` | int (seconds) | Seconds until the server gives up re-notifying. **Maximum 10800** (3 hours). |
+| `sound` | string | Notification sound name. See the [Pushover sounds list](https://pushover.net/api#sounds). |
+| `url` | string | Supplementary URL. Truncated to 512 bytes. |
+| `url_title` | string | Label for `url`. Truncated to 100 bytes. |
+| `device` | string | Deliver to a specific device name only. |
+| `html` | bool | Render message as HTML. Mutually exclusive with `monospace`. |
+| `monospace` | bool | Render message as monospace. Mutually exclusive with `html`. |
+| `timestamp` | int | Unix timestamp of the originating event. |
+| `ttl` | int | Auto-delete after N seconds. |
+
+### Client-side validation
+
+The provider rejects obviously-broken payloads at build time instead of letting the Pushover server return an error:
+
+- `priority = 2` without both `retry` and `expire` → `Serialization` error.
+- `retry < 30` or `expire > 10800` → `Serialization` error.
+- `html = true` **and** `monospace = true` → `Serialization` error.
+- `priority` outside `-2..=2` → `Serialization` error.
+- Unknown `user_key` → `Configuration` error.
+
+All of these are non-retryable — retrying a malformed payload will never succeed.
+
+## Rule integration
+
+Because Pushover is just another named provider, every routing primitive Acteon already has works with it:
+
+- **Reroute high-priority events** to Pushover by matching on `action.payload.priority >= 1` with a `reroute` rule.
+- **Silence maintenance windows** with [silences](silences.md) — silences apply before the provider dispatch, so a Pushover notification never leaves the gateway during an active silence.
+- **Quota-bound a Pushover account** with a [per-provider tenant quota](tenant-quotas.md) scoped to `provider: "pushover-ops"` — useful if you're on the free 10k-messages/month tier and need to enforce monthly caps.
+- **Dedup noisy notifications** with Acteon's [deduplication](deduplication.md) using `Action.dedup_key` since Pushover itself has no server-side dedup.
+
+## Outcome body
+
+On success the provider returns an `Executed` outcome whose `body` carries the Pushover response:
+
+```json
+{
+  "status": 1,
+  "request": "a7b3e0c2-...",
+  "receipt": "u1iycscu4e..."
+}
+```
+
+The `request` field is the Pushover server request ID (useful for support tickets). The `receipt` field is only populated for **emergency-priority** notifications — you can poll the [Pushover receipts endpoint](https://pushover.net/api/receipts) with it to check whether the user has acknowledged the alert.
+
+## Error mapping
+
+| HTTP status | Pushover `status` | `ProviderError` | Retryable? |
+|-------------|-------------------|-----------------|------------|
+| 2xx | 1 | `Executed` (success) | — |
+| 2xx | 0 | `ExecutionFailed(...)` | No — permanent API error in the body |
+| 401 / 403 | — | `Configuration(...)` | No |
+| 429 | — | `RateLimited` | Yes |
+| 408, 5xx | — | `Connection(...)` (via `Transient`) | **Yes** — brief Pushover outages re-queue |
+| Other 4xx | — | `ExecutionFailed(...)` | No |
+| Transport failure | — | `Connection(...)` | Yes |
+
+## Simulation example
+
+A full demo — normal priority, emergency priority, and a rule-based reroute — is in `crates/simulation/examples/pushover_simulation.rs`:
+
+```bash
+cargo run -p acteon-simulation --example pushover_simulation
+```
+
+The simulation uses a recording provider, so it runs offline with no real Pushover credentials.

--- a/docs/design-alertmanager-parity.md
+++ b/docs/design-alertmanager-parity.md
@@ -37,7 +37,7 @@ A fresh audit against Alertmanager v0.27 features found the following gaps.
 | 3 | Per-receiver rate limits | **Shipped in Phase 3.** Generic tenant/namespace quotas now stack with optional per-provider scoped policies; strictest outcome wins; each scope has its own counter bucket. | ~~Medium~~ Done |
 | 4 | OpsGenie receiver | **Shipped in Phase 4a.** New `acteon-opsgenie` crate implements the Alert API v2 (create / acknowledge / close) against both US and EU regions, wired into the server's TOML provider config as `type = "opsgenie"`. | ~~Medium~~ Done |
 | 5 | VictorOps receiver | **Shipped in Phase 4b.** New `acteon-victorops` crate implements the REST endpoint integration (trigger / warn / info / acknowledge / resolve) with routing-key fan-out, auto-scoped `entity_id` for multi-tenant safety, and retryable 5xx/408. | ~~Medium~~ Done |
-| 6 | Pushover receiver | Missing | Low |
+| 6 | Pushover receiver | **Shipped in Phase 4c.** New `acteon-pushover` crate implements the Pushover Messages API with form-encoded POST, fan-out across multiple user/group keys, priority 0–2 (including emergency retry/expire), client-side validation, and the same transient retry semantics as the other on-call receivers. | ~~Low~~ Done |
 | 7 | WeChat receiver | Missing | Low |
 | 8 | Telegram receiver | Missing | Low |
 | 9 | Alert-centric admin UI (active alerts grouped by labels) | Missing — UI is action-centric and event-centric | Low |
@@ -209,8 +209,58 @@ Simulation: `crates/simulation/examples/victorops_simulation.rs`
 walks the full lifecycle plus a severity-based reroute. Docs:
 `docs/book/features/victorops.md`.
 
-#### Phase 4c–4d — Pushover, WeChat, Telegram
-**Gaps**: #6–#8
+#### Phase 4c — Pushover ✅ Shipped
+**Gap**: #6
+**Status**: Shipped in PR (feat/pushover-provider).
+**Scope as built**: new `acteon-pushover` crate (~1200 LOC with tests) plus server wiring, simulation example, and docs.
+
+The `acteon-pushover` crate is the lowest-ceremony receiver in
+the parity set — Pushover has no lifecycle (just fire-and-forget
+sends) and no server-side deduplication, so the provider is
+deliberately thin:
+- **Wire format**: Pushover's API is `application/x-www-form-urlencoded`
+  (not JSON), so the request type serializes through
+  `serde_urlencoded` and reqwest's `.form()` helper. No nested
+  fields.
+- **Priority support**: full 0–2 range including emergency
+  (priority=2) with `retry`/`expire` fields. Client-side
+  validation rejects emergency priority without both fields,
+  `retry < 30`, `expire > 10800`, and `html` + `monospace` set
+  simultaneously.
+- **Recipient fan-out**: map of logical name → user/group key,
+  with a configurable default and single-entry implicit fallback.
+  Pattern matches the `VictorOps` provider.
+- **Secret hygiene**: both `app_token` and every recipient key
+  are `SecretString`, zeroized on drop. Debug impl redacts both.
+- **Client-side truncation**: `message`, `title`, `url`, and
+  `url_title` are truncated to their documented API limits with
+  UTF-8 boundary-aware cutting so multi-byte characters are
+  never split.
+- **HTTP 200 + `status: 0` handling**: Pushover sometimes returns
+  a successful HTTP round-trip with a body that says
+  `status: 0` (permanent API failure). The provider classifies
+  this as non-retryable `ExecutionFailed` rather than silently
+  succeeding.
+- **Retry map**: identical to opsgenie/victorops — 401/403 →
+  non-retryable `Configuration`; 429 → retryable `RateLimited`;
+  5xx/408 → retryable `Connection` (via `Transient`); other 4xx
+  → non-retryable `ExecutionFailed`.
+- **Testing**: 52 unit tests including a mock HTTP server that
+  captures the form-encoded request body so tests assert on the
+  wire format (field ordering, URL encoding of reserved chars,
+  `priority=2` plus `retry`/`expire`, etc.).
+
+Config uses the same nested provider sub-struct pattern as the
+other receivers: `pushover.app_token`, `pushover.recipients`,
+`pushover.default_recipient`. Both secrets support `ENC[...]`.
+
+Simulation: `crates/simulation/examples/pushover_simulation.rs`
+walks through a normal-priority deploy notification, an
+emergency-priority alert, and a rule-based priority reroute.
+Docs: `docs/book/features/pushover.md`.
+
+#### Phase 4d — WeChat, Telegram
+**Gaps**: #7–#8
 **Status**: Pending. Each provider ships as its own PR so a
 review problem in one cannot block the others.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
     - Native Providers: features/native-providers.md
     - OpsGenie: features/opsgenie.md
     - VictorOps: features/victorops.md
+    - Pushover: features/pushover.md
   - Backends:
     - backends/index.md
     - State Backends: backends/state-backends.md


### PR DESCRIPTION
## Summary

Phase 4c of the [Alertmanager feature parity plan](https://github.com/penserai/acteon/blob/main/docs/design-alertmanager-parity.md): closes gap #6 by shipping a first-class `acteon-pushover` provider crate for [Pushover](https://pushover.net), the push-notification service Alertmanager supports via `pushover_configs`.

Pushover is the lowest-ceremony receiver in the parity set — it has no lifecycle (just fire-and-forget sends) and no server-side deduplication. The provider is deliberately thin, but picks up every security + resilience pattern the OpsGenie (PR #86) and VictorOps (PR #87) reviews established.

## Design

**Wire format** — Pushover's API is `application/x-www-form-urlencoded`, not JSON. The request type is a flat struct with `#[serde(skip_serializing_if = "Option::is_none")]` on optional fields, serialized through reqwest's `.form()` helper.

**Priority support** — full `-2..=2` range including **emergency** (`priority = 2`) which requires `retry` + `expire` fields. The server keeps re-notifying the user every `retry` seconds (min 30) until they tap the notification, or `expire` seconds elapse (max 10800 = 3 hours). On success the provider surfaces the `receipt` in the outcome body so callers can poll acknowledgment state.

**Recipient fan-out** — map of logical name → Pushover user or group key, with a configurable default and single-entry implicit fallback. Matches the routing-keys pattern from VictorOps.

**Secret hygiene** — both `app_token` and every recipient key live in `SecretString`, zeroized on drop. The `Debug` impl redacts both; logical recipient names stay visible for operator debugging.

**Client-side validation** — rejects obviously-broken payloads at build time:
- `priority = 2` without both `retry` and `expire`
- `retry < 30` or `expire > 10800`
- `html` **and** `monospace` set simultaneously
- `priority` outside `-2..=2`
- Unknown `user_key`

All non-retryable.

**UTF-8 boundary-aware truncation** — `message` (1024 bytes), `title` (250), `url` (512), `url_title` (100) are all truncated client-side with a UTF-8 boundary walk so multi-byte characters are never split.

**"200 OK + status:0" handling** — Pushover sometimes returns a successful HTTP round-trip with a body that contains `status: 0` (permanent API failure). The provider classifies these as non-retryable `ExecutionFailed` rather than silently succeeding.

**Retry map** — identical to opsgenie/victorops:
- 401/403 → non-retryable `Configuration`
- 429 → retryable `RateLimited`
- 5xx/408 → retryable `Connection` (via `Transient`)
- Other 4xx → non-retryable `ExecutionFailed`

## Example TOML

```toml
[[providers]]
name = "pushover-ops"
type = "pushover"
pushover.app_token = "ENC[AES256_GCM,data:...]"
pushover.default_recipient = "ops-oncall"

[providers.pushover.recipients]
ops-oncall = "ENC[AES256_GCM,data:...]"
dev-team   = "ENC[AES256_GCM,data:...]"
```

## Example payloads

**Normal priority:**

```json
{
  "message": "Deploy #4823 completed successfully.",
  "title": "CI/CD — production",
  "priority": 0,
  "url": "https://ci.example.com/build/4823",
  "url_title": "View build"
}
```

**Emergency priority (pages until acknowledged):**

```json
{
  "message": "Checkout API returning 5xx for >50% of traffic.",
  "title": "CRITICAL: checkout-api down",
  "priority": 2,
  "retry": 60,
  "expire": 3600,
  "sound": "siren"
}
```

## Test plan

- [x] `cargo test -p acteon-pushover --lib` — **52 passing**
- [x] `cargo test --workspace --lib --bins --tests` — full suite green
- [x] `cargo clippy -p acteon-pushover --no-deps --lib --tests -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p acteon-pushover --no-deps` — clean
- [x] `cargo run -p acteon-simulation --example pushover_simulation` — normal + emergency + reroute all pass
- [x] UI lint + build — green

## Remaining Phase 4 providers

WeChat and Telegram are still pending — each will ship as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)