### PR TITLE
feat: Telegram Bot provider (Phase 4d of Alertmanager parity)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,7 @@ dependencies = [
  "acteon-state-postgres",
  "acteon-state-redis",
  "acteon-teams",
+ "acteon-telegram",
  "acteon-twilio",
  "acteon-victorops",
  "acteon-wasm-runtime",
@@ -719,6 +720,22 @@ version = "0.1.0"
 dependencies = [
  "acteon-core",
  "acteon-provider",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "acteon-telegram"
+version = "0.1.0"
+dependencies = [
+ "acteon-core",
+ "acteon-crypto",
+ "acteon-provider",
+ "percent-encoding",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "crates/integrations/opsgenie",
     "crates/integrations/victorops",
     "crates/integrations/pushover",
+    "crates/integrations/telegram",
     "crates/integrations/webhook",
     "crates/integrations/twilio",
     "crates/integrations/teams",
@@ -133,6 +134,7 @@ acteon-pagerduty = { path = "crates/integrations/pagerduty" }
 acteon-opsgenie = { path = "crates/integrations/opsgenie" }
 acteon-victorops = { path = "crates/integrations/victorops" }
 acteon-pushover = { path = "crates/integrations/pushover" }
+acteon-telegram = { path = "crates/integrations/telegram" }
 acteon-webhook = { path = "crates/integrations/webhook" }
 acteon-twilio = { path = "crates/integrations/twilio" }
 acteon-teams = { path = "crates/integrations/teams" }

--- a/crates/integrations/telegram/Cargo.toml
+++ b/crates/integrations/telegram/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "acteon-telegram"
+description = "Telegram Bot provider for Acteon — sends messages via the Bot API sendMessage endpoint"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+
+[dependencies]
+acteon-core = { workspace = true }
+acteon-crypto = { workspace = true }
+acteon-provider = { workspace = true, features = ["trace-context"] }
+percent-encoding = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/integrations/telegram/src/config.rs
+++ b/crates/integrations/telegram/src/config.rs
@@ -5,14 +5,14 @@ use acteon_crypto::{ExposeSecret, SecretString};
 use crate::error::TelegramError;
 
 /// Default maximum length for the `text` field sent to Telegram,
-/// in UTF-8 bytes. The actual API cap is 4096 **UTF-16 code units**,
-/// which for mostly-ASCII text works out to ~4096 bytes; for
-/// non-BMP characters (emoji above U+FFFF, CJK surrogate pairs)
-/// the per-byte cap is stricter than necessary but never
-/// over-estimates. Override via
-/// [`TelegramConfig::with_text_max_bytes`] if you know your
-/// traffic is all-ASCII and want the full 4096-byte runway.
-pub const DEFAULT_TEXT_MAX_BYTES: usize = 4096;
+/// expressed in **UTF-16 code units** — the same unit Telegram's
+/// API uses for its 4096-unit cap. One BMP character costs 1
+/// code unit; one non-BMP character (most emoji, some CJK
+/// supplementary ideographs) costs 2. This gives CJK and
+/// emoji-heavy traffic the full runway the API actually permits,
+/// rather than the ~1365 characters a byte-based 4096 cap would
+/// allow.
+pub const DEFAULT_TEXT_MAX_UTF16_UNITS: usize = 4096;
 
 /// Configuration for the Telegram Bot provider.
 ///
@@ -52,8 +52,9 @@ pub struct TelegramConfig {
     /// text) is used.
     pub default_parse_mode: Option<String>,
 
-    /// Client-side text truncation cap, in bytes.
-    pub text_max_bytes: usize,
+    /// Client-side `text` truncation cap, in **UTF-16 code units**
+    /// — matches the units Telegram's API uses for its 4096 cap.
+    pub text_max_utf16_units: usize,
 }
 
 impl std::fmt::Debug for TelegramConfig {
@@ -64,7 +65,7 @@ impl std::fmt::Debug for TelegramConfig {
             .field("default_chat_name", &self.default_chat_name)
             .field("api_base_url", &self.api_base_url)
             .field("default_parse_mode", &self.default_parse_mode)
-            .field("text_max_bytes", &self.text_max_bytes)
+            .field("text_max_utf16_units", &self.text_max_utf16_units)
             .finish()
     }
 }
@@ -81,7 +82,7 @@ impl TelegramConfig {
             default_chat_name: None,
             api_base_url: "https://api.telegram.org".to_owned(),
             default_parse_mode: None,
-            text_max_bytes: DEFAULT_TEXT_MAX_BYTES,
+            text_max_utf16_units: DEFAULT_TEXT_MAX_UTF16_UNITS,
         }
     }
 
@@ -130,15 +131,38 @@ impl TelegramConfig {
         self
     }
 
-    /// Override the client-side `text` truncation cap.
+    /// Override the client-side `text` truncation cap. The value
+    /// is in **UTF-16 code units**, matching the units Telegram's
+    /// API uses for its 4096 cap. See
+    /// [`DEFAULT_TEXT_MAX_UTF16_UNITS`] for the default.
     #[must_use]
-    pub fn with_text_max_bytes(mut self, bytes: usize) -> Self {
-        self.text_max_bytes = bytes;
+    pub fn with_text_max_utf16_units(mut self, units: usize) -> Self {
+        self.text_max_utf16_units = units;
         self
     }
 
     /// Decrypt any `ENC[...]` bot token in place. Plaintext tokens
     /// pass through unchanged.
+    ///
+    /// # When to use which decrypt path
+    ///
+    /// The Acteon server has two code paths that can decrypt a
+    /// config field, and they intentionally do not overlap:
+    ///
+    /// 1. **Server TOML config** → `main.rs` calls
+    ///    `require_decrypt(raw, master_key)` per-field *before*
+    ///    constructing the provider. This is the path every
+    ///    operator exercises via `acteon-server`'s TOML config,
+    ///    and [`Self::decrypt_secrets`] is **not** called on that
+    ///    path.
+    /// 2. **Rust API users** → downstream crates that build a
+    ///    [`TelegramConfig`] programmatically from encrypted
+    ///    values (for example a test harness or a CLI) call
+    ///    [`Self::decrypt_secrets`] on the fully-constructed
+    ///    config to decrypt in place.
+    ///
+    /// Both approaches are valid; they serve different call
+    /// sites, not two ways to do the same thing.
     #[must_use = "returns the config with the decrypted bot token"]
     pub fn decrypt_secrets(
         mut self,
@@ -200,7 +224,7 @@ mod tests {
         assert!(config.chats.is_empty());
         assert!(config.default_chat_name.is_none());
         assert!(config.default_parse_mode.is_none());
-        assert_eq!(config.text_max_bytes, DEFAULT_TEXT_MAX_BYTES);
+        assert_eq!(config.text_max_utf16_units, DEFAULT_TEXT_MAX_UTF16_UNITS);
     }
 
     #[test]
@@ -218,9 +242,9 @@ mod tests {
             .with_default_chat("ops")
             .with_api_base_url("http://mock")
             .with_default_parse_mode("HTML")
-            .with_text_max_bytes(1024);
+            .with_text_max_utf16_units(1024);
         assert_eq!(config.default_parse_mode.as_deref(), Some("HTML"));
-        assert_eq!(config.text_max_bytes, 1024);
+        assert_eq!(config.text_max_utf16_units, 1024);
         assert_eq!(config.resolve_chat_id(None).unwrap(), "-1001234");
         assert_eq!(config.resolve_chat_id(Some("dev")).unwrap(), "@devchannel");
     }

--- a/crates/integrations/telegram/src/config.rs
+++ b/crates/integrations/telegram/src/config.rs
@@ -1,0 +1,303 @@
+use std::collections::HashMap;
+
+use acteon_crypto::{ExposeSecret, SecretString};
+
+use crate::error::TelegramError;
+
+/// Default maximum length for the `text` field sent to Telegram,
+/// in UTF-8 bytes. The actual API cap is 4096 **UTF-16 code units**,
+/// which for mostly-ASCII text works out to ~4096 bytes; for
+/// non-BMP characters (emoji above U+FFFF, CJK surrogate pairs)
+/// the per-byte cap is stricter than necessary but never
+/// over-estimates. Override via
+/// [`TelegramConfig::with_text_max_bytes`] if you know your
+/// traffic is all-ASCII and want the full 4096-byte runway.
+pub const DEFAULT_TEXT_MAX_BYTES: usize = 4096;
+
+/// Configuration for the Telegram Bot provider.
+///
+/// Telegram bots authenticate via a single token embedded in the
+/// URL path (`https://api.telegram.org/bot{token}/sendMessage`).
+/// The token lives in [`SecretString`] so its plaintext is
+/// zeroized on drop (via the `zeroize` crate, transitively through
+/// `secrecy`) and the `Debug` impl redacts it.
+///
+/// Chat IDs, by contrast, are **not** secrets — they're routing
+/// identifiers that appear in every message payload and can be
+/// recovered from the bot's own `getUpdates` response. They're
+/// stored as plain `String` values in a `HashMap` keyed by a
+/// logical name the dispatch payload uses to pick between them.
+#[derive(Clone)]
+pub struct TelegramConfig {
+    /// Bot token (`{bot_id}:{auth-string}`) — the secret that
+    /// authenticates every API call.
+    bot_token: SecretString,
+
+    /// Map of logical chat name → Telegram `chat_id`.
+    ///
+    /// Chat IDs can be numeric (`-1001234567890`) or string
+    /// `@channelusername` handles. Both forms are passed through
+    /// verbatim to the API.
+    chats: HashMap<String, String>,
+
+    /// Name of the default chat used when the payload omits
+    /// `chat`.
+    default_chat_name: Option<String>,
+
+    /// Base URL for the Bot API. Override for tests.
+    api_base_url: String,
+
+    /// Default `parse_mode` applied to outgoing messages when the
+    /// payload omits it. `None` means Telegram's default (plain
+    /// text) is used.
+    pub default_parse_mode: Option<String>,
+
+    /// Client-side text truncation cap, in bytes.
+    pub text_max_bytes: usize,
+}
+
+impl std::fmt::Debug for TelegramConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TelegramConfig")
+            .field("bot_token", &"[REDACTED]")
+            .field("chats", &self.chats)
+            .field("default_chat_name", &self.default_chat_name)
+            .field("api_base_url", &self.api_base_url)
+            .field("default_parse_mode", &self.default_parse_mode)
+            .field("text_max_bytes", &self.text_max_bytes)
+            .finish()
+    }
+}
+
+impl TelegramConfig {
+    /// Create an empty configuration with the given bot token.
+    /// Callers typically chain [`Self::with_chat`] to register
+    /// at least one chat id before building a provider.
+    #[must_use]
+    pub fn new(bot_token: impl Into<String>) -> Self {
+        Self {
+            bot_token: SecretString::new(bot_token.into()),
+            chats: HashMap::new(),
+            default_chat_name: None,
+            api_base_url: "https://api.telegram.org".to_owned(),
+            default_parse_mode: None,
+            text_max_bytes: DEFAULT_TEXT_MAX_BYTES,
+        }
+    }
+
+    /// Convenience shorthand for the single-chat case — registers
+    /// one chat id under the given name and marks it as the
+    /// default.
+    #[must_use]
+    pub fn single_chat(
+        bot_token: impl Into<String>,
+        chat_name: impl Into<String>,
+        chat_id: impl Into<String>,
+    ) -> Self {
+        let chat_name = chat_name.into();
+        let mut config = Self::new(bot_token);
+        config.chats.insert(chat_name.clone(), chat_id.into());
+        config.default_chat_name = Some(chat_name);
+        config
+    }
+
+    /// Register an additional chat under a logical name.
+    #[must_use]
+    pub fn with_chat(mut self, name: impl Into<String>, chat_id: impl Into<String>) -> Self {
+        self.chats.insert(name.into(), chat_id.into());
+        self
+    }
+
+    /// Set the default chat used when the payload omits `chat`.
+    #[must_use]
+    pub fn with_default_chat(mut self, name: impl Into<String>) -> Self {
+        self.default_chat_name = Some(name.into());
+        self
+    }
+
+    /// Override the API base URL (tests only).
+    #[must_use]
+    pub fn with_api_base_url(mut self, url: impl Into<String>) -> Self {
+        self.api_base_url = url.into();
+        self
+    }
+
+    /// Set the default `parse_mode` (`"HTML"`, `"Markdown"`, or
+    /// `"MarkdownV2"`).
+    #[must_use]
+    pub fn with_default_parse_mode(mut self, mode: impl Into<String>) -> Self {
+        self.default_parse_mode = Some(mode.into());
+        self
+    }
+
+    /// Override the client-side `text` truncation cap.
+    #[must_use]
+    pub fn with_text_max_bytes(mut self, bytes: usize) -> Self {
+        self.text_max_bytes = bytes;
+        self
+    }
+
+    /// Decrypt any `ENC[...]` bot token in place. Plaintext tokens
+    /// pass through unchanged.
+    #[must_use = "returns the config with the decrypted bot token"]
+    pub fn decrypt_secrets(
+        mut self,
+        master_key: &acteon_crypto::MasterKey,
+    ) -> Result<Self, TelegramError> {
+        self.bot_token = acteon_crypto::decrypt_value(self.bot_token.expose_secret(), master_key)
+            .map_err(|e| {
+            TelegramError::InvalidPayload(format!("failed to decrypt bot_token: {e}"))
+        })?;
+        Ok(self)
+    }
+
+    /// Return the API base URL.
+    #[must_use]
+    pub fn api_base_url(&self) -> &str {
+        &self.api_base_url
+    }
+
+    /// Return the bot token (kept `pub(crate)` so the secret stays
+    /// inside this crate).
+    pub(crate) fn bot_token(&self) -> &str {
+        self.bot_token.expose_secret()
+    }
+
+    /// Resolve a chat name to its chat id, honoring the default
+    /// and single-entry implicit fallbacks.
+    pub(crate) fn resolve_chat_id(&self, name: Option<&str>) -> Result<&str, TelegramError> {
+        match name {
+            Some(n) => self
+                .chats
+                .get(n)
+                .map(String::as_str)
+                .ok_or_else(|| TelegramError::UnknownChat(n.to_owned())),
+            None => {
+                if let Some(default_name) = &self.default_chat_name {
+                    self.chats
+                        .get(default_name.as_str())
+                        .map(String::as_str)
+                        .ok_or_else(|| TelegramError::UnknownChat(default_name.clone()))
+                } else if self.chats.len() == 1 {
+                    Ok(self.chats.values().next().unwrap())
+                } else {
+                    Err(TelegramError::NoDefaultChat)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_defaults() {
+        let config = TelegramConfig::new("tok");
+        assert_eq!(config.bot_token(), "tok");
+        assert_eq!(config.api_base_url(), "https://api.telegram.org");
+        assert!(config.chats.is_empty());
+        assert!(config.default_chat_name.is_none());
+        assert!(config.default_parse_mode.is_none());
+        assert_eq!(config.text_max_bytes, DEFAULT_TEXT_MAX_BYTES);
+    }
+
+    #[test]
+    fn single_chat_constructor() {
+        let config = TelegramConfig::single_chat("tok", "ops", "-1001234");
+        assert_eq!(config.resolve_chat_id(None).unwrap(), "-1001234");
+        assert_eq!(config.resolve_chat_id(Some("ops")).unwrap(), "-1001234");
+    }
+
+    #[test]
+    fn builder_chain() {
+        let config = TelegramConfig::new("tok")
+            .with_chat("ops", "-1001234")
+            .with_chat("dev", "@devchannel")
+            .with_default_chat("ops")
+            .with_api_base_url("http://mock")
+            .with_default_parse_mode("HTML")
+            .with_text_max_bytes(1024);
+        assert_eq!(config.default_parse_mode.as_deref(), Some("HTML"));
+        assert_eq!(config.text_max_bytes, 1024);
+        assert_eq!(config.resolve_chat_id(None).unwrap(), "-1001234");
+        assert_eq!(config.resolve_chat_id(Some("dev")).unwrap(), "@devchannel");
+    }
+
+    #[test]
+    fn resolve_explicit() {
+        let config = TelegramConfig::new("tok")
+            .with_chat("ops", "-1")
+            .with_chat("dev", "@dev");
+        assert_eq!(config.resolve_chat_id(Some("dev")).unwrap(), "@dev");
+    }
+
+    #[test]
+    fn resolve_implicit_single() {
+        let config = TelegramConfig::new("tok").with_chat("only", "-1");
+        assert_eq!(config.resolve_chat_id(None).unwrap(), "-1");
+    }
+
+    #[test]
+    fn resolve_unknown() {
+        let config = TelegramConfig::single_chat("tok", "ops", "-1");
+        let err = config.resolve_chat_id(Some("dev")).unwrap_err();
+        assert!(matches!(err, TelegramError::UnknownChat(ref n) if n == "dev"));
+    }
+
+    #[test]
+    fn resolve_no_default_multi() {
+        let config = TelegramConfig::new("tok")
+            .with_chat("ops", "-1")
+            .with_chat("dev", "-2");
+        let err = config.resolve_chat_id(None).unwrap_err();
+        assert!(matches!(err, TelegramError::NoDefaultChat));
+    }
+
+    fn test_master_key() -> acteon_crypto::MasterKey {
+        acteon_crypto::parse_master_key(&"42".repeat(32)).unwrap()
+    }
+
+    #[test]
+    fn decrypt_secrets_roundtrip() {
+        let master_key = test_master_key();
+        let plain = "123456:ABC-DEF";
+        let encrypted = acteon_crypto::encrypt_value(plain, &master_key).unwrap();
+
+        let config = TelegramConfig::new(encrypted)
+            .decrypt_secrets(&master_key)
+            .unwrap();
+        assert_eq!(config.bot_token(), plain);
+    }
+
+    #[test]
+    fn decrypt_secrets_plaintext_passthrough() {
+        let master_key = test_master_key();
+        let config = TelegramConfig::new("plain-token")
+            .decrypt_secrets(&master_key)
+            .unwrap();
+        assert_eq!(config.bot_token(), "plain-token");
+    }
+
+    #[test]
+    fn decrypt_secrets_invalid() {
+        let master_key = test_master_key();
+        let config = TelegramConfig::new("ENC[AES256-GCM,data:bad,iv:bad,tag:bad]");
+        let err = config.decrypt_secrets(&master_key).unwrap_err();
+        assert!(matches!(err, TelegramError::InvalidPayload(_)));
+    }
+
+    #[test]
+    fn debug_redacts_bot_token() {
+        let config =
+            TelegramConfig::single_chat("super-secret-bot-token-placeholder", "ops", "-1001234");
+        let debug = format!("{config:?}");
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("super-secret-bot-token-placeholder"));
+        // Chat IDs and names are NOT secrets — they should still
+        // appear in debug output.
+        assert!(debug.contains("ops"));
+        assert!(debug.contains("-1001234"));
+    }
+}

--- a/crates/integrations/telegram/src/error.rs
+++ b/crates/integrations/telegram/src/error.rs
@@ -1,0 +1,142 @@
+use acteon_provider::ProviderError;
+use thiserror::Error;
+
+/// Errors specific to the Telegram Bot provider.
+///
+/// These internal errors get converted into [`ProviderError`] at
+/// the public API boundary. Variants deliberately mirror the
+/// other on-call receiver crates so operators see consistent
+/// retry semantics across the Alertmanager parity set.
+#[derive(Debug, Error)]
+pub enum TelegramError {
+    /// An HTTP-level transport error occurred.
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// The Telegram API returned a **permanent** non-success
+    /// response (a 4xx that is not a rate-limit or auth failure).
+    /// Surfaced as `ExecutionFailed` and not retried.
+    #[error("Telegram API error: {0}")]
+    Api(String),
+
+    /// The Telegram API returned a **transient** non-success
+    /// response (5xx server error or 408 Request Timeout).
+    /// Surfaced as `ProviderError::Connection` so the gateway's
+    /// retry logic re-queues the dispatch.
+    #[error("Telegram transient error: {0}")]
+    Transient(String),
+
+    /// The action payload is missing required fields or has
+    /// invalid structure.
+    #[error("invalid payload: {0}")]
+    InvalidPayload(String),
+
+    /// The provider received an HTTP 429 (Too Many Requests)
+    /// response.
+    #[error("rate limited by Telegram")]
+    RateLimited,
+
+    /// The provider received an HTTP 401/403/404 response — for
+    /// Telegram bots, `404 Not Found` typically means the bot
+    /// token is unrecognized, so it is classified as an auth
+    /// failure rather than a generic 4xx.
+    #[error("authentication failed: {0}")]
+    Unauthorized(String),
+
+    /// The payload referenced a `chat` name that is not in the
+    /// configured chats map.
+    #[error("unknown Telegram chat: {0}")]
+    UnknownChat(String),
+
+    /// No `chat` was provided in the payload and no fallback
+    /// applies (no default chat, and the chats map is not a
+    /// single-entry map).
+    #[error("no chat in payload and no default chat configured")]
+    NoDefaultChat,
+}
+
+impl From<TelegramError> for ProviderError {
+    fn from(err: TelegramError) -> Self {
+        match err {
+            TelegramError::Http(e) => ProviderError::Connection(e.to_string()),
+            TelegramError::Api(msg) => ProviderError::ExecutionFailed(msg),
+            TelegramError::Transient(msg) => ProviderError::Connection(msg),
+            TelegramError::InvalidPayload(msg) => ProviderError::Serialization(msg),
+            TelegramError::RateLimited => ProviderError::RateLimited,
+            TelegramError::Unauthorized(msg) => ProviderError::Configuration(msg),
+            TelegramError::UnknownChat(name) => {
+                ProviderError::Configuration(format!("unknown Telegram chat: {name}"))
+            }
+            TelegramError::NoDefaultChat => ProviderError::Configuration(
+                "no chat in payload and no default chat configured".into(),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limited_is_retryable() {
+        let e: ProviderError = TelegramError::RateLimited.into();
+        assert!(e.is_retryable());
+        assert!(matches!(e, ProviderError::RateLimited));
+    }
+
+    #[test]
+    fn transient_maps_to_retryable_connection() {
+        let e: ProviderError = TelegramError::Transient("HTTP 503".into()).into();
+        assert!(e.is_retryable());
+        assert!(matches!(e, ProviderError::Connection(_)));
+    }
+
+    #[test]
+    fn api_is_non_retryable() {
+        let e: ProviderError = TelegramError::Api("bad request".into()).into();
+        assert!(!e.is_retryable());
+        assert!(matches!(e, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn unauthorized_is_configuration() {
+        let e: ProviderError = TelegramError::Unauthorized("bad token".into()).into();
+        assert!(!e.is_retryable());
+        assert!(matches!(e, ProviderError::Configuration(_)));
+    }
+
+    #[test]
+    fn unknown_chat_is_configuration() {
+        let e: ProviderError = TelegramError::UnknownChat("ops-gone".into()).into();
+        assert!(!e.is_retryable());
+        assert!(matches!(e, ProviderError::Configuration(_)));
+    }
+
+    #[test]
+    fn invalid_payload_is_serialization() {
+        let e: ProviderError = TelegramError::InvalidPayload("missing text".into()).into();
+        assert!(!e.is_retryable());
+        assert!(matches!(e, ProviderError::Serialization(_)));
+    }
+
+    #[test]
+    fn display_messages() {
+        assert_eq!(
+            TelegramError::Api("bad".into()).to_string(),
+            "Telegram API error: bad"
+        );
+        assert_eq!(
+            TelegramError::Transient("503".into()).to_string(),
+            "Telegram transient error: 503"
+        );
+        assert_eq!(
+            TelegramError::RateLimited.to_string(),
+            "rate limited by Telegram"
+        );
+        assert_eq!(
+            TelegramError::UnknownChat("ops".into()).to_string(),
+            "unknown Telegram chat: ops"
+        );
+    }
+}

--- a/crates/integrations/telegram/src/lib.rs
+++ b/crates/integrations/telegram/src/lib.rs
@@ -49,7 +49,7 @@ pub mod error;
 pub mod provider;
 pub mod types;
 
-pub use config::{DEFAULT_TEXT_MAX_BYTES, TelegramConfig};
+pub use config::{DEFAULT_TEXT_MAX_UTF16_UNITS, TelegramConfig};
 pub use error::TelegramError;
 pub use provider::TelegramProvider;
 pub use types::{TelegramApiResponse, TelegramSendMessageRequest};

--- a/crates/integrations/telegram/src/lib.rs
+++ b/crates/integrations/telegram/src/lib.rs
@@ -1,0 +1,55 @@
+//! Telegram Bot provider for the Acteon notification gateway.
+//!
+//! This crate implements the [`Provider`](acteon_provider::Provider)
+//! trait against the [Telegram Bot API's][api] `sendMessage`
+//! endpoint. It's the same endpoint Alertmanager targets via its
+//! `telegram_configs`, so a migration is just re-authoring the
+//! routing.
+//!
+//! # Quick start
+//!
+//! ```rust,no_run
+//! use acteon_telegram::{TelegramConfig, TelegramProvider};
+//!
+//! // Single chat (the common case).
+//! let config = TelegramConfig::single_chat(
+//!     "123456:ABC-DEF-bot-token",
+//!     "ops-channel",
+//!     "-1001234567890",
+//! )
+//! .with_default_parse_mode("HTML");
+//! let provider = TelegramProvider::new(config);
+//! ```
+//!
+//! Multiple chats are supported for deployments that route
+//! different alerts to different Telegram groups, users, or
+//! channels based on the payload's `chat` field.
+//!
+//! # Supported event actions
+//!
+//! Telegram has no lifecycle concept — the provider accepts one
+//! `event_action`, `"send"` (also the default when omitted). The
+//! only required payload field is `text`.
+//!
+//! | Payload field | Type | Purpose |
+//! |---|---|---|
+//! | `text` | string | **Required.** Message body (max 4096 UTF-16 code units per the API) |
+//! | `chat` | string | Logical chat name matching an entry in `chats` |
+//! | `parse_mode` | `"HTML"` / `"Markdown"` / `"MarkdownV2"` | Rich-text rendering |
+//! | `disable_notification` | bool | Silent delivery |
+//! | `disable_web_page_preview` | bool | Suppress URL previews |
+//! | `protect_content` | bool | Block forwarding / saving |
+//! | `reply_to_message_id` | int | Threaded reply |
+//! | `message_thread_id` | int | Target a topic in a forum group |
+//!
+//! [api]: https://core.telegram.org/bots/api#sendmessage
+
+pub mod config;
+pub mod error;
+pub mod provider;
+pub mod types;
+
+pub use config::{DEFAULT_TEXT_MAX_BYTES, TelegramConfig};
+pub use error::TelegramError;
+pub use provider::TelegramProvider;
+pub use types::{TelegramApiResponse, TelegramSendMessageRequest};

--- a/crates/integrations/telegram/src/provider.rs
+++ b/crates/integrations/telegram/src/provider.rs
@@ -85,20 +85,37 @@ impl TelegramProvider {
         Self { config, client }
     }
 
-    /// Truncate a string to `max_bytes` UTF-8 bytes without splitting
-    /// a multi-byte character. Returns the input unchanged when it
-    /// already fits.
-    fn truncate_utf8(s: String, max_bytes: usize) -> String {
-        if s.len() <= max_bytes {
-            return s;
+    /// Truncate a string so it serializes to at most `max_units`
+    /// **UTF-16 code units** — the units Telegram's API uses for
+    /// its 4096 cap on the `text` field.
+    ///
+    /// Counting UTF-16 units matches the API exactly: one BMP
+    /// character costs 1 unit, one non-BMP character (most emoji,
+    /// some CJK supplementary ideographs) costs 2. This is less
+    /// conservative than byte-based truncation for CJK and
+    /// emoji-heavy traffic — a 4096-character CJK message can
+    /// legitimately be ~12 KB of UTF-8, and a byte cap would
+    /// truncate it at ~1365 characters even though the API
+    /// would accept the full message.
+    ///
+    /// Returns the input unchanged when it already fits. The
+    /// algorithm walks chars in order and stops as soon as
+    /// adding the next char would exceed the cap — no
+    /// intermediate allocation.
+    fn truncate_to_utf16_units(s: String, max_units: usize) -> String {
+        let mut units = 0usize;
+        let mut byte_end = 0usize;
+        for (i, ch) in s.char_indices() {
+            let ch_units = ch.len_utf16();
+            if units + ch_units > max_units {
+                let mut out = s;
+                out.truncate(byte_end);
+                return out;
+            }
+            units += ch_units;
+            byte_end = i + ch.len_utf8();
         }
-        let mut cut = max_bytes;
-        while cut > 0 && !s.is_char_boundary(cut) {
-            cut -= 1;
-        }
-        let mut out = s;
-        out.truncate(cut);
-        out
+        s
     }
 
     /// Percent-encode a value for safe inclusion in an URL path
@@ -138,7 +155,7 @@ impl TelegramProvider {
         let text = payload
             .text
             .ok_or_else(|| TelegramError::InvalidPayload("missing 'text' field".into()))?;
-        let text = Self::truncate_utf8(text, self.config.text_max_bytes);
+        let text = Self::truncate_to_utf16_units(text, self.config.text_max_utf16_units);
 
         let chat_id = self
             .config
@@ -177,7 +194,23 @@ impl TelegramProvider {
         let status = response.status();
 
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            warn!("Telegram API rate limit hit");
+            // Telegram's 429 body includes `parameters.retry_after`
+            // with the server-suggested wait in seconds. We still
+            // return `RateLimited` (not a typed backoff) because
+            // `ProviderError::RateLimited` does not currently carry
+            // a duration, but surfacing the hint in the log lets
+            // operators see how long Telegram wants the bot to
+            // back off without digging into request traces.
+            let body = response.text().await.unwrap_or_default();
+            let retry_after = serde_json::from_str::<TelegramApiResponse>(&body)
+                .ok()
+                .and_then(|r| r.parameters)
+                .and_then(|p| p.retry_after);
+            if let Some(seconds) = retry_after {
+                warn!(retry_after_seconds = seconds, "Telegram API rate limit hit");
+            } else {
+                warn!("Telegram API rate limit hit");
+            }
             return Err(TelegramError::RateLimited);
         }
         // 401 Unauthorized or 404 Not Found on `/bot{token}/...`
@@ -258,11 +291,21 @@ impl Provider for TelegramProvider {
 
     #[instrument(skip(self), fields(provider = "telegram"))]
     async fn health_check(&self) -> Result<(), ProviderError> {
-        // Telegram exposes a `getMe` endpoint that returns the
-        // bot's identity on any valid token. We only care that the
-        // request round-trips at the HTTP layer; a 401/404 still
-        // means the endpoint is reachable, and only a transport
-        // failure is a hard health-check error.
+        // Telegram's `getMe` endpoint is explicitly designed as a
+        // credential-validity check: it's a free, idempotent GET
+        // that returns the bot's identity on a valid token and
+        // rejects bad tokens with a 401 / 404. That lets this
+        // provider verify **both** connectivity *and* the bot
+        // token on every health check — a stronger guarantee than
+        // the other receiver crates in the repo, whose APIs lack
+        // a comparable no-op endpoint.
+        //
+        // Failure classification:
+        // - Transport error → `Connection` (retryable)
+        // - 401 / 403 / 404 → `Configuration` (bad token)
+        // - Other non-2xx → `Connection` (transient)
+        // - 2xx but `ok: false` → `Configuration`
+        // - 2xx with `ok: true` → health OK
         let token_seg = Self::percent_encode_path_segment(self.config.bot_token());
         let url = format!("{}/bot{token_seg}/getMe", self.config.api_base_url());
         debug!("performing Telegram health check");
@@ -272,7 +315,37 @@ impl Provider for TelegramProvider {
             .send()
             .await
             .map_err(|e| ProviderError::Connection(e.to_string()))?;
-        debug!(status = %response.status(), "Telegram health check response");
+        let status = response.status();
+        debug!(%status, "Telegram health check response");
+
+        if matches!(
+            status,
+            reqwest::StatusCode::UNAUTHORIZED
+                | reqwest::StatusCode::FORBIDDEN
+                | reqwest::StatusCode::NOT_FOUND
+        ) {
+            return Err(ProviderError::Configuration(format!(
+                "Telegram getMe rejected the bot token: HTTP {status}"
+            )));
+        }
+        if !status.is_success() {
+            // Transient non-2xx — surface as retryable Connection
+            // so the gateway's circuit breaker treats it as a
+            // reachability blip rather than a credential problem.
+            return Err(ProviderError::Connection(format!(
+                "Telegram getMe returned non-success: HTTP {status}"
+            )));
+        }
+
+        let body: TelegramApiResponse = response.json().await.map_err(|e| {
+            ProviderError::Connection(format!("failed to parse Telegram getMe response: {e}"))
+        })?;
+        if !body.ok {
+            return Err(ProviderError::Configuration(format!(
+                "Telegram getMe returned ok=false: {}",
+                body.description.as_deref().unwrap_or("(no description)")
+            )));
+        }
         Ok(())
     }
 }
@@ -284,7 +357,7 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use super::*;
-    use crate::config::{DEFAULT_TEXT_MAX_BYTES, TelegramConfig};
+    use crate::config::{DEFAULT_TEXT_MAX_UTF16_UNITS, TelegramConfig};
 
     /// Tiny mock HTTP server for integration-style tests. Same
     /// pattern as the other integration crates — accept one
@@ -345,24 +418,79 @@ mod tests {
     }
 
     #[test]
-    fn truncate_utf8_passthrough() {
+    fn truncate_to_utf16_units_passthrough() {
         assert_eq!(
-            TelegramProvider::truncate_utf8("short".into(), 100),
+            TelegramProvider::truncate_to_utf16_units("short".into(), 100),
             "short"
         );
     }
 
     #[test]
-    fn truncate_utf8_ascii_cut() {
-        assert_eq!(TelegramProvider::truncate_utf8("abcde".into(), 4), "abcd");
+    fn truncate_to_utf16_units_ascii_cut() {
+        assert_eq!(
+            TelegramProvider::truncate_to_utf16_units("abcde".into(), 4),
+            "abcd"
+        );
     }
 
     #[test]
-    fn truncate_utf8_respects_char_boundaries() {
-        // "café" = c, a, f, 0xC3, 0xA9 — naive 4-byte cut would
-        // split the é. The helper must back up to the boundary.
-        let out = TelegramProvider::truncate_utf8("café".into(), 4);
-        assert_eq!(out, "caf");
+    fn truncate_to_utf16_units_char_boundaries() {
+        // "café" → c, a, f, é. `é` is a single BMP char (1
+        // UTF-16 unit, 2 UTF-8 bytes). A 4-unit cap fits the
+        // whole string; a 3-unit cap stops at "caf".
+        assert_eq!(
+            TelegramProvider::truncate_to_utf16_units("café".into(), 4),
+            "café"
+        );
+        assert_eq!(
+            TelegramProvider::truncate_to_utf16_units("café".into(), 3),
+            "caf"
+        );
+    }
+
+    #[test]
+    fn truncate_to_utf16_units_cjk_is_less_conservative_than_bytes() {
+        // Four CJK characters. Each is 3 UTF-8 bytes but 1
+        // UTF-16 unit (all in the BMP), so a 4-unit cap fits
+        // the whole string — whereas a byte-based 4-cap would
+        // fit only 1 character and 1 byte of the next (which we
+        // would then have to back off to a char boundary). This
+        // is the whole point of the refactor: CJK traffic was
+        // being truncated at ~1365 characters under the old
+        // byte-based 4096 cap even though the API accepts 4096
+        // characters.
+        let cjk = "字符串测".to_owned();
+        assert_eq!(cjk.len(), 12, "four CJK chars = 12 UTF-8 bytes");
+        assert_eq!(cjk.encode_utf16().count(), 4, "but 4 UTF-16 units");
+        let truncated = TelegramProvider::truncate_to_utf16_units(cjk.clone(), 4);
+        assert_eq!(truncated, cjk, "4-unit cap fits all 4 CJK chars");
+    }
+
+    #[test]
+    fn truncate_to_utf16_units_handles_surrogate_pairs() {
+        // Non-BMP emoji (U+1F680 ROCKET) costs 2 UTF-16 code
+        // units (one surrogate pair). A 2-unit cap fits one
+        // rocket; a 1-unit cap fits nothing because we cannot
+        // split a surrogate pair.
+        let two_rockets = "🚀🚀".to_owned();
+        assert_eq!(
+            two_rockets.encode_utf16().count(),
+            4,
+            "two rockets = 4 UTF-16 units"
+        );
+        assert_eq!(
+            TelegramProvider::truncate_to_utf16_units(two_rockets.clone(), 2),
+            "🚀"
+        );
+        assert_eq!(
+            TelegramProvider::truncate_to_utf16_units(two_rockets.clone(), 1),
+            "",
+            "a 1-unit cap cannot fit a surrogate pair"
+        );
+        assert_eq!(
+            TelegramProvider::truncate_to_utf16_units(two_rockets.clone(), 4),
+            two_rockets
+        );
     }
 
     #[test]
@@ -571,7 +699,10 @@ mod tests {
         let config =
             TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
         let provider = TelegramProvider::new(config);
-        let long = "x".repeat(DEFAULT_TEXT_MAX_BYTES + 1000);
+        // ASCII `x` costs 1 UTF-16 unit per char, so sending
+        // DEFAULT_TEXT_MAX_UTF16_UNITS + 1000 characters triggers
+        // truncation down to the cap.
+        let long = "x".repeat(DEFAULT_TEXT_MAX_UTF16_UNITS + 1000);
         let action = make_action(serde_json::json!({ "text": long }));
         let server_handle = tokio::spawn(async move {
             server
@@ -580,19 +711,19 @@ mod tests {
         });
         let _ = provider.execute(&action).await.unwrap();
         let request = server_handle.await.unwrap();
-        let marker = format!("\"text\":\"{}\"", "x".repeat(DEFAULT_TEXT_MAX_BYTES));
+        let marker = format!("\"text\":\"{}\"", "x".repeat(DEFAULT_TEXT_MAX_UTF16_UNITS));
         assert!(
             request.contains(&marker),
-            "text should be truncated to {DEFAULT_TEXT_MAX_BYTES} bytes"
+            "text should be truncated to {DEFAULT_TEXT_MAX_UTF16_UNITS} UTF-16 code units"
         );
     }
 
     #[tokio::test]
-    async fn execute_respects_configured_text_max_bytes() {
+    async fn execute_respects_configured_text_max_utf16_units() {
         let server = MockTelegramServer::start().await;
         let config = TelegramConfig::single_chat("t", "ops", "-1")
             .with_api_base_url(&server.base_url)
-            .with_text_max_bytes(100);
+            .with_text_max_utf16_units(100);
         let provider = TelegramProvider::new(config);
         let long = "y".repeat(200);
         let action = make_action(serde_json::json!({ "text": long }));
@@ -608,7 +739,45 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_rate_limited() {
+    async fn execute_allows_full_utf16_runway_for_cjk() {
+        // 4096 CJK characters is 12288 UTF-8 bytes — the old
+        // byte-based cap would have truncated at ~1365 characters.
+        // The UTF-16-unit cap lets us send the full 4096 chars
+        // because each CJK character is a single UTF-16 unit.
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let cjk_4096 = "字".repeat(DEFAULT_TEXT_MAX_UTF16_UNITS);
+        let action = make_action(serde_json::json!({ "text": cjk_4096.clone() }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"ok":true,"result":{}}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        // The full 4096 characters (12288 bytes) should appear in
+        // the request body — proof that CJK traffic no longer hits
+        // the conservative byte cap.
+        assert!(
+            request.contains(&cjk_4096),
+            "full 4096-char CJK text should pass through unchanged"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_rate_limited_parses_retry_after_body() {
+        // Telegram's 429 body carries `parameters.retry_after`
+        // with the server-suggested backoff in seconds. The
+        // provider logs it but still returns the unparameterized
+        // `RateLimited` because `ProviderError` does not carry a
+        // backoff duration. This test exercises the body-parsing
+        // path — the retry_after value lands in the warn log
+        // (not observable here without a tracing subscriber
+        // capture), but the test does verify the error
+        // classification is correct and that the body parse does
+        // not break on the `parameters` sub-object.
         let server = MockTelegramServer::start().await;
         let config =
             TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
@@ -626,6 +795,28 @@ mod tests {
         server_handle.await.unwrap();
         assert!(matches!(err, ProviderError::RateLimited));
         assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_rate_limited_tolerates_missing_retry_after() {
+        // If the 429 body has no `parameters.retry_after` (or is
+        // completely unparseable), the provider still classifies
+        // it as RateLimited — the parse is best-effort for the
+        // log line, never a hard requirement.
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({ "text": "hi" }));
+        let server_handle = tokio::spawn(async move {
+            // Empty body — parse returns None for retry_after
+            // and the code falls through to the "hit, no hint"
+            // log branch.
+            server.respond_once(429, "").await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::RateLimited));
     }
 
     #[tokio::test]
@@ -732,17 +923,111 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn health_check_reachable() {
+    async fn health_check_ok_true_succeeds() {
+        // Happy path: getMe returns 200 with `ok: true` and a
+        // non-empty bot identity result.
         let server = MockTelegramServer::start().await;
         let config =
             TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
         let provider = TelegramProvider::new(config);
-        // Even a 401 still means reachable.
-        let server_handle =
-            tokio::spawn(async move { server.respond_once(401, r#"{"ok":false}"#).await });
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(
+                    200,
+                    r#"{"ok":true,"result":{"id":12345,"is_bot":true,"first_name":"acteon-bot","username":"acteon_bot"}}"#,
+                )
+                .await;
+        });
         let result = provider.health_check().await;
         server_handle.await.unwrap();
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "getMe ok=true should succeed: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn health_check_401_is_configuration() {
+        // Bad bot token: Telegram returns 401. This is the whole
+        // point of verifying credentials in the health check — the
+        // gateway's health dashboard should see it as
+        // Configuration rather than a transient connection blip.
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(
+                    401,
+                    r#"{"ok":false,"error_code":401,"description":"Unauthorized"}"#,
+                )
+                .await;
+        });
+        let err = provider.health_check().await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(
+            matches!(err, ProviderError::Configuration(_)),
+            "401 should be Configuration, got {err:?}"
+        );
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn health_check_404_is_configuration() {
+        // 404 on /bot{token}/getMe — unrecognized token.
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(
+                    404,
+                    r#"{"ok":false,"error_code":404,"description":"Not Found"}"#,
+                )
+                .await;
+        });
+        let err = provider.health_check().await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::Configuration(_)));
+    }
+
+    #[tokio::test]
+    async fn health_check_200_ok_false_is_configuration() {
+        // 200 envelope with `ok: false` (rare but possible) still
+        // indicates a credential/config problem, not a transient
+        // one.
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(
+                    200,
+                    r#"{"ok":false,"error_code":401,"description":"bot token revoked"}"#,
+                )
+                .await;
+        });
+        let err = provider.health_check().await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::Configuration(_)));
+    }
+
+    #[tokio::test]
+    async fn health_check_500_is_connection() {
+        // Transient non-2xx: the endpoint is reachable but the
+        // server is unhappy. Classify as Connection so the
+        // circuit breaker treats it as a reachability blip.
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(500, r#"{"ok":false}"#).await;
+        });
+        let err = provider.health_check().await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::Connection(_)));
+        assert!(err.is_retryable());
     }
 
     #[tokio::test]

--- a/crates/integrations/telegram/src/provider.rs
+++ b/crates/integrations/telegram/src/provider.rs
@@ -1,0 +1,757 @@
+use acteon_core::{Action, ProviderResponse};
+use acteon_provider::{Provider, ProviderError, truncate_error_body};
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
+use reqwest::Client;
+use serde::Deserialize;
+use tracing::{debug, instrument, warn};
+
+use crate::config::TelegramConfig;
+use crate::error::TelegramError;
+use crate::types::{TelegramApiResponse, TelegramSendMessageRequest};
+
+/// RFC 3986 path-segment encode set — matches the set used by the
+/// `OpsGenie` and `VictorOps` providers for consistency.
+const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'%')
+    .add(b'/')
+    .add(b'<')
+    .add(b'>')
+    .add(b'?')
+    .add(b'@')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}')
+    .add(b':')
+    .add(b';')
+    .add(b'&')
+    .add(b'=')
+    .add(b'+')
+    .add(b'$')
+    .add(b',');
+
+/// Telegram Bot provider that posts messages via `sendMessage`.
+pub struct TelegramProvider {
+    config: TelegramConfig,
+    client: Client,
+}
+
+/// Fields extracted from an action payload.
+#[derive(Debug, Deserialize)]
+struct EventPayload {
+    /// Optional — defaults to `"send"`. Present for symmetry with
+    /// the other receivers that have real lifecycles; Telegram has
+    /// only one action.
+    #[serde(default)]
+    event_action: Option<String>,
+    #[serde(default)]
+    chat: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    parse_mode: Option<String>,
+    #[serde(default)]
+    disable_notification: Option<bool>,
+    #[serde(default)]
+    disable_web_page_preview: Option<bool>,
+    #[serde(default)]
+    protect_content: Option<bool>,
+    #[serde(default)]
+    reply_to_message_id: Option<i64>,
+    #[serde(default)]
+    message_thread_id: Option<i64>,
+}
+
+impl TelegramProvider {
+    /// Create a new Telegram provider with a default HTTP client
+    /// (30-second timeout).
+    pub fn new(config: TelegramConfig) -> Self {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("failed to build HTTP client");
+        Self { config, client }
+    }
+
+    /// Create a new provider with a custom HTTP client.
+    pub fn with_client(config: TelegramConfig, client: Client) -> Self {
+        Self { config, client }
+    }
+
+    /// Truncate a string to `max_bytes` UTF-8 bytes without splitting
+    /// a multi-byte character. Returns the input unchanged when it
+    /// already fits.
+    fn truncate_utf8(s: String, max_bytes: usize) -> String {
+        if s.len() <= max_bytes {
+            return s;
+        }
+        let mut cut = max_bytes;
+        while cut > 0 && !s.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        let mut out = s;
+        out.truncate(cut);
+        out
+    }
+
+    /// Percent-encode a value for safe inclusion in an URL path
+    /// segment. Used for the bot token in the request URL — the
+    /// token has a mixed alphanumeric + `-` + `:` format so `:`
+    /// specifically must be escaped.
+    fn percent_encode_path_segment(raw: &str) -> String {
+        utf8_percent_encode(raw, PATH_SEGMENT_ENCODE_SET).to_string()
+    }
+
+    /// Build the full `sendMessage` URL for this provider's bot.
+    /// The bot token is embedded in the URL path and percent-encoded
+    /// so any special characters (notably the `:` separator between
+    /// the bot id and the secret) cannot collapse the path.
+    fn send_message_url(&self) -> String {
+        let token_seg = Self::percent_encode_path_segment(self.config.bot_token());
+        format!("{}/bot{token_seg}/sendMessage", self.config.api_base_url())
+    }
+
+    /// Build a [`TelegramSendMessageRequest`] from the payload,
+    /// applying config defaults and client-side validation.
+    fn build_request(
+        &self,
+        payload: EventPayload,
+    ) -> Result<TelegramSendMessageRequest, TelegramError> {
+        // event_action defaults to "send"; any other value is an
+        // explicit caller error.
+        match payload.event_action.as_deref() {
+            None | Some("send") => {}
+            Some(other) => {
+                return Err(TelegramError::InvalidPayload(format!(
+                    "invalid event_action '{other}': Telegram only supports 'send' (or no event_action)"
+                )));
+            }
+        }
+
+        let text = payload
+            .text
+            .ok_or_else(|| TelegramError::InvalidPayload("missing 'text' field".into()))?;
+        let text = Self::truncate_utf8(text, self.config.text_max_bytes);
+
+        let chat_id = self
+            .config
+            .resolve_chat_id(payload.chat.as_deref())?
+            .to_owned();
+
+        let parse_mode = payload
+            .parse_mode
+            .or_else(|| self.config.default_parse_mode.clone());
+
+        Ok(TelegramSendMessageRequest {
+            chat_id,
+            text,
+            parse_mode,
+            disable_notification: payload.disable_notification,
+            disable_web_page_preview: payload.disable_web_page_preview,
+            protect_content: payload.protect_content,
+            reply_to_message_id: payload.reply_to_message_id,
+            message_thread_id: payload.message_thread_id,
+        })
+    }
+
+    /// POST a JSON body to the `sendMessage` endpoint and classify
+    /// the response into a [`TelegramError`] or a success.
+    async fn post_send(
+        &self,
+        request: &TelegramSendMessageRequest,
+    ) -> Result<TelegramApiResponse, TelegramError> {
+        // NOTE: do not include the URL in debug/error output — it
+        // contains the bot token as a path segment.
+        debug!("sending message to Telegram");
+        let url = self.send_message_url();
+        let builder = self.client.post(&url).json(request);
+        let req = acteon_provider::inject_trace_context(builder);
+        let response = req.send().await?;
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            warn!("Telegram API rate limit hit");
+            return Err(TelegramError::RateLimited);
+        }
+        // 401 Unauthorized or 404 Not Found on `/bot{token}/...`
+        // both mean "the bot token is unrecognized" from the
+        // server's perspective. Surface them as Configuration so
+        // operators get pointed at the credential.
+        if matches!(
+            status,
+            reqwest::StatusCode::UNAUTHORIZED
+                | reqwest::StatusCode::FORBIDDEN
+                | reqwest::StatusCode::NOT_FOUND
+        ) {
+            let body = response.text().await.unwrap_or_default();
+            return Err(TelegramError::Unauthorized(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            )));
+        }
+        if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
+            let body = response.text().await.unwrap_or_default();
+            warn!(%status, "Telegram transient error — will be retried by gateway");
+            return Err(TelegramError::Transient(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            )));
+        }
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(TelegramError::Api(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            )));
+        }
+
+        let api_response: TelegramApiResponse = response
+            .json()
+            .await
+            .map_err(|e| TelegramError::Api(format!("failed to parse Telegram response: {e}")))?;
+        if !api_response.ok {
+            return Err(TelegramError::Api(format!(
+                "Telegram returned ok=false error_code={:?} description={:?}",
+                api_response.error_code, api_response.description
+            )));
+        }
+        Ok(api_response)
+    }
+}
+
+impl Provider for TelegramProvider {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "telegram"
+    }
+
+    #[instrument(skip(self, action), fields(action_id = %action.id, provider = "telegram"))]
+    async fn execute(&self, action: &Action) -> Result<ProviderResponse, ProviderError> {
+        let payload: EventPayload = serde_json::from_value(action.payload.clone())
+            .map_err(|e| TelegramError::InvalidPayload(format!("failed to parse payload: {e}")))?;
+        let request = self.build_request(payload)?;
+        let api_response = self.post_send(&request).await?;
+
+        // Extract message_id from the result object if present;
+        // surface it in the outcome body so chains and audit can
+        // reference specific messages.
+        let message_id = api_response
+            .result
+            .as_ref()
+            .and_then(|v| v.get("message_id"))
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+
+        let body = serde_json::json!({
+            "ok": api_response.ok,
+            "message_id": message_id,
+        });
+        Ok(ProviderResponse::success(body))
+    }
+
+    #[instrument(skip(self), fields(provider = "telegram"))]
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        // Telegram exposes a `getMe` endpoint that returns the
+        // bot's identity on any valid token. We only care that the
+        // request round-trips at the HTTP layer; a 401/404 still
+        // means the endpoint is reachable, and only a transport
+        // failure is a hard health-check error.
+        let token_seg = Self::percent_encode_path_segment(self.config.bot_token());
+        let url = format!("{}/bot{token_seg}/getMe", self.config.api_base_url());
+        debug!("performing Telegram health check");
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| ProviderError::Connection(e.to_string()))?;
+        debug!(status = %response.status(), "Telegram health check response");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use acteon_core::Action;
+    use acteon_provider::{Provider, ProviderError};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+    use crate::config::{DEFAULT_TEXT_MAX_BYTES, TelegramConfig};
+
+    /// Tiny mock HTTP server for integration-style tests. Same
+    /// pattern as the other integration crates — accept one
+    /// connection, return a canned response, capture the request
+    /// body for assertions.
+    struct MockTelegramServer {
+        listener: tokio::net::TcpListener,
+        base_url: String,
+    }
+
+    impl MockTelegramServer {
+        async fn start() -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("failed to bind mock server");
+            let port = listener.local_addr().unwrap().port();
+            let base_url = format!("http://127.0.0.1:{port}");
+            Self { listener, base_url }
+        }
+
+        async fn respond_once(self, status_code: u16, body: &str) {
+            let body = body.to_owned();
+            let (mut stream, _) = self.listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 16384];
+            let _ = stream.read(&mut buf).await.unwrap();
+            let response = format!(
+                "HTTP/1.1 {status_code} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+        }
+
+        async fn respond_once_capturing(self, status_code: u16, body: &str) -> String {
+            let body = body.to_owned();
+            let (mut stream, _) = self.listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 16384];
+            let n = stream.read(&mut buf).await.unwrap();
+            let raw = String::from_utf8_lossy(&buf[..n]).to_string();
+            let response = format!(
+                "HTTP/1.1 {status_code} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+            raw
+        }
+    }
+
+    fn make_action(payload: serde_json::Value) -> Action {
+        Action::new("notifications", "tenant-1", "telegram", "notify", payload)
+    }
+
+    #[test]
+    fn provider_name() {
+        let provider = TelegramProvider::new(TelegramConfig::single_chat("tok", "ops", "-1001234"));
+        assert_eq!(provider.name(), "telegram");
+    }
+
+    #[test]
+    fn truncate_utf8_passthrough() {
+        assert_eq!(
+            TelegramProvider::truncate_utf8("short".into(), 100),
+            "short"
+        );
+    }
+
+    #[test]
+    fn truncate_utf8_ascii_cut() {
+        assert_eq!(TelegramProvider::truncate_utf8("abcde".into(), 4), "abcd");
+    }
+
+    #[test]
+    fn truncate_utf8_respects_char_boundaries() {
+        // "café" = c, a, f, 0xC3, 0xA9 — naive 4-byte cut would
+        // split the é. The helper must back up to the boundary.
+        let out = TelegramProvider::truncate_utf8("café".into(), 4);
+        assert_eq!(out, "caf");
+    }
+
+    #[test]
+    fn percent_encode_bot_token_segment() {
+        // Bot token format: "{bot_id}:{auth}" — the colon must
+        // be percent-encoded so it does not collapse the URL
+        // path.
+        assert_eq!(
+            TelegramProvider::percent_encode_path_segment("123456:ABC-DEF"),
+            "123456%3AABC-DEF"
+        );
+    }
+
+    #[test]
+    fn percent_encode_utf8() {
+        assert_eq!(
+            TelegramProvider::percent_encode_path_segment("café"),
+            "caf%C3%A9"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_send_success() {
+        let server = MockTelegramServer::start().await;
+        let config = TelegramConfig::single_chat("123:TOK", "ops", "-1001234")
+            .with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "text": "Deploy complete",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(
+                    200,
+                    r#"{"ok":true,"result":{"message_id":42,"text":"Deploy complete"}}"#,
+                )
+                .await
+        });
+        let result = provider.execute(&action).await;
+        let request = server_handle.await.unwrap();
+        let response = result.expect("execute should succeed");
+        assert_eq!(response.status, acteon_core::ResponseStatus::Success);
+        assert_eq!(response.body["ok"], true);
+        assert_eq!(response.body["message_id"], 42);
+
+        // URL embeds the percent-encoded bot token.
+        assert!(
+            request.contains("POST /bot123%3ATOK/sendMessage"),
+            "URL should embed percent-encoded bot token: {request}"
+        );
+        assert!(request.contains("content-type: application/json"));
+        assert!(request.contains("\"chat_id\":\"-1001234\""));
+        assert!(request.contains("\"text\":\"Deploy complete\""));
+    }
+
+    #[tokio::test]
+    async fn execute_send_with_full_options() {
+        let server = MockTelegramServer::start().await;
+        let config = TelegramConfig::single_chat("t", "ops", "-1")
+            .with_api_base_url(&server.base_url)
+            .with_default_parse_mode("HTML");
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "text": "<b>HIGH CPU</b>",
+            "disable_notification": false,
+            "disable_web_page_preview": true,
+            "protect_content": true,
+            "reply_to_message_id": 42,
+            "message_thread_id": 7,
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"ok":true,"result":{"message_id":100}}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+
+        assert!(request.contains("\"parse_mode\":\"HTML\""));
+        assert!(request.contains("\"disable_web_page_preview\":true"));
+        assert!(request.contains("\"protect_content\":true"));
+        assert!(request.contains("\"reply_to_message_id\":42"));
+        assert!(request.contains("\"message_thread_id\":7"));
+    }
+
+    #[tokio::test]
+    async fn execute_payload_parse_mode_overrides_config_default() {
+        let server = MockTelegramServer::start().await;
+        let config = TelegramConfig::single_chat("t", "ops", "-1")
+            .with_api_base_url(&server.base_url)
+            .with_default_parse_mode("HTML");
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "text": "*bold*",
+            "parse_mode": "MarkdownV2",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"ok":true,"result":{"message_id":1}}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        // Payload override wins.
+        assert!(request.contains("\"parse_mode\":\"MarkdownV2\""));
+        assert!(!request.contains("\"parse_mode\":\"HTML\""));
+    }
+
+    #[tokio::test]
+    async fn execute_send_event_action_default_and_explicit() {
+        // event_action omitted.
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({ "text": "hi" }));
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(200, r#"{"ok":true,"result":{}}"#).await;
+        });
+        let r = provider.execute(&action).await;
+        server_handle.await.unwrap();
+        assert!(r.is_ok());
+
+        // event_action = "send" explicitly.
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "send",
+            "text": "hi",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(200, r#"{"ok":true,"result":{}}"#).await;
+        });
+        let r = provider.execute(&action).await;
+        server_handle.await.unwrap();
+        assert!(r.is_ok());
+    }
+
+    #[tokio::test]
+    async fn execute_invalid_event_action() {
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url("http://127.0.0.1:1");
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "event_action": "acknowledge",
+            "text": "hi",
+        }));
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+    }
+
+    #[tokio::test]
+    async fn execute_missing_text() {
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url("http://127.0.0.1:1");
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({ "chat": "ops" }));
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Serialization(_)));
+    }
+
+    #[tokio::test]
+    async fn execute_with_explicit_chat() {
+        let server = MockTelegramServer::start().await;
+        let config = TelegramConfig::new("t")
+            .with_chat("ops", "-1001")
+            .with_chat("dev", "@dev")
+            .with_default_chat("ops")
+            .with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "text": "hi",
+            "chat": "dev",
+        }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"ok":true,"result":{}}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        assert!(
+            request.contains("\"chat_id\":\"@dev\""),
+            "explicit chat should pick @dev: {request}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_unknown_chat_is_configuration() {
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url("http://127.0.0.1:1");
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({
+            "text": "hi",
+            "chat": "nope",
+        }));
+        let err = provider.execute(&action).await.unwrap_err();
+        assert!(matches!(err, ProviderError::Configuration(_)));
+    }
+
+    #[tokio::test]
+    async fn execute_truncates_long_text() {
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let long = "x".repeat(DEFAULT_TEXT_MAX_BYTES + 1000);
+        let action = make_action(serde_json::json!({ "text": long }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"ok":true,"result":{}}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        let marker = format!("\"text\":\"{}\"", "x".repeat(DEFAULT_TEXT_MAX_BYTES));
+        assert!(
+            request.contains(&marker),
+            "text should be truncated to {DEFAULT_TEXT_MAX_BYTES} bytes"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_respects_configured_text_max_bytes() {
+        let server = MockTelegramServer::start().await;
+        let config = TelegramConfig::single_chat("t", "ops", "-1")
+            .with_api_base_url(&server.base_url)
+            .with_text_max_bytes(100);
+        let provider = TelegramProvider::new(config);
+        let long = "y".repeat(200);
+        let action = make_action(serde_json::json!({ "text": long }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once_capturing(200, r#"{"ok":true,"result":{}}"#)
+                .await
+        });
+        let _ = provider.execute(&action).await.unwrap();
+        let request = server_handle.await.unwrap();
+        let marker = format!("\"text\":\"{}\"", "y".repeat(100));
+        assert!(request.contains(&marker));
+    }
+
+    #[tokio::test]
+    async fn execute_rate_limited() {
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({ "text": "hi" }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(
+                    429,
+                    r#"{"ok":false,"error_code":429,"description":"retry after 5","parameters":{"retry_after":5}}"#,
+                )
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::RateLimited));
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_503_retryable_connection() {
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({ "text": "hi" }));
+        let server_handle = tokio::spawn(async move {
+            server.respond_once(503, r#"{"ok":false}"#).await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::Connection(_)));
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_401_maps_to_configuration() {
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({ "text": "hi" }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(
+                    401,
+                    r#"{"ok":false,"error_code":401,"description":"Unauthorized"}"#,
+                )
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::Configuration(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_404_maps_to_configuration() {
+        // 404 on /bot{token}/... means the token is unrecognized.
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({ "text": "hi" }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(
+                    404,
+                    r#"{"ok":false,"error_code":404,"description":"Not Found"}"#,
+                )
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(
+            matches!(err, ProviderError::Configuration(_)),
+            "404 should surface as Configuration (bad bot token), got {err:?}"
+        );
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_400_non_retryable() {
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({ "text": "hi" }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(
+                    400,
+                    r#"{"ok":false,"error_code":400,"description":"Bad Request: chat not found"}"#,
+                )
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn execute_200_but_ok_false_is_api_error() {
+        // Telegram sometimes returns 200 with ok=false (rare but
+        // possible) — classify as permanent API error.
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        let action = make_action(serde_json::json!({ "text": "hi" }));
+        let server_handle = tokio::spawn(async move {
+            server
+                .respond_once(200, r#"{"ok":false,"error_code":400,"description":"nope"}"#)
+                .await;
+        });
+        let err = provider.execute(&action).await.unwrap_err();
+        server_handle.await.unwrap();
+        assert!(matches!(err, ProviderError::ExecutionFailed(_)));
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn health_check_reachable() {
+        let server = MockTelegramServer::start().await;
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url(&server.base_url);
+        let provider = TelegramProvider::new(config);
+        // Even a 401 still means reachable.
+        let server_handle =
+            tokio::spawn(async move { server.respond_once(401, r#"{"ok":false}"#).await });
+        let result = provider.health_check().await;
+        server_handle.await.unwrap();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn health_check_connection_failure() {
+        let config =
+            TelegramConfig::single_chat("t", "ops", "-1").with_api_base_url("http://127.0.0.1:1");
+        let provider = TelegramProvider::new(config);
+        let err = provider.health_check().await.unwrap_err();
+        assert!(matches!(err, ProviderError::Connection(_)));
+        assert!(err.is_retryable());
+    }
+}

--- a/crates/integrations/telegram/src/types.rs
+++ b/crates/integrations/telegram/src/types.rs
@@ -1,0 +1,171 @@
+use serde::{Deserialize, Serialize};
+
+/// Request body for the Telegram Bot API's `sendMessage` endpoint.
+///
+/// The API is JSON and accepts the shape documented at
+/// <https://core.telegram.org/bots/api#sendmessage>. Only `chat_id`
+/// and `text` are required; everything else is optional and skipped
+/// at serialization time when `None`.
+#[derive(Debug, Clone, Serialize)]
+pub struct TelegramSendMessageRequest {
+    /// Target chat identifier. Can be numeric (`-1001234567890`)
+    /// or a string `@channelusername`.
+    pub chat_id: String,
+    /// Message body.
+    pub text: String,
+    /// Rich-text parse mode: `"HTML"`, `"Markdown"`, or `"MarkdownV2"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parse_mode: Option<String>,
+    /// When `true`, Telegram delivers the message silently.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disable_notification: Option<bool>,
+    /// When `true`, Telegram suppresses URL previews in the message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disable_web_page_preview: Option<bool>,
+    /// When `true`, recipients cannot forward or save the message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protect_content: Option<bool>,
+    /// ID of an existing message this message replies to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reply_to_message_id: Option<i64>,
+    /// Topic ID inside a forum group — required for bots posting
+    /// to a specific topic in a topics-enabled group.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_thread_id: Option<i64>,
+}
+
+/// Response body returned by the Telegram Bot API.
+///
+/// On success `ok == true` and `result` carries the full message
+/// object. On failure `ok == false` and `description` carries a
+/// human-readable error string; rate-limit failures additionally
+/// populate `parameters.retry_after` with the number of seconds
+/// to wait before retrying.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TelegramApiResponse {
+    /// `true` on success, `false` on failure. Independent of the
+    /// HTTP status code.
+    #[serde(default)]
+    pub ok: bool,
+    /// Numeric error code on failure (e.g. `400`, `403`, `429`).
+    #[serde(default)]
+    pub error_code: Option<i32>,
+    /// Human-readable error description on failure.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Full message object on success (opaque here — we surface
+    /// the `message_id` field to the outcome body via a
+    /// `serde_json::Value` because we don't need the full shape).
+    #[serde(default)]
+    pub result: Option<serde_json::Value>,
+    /// Error parameters. Populated with `retry_after` on HTTP 429.
+    #[serde(default)]
+    pub parameters: Option<TelegramResponseParameters>,
+}
+
+/// Supplementary fields returned alongside an error response.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct TelegramResponseParameters {
+    /// Number of seconds to wait before retrying (populated on
+    /// rate-limit failures).
+    #[serde(default)]
+    pub retry_after: Option<u32>,
+    /// When a group is migrated to a supergroup, this field holds
+    /// the new supergroup's chat id.
+    #[serde(default)]
+    pub migrate_to_chat_id: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_serializes_minimum() {
+        let req = TelegramSendMessageRequest {
+            chat_id: "-1001234".into(),
+            text: "hello".into(),
+            parse_mode: None,
+            disable_notification: None,
+            disable_web_page_preview: None,
+            protect_content: None,
+            reply_to_message_id: None,
+            message_thread_id: None,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["chat_id"], "-1001234");
+        assert_eq!(json["text"], "hello");
+        // Every optional field is omitted.
+        assert!(json.get("parse_mode").is_none());
+        assert!(json.get("disable_notification").is_none());
+        assert!(json.get("reply_to_message_id").is_none());
+    }
+
+    #[test]
+    fn request_serializes_full() {
+        let req = TelegramSendMessageRequest {
+            chat_id: "@opschannel".into(),
+            text: "<b>ALERT</b>".into(),
+            parse_mode: Some("HTML".into()),
+            disable_notification: Some(false),
+            disable_web_page_preview: Some(true),
+            protect_content: Some(true),
+            reply_to_message_id: Some(42),
+            message_thread_id: Some(7),
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["chat_id"], "@opschannel");
+        assert_eq!(json["parse_mode"], "HTML");
+        assert_eq!(json["disable_web_page_preview"], true);
+        assert_eq!(json["protect_content"], true);
+        assert_eq!(json["reply_to_message_id"], 42);
+        assert_eq!(json["message_thread_id"], 7);
+    }
+
+    #[test]
+    fn response_deserializes_success() {
+        let json = r#"{"ok":true,"result":{"message_id":123,"text":"hi"}}"#;
+        let resp: TelegramApiResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.ok);
+        assert_eq!(resp.result.as_ref().unwrap()["message_id"], 123);
+    }
+
+    #[test]
+    fn response_deserializes_error_with_retry_after() {
+        let json = r#"{
+            "ok": false,
+            "error_code": 429,
+            "description": "Too Many Requests: retry after 15",
+            "parameters": {"retry_after": 15}
+        }"#;
+        let resp: TelegramApiResponse = serde_json::from_str(json).unwrap();
+        assert!(!resp.ok);
+        assert_eq!(resp.error_code, Some(429));
+        assert_eq!(
+            resp.parameters.as_ref().and_then(|p| p.retry_after),
+            Some(15)
+        );
+    }
+
+    #[test]
+    fn response_deserializes_error_without_parameters() {
+        let json = r#"{"ok":false,"error_code":400,"description":"Bad Request: chat not found"}"#;
+        let resp: TelegramApiResponse = serde_json::from_str(json).unwrap();
+        assert!(!resp.ok);
+        assert_eq!(resp.error_code, Some(400));
+        assert_eq!(
+            resp.description.as_deref(),
+            Some("Bad Request: chat not found")
+        );
+        assert!(resp.parameters.is_none());
+    }
+
+    #[test]
+    fn response_tolerates_missing_fields() {
+        let resp: TelegramApiResponse = serde_json::from_str("{}").unwrap();
+        assert!(!resp.ok);
+        assert!(resp.error_code.is_none());
+        assert!(resp.description.is_none());
+        assert!(resp.result.is_none());
+    }
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -67,6 +67,7 @@ acteon-discord = { workspace = true }
 acteon-opsgenie = { workspace = true }
 acteon-victorops = { workspace = true }
 acteon-pushover = { workspace = true }
+acteon-telegram = { workspace = true }
 acteon-executor = { workspace = true }
 acteon-gateway = { workspace = true }
 acteon-llm = { workspace = true }

--- a/crates/server/src/config/providers.rs
+++ b/crates/server/src/config/providers.rs
@@ -21,10 +21,10 @@ pub struct ProviderConfig {
     /// Unique name for this provider.
     pub name: String,
     /// Provider type: `"webhook"`, `"log"`, `"twilio"`, `"teams"`, `"discord"`,
-    /// `"email"`, `"opsgenie"`, `"victorops"`, `"pushover"`, `"aws-sns"`,
-    /// `"aws-lambda"`, `"aws-eventbridge"`, `"aws-sqs"`, `"aws-s3"`, `"aws-ec2"`,
-    /// `"aws-autoscaling"`, `"azure-blob"`, `"azure-eventhubs"`, `"gcp-pubsub"`,
-    /// or `"gcp-storage"`.
+    /// `"email"`, `"opsgenie"`, `"victorops"`, `"pushover"`, `"telegram"`,
+    /// `"aws-sns"`, `"aws-lambda"`, `"aws-eventbridge"`, `"aws-sqs"`,
+    /// `"aws-s3"`, `"aws-ec2"`, `"aws-autoscaling"`, `"azure-blob"`,
+    /// `"azure-eventhubs"`, `"gcp-pubsub"`, or `"gcp-storage"`.
     #[serde(rename = "type")]
     pub provider_type: String,
     /// Target URL (required for `"webhook"` type).
@@ -191,6 +191,21 @@ pub struct ProviderConfig {
     /// ```
     #[serde(default)]
     pub pushover: PushoverProviderConfig,
+
+    /// Nested configuration block for the `"telegram"` provider type.
+    ///
+    /// Example TOML:
+    /// ```toml
+    /// [[providers]]
+    /// name = "telegram-ops"
+    /// type = "telegram"
+    /// telegram.bot_token = "ENC[...]"
+    /// telegram.default_chat = "ops-channel"
+    /// telegram.default_parse_mode = "HTML"
+    /// telegram.chats = { ops-channel = "-1001234567890", devs = "@devchannel" }
+    /// ```
+    #[serde(default)]
+    pub telegram: TelegramProviderConfig,
 }
 
 /// Nested configuration block for the `OpsGenie` provider.
@@ -262,5 +277,27 @@ pub struct PushoverProviderConfig {
     /// omits `user_key`.
     pub default_recipient: Option<String>,
     /// Override base URL for the Pushover Messages API (testing only).
+    pub api_base_url: Option<String>,
+}
+
+/// Nested configuration block for the `Telegram` Bot provider.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct TelegramProviderConfig {
+    /// Telegram bot token (`{bot_id}:{auth-string}`). Supports `ENC[...]`.
+    pub bot_token: Option<String>,
+    /// Map of logical chat name → Telegram `chat_id`. Chat IDs
+    /// can be numeric (`-1001234567890`) or string
+    /// `@channelusername` handles. Chat IDs are **not** secrets.
+    pub chats: HashMap<String, String>,
+    /// Name of the default chat used when the dispatch payload
+    /// omits `chat`.
+    pub default_chat: Option<String>,
+    /// Default `parse_mode` applied to outgoing messages when the
+    /// payload omits it. `"HTML"`, `"Markdown"`, or `"MarkdownV2"`.
+    pub default_parse_mode: Option<String>,
+    /// Client-side `text` truncation cap, in bytes.
+    pub text_max_bytes: Option<usize>,
+    /// Override base URL for the Telegram Bot API (testing only).
     pub api_base_url: Option<String>,
 }

--- a/crates/server/src/config/providers.rs
+++ b/crates/server/src/config/providers.rs
@@ -296,8 +296,11 @@ pub struct TelegramProviderConfig {
     /// Default `parse_mode` applied to outgoing messages when the
     /// payload omits it. `"HTML"`, `"Markdown"`, or `"MarkdownV2"`.
     pub default_parse_mode: Option<String>,
-    /// Client-side `text` truncation cap, in bytes.
-    pub text_max_bytes: Option<usize>,
+    /// Client-side `text` truncation cap, in **UTF-16 code units**
+    /// — matches the units Telegram's API uses for its 4096 cap.
+    /// One BMP character costs 1 unit; one non-BMP character
+    /// (most emoji, some CJK supplementary ideographs) costs 2.
+    pub text_max_utf16_units: Option<usize>,
     /// Override base URL for the Telegram Bot API (testing only).
     pub api_base_url: Option<String>,
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -835,6 +835,44 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     shared_http_client.clone(),
                 ))
             }
+            "telegram" => {
+                let tg = &provider_cfg.telegram;
+                let bot_token_raw = tg.bot_token.as_deref().ok_or_else(|| {
+                    format!(
+                        "provider '{}': telegram type requires a 'telegram.bot_token' field",
+                        provider_cfg.name
+                    )
+                })?;
+                if tg.chats.is_empty() {
+                    return Err(format!(
+                        "provider '{}': telegram type requires at least one entry in 'telegram.chats'",
+                        provider_cfg.name
+                    )
+                    .into());
+                }
+                let bot_token = require_decrypt(bot_token_raw, master_key.as_ref())?;
+                let mut telegram_config = acteon_telegram::TelegramConfig::new(bot_token);
+                for (name, chat_id) in &tg.chats {
+                    telegram_config = telegram_config.with_chat(name, chat_id);
+                }
+                if let Some(ref default_chat) = tg.default_chat {
+                    telegram_config = telegram_config.with_default_chat(default_chat);
+                }
+                if let Some(ref parse_mode) = tg.default_parse_mode {
+                    telegram_config = telegram_config.with_default_parse_mode(parse_mode);
+                }
+                if let Some(bytes) = tg.text_max_bytes {
+                    telegram_config = telegram_config.with_text_max_bytes(bytes);
+                }
+                if let Some(ref url) = tg.api_base_url {
+                    validate_provider_url(&provider_cfg.name, url)?;
+                    telegram_config = telegram_config.with_api_base_url(url);
+                }
+                std::sync::Arc::new(acteon_telegram::TelegramProvider::with_client(
+                    telegram_config,
+                    shared_http_client.clone(),
+                ))
+            }
             "email" => {
                 let from_address = provider_cfg.from_address.as_deref().ok_or_else(|| {
                     format!(

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -861,8 +861,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if let Some(ref parse_mode) = tg.default_parse_mode {
                     telegram_config = telegram_config.with_default_parse_mode(parse_mode);
                 }
-                if let Some(bytes) = tg.text_max_bytes {
-                    telegram_config = telegram_config.with_text_max_bytes(bytes);
+                if let Some(units) = tg.text_max_utf16_units {
+                    telegram_config = telegram_config.with_text_max_utf16_units(units);
                 }
                 if let Some(ref url) = tg.api_base_url {
                     validate_provider_url(&provider_cfg.name, url)?;

--- a/crates/simulation/examples/telegram_simulation.rs
+++ b/crates/simulation/examples/telegram_simulation.rs
@@ -1,0 +1,163 @@
+//! Telegram Bot provider simulation scenarios.
+//!
+//! Demonstrates dispatching messages through the Telegram provider:
+//! a plain-text deploy notification, an HTML-formatted alert with
+//! a thread id targeting a forum-group topic, and a rule-based
+//! reroute that sends high-priority events to Telegram.
+//!
+//! The scenarios use the simulation harness' recording provider
+//! named `"telegram"`, so no real Telegram bot credentials are
+//! needed.
+//!
+//! Run with: `cargo run -p acteon-simulation --example telegram_simulation`
+
+use acteon_core::Action;
+use acteon_simulation::prelude::*;
+use tracing::info;
+
+const REROUTE_HIGH_TO_TELEGRAM_RULE: &str = r#"
+rules:
+  - name: reroute-high-to-telegram
+    priority: 1
+    condition:
+      field: action.payload.severity
+      eq: "critical"
+    action:
+      type: reroute
+      target_provider: telegram
+"#;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    info!("╔══════════════════════════════════════════════════════════════╗");
+    info!("║          TELEGRAM PROVIDER SIMULATION DEMO                  ║");
+    info!("╚══════════════════════════════════════════════════════════════╝\n");
+
+    // =========================================================================
+    // DEMO 1: Plain-text notification
+    // =========================================================================
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    info!("  DEMO 1: PLAIN-TEXT DEPLOY NOTIFICATION");
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("telegram")
+            .build(),
+    )
+    .await?;
+    info!("✓ Started simulation cluster with 1 node");
+    info!("✓ Registered 'telegram' recording provider\n");
+
+    let deploy = Action::new(
+        "notifications",
+        "tenant-1",
+        "telegram",
+        "notify",
+        serde_json::json!({
+            "text": "Deploy #4823 completed successfully.",
+            "chat": "ops-channel",
+        }),
+    );
+    info!("→ Dispatching plain-text deploy notification...");
+    let outcome = harness.dispatch(&deploy).await?;
+    info!("  Outcome: {outcome:?}\n");
+
+    // =========================================================================
+    // DEMO 2: HTML-formatted alert with topic thread
+    // =========================================================================
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    info!("  DEMO 2: HTML-FORMATTED ALERT (with forum-group thread)");
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let alert = Action::new(
+        "incidents",
+        "tenant-1",
+        "telegram",
+        "notify",
+        serde_json::json!({
+            "text": "<b>CRITICAL</b>: checkout-api error rate above SLO.\n<i>Investigate immediately.</i>",
+            "chat": "ops-channel",
+            "parse_mode": "HTML",
+            "disable_web_page_preview": true,
+            "protect_content": true,
+            "message_thread_id": 7,
+        }),
+    );
+    info!("→ Dispatching HTML alert to topic thread 7...");
+    let outcome = harness.dispatch(&alert).await?;
+    info!("  Outcome: {outcome:?}");
+
+    let provider = harness.provider("telegram").unwrap();
+    info!(
+        "\n  Telegram provider received {} message(s)",
+        provider.call_count()
+    );
+    assert_eq!(provider.call_count(), 2);
+    harness.teardown().await?;
+    info!("✓ Simulation cluster shut down\n");
+
+    // =========================================================================
+    // DEMO 3: Rule-based reroute of critical severity to Telegram
+    // =========================================================================
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    info!("  DEMO 3: RULE-BASED REROUTE — severity=critical → Telegram");
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    let harness = SimulationHarness::start(
+        SimulationConfig::builder()
+            .nodes(1)
+            .add_recording_provider("log")
+            .add_recording_provider("telegram")
+            .add_rule_yaml(REROUTE_HIGH_TO_TELEGRAM_RULE)
+            .build(),
+    )
+    .await?;
+    info!("✓ Started cluster with log + telegram recording providers");
+    info!("✓ Loaded reroute rule: severity=critical → telegram\n");
+
+    // Warning severity — stays on log.
+    let warn = Action::new(
+        "incidents",
+        "tenant-1",
+        "log",
+        "notify",
+        serde_json::json!({
+            "severity": "warning",
+            "text": "Queue depth above warning threshold",
+        }),
+    );
+    info!("→ Dispatching severity=warning (should stay on 'log')...");
+    let outcome = harness.dispatch(&warn).await?;
+    info!("  Outcome: {outcome:?}");
+
+    // Critical severity — routed to telegram.
+    let critical = Action::new(
+        "incidents",
+        "tenant-1",
+        "log",
+        "notify",
+        serde_json::json!({
+            "severity": "critical",
+            "text": "checkout-api is down",
+        }),
+    );
+    info!("→ Dispatching severity=critical (should reroute to 'telegram')...");
+    let outcome = harness.dispatch(&critical).await?;
+    info!("  Outcome: {outcome:?}");
+
+    let log_calls = harness.provider("log").unwrap().call_count();
+    let telegram_calls = harness.provider("telegram").unwrap().call_count();
+    info!("\n  Provider call counts:");
+    info!("    log:      {log_calls}");
+    info!("    telegram: {telegram_calls}");
+    assert_eq!(log_calls, 1);
+    assert_eq!(telegram_calls, 1);
+
+    harness.teardown().await?;
+    info!("\n✓ All demos complete.");
+    Ok(())
+}

--- a/docs/book/features/telegram.md
+++ b/docs/book/features/telegram.md
@@ -1,0 +1,123 @@
+# Telegram Bot Provider
+
+Acteon ships with a first-class **Telegram Bot** provider that sends messages via the [Telegram Bot API's `sendMessage` endpoint][api] — the same endpoint Alertmanager targets via its `telegram_configs`. It was built as part of Phase 4d of the Alertmanager feature-parity initiative so teams migrating off Alertmanager can re-use their existing Telegram receivers.
+
+[api]: https://core.telegram.org/bots/api#sendmessage
+
+Like the other native providers, `acteon-telegram`:
+
+- Holds the bot token as `SecretString`, zeroized on drop. The token is percent-encoded in the URL path so the `{bot_id}:{auth}` colon separator cannot collapse the route.
+- Supports multiple chats per provider instance so one config can fan messages out to several groups, users, or channels.
+- Maps 5xx / 408 → retryable `Connection` (via a `Transient` variant); 429 → retryable `RateLimited`; 401/403/404 → non-retryable `Configuration` (404 on `/bot{token}/...` means an unrecognized token — operator error, not transient); other 4xx → non-retryable `ExecutionFailed`.
+- Handles Telegram's **200 OK + `ok: false`** edge case by classifying it as a permanent `ExecutionFailed`.
+- Reuses the server's shared HTTP client, so it participates in circuit breaking, provider health checks, and per-provider metrics automatically.
+- Propagates W3C Trace Context headers.
+
+## TOML configuration
+
+```toml
+[[providers]]
+name = "telegram-ops"
+type = "telegram"
+telegram.bot_token = "ENC[AES256_GCM,data:abc123...]"
+telegram.default_chat = "ops-channel"
+telegram.default_parse_mode = "HTML"   # optional
+# telegram.text_max_bytes = 4096       # default; override if you know your text is all-ASCII
+
+[providers.telegram.chats]
+ops-channel  = "-1001234567890"
+dev-channel  = "@devchannel"
+alice-direct = "123456789"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique provider name used when dispatching actions |
+| `type` | Yes | Must be `"telegram"` |
+| `telegram.bot_token` | Yes | Bot token (`{bot_id}:{auth-string}`). Supports `ENC[...]`. |
+| `telegram.chats` | Yes (≥1) | Map of logical chat name → Telegram `chat_id`. Values can be numeric (`-1001234567890`) or string handles (`@channelusername`). Chat IDs are **not** secrets. |
+| `telegram.default_chat` | No | Name of the default chat used when the dispatch payload omits `chat`. If there is only one chat, it is used implicitly. |
+| `telegram.default_parse_mode` | No | Default `parse_mode` applied when the payload omits it: `"HTML"`, `"Markdown"`, or `"MarkdownV2"`. |
+| `telegram.text_max_bytes` | No | Client-side `text` truncation cap (default `4096`, matching the API limit for ASCII-heavy text). |
+| `telegram.api_base_url` | No | Override the Bot API base URL. Tests only. |
+
+## Payload shape
+
+Telegram has no lifecycle concept — the provider accepts one `event_action`, `"send"` (also the default when omitted). Only `text` is required.
+
+```json
+{
+  "text": "Deploy #4823 completed successfully.",
+  "chat": "ops-channel"
+}
+```
+
+### HTML-formatted alert to a forum-group topic
+
+```json
+{
+  "text": "<b>CRITICAL</b>: checkout-api error rate above SLO.\n<i>Investigate immediately.</i>",
+  "chat": "ops-channel",
+  "parse_mode": "HTML",
+  "disable_web_page_preview": true,
+  "protect_content": true,
+  "message_thread_id": 7
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `text` | string | **Required.** Message body. Truncated client-side to `text_max_bytes` (default 4096) on UTF-8 boundaries, so multi-byte characters are never split. |
+| `chat` | string | Logical chat name (matching a key in `telegram.chats`). Falls back to `telegram.default_chat` or the single-entry implicit default. |
+| `parse_mode` | string | `"HTML"`, `"Markdown"`, or `"MarkdownV2"`. Overrides `telegram.default_parse_mode`. |
+| `disable_notification` | bool | Silent delivery — recipients get no sound or vibration. |
+| `disable_web_page_preview` | bool | Suppress URL previews. |
+| `protect_content` | bool | Block forwarding and saving. |
+| `reply_to_message_id` | int | Mark this message as a reply to an existing one. |
+| `message_thread_id` | int | Target a specific topic inside a forum-enabled group. |
+
+## Rule integration
+
+Because Telegram is just another named provider, every routing primitive Acteon already has works with it:
+
+- **Reroute critical alerts** to a Telegram channel by matching on `action.payload.severity == "critical"` with a `reroute` rule.
+- **Silence maintenance windows** with [silences](silences.md) — silences apply before the provider dispatch.
+- **Quota-bound a Telegram bot** with a [per-provider tenant quota](tenant-quotas.md) scoped to `provider: "telegram-ops"` — Telegram's own per-bot limits are 30 messages/second globally and 20 messages/minute per group, so a quota is useful defense-in-depth.
+- **Dedup noisy events** with Acteon's [deduplication](deduplication.md) using `Action.dedup_key`.
+
+## Outcome body
+
+On success the provider returns an `Executed` outcome whose `body` carries the Telegram response:
+
+```json
+{
+  "ok": true,
+  "message_id": 42
+}
+```
+
+The `message_id` is the Telegram server's assignment for the delivered message — useful in chains where a later step needs to edit or reply to an earlier Telegram post.
+
+## Error mapping
+
+| HTTP status | Telegram `ok` | `ProviderError` | Retryable? |
+|-------------|----------------|-----------------|------------|
+| 2xx | `true` | `Executed` (success) | — |
+| 2xx | `false` | `ExecutionFailed(...)` | No — permanent API error in the body |
+| 401 / 403 / 404 | — | `Configuration(...)` | No — bad bot token |
+| 429 | — | `RateLimited` | Yes |
+| 408, 5xx | — | `Connection(...)` (via `Transient`) | **Yes** |
+| Other 4xx | — | `ExecutionFailed(...)` | No |
+| Transport failure | — | `Connection(...)` | Yes |
+
+**Why 404 → `Configuration`:** the Telegram Bot API routes every call through `/bot{token}/...`. A 404 on that path means the server did not recognize the token — which is an operator problem, not a transient one. The same class of response on the other provider crates would be 401, but Telegram sometimes uses 404 here.
+
+## Simulation example
+
+A full demo — plain-text notification, HTML alert to a forum-group topic, and a rule-based reroute — is in `crates/simulation/examples/telegram_simulation.rs`:
+
+```bash
+cargo run -p acteon-simulation --example telegram_simulation
+```
+
+The simulation uses a recording provider, so it runs offline with no real Telegram credentials.

--- a/docs/book/features/telegram.md
+++ b/docs/book/features/telegram.md
@@ -11,6 +11,7 @@ Like the other native providers, `acteon-telegram`:
 - Maps 5xx / 408 → retryable `Connection` (via a `Transient` variant); 429 → retryable `RateLimited`; 401/403/404 → non-retryable `Configuration` (404 on `/bot{token}/...` means an unrecognized token — operator error, not transient); other 4xx → non-retryable `ExecutionFailed`.
 - Handles Telegram's **200 OK + `ok: false`** edge case by classifying it as a permanent `ExecutionFailed`.
 - Reuses the server's shared HTTP client, so it participates in circuit breaking, provider health checks, and per-provider metrics automatically.
+- **Verifies credentials** in the health check: unlike most provider APIs, Telegram ships a free, idempotent `getMe` endpoint explicitly designed as a credential-validity probe. The Telegram provider parses the response and surfaces bad tokens as non-retryable `Configuration` errors — operators see token problems on the health dashboard instead of only at dispatch time.
 - Propagates W3C Trace Context headers.
 
 ## TOML configuration
@@ -21,8 +22,8 @@ name = "telegram-ops"
 type = "telegram"
 telegram.bot_token = "ENC[AES256_GCM,data:abc123...]"
 telegram.default_chat = "ops-channel"
-telegram.default_parse_mode = "HTML"   # optional
-# telegram.text_max_bytes = 4096       # default; override if you know your text is all-ASCII
+telegram.default_parse_mode = "HTML"         # optional
+# telegram.text_max_utf16_units = 4096        # default — matches the Bot API's UTF-16 unit cap
 
 [providers.telegram.chats]
 ops-channel  = "-1001234567890"
@@ -38,8 +39,14 @@ alice-direct = "123456789"
 | `telegram.chats` | Yes (≥1) | Map of logical chat name → Telegram `chat_id`. Values can be numeric (`-1001234567890`) or string handles (`@channelusername`). Chat IDs are **not** secrets. |
 | `telegram.default_chat` | No | Name of the default chat used when the dispatch payload omits `chat`. If there is only one chat, it is used implicitly. |
 | `telegram.default_parse_mode` | No | Default `parse_mode` applied when the payload omits it: `"HTML"`, `"Markdown"`, or `"MarkdownV2"`. |
-| `telegram.text_max_bytes` | No | Client-side `text` truncation cap (default `4096`, matching the API limit for ASCII-heavy text). |
+| `telegram.text_max_utf16_units` | No | Client-side `text` truncation cap, in **UTF-16 code units** — the same unit Telegram's API uses for its 4096-unit cap. Default `4096`. |
 | `telegram.api_base_url` | No | Override the Bot API base URL. Tests only. |
+
+### Why UTF-16 code units (not bytes)
+
+The Telegram Bot API expresses the 4096-character `text` limit in UTF-16 code units, not UTF-8 bytes. One BMP character (Latin, Cyrillic, Hebrew, Arabic, most CJK) costs 1 code unit; one non-BMP character (most emoji at U+1F000 and above, supplementary CJK ideographs) costs 2 code units (a surrogate pair).
+
+Counting in UTF-16 units matches the API exactly. The earlier revision of this provider counted bytes instead, which meant CJK traffic truncated at ~1365 characters (because CJK is 3 bytes per character in UTF-8) even though the API would have accepted the full 4096-character message. The current implementation gives CJK and emoji-heavy deployments the full runway the API actually permits.
 
 ## Payload shape
 
@@ -67,7 +74,7 @@ Telegram has no lifecycle concept — the provider accepts one `event_action`, `
 
 | Field | Type | Notes |
 |-------|------|-------|
-| `text` | string | **Required.** Message body. Truncated client-side to `text_max_bytes` (default 4096) on UTF-8 boundaries, so multi-byte characters are never split. |
+| `text` | string | **Required.** Message body. Truncated client-side to `text_max_utf16_units` UTF-16 code units (default 4096, matching the API limit). Multi-byte characters are never split. |
 | `chat` | string | Logical chat name (matching a key in `telegram.chats`). Falls back to `telegram.default_chat` or the single-entry implicit default. |
 | `parse_mode` | string | `"HTML"`, `"Markdown"`, or `"MarkdownV2"`. Overrides `telegram.default_parse_mode`. |
 | `disable_notification` | bool | Silent delivery — recipients get no sound or vibration. |

--- a/docs/design-alertmanager-parity.md
+++ b/docs/design-alertmanager-parity.md
@@ -39,7 +39,7 @@ A fresh audit against Alertmanager v0.27 features found the following gaps.
 | 5 | VictorOps receiver | **Shipped in Phase 4b.** New `acteon-victorops` crate implements the REST endpoint integration (trigger / warn / info / acknowledge / resolve) with routing-key fan-out, auto-scoped `entity_id` for multi-tenant safety, and retryable 5xx/408. | ~~Medium~~ Done |
 | 6 | Pushover receiver | **Shipped in Phase 4c.** New `acteon-pushover` crate implements the Pushover Messages API with form-encoded POST, fan-out across multiple user/group keys, priority 0–2 (including emergency retry/expire), client-side validation, and the same transient retry semantics as the other on-call receivers. | ~~Low~~ Done |
 | 7 | WeChat receiver | Missing | Low |
-| 8 | Telegram receiver | Missing | Low |
+| 8 | Telegram receiver | **Shipped in Phase 4d.** New `acteon-telegram` crate implements the Bot API `sendMessage` endpoint with HTML / Markdown / MarkdownV2 parse modes, forum-group topic support, multi-chat fan-out, 4096-byte text truncation, and the same transient retry semantics as the other receivers. | ~~Low~~ Done |
 | 9 | Alert-centric admin UI (active alerts grouped by labels) | Missing — UI is action-centric and event-centric | Low |
 | 10 | First-class `Alert` primitive | Missing | **Skip** — handle via generic `Action` + convention |
 
@@ -259,10 +259,69 @@ walks through a normal-priority deploy notification, an
 emergency-priority alert, and a rule-based priority reroute.
 Docs: `docs/book/features/pushover.md`.
 
-#### Phase 4d — WeChat, Telegram
-**Gaps**: #7–#8
-**Status**: Pending. Each provider ships as its own PR so a
-review problem in one cannot block the others.
+#### Phase 4d-Telegram — Telegram ✅ Shipped
+**Gap**: #8
+**Status**: Shipped in PR (feat/telegram-provider).
+**Scope as built**: new `acteon-telegram` crate (~1600 LOC with
+tests) plus server wiring, simulation example, and docs.
+
+The `acteon-telegram` crate implements the Bot API `sendMessage`
+endpoint — the same one Alertmanager targets via its
+`telegram_configs`:
+- **Lifecycle**: Telegram has no multi-step lifecycle. The
+  provider accepts one `event_action` (`"send"`, also the
+  default) and requires only `text`. Everything else is
+  optional and passes through.
+- **Multi-chat fan-out**: a map of logical chat name →
+  Telegram `chat_id`, with a configurable default and
+  single-entry implicit fallback. Chat IDs can be numeric
+  (`-1001234567890`) or string `@channelusername` handles and
+  pass through verbatim.
+- **Rich text**: `parse_mode` supports `HTML`, `Markdown`,
+  and `MarkdownV2`. A config-level `default_parse_mode`
+  applies globally, the payload can override per-message.
+- **Forum-group topics**: the payload accepts `message_thread_id`
+  for bots posting into a specific topic in a topics-enabled
+  supergroup.
+- **Client-side text truncation**: `text` is truncated to
+  `text_max_bytes` (default 4096) on UTF-8 boundaries, so
+  multi-byte characters are never split.
+- **Bot token as `SecretString`**: zeroized on drop, redacted
+  in `Debug`, percent-encoded in the URL path segment so the
+  `{bot_id}:{auth}` colon separator cannot collapse the route.
+  Chat IDs are stored as plain `String` (they are not
+  secrets — they appear in every message and can be
+  recovered from `getUpdates`).
+- **Retry map**: aligned with the other receivers —
+  401/403/404 → non-retryable `Configuration` (404 on
+  `/bot{token}/...` means an unrecognized bot token, which is
+  an operator problem); 429 → retryable `RateLimited`;
+  5xx/408 → retryable `Connection` (via `Transient`); other
+  4xx → non-retryable `ExecutionFailed`.
+- **HTTP 200 + `ok: false` handling**: the Bot API's response
+  envelope carries an `ok` boolean. A successful HTTP
+  round-trip with `ok: false` is classified as permanent
+  `ExecutionFailed` rather than silently succeeding.
+- **Testing**: 48 unit tests including a mock HTTP server that
+  captures the request body so tests assert on the full wire
+  format — URL shape (percent-encoded bot token segment),
+  JSON payload (chat_id, text, parse_mode, thread id), and
+  every retry class.
+
+Config uses the same nested provider sub-struct pattern as the
+other receivers: `telegram.bot_token`, `telegram.chats`,
+`telegram.default_chat`, `telegram.default_parse_mode`,
+`telegram.text_max_bytes`. The bot token supports `ENC[...]`.
+
+Simulation: `crates/simulation/examples/telegram_simulation.rs`
+walks through a plain-text deploy notification, an
+HTML-formatted alert targeting a forum-group topic, and a
+rule-based severity reroute. Docs:
+`docs/book/features/telegram.md`.
+
+#### Phase 4d-WeChat — WeChat
+**Gap**: #7
+**Status**: Pending. Ships as its own PR.
 
 ### Phase 5 — Alert-centric admin UI
 **Gap**: #9

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
     - OpsGenie: features/opsgenie.md
     - VictorOps: features/victorops.md
     - Pushover: features/pushover.md
+    - Telegram: features/telegram.md
   - Backends:
     - backends/index.md
     - State Backends: backends/state-backends.md


### PR DESCRIPTION
## Summary

Phase 4d of the [Alertmanager feature parity plan](https://github.com/penserai/acteon/blob/main/docs/design-alertmanager-parity.md): closes gap #8 by shipping a first-class `acteon-telegram` provider crate targeting the [Telegram Bot API's `sendMessage` endpoint](https://core.telegram.org/bots/api#sendmessage) — the same one Alertmanager uses via `telegram_configs`.

With this merged, only **WeChat** (gap #7) remains in Phase 4.

## Design

**Lifecycle** — Telegram has no multi-step lifecycle. The provider accepts one `event_action` (`"send"`, also the default) and requires only `text`. Everything else is optional and passes through.

**Multi-chat fan-out** — map of logical chat name → Telegram `chat_id` with a configurable default and single-entry implicit fallback. Chat IDs can be numeric (`-1001234567890`) or string `@channelusername` handles, and they're **not** secrets (they appear in every message and can be recovered from `getUpdates`), so they're stored as plain `String`.

**Rich text** — `parse_mode` supports `HTML`, `Markdown`, and `MarkdownV2`, both via a config default and a per-payload override.

**Forum-group topics** — the payload accepts `message_thread_id` so bots posting into topics-enabled supergroups can target a specific topic.

**Secret hygiene** — the bot token lives in `SecretString`, zeroized on drop, redacted in `Debug`. It's percent-encoded in the URL path segment so the `{bot_id}:{auth}` colon separator cannot collapse the route.

**Client-side truncation** — `text` is truncated to `text_max_bytes` (default 4096, matching the API cap for ASCII) on UTF-8 boundaries so multi-byte characters are never split. Configurable via `with_text_max_bytes`.

**Retry map** — aligned with the other receivers:
- 401/403/**404** → non-retryable `Configuration` (404 on `/bot{token}/...` means an unrecognized bot token — operator problem, not transient)
- 429 → retryable `RateLimited`
- 5xx/408 → retryable `Connection` (via `Transient`)
- Other 4xx → non-retryable `ExecutionFailed`

**HTTP 200 + `ok: false` handling** — the Bot API response envelope carries an `ok` boolean. A successful HTTP round-trip with `ok: false` is classified as permanent `ExecutionFailed` rather than silently succeeding.

## Example TOML

```toml
[[providers]]
name = "telegram-ops"
type = "telegram"
telegram.bot_token = "ENC[AES256_GCM,data:...]"
telegram.default_chat = "ops-channel"
telegram.default_parse_mode = "HTML"

[providers.telegram.chats]
ops-channel  = "-1001234567890"
dev-channel  = "@devchannel"
alice-direct = "123456789"
```

## Example payloads

**Plain text:**

```json
{
  "text": "Deploy #4823 completed successfully.",
  "chat": "ops-channel"
}
```

**HTML alert to a forum-group topic:**

```json
{
  "text": "<b>CRITICAL</b>: checkout-api error rate above SLO.",
  "chat": "ops-channel",
  "parse_mode": "HTML",
  "disable_web_page_preview": true,
  "protect_content": true,
  "message_thread_id": 7
}
```

## Test plan

- [x] `cargo test -p acteon-telegram --lib` — **48 passing**
- [x] `cargo test --workspace --lib --bins --tests` — full suite green
- [x] `cargo clippy -p acteon-telegram --no-deps --lib --tests -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p acteon-telegram --no-deps` — clean
- [x] `cargo run -p acteon-simulation --example telegram_simulation` — all three demos pass
- [x] UI lint + build — green

## Remaining Phase 4 providers

**WeChat** (gap #7) is the only remaining receiver — it will ship as its own PR. WeChat is meaningfully more complex than the others (access-token refresh every 7200s, multiple message types, multiple recipient types) so it deserves a dedicated review window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)