### PR TITLE
docs: complete provider list + feature-gate niche messaging providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         run: cargo nextest run -p acteon-aws --features full --lib --tests
       - name: Test Azure providers
         run: cargo nextest run -p acteon-azure --features full --lib --tests
+      - name: Build server with opt-in messaging providers
+        run: cargo check -p acteon-server --features extras-alerting
       - name: Run doctests
         run: cargo test --workspace --doc
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -40,6 +40,17 @@ azure-all = ["azure-blob", "azure-eventhubs"]
 gcp-pubsub = ["acteon-gcp/pubsub"]
 gcp-storage = ["acteon-gcp/storage"]
 gcp-all = ["gcp-pubsub", "gcp-storage"]
+# Niche / regional messaging providers — opt-in to keep the default
+# binary from shipping support for integrations most deployments do
+# not need. Widely-used providers (email, slack, pagerduty, webhook,
+# twilio, teams) remain part of the default build.
+opsgenie = ["dep:acteon-opsgenie"]
+victorops = ["dep:acteon-victorops"]
+pushover = ["dep:acteon-pushover"]
+telegram = ["dep:acteon-telegram"]
+wechat = ["dep:acteon-wechat"]
+discord = ["dep:acteon-discord"]
+extras-alerting = ["opsgenie", "victorops", "pushover", "telegram", "wechat", "discord"]
 
 [dependencies]
 acteon-audit = { workspace = true, features = ["openapi"] }
@@ -63,12 +74,12 @@ acteon-azure = { workspace = true, optional = true }
 acteon-gcp = { workspace = true, optional = true }
 acteon-twilio = { workspace = true }
 acteon-teams = { workspace = true }
-acteon-discord = { workspace = true }
-acteon-opsgenie = { workspace = true }
-acteon-victorops = { workspace = true }
-acteon-pushover = { workspace = true }
-acteon-telegram = { workspace = true }
-acteon-wechat = { workspace = true }
+acteon-discord = { workspace = true, optional = true }
+acteon-opsgenie = { workspace = true, optional = true }
+acteon-victorops = { workspace = true, optional = true }
+acteon-pushover = { workspace = true, optional = true }
+acteon-telegram = { workspace = true, optional = true }
+acteon-wechat = { workspace = true, optional = true }
 acteon-executor = { workspace = true }
 acteon-gateway = { workspace = true }
 acteon-llm = { workspace = true }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -691,6 +691,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     shared_http_client.clone(),
                 ))
             }
+            #[cfg(feature = "discord")]
             "discord" => {
                 let webhook_url = provider_cfg
                     .webhook_url
@@ -712,6 +713,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     shared_http_client.clone(),
                 ))
             }
+            #[cfg(feature = "opsgenie")]
             "opsgenie" => {
                 let og = &provider_cfg.opsgenie;
                 let api_key_raw = og.api_key.as_deref().ok_or_else(|| {
@@ -763,6 +765,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     shared_http_client.clone(),
                 ))
             }
+            #[cfg(feature = "victorops")]
             "victorops" => {
                 let vo = &provider_cfg.victorops;
                 let api_key_raw = vo.api_key.as_deref().ok_or_else(|| {
@@ -802,6 +805,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     shared_http_client.clone(),
                 ))
             }
+            #[cfg(feature = "pushover")]
             "pushover" => {
                 let po = &provider_cfg.pushover;
                 let app_token_raw = po.app_token.as_deref().ok_or_else(|| {
@@ -835,6 +839,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     shared_http_client.clone(),
                 ))
             }
+            #[cfg(feature = "telegram")]
             "telegram" => {
                 let tg = &provider_cfg.telegram;
                 let bot_token_raw = tg.bot_token.as_deref().ok_or_else(|| {
@@ -873,6 +878,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     shared_http_client.clone(),
                 ))
             }
+            #[cfg(feature = "wechat")]
             "wechat" => {
                 let wc = &provider_cfg.wechat;
                 let corp_id_raw = wc.corp_id.as_deref().ok_or_else(|| {
@@ -1301,7 +1307,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let feature_hint = match other {
                     "aws-sns" | "aws-lambda" | "aws-eventbridge" | "aws-sqs" | "aws-s3"
                     | "aws-ec2" | "aws-autoscaling" | "azure-blob" | "azure-eventhubs"
-                    | "gcp-pubsub" | "gcp-storage" => {
+                    | "gcp-pubsub" | "gcp-storage" | "opsgenie" | "victorops" | "pushover"
+                    | "telegram" | "wechat" | "discord" => {
                         format!(
                             ". Hint: enable the '{other}' feature on acteon-server \
                              (cargo build --features {other})"

--- a/docs/book/concepts/providers.md
+++ b/docs/book/concepts/providers.md
@@ -147,21 +147,24 @@ Acteon ships with built-in providers organized into four categories. Every provi
 
 ### Messaging and on-call
 
-Providers that deliver human-facing notifications — chat messages, SMS, push notifications, and incident paging.
+Providers that deliver human-facing notifications — chat messages, SMS, push notifications, and incident paging. Widely-used providers ship in the default `acteon-server` binary. Niche or regional providers are opt-in behind a Cargo feature flag so the default build does not pull in integrations most deployments will never touch — enable individual flags or use the `extras-alerting` group flag to turn them all on.
 
-| Provider | Crate | `type` | Transport / Auth | Feature docs |
-|---|---|---|---|---|
-| Email (SMTP) | `acteon-email` | `email` | SMTP (Lettre) with STARTTLS / TLS | [Native providers](../features/native-providers.md) |
-| Slack | `acteon-slack` | `slack` | Bot token or incoming webhook | [Native providers](../features/native-providers.md) |
-| Microsoft Teams | `acteon-teams` | `teams` | Incoming webhook URL | [Native providers](../features/native-providers.md) |
-| Discord | `acteon-discord` | `discord` | Webhook URL | [Native providers](../features/native-providers.md) |
-| Twilio (SMS / MMS) | `acteon-twilio` | `twilio` | Account SID + Auth Token (HTTP Basic) | [Native providers](../features/native-providers.md) |
-| PagerDuty | `acteon-pagerduty` | `pagerduty` | Events API v2 routing key | [Native providers](../features/native-providers.md) |
-| OpsGenie | `acteon-opsgenie` | `opsgenie` | Alert API v2 integration key (US / EU regions) | [OpsGenie](../features/opsgenie.md) |
-| VictorOps / Splunk On-Call | `acteon-victorops` | `victorops` | REST endpoint routing key | [VictorOps](../features/victorops.md) |
-| Pushover | `acteon-pushover` | `pushover` | App token + user / group key | [Pushover](../features/pushover.md) |
-| Telegram Bot | `acteon-telegram` | `telegram` | Bot token + chat ID | [Telegram](../features/telegram.md) |
-| WeChat Work (企业微信) | `acteon-wechat` | `wechat` | Corp ID + corp secret + agent ID (lazy token refresh) | [WeChat Work](../features/wechat.md) |
+| Provider | Crate | `type` | Default build? | Transport / Auth | Feature docs |
+|---|---|---|---|---|---|
+| Email (SMTP) | `acteon-email` | `email` | ✅ Default | SMTP (Lettre) with STARTTLS / TLS | [Native providers](../features/native-providers.md) |
+| Slack | `acteon-slack` | `slack` | ✅ Default | Bot token or incoming webhook | [Native providers](../features/native-providers.md) |
+| Microsoft Teams | `acteon-teams` | `teams` | ✅ Default | Incoming webhook URL | [Native providers](../features/native-providers.md) |
+| Twilio (SMS / MMS) | `acteon-twilio` | `twilio` | ✅ Default | Account SID + Auth Token (HTTP Basic) | [Native providers](../features/native-providers.md) |
+| PagerDuty | `acteon-pagerduty` | `pagerduty` | ✅ Default | Events API v2 routing key | [Native providers](../features/native-providers.md) |
+| Discord | `acteon-discord` | `discord` | `--features discord` | Webhook URL | [Native providers](../features/native-providers.md) |
+| OpsGenie | `acteon-opsgenie` | `opsgenie` | `--features opsgenie` | Alert API v2 integration key (US / EU regions) | [OpsGenie](../features/opsgenie.md) |
+| VictorOps / Splunk On-Call | `acteon-victorops` | `victorops` | `--features victorops` | REST endpoint routing key | [VictorOps](../features/victorops.md) |
+| Pushover | `acteon-pushover` | `pushover` | `--features pushover` | App token + user / group key | [Pushover](../features/pushover.md) |
+| Telegram Bot | `acteon-telegram` | `telegram` | `--features telegram` | Bot token + chat ID | [Telegram](../features/telegram.md) |
+| WeChat Work (企业微信) | `acteon-wechat` | `wechat` | `--features wechat` | Corp ID + corp secret + agent ID (lazy token refresh) | [WeChat Work](../features/wechat.md) |
+
+!!! note "How opt-in flags behave"
+    If you run a binary compiled without the relevant feature and put `type = "opsgenie"` in your TOML config, the server fails fast at startup with an actionable error: `provider 'X': unknown type 'opsgenie'. Hint: enable the 'opsgenie' feature on acteon-server (cargo build --features opsgenie)`. No silent fallthrough.
 
 ### AWS cloud services
 

--- a/docs/book/concepts/providers.md
+++ b/docs/book/concepts/providers.md
@@ -7,17 +7,21 @@ Providers are the execution endpoints in Acteon. They receive actions and perfor
 ```mermaid
 flowchart LR
     G[Gateway] --> R[Provider Registry]
-    R --> E[Email SMTP]
-    R --> S[Slack]
-    R --> P[PagerDuty]
-    R --> T[Twilio SMS]
-    R --> TM[Teams]
-    R --> DC[Discord]
-    R --> W[Webhook]
-    R --> C[Custom Provider]
+    R --> M[Messaging & on-call]
+    R --> C[Cloud services]
+    R --> GEN[Generic HTTP]
+    R --> CUST[Custom provider]
+    M --> M1[Slack / Teams / Discord]
+    M --> M2[PagerDuty / OpsGenie / VictorOps]
+    M --> M3[Pushover / Telegram / WeChat]
+    M --> M4[Email / Twilio SMS]
+    C --> C1[AWS: SNS, Lambda, SQS, S3, SES, EventBridge, EC2, ASG]
+    C --> C2[Azure: Blob Storage, Event Hubs]
+    C --> C3[GCP: Cloud Storage, Pub/Sub]
+    GEN --> GEN1[Webhook]
 ```
 
-The gateway looks up the provider by the action's `provider` field and dispatches accordingly.
+The gateway looks up the provider by the action's `provider` field and dispatches accordingly. All providers — whether built-in or user-written — implement the same `Provider` trait and participate uniformly in circuit breaking, health checks, per-provider metrics, and tenant quotas.
 
 ## Provider Traits
 
@@ -120,9 +124,11 @@ let gateway = GatewayBuilder::new()
     .provider(Arc::new(EmailProvider::new(smtp_config)))
     .provider(Arc::new(SlackProvider::new(slack_config)))
     .provider(Arc::new(PagerDutyProvider::new(pagerduty_config)))
+    .provider(Arc::new(OpsGenieProvider::new(opsgenie_config)))
     .provider(Arc::new(TwilioProvider::new(twilio_config)))
     .provider(Arc::new(TeamsProvider::new(teams_config)))
     .provider(Arc::new(DiscordProvider::new(discord_config)))
+    .provider(Arc::new(TelegramProvider::new(telegram_config)))
     .provider(Arc::new(MyWebhookProvider {
         client: reqwest::Client::new(),
         base_url: "https://api.example.com".into(),
@@ -130,9 +136,71 @@ let gateway = GatewayBuilder::new()
     .build()?;
 ```
 
-Actions are routed to providers by matching the action's `provider` field to the provider's `name()`.
+Actions are routed to providers by matching the action's `provider` field to the provider's `name()`. Most real deployments register providers declaratively from TOML via `[[providers]]` blocks rather than building them in Rust — see [Configuration](../getting-started/configuration.md) for the TOML schema.
+
+!!! note "Cloud providers are feature-gated"
+    AWS, Azure, and GCP providers live in the `acteon-aws`, `acteon-azure`, and `acteon-gcp` crates and are gated behind individual Cargo feature flags on `acteon-server` (e.g. `aws-sns`, `azure-blob`, `gcp-pubsub`). The default `cargo build` does not compile any of them. Pick the flags you need, or use the `aws-all` / `azure-all` / `gcp-all` group flags. See the [AWS](../features/aws-providers.md), [Azure](../features/azure-providers.md), and [GCP](../features/gcp-providers.md) feature pages for the full flag table and IAM / auth setup.
 
 ## Built-in Providers
+
+Acteon ships with built-in providers organized into four categories. Every provider below is a first-class citizen: uniform circuit breaking, health checks, per-provider metrics, tenant quotas, W3C trace context propagation, and `ENC[...]` encrypted-secret support where applicable.
+
+### Messaging and on-call
+
+Providers that deliver human-facing notifications — chat messages, SMS, push notifications, and incident paging.
+
+| Provider | Crate | `type` | Transport / Auth | Feature docs |
+|---|---|---|---|---|
+| Email (SMTP) | `acteon-email` | `email` | SMTP (Lettre) with STARTTLS / TLS | [Native providers](../features/native-providers.md) |
+| Slack | `acteon-slack` | `slack` | Bot token or incoming webhook | [Native providers](../features/native-providers.md) |
+| Microsoft Teams | `acteon-teams` | `teams` | Incoming webhook URL | [Native providers](../features/native-providers.md) |
+| Discord | `acteon-discord` | `discord` | Webhook URL | [Native providers](../features/native-providers.md) |
+| Twilio (SMS / MMS) | `acteon-twilio` | `twilio` | Account SID + Auth Token (HTTP Basic) | [Native providers](../features/native-providers.md) |
+| PagerDuty | `acteon-pagerduty` | `pagerduty` | Events API v2 routing key | [Native providers](../features/native-providers.md) |
+| OpsGenie | `acteon-opsgenie` | `opsgenie` | Alert API v2 integration key (US / EU regions) | [OpsGenie](../features/opsgenie.md) |
+| VictorOps / Splunk On-Call | `acteon-victorops` | `victorops` | REST endpoint routing key | [VictorOps](../features/victorops.md) |
+| Pushover | `acteon-pushover` | `pushover` | App token + user / group key | [Pushover](../features/pushover.md) |
+| Telegram Bot | `acteon-telegram` | `telegram` | Bot token + chat ID | [Telegram](../features/telegram.md) |
+| WeChat Work (企业微信) | `acteon-wechat` | `wechat` | Corp ID + corp secret + agent ID (lazy token refresh) | [WeChat Work](../features/wechat.md) |
+
+### AWS cloud services
+
+AWS providers are gated behind individual Cargo feature flags on `acteon-server` so the default build doesn't pay the cost of eight AWS SDK crates. Enable `aws-all` for the full set, or pick individual flags. See [AWS providers](../features/aws-providers.md) for config, payload shapes, and IAM requirements.
+
+| Provider `type` | AWS service | Feature flag | Use case |
+|---|---|---|---|
+| `aws-sns` | Simple Notification Service | `aws-sns` | Publish to topics (fan-out to email/SMS/Lambda/HTTP) |
+| `aws-lambda` | Lambda | `aws-lambda` | Synchronous or async function invocation |
+| `aws-eventbridge` | EventBridge | `aws-eventbridge` | Publish custom events to event buses |
+| `aws-sqs` | Simple Queue Service | `aws-sqs` | Enqueue messages for async processing |
+| `aws-s3` | S3 | `aws-s3` | Write objects, trigger event notifications |
+| `aws-ses` | Simple Email Service | `aws-ses` | Send transactional / bulk email |
+| `aws-ec2` | EC2 | `aws-ec2` | Start / stop / reboot instances (ops automation) |
+| `aws-autoscaling` | Auto Scaling | `aws-autoscaling` | Trigger scaling actions |
+
+### Azure and GCP
+
+| Provider `type` | Cloud service | Feature flag | Feature docs |
+|---|---|---|---|
+| `azure-blob` | Azure Blob Storage | `azure-blob` | [Azure providers](../features/azure-providers.md) |
+| `azure-eventhubs` | Azure Event Hubs | `azure-eventhubs` | [Azure providers](../features/azure-providers.md) |
+| `gcp-storage` | Google Cloud Storage | `gcp-storage` | [GCP providers](../features/gcp-providers.md) |
+| `gcp-pubsub` | Google Cloud Pub/Sub | `gcp-pubsub` | [GCP providers](../features/gcp-providers.md) |
+
+### Generic and testing
+
+| Provider | Crate | `type` | Purpose |
+|---|---|---|---|
+| Webhook | `acteon-webhook` | `webhook` | Generic HTTP dispatcher — Bearer / Basic / API key / HMAC-SHA256 auth, custom headers, configurable method, payload modes |
+| Log | `acteon-provider` (built-in) | `log` | Writes the dispatched action to the tracing log at INFO. Ships with every Acteon binary and is the default target in most example configs. Ideal for local dev, tests, and dry runs. |
+| Recording | `acteon-simulation` | — | Test-only in-memory provider that captures every dispatched action for assertions. Used by the simulation harness — see [Simulation & Testing](../examples/simulation.md). |
+
+!!! tip "Custom providers"
+    None of these lists are exhaustive for *your* deployment — any type implementing `Provider` / `DynProvider` can be registered alongside the built-ins. Acteon routes to providers purely by the `name()` returned from the trait implementation, so a custom Rust provider is indistinguishable from a built-in one to the gateway and rule engine.
+
+---
+
+The rest of this page drills into a representative subset of payload shapes. For the remaining providers, follow the feature-doc links in the tables above.
 
 ### Email (SMTP)
 

--- a/docs/book/features/native-providers.md
+++ b/docs/book/features/native-providers.md
@@ -2,6 +2,9 @@
 
 Acteon ships with built-in provider integrations for **Twilio** (SMS), **Microsoft Teams**, and **Discord**, alongside the existing Webhook, Email, Slack, and PagerDuty providers. Native providers are first-class citizens -- they implement the same `Provider` trait, participate in circuit breaking, health checks, and per-provider metrics, and require no external plugins.
 
+!!! note "Discord is opt-in"
+    Twilio, Microsoft Teams, Email, Slack, PagerDuty, and Webhook are part of the default `acteon-server` build. Discord is compiled only when the `discord` feature flag is enabled (`cargo build -p acteon-server --features discord`) or as part of the `extras-alerting` feature group. See [Providers](../concepts/providers.md#messaging-and-on-call) for the full list of default vs opt-in messaging providers.
+
 ## Overview
 
 | Provider | Transport | Auth Mechanism | Payload Format |

--- a/docs/book/features/opsgenie.md
+++ b/docs/book/features/opsgenie.md
@@ -1,5 +1,8 @@
 # OpsGenie Provider
 
+!!! note "Opt-in feature flag"
+    OpsGenie is not compiled into the default `acteon-server` build. Enable it with `cargo build -p acteon-server --features opsgenie`, or use `--features extras-alerting` to enable all opt-in messaging providers at once.
+
 Acteon ships with a first-class **OpsGenie** provider that creates, acknowledges, and closes incidents through the [OpsGenie Alert API v2](https://docs.opsgenie.com/docs/alert-api). Operators use it for any workflow that maps to an Acteon `Action` — on-call alerting, deployment notifications, approval callbacks inside chains, scheduled reminders, and anything else that fits the create/acknowledge/close shape the Alert API exposes.
 
 Like Acteon's other native providers, `acteon-opsgenie`:

--- a/docs/book/features/pushover.md
+++ b/docs/book/features/pushover.md
@@ -1,5 +1,8 @@
 # Pushover Provider
 
+!!! note "Opt-in feature flag"
+    Pushover is not compiled into the default `acteon-server` build. Enable it with `cargo build -p acteon-server --features pushover`, or use `--features extras-alerting` to enable all opt-in messaging providers at once.
+
 Acteon ships with a first-class **Pushover** provider that sends push notifications to mobile devices via the [Pushover Messages API][api]. Operators use it for any workflow that needs to reach a human phone or desktop — on-call paging, deployment notifications, approval prompts, scheduled reminders, and anything else that fits the single-shot "send a notification" shape of the Pushover API.
 
 [api]: https://pushover.net/api

--- a/docs/book/features/telegram.md
+++ b/docs/book/features/telegram.md
@@ -1,5 +1,8 @@
 # Telegram Bot Provider
 
+!!! note "Opt-in feature flag"
+    Telegram is not compiled into the default `acteon-server` build. Enable it with `cargo build -p acteon-server --features telegram`, or use `--features extras-alerting` to enable all opt-in messaging providers at once.
+
 Acteon ships with a first-class **Telegram Bot** provider that sends messages via the [Telegram Bot API's `sendMessage` endpoint][api]. Operators use it for any workflow that maps to an Acteon `Action` — on-call alerting, deployment notifications, approval callbacks inside chains, scheduled reminders, and anything else that fits the single-shot "post to a chat" shape of the Telegram Bot API.
 
 [api]: https://core.telegram.org/bots/api#sendmessage

--- a/docs/book/features/victorops.md
+++ b/docs/book/features/victorops.md
@@ -1,5 +1,8 @@
 # VictorOps / Splunk On-Call Provider
 
+!!! note "Opt-in feature flag"
+    VictorOps is not compiled into the default `acteon-server` build. Enable it with `cargo build -p acteon-server --features victorops`, or use `--features extras-alerting` to enable all opt-in messaging providers at once.
+
 Acteon ships with a first-class **VictorOps** (now Splunk On-Call) provider that posts events to the [REST endpoint integration][integration]. Operators use it for any workflow that maps to an Acteon `Action` — on-call paging, deployment notifications, chain callbacks, scheduled reminders, and anything else that fits VictorOps' `message_type` lifecycle.
 
 [integration]: https://help.victorops.com/knowledge-base/rest-endpoint-integration-guide/

--- a/docs/book/features/wechat.md
+++ b/docs/book/features/wechat.md
@@ -1,5 +1,8 @@
 # WeChat Work Provider
 
+!!! note "Opt-in feature flag"
+    WeChat Work is not compiled into the default `acteon-server` build. Enable it with `cargo build -p acteon-server --features wechat`, or use `--features extras-alerting` to enable all opt-in messaging providers at once.
+
 Acteon ships with a first-class **WeChat Work** (企业微信 / Enterprise WeChat) provider that sends messages via the [Message Send API][api]. Operators use it for any workflow that maps to an Acteon `Action` — on-call alerting, deployment notifications, approval callbacks inside chains, scheduled reminders, and anything else that fits the send-a-message shape of the WeChat Work API. It's the most architecturally involved of Acteon's native messaging providers because of three WeChat-specific quirks the provider handles transparently.
 
 [api]: https://developer.work.weixin.qq.com/document/path/90236

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,8 +138,10 @@ nav:
     - Provider Health: features/provider-health.md
     - Grafana Dashboards: features/grafana-dashboards.md
     - WASM Plugins: features/wasm-plugins.md
-    - AWS Providers: features/aws-providers.md
     - Native Providers: features/native-providers.md
+    - AWS Providers: features/aws-providers.md
+    - Azure Providers: features/azure-providers.md
+    - GCP Providers: features/gcp-providers.md
     - OpsGenie: features/opsgenie.md
     - VictorOps: features/victorops.md
     - Pushover: features/pushover.md


### PR DESCRIPTION
## Summary

Two coupled changes that ship together so the docs and the implementing code stay in sync (folded in from #93 which was originally stacked on top).

### 1. Complete the provider list on `concepts/providers`

The [Providers concept page](https://penserai.github.io/acteon/concepts/providers) only deep-dived into 7 providers (Email, Slack, PagerDuty, Twilio, Teams, Discord, Webhook) and never mentioned the 18+ other built-in providers Acteon ships. Add a comprehensive **Built-in Providers** overview grouped by category:

- **Messaging and on-call** (11): Email, Slack, Teams, Discord, Twilio, PagerDuty, OpsGenie, VictorOps, Pushover, Telegram, WeChat Work.
- **AWS cloud** (8): SNS, Lambda, EventBridge, SQS, S3, SES, EC2, Auto Scaling — with the per-provider Cargo feature flag for each.
- **Azure** (2): Blob Storage, Event Hubs.
- **GCP** (2): Cloud Storage, Pub/Sub.
- **Generic / testing**: Webhook, Log, Recording.

Also:

- Architecture mermaid diagram updated to show four provider categories instead of 7 standalone boxes.
- `features/azure-providers.md` and `features/gcp-providers.md` wired into the mkdocs nav (both pages existed in the repo but were orphaned from navigation).

### 2. Feature-gate niche messaging providers

Widely-used dispatch surfaces (Email, Slack, Microsoft Teams, Twilio, PagerDuty, Webhook) remain part of the default `acteon-server` build. Niche or regional providers most deployments will never touch are now **opt-in** behind individual Cargo feature flags, mirroring the existing AWS / Azure / GCP provider gating pattern:

| Flag | Provider | Why it's opt-in |
|---|---|---|
| `opsgenie` | Atlassian OpsGenie | Distant #2 behind PagerDuty for incident management |
| `victorops` | VictorOps / Splunk On-Call | Niche, post-acquisition tail |
| `pushover` | Pushover | Hobbyist / small-team push |
| `telegram` | Telegram Bot | Consumer chat, not enterprise ops |
| `wechat` | WeChat Work (企业微信) | China-only deployments |
| `discord` | Discord | Gaming / community chat — borderline; flag if you want it back in default |

An `extras-alerting` group flag enables all six at once for users who want the broader set.

**Motivation**: trim the default binary so Acteon does not read as "look how many providers we have!" when half those integrations are regional (WeChat), niche (Pushover), or consumer-grade (Telegram, Discord) rather than deployment staples. Compile-cost reduction is a side effect — the primary goal is trimming surface area and perception.

### Behavior when a disabled provider is referenced

- Workspace dep is marked `optional = true`, so the SDK crate is neither compiled nor linked in the default build.
- Each provider arm in `main.rs` is wrapped in `#[cfg(feature = "…")]` so the unused registration branch is compiled out.
- If a user puts `type = "opsgenie"` in a config loaded by a binary compiled without the feature, the existing `other =>` fallback arm produces a targeted error:

```
provider 'my-opsgenie': unknown type 'opsgenie'. Hint: enable the 'opsgenie' feature on acteon-server (cargo build --features opsgenie)
```

No silent fallthrough.

### CI

Adds `cargo check -p acteon-server --features extras-alerting` to the main CI job so any future regression in the gated branch arms is caught before merge. Each gated provider crate still has its own unit tests that run under `cargo nextest run --workspace`.

### Docs cross-updates

- `concepts/providers.md` — the messaging-and-on-call table gains a **Default build?** column splitting default-compiled providers from the six opt-in ones, plus a callout explaining the fail-fast startup error.
- `features/opsgenie.md`, `victorops.md`, `pushover.md`, `telegram.md`, `wechat.md` — each opens with an opt-in flag callout showing the exact `cargo build` invocation.
- `features/native-providers.md` — Discord note + cross-link to the concept page's default vs opt-in split.

### Discord caveat

Discord is the most debatable inclusion in the gated set — it's widely used in dev communities and for automation tooling, but less so as an enterprise paging target. If you want Discord to stay in the default build we can move it back with a one-line Cargo.toml change in a follow-up.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --no-deps -- -D warnings` — default features
- [x] `cargo test --workspace --lib --bins --tests` — default features
- [x] `cargo check -p acteon-server` — default build succeeds without pulling in `acteon-opsgenie`, `acteon-victorops`, `acteon-pushover`, `acteon-telegram`, `acteon-wechat`, `acteon-discord`
- [x] `cargo check -p acteon-server --features extras-alerting` — full opt-in build succeeds
- [x] `cargo check -p acteon-server --features opsgenie` — single-feature build succeeds
- [x] `python3 -m mkdocs build --strict` — clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)