### PR TITLE
fix: replay protection and key scoping for action signing

### DIFF
--- a/crates/server/src/api/dispatch.rs
+++ b/crates/server/src/api/dispatch.rs
@@ -96,6 +96,37 @@ pub async fn dispatch(
         ));
     }
 
+    // Replay protection: reject if this action ID has already been dispatched.
+    // Uses check_and_set (atomic set-if-not-exists) to close the race window
+    // between checking and marking. Returns false if the key already existed.
+    if let Some((true, ttl)) = state.replay_protection {
+        let gw = state.gateway.read().await;
+        let replay_key = acteon_state::StateKey::new(
+            action.namespace.clone(),
+            action.tenant.clone(),
+            acteon_state::KeyKind::Custom("action_replay".into()),
+            action.id.to_string(),
+        );
+        if let Ok(false) = gw
+            .state_store()
+            .check_and_set(&replay_key, "1", Some(std::time::Duration::from_secs(ttl)))
+            .await
+        {
+            // Already existed — replay detected.
+            return Ok((
+                StatusCode::CONFLICT,
+                Json(serde_json::json!(ErrorResponse {
+                    error: format!(
+                        "replay rejected: action ID '{}' has already been dispatched",
+                        action.id
+                    ),
+                })),
+            ));
+        }
+        // Ok(true) = fresh ID claimed; Err(_) = state store unavailable, fail open.
+        drop(gw);
+    }
+
     // Check per-tenant rate limit if enabled (skip for dry-run).
     if !query.dry_run
         && let Some(ref limiter) = state.rate_limiter

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -90,6 +90,8 @@ pub struct AppState {
     pub cors_allowed_origins: Vec<String>,
     /// Optional signature verifier for Ed25519 action signing.
     pub signature_verifier: Option<Arc<SignatureVerifier>>,
+    /// Replay protection config: (enabled, `ttl_seconds`).
+    pub replay_protection: Option<(bool, u64)>,
 }
 
 /// Build the Axum router with all API routes, middleware, and Swagger UI.

--- a/crates/server/src/api/verify.rs
+++ b/crates/server/src/api/verify.rs
@@ -19,17 +19,41 @@ use utoipa::ToSchema;
 use super::AppState;
 use super::schemas::ErrorResponse;
 
+/// Per-signer scope restrictions.
+#[derive(Clone, Debug)]
+pub struct SignerScope {
+    /// Allowed tenants. `["*"]` means all.
+    pub tenants: Vec<String>,
+    /// Allowed namespaces. `["*"]` means all.
+    pub namespaces: Vec<String>,
+}
+
+impl SignerScope {
+    fn allows(&self, tenant: &str, namespace: &str) -> bool {
+        let tenant_ok = self.tenants.iter().any(|t| t == "*" || t == tenant);
+        let ns_ok = self.namespaces.iter().any(|n| n == "*" || n == namespace);
+        tenant_ok && ns_ok
+    }
+}
+
 /// Verifies Ed25519 signatures on dispatched actions.
 ///
-/// Used in two contexts:
-/// 1. **Inline dispatch verification** — called before dispatch to
-///    accept or reject an action based on its signature.
-/// 2. **Post-hoc audit verification** — the `GET /v1/actions/{id}/verify`
-///    endpoint recomputes canonical bytes and checks the stored signature.
+/// Performs three checks on signed actions:
+/// 1. **Signature validity** — the Ed25519 signature verifies against
+///    the keyring's public key for the given `signer_id`.
+/// 2. **Scope enforcement** — the signer is authorized for the
+///    action's `(tenant, namespace)` pair. Prevents a compromised
+///    key for one tenant from signing actions for another.
+/// 3. **Replay rejection** (when `reject_replay` is enabled) — the
+///    action ID must not have been seen before (checked externally
+///    by the dispatch handler against the state store).
 #[derive(Clone)]
 pub struct SignatureVerifier {
     keyring: Arc<Keyring>,
     reject_unsigned: bool,
+    /// Per-signer scope restrictions. Missing entries default to
+    /// allow-all (the server key is inserted without scope limits).
+    scopes: std::collections::HashMap<String, SignerScope>,
 }
 
 impl SignatureVerifier {
@@ -39,7 +63,19 @@ impl SignatureVerifier {
         Self {
             keyring: Arc::new(keyring),
             reject_unsigned,
+            scopes: std::collections::HashMap::new(),
         }
+    }
+
+    /// Register a scope restriction for a signer.
+    pub fn add_scope(&mut self, signer_id: impl Into<String>, scope: SignerScope) {
+        self.scopes.insert(signer_id.into(), scope);
+    }
+
+    /// Number of keys in the keyring.
+    #[must_use]
+    pub fn keyring_len(&self) -> usize {
+        self.keyring.len()
     }
 
     /// Check whether a `signer_id` is known to the keyring.
@@ -54,10 +90,24 @@ impl SignatureVerifier {
     /// error string suitable for an HTTP 400 response body.
     pub fn verify_action(&self, action: &Action) -> Result<(), String> {
         if let (Some(sig), Some(signer_id)) = (&action.signature, &action.signer_id) {
+            // 1. Cryptographic verification.
             let canonical = action.canonical_bytes();
             self.keyring
                 .verify(signer_id, sig, &canonical)
-                .map_err(|e| format!("signature verification failed: {e}"))
+                .map_err(|e| format!("signature verification failed: {e}"))?;
+
+            // 2. Scope enforcement.
+            if let Some(scope) = self.scopes.get(signer_id.as_str())
+                && !scope.allows(&action.tenant, &action.namespace)
+            {
+                return Err(format!(
+                    "signer '{signer_id}' is not authorized for \
+                     tenant={} namespace={}",
+                    action.tenant, action.namespace
+                ));
+            }
+
+            Ok(())
         } else if self.reject_unsigned {
             Err(
                 "unsigned action rejected: signing.reject_unsigned is enabled; \

--- a/crates/server/src/config/signing.rs
+++ b/crates/server/src/config/signing.rs
@@ -35,6 +35,18 @@ pub struct SigningConfig {
     /// unsigned actions pass through normally.
     pub reject_unsigned: bool,
 
+    /// When true, reject any dispatch whose action ID has already
+    /// been processed (replay protection). Uses the state store to
+    /// track seen action IDs with a configurable TTL. Defaults to
+    /// false for backward compatibility.
+    pub reject_replay: bool,
+
+    /// TTL in seconds for replay-protection entries in the state
+    /// store. After this period, a replayed action ID would be
+    /// accepted again. Defaults to 86400 (24 hours).
+    #[serde(default = "default_replay_ttl")]
+    pub replay_ttl_seconds: u64,
+
     /// Ed25519 secret key for signing server-originated actions
     /// (chains, recurring, DLQ replays). Supports `ENC[...]` for
     /// encrypted storage. When absent, server-originated actions are
@@ -51,6 +63,10 @@ pub struct SigningConfig {
     pub keyring: Vec<KeyringEntry>,
 }
 
+fn default_replay_ttl() -> u64 {
+    86_400 // 24 hours
+}
+
 /// A single entry in the signing keyring.
 #[derive(Debug, Deserialize)]
 pub struct KeyringEntry {
@@ -59,4 +75,18 @@ pub struct KeyringEntry {
     pub signer_id: String,
     /// Ed25519 public key, encoded as hex (64 chars) or base64.
     pub public_key: String,
+    /// Optional tenant scope. When set, this signer can only sign
+    /// actions for the listed tenants. A wildcard `["*"]` (the
+    /// default) allows all tenants.
+    #[serde(default = "default_wildcard")]
+    pub tenants: Vec<String>,
+    /// Optional namespace scope. When set, this signer can only sign
+    /// actions for the listed namespaces. A wildcard `["*"]` (the
+    /// default) allows all namespaces.
+    #[serde(default = "default_wildcard")]
+    pub namespaces: Vec<String>,
+}
+
+fn default_wildcard() -> Vec<String> {
+    vec!["*".into()]
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -2172,15 +2172,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             )?;
             keyring.insert(sk.verifying_key());
         }
+        let mut verifier =
+            acteon_server::api::SignatureVerifier::new(keyring, config.signing.reject_unsigned);
+        // Wire per-signer scope restrictions from config.
+        for entry in &config.signing.keyring {
+            verifier.add_scope(
+                &entry.signer_id,
+                acteon_server::api::verify::SignerScope {
+                    tenants: entry.tenants.clone(),
+                    namespaces: entry.namespaces.clone(),
+                },
+            );
+        }
         info!(
-            keyring_size = keyring.len(),
+            keyring_size = verifier.keyring_len(),
             reject_unsigned = config.signing.reject_unsigned,
+            reject_replay = config.signing.reject_replay,
             "action signing enabled"
         );
-        Some(Arc::new(acteon_server::api::SignatureVerifier::new(
-            keyring,
-            config.signing.reject_unsigned,
-        )))
+        Some(Arc::new(verifier))
     } else {
         None
     };
@@ -2202,6 +2212,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ui_enabled: config.ui.enabled,
         cors_allowed_origins: config.server.cors_allowed_origins.clone(),
         signature_verifier,
+        replay_protection: if config.signing.enabled && config.signing.reject_replay {
+            Some((true, config.signing.replay_ttl_seconds))
+        } else {
+            None
+        },
     };
     let app = acteon_server::api::router(state);
 

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -114,6 +114,7 @@ fn build_test_state_with_audit_and_analytics(
         ui_enabled: false,
         cors_allowed_origins: Vec::new(),
         signature_verifier: None,
+        replay_protection: None,
     }
 }
 
@@ -943,6 +944,7 @@ fn build_approval_state_with_providers(
         ui_enabled: false,
         cors_allowed_origins: Vec::new(),
         signature_verifier: None,
+        replay_protection: None,
     }
 }
 

--- a/crates/server/tests/ui_tests.rs
+++ b/crates/server/tests/ui_tests.rs
@@ -48,6 +48,7 @@ async fn ui_serves_index_html() {
         ui_enabled: ui_config.enabled,
         cors_allowed_origins: Vec::new(),
         signature_verifier: None,
+        replay_protection: None,
     };
 
     let app = acteon_server::api::router(state);


### PR DESCRIPTION
## Summary

Addresses the two HIGH-severity findings from the adversarial review of action signing (#95):

### 1. Replay Protection (#3 from review)

**Problem:** The server accepts the full `Action` object from the caller including its `id`. While the signature protects the `id` from being changed, nothing prevented an intercepted signed action from being replayed indefinitely.

**Fix:** New `signing.reject_replay` config flag. When enabled, the dispatch handler checks the state store for the action ID before dispatching:
- Already-seen ID → HTTP 409 Conflict with actionable error message
- New ID → stored in state with configurable TTL (`replay_ttl_seconds`, default 24h)
- State store unreachable → fails open (dispatch proceeds) to avoid blocking all traffic

Uses `KeyKind::Custom("action_replay")` so replay entries are namespaced separately from other state data.

### 2. Key Scoping (#4 from review)

**Problem:** The global keyring had no tenant/namespace binding. A compromised key for Tenant-A could sign actions for Tenant-B.

**Fix:** Each `[[signing.keyring]]` entry now accepts optional `tenants` and `namespaces` arrays. When set, the signer can only sign actions for the listed scopes. Defaults to `["*"]` for backward compat.

The scope check runs after signature verification and before dispatch, so an action with a valid signature but wrong scope is rejected with HTTP 400.

### Config

```toml
[signing]
enabled = true
reject_replay = true
replay_ttl_seconds = 86400

[[signing.keyring]]
signer_id = "ci-bot"
public_key = "..."
tenants = ["acme"]
namespaces = ["prod", "staging"]
```

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --no-deps -- -D warnings`
- [x] `cargo test --workspace --lib --bins --tests` — all pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)