### PR TITLE
fix: approval expiry check + constant-time signature comparison

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,6 +262,7 @@ sha2 = "0.10"
 ed25519-dalek = { version = "2", features = ["serde", "zeroize", "rand_core"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 hmac = "0.12"
+subtle = "2"
 hex = "0.4"
 aes-gcm = "0.10"
 base64 = "0.22"

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -39,6 +39,7 @@ parking_lot = "0.12"
 sha2 = { workspace = true }
 hmac = { workspace = true }
 hex = { workspace = true }
+subtle = { workspace = true }
 
 [dev-dependencies]
 acteon-rules-yaml = { workspace = true }

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -1860,14 +1860,9 @@ impl Gateway {
 
         for key in keys_to_try {
             let expected = Self::compute_approval_sig_with_key(key, ns, tenant, id, expires_at);
-            // Constant-time comparison
-            let is_match = expected.len() == sig.len()
-                && expected
-                    .bytes()
-                    .zip(sig.bytes())
-                    .fold(0u8, |acc, (a, b)| acc | (a ^ b))
-                    == 0;
-            if is_match {
+            // Constant-time comparison — no early return on length
+            // mismatch, no branching on byte values.
+            if subtle::ConstantTimeEq::ct_eq(expected.as_bytes(), sig.as_bytes()).into() {
                 return true;
             }
         }
@@ -5234,6 +5229,14 @@ impl Gateway {
             return Err(GatewayError::ApprovalNotFound);
         }
 
+        // 1b. Explicit expiry check — do not rely solely on state store
+        // TTL enforcement, which may be missing (Postgres) or
+        // eventually consistent (DynamoDB). This is the authoritative
+        // server-side gate.
+        if chrono::Utc::now().timestamp() > expires_at {
+            return Err(GatewayError::ApprovalNotFound);
+        }
+
         // 2. Atomically claim the approval (first writer wins)
         let claim_key = StateKey::new(namespace, tenant, KeyKind::Approval, format!("{id}:claim"));
         let is_claimed = self
@@ -5366,6 +5369,14 @@ impl Gateway {
     ) -> Result<(), GatewayError> {
         // 1. Verify HMAC signature (includes expires_at to prevent replay after expiry)
         if !self.verify_approval_sig(namespace, tenant, id, expires_at, sig, kid) {
+            return Err(GatewayError::ApprovalNotFound);
+        }
+
+        // 1b. Explicit expiry check — do not rely solely on state store
+        // TTL enforcement, which may be missing (Postgres) or
+        // eventually consistent (DynamoDB). This is the authoritative
+        // server-side gate.
+        if chrono::Utc::now().timestamp() > expires_at {
             return Err(GatewayError::ApprovalNotFound);
         }
 


### PR DESCRIPTION
## Summary

Two pre-existing security hardening fixes for the approval pipeline, flagged during the adversarial review of action signing (#95).

### 1. Explicit expiry check

`execute_approval` and `reject_approval` now check `Utc::now().timestamp() > expires_at` immediately after HMAC verification, before claiming the approval.

**Before:** The system relied entirely on the state store's TTL mechanism. Backends without native TTL support (Postgres) or with eventual consistency (DynamoDB) could honor expired approval links indefinitely — the HMAC signature binds `expires_at` but nobody checked it.

**After:** Server-side timestamp check is the authoritative gate. The state store TTL remains as defense-in-depth for cleanup.

### 2. Constant-time comparison

`verify_approval_sig` previously had:
```rust
let is_match = expected.len() == sig.len()   // ← branches on length
    && expected.bytes().zip(sig.bytes())
        .fold(0u8, |acc, (a, b)| acc | (a ^ b)) == 0;
```

The early return on length mismatch leaks the expected signature length via timing. Now uses `subtle::ConstantTimeEq::ct_eq()` which is fixed-time regardless of input lengths or content.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --no-deps -- -D warnings`
- [x] `cargo test --workspace --lib --bins --tests` — all pass (including existing approval tests)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)