### PR TITLE
feat: action signing — client helpers, SDK fields, and docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ name = "acteon-client"
 version = "0.1.0"
 dependencies = [
  "acteon-core",
+ "acteon-crypto",
  "chrono",
  "futures",
  "reqwest 0.12.28",
@@ -292,6 +293,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "subtle",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/clients/go/acteon/models.go
+++ b/clients/go/acteon/models.go
@@ -40,7 +40,9 @@ type Action struct {
 	Metadata    *ActionMetadata `json:"metadata,omitempty"`
 	CreatedAt   time.Time       `json:"created_at"`
 	Template    string          `json:"template,omitempty"`
-	Attachments []Attachment    `json:"attachments,omitempty"`
+	Attachments []Attachment `json:"attachments,omitempty"`
+	Signature   string       `json:"signature,omitempty"`
+	SignerID    string       `json:"signer_id,omitempty"`
 }
 
 // ActionMetadata contains optional metadata for an action.

--- a/clients/java/src/main/java/com/acteon/client/models/Action.java
+++ b/clients/java/src/main/java/com/acteon/client/models/Action.java
@@ -27,6 +27,11 @@ public class Action {
     private String createdAt;
     private String template;
     private List<Attachment> attachments;
+    /** Ed25519 signature over the action's canonical bytes, base64-encoded. */
+    private String signature;
+    /** Identifier of the key that produced the signature. */
+    @JsonProperty("signer_id")
+    private String signerId;
 
     public Action() {
         this.id = UUID.randomUUID().toString();
@@ -80,6 +85,12 @@ public class Action {
 
     public List<Attachment> getAttachments() { return attachments; }
     public void setAttachments(List<Attachment> attachments) { this.attachments = attachments; }
+
+    public String getSignature() { return signature; }
+    public void setSignature(String signature) { this.signature = signature; }
+
+    public String getSignerId() { return signerId; }
+    public void setSignerId(String signerId) { this.signerId = signerId; }
 
     public Action withDedupKey(String dedupKey) {
         this.dedupKey = dedupKey;

--- a/clients/nodejs/src/models.ts
+++ b/clients/nodejs/src/models.ts
@@ -46,6 +46,10 @@ export interface Action {
   template?: string;
   /** Optional attachments. */
   attachments?: Attachment[];
+  /** Ed25519 signature over the action's canonical bytes, base64-encoded. */
+  signature?: string;
+  /** Identifier of the key that produced the signature. */
+  signerId?: string;
 }
 
 /**

--- a/clients/python/acteon_client/models.py
+++ b/clients/python/acteon_client/models.py
@@ -62,6 +62,8 @@ class Action:
     created_at: datetime = field(default_factory=datetime.utcnow)
     template: Optional[str] = None
     attachments: Optional[list[Attachment]] = None
+    signature: Optional[str] = None
+    signer_id: Optional[str] = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
@@ -82,6 +84,10 @@ class Action:
             result["template"] = self.template
         if self.attachments:
             result["attachments"] = [a.to_dict() for a in self.attachments]
+        if self.signature:
+            result["signature"] = self.signature
+        if self.signer_id:
+            result["signer_id"] = self.signer_id
         return result
 
 

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -7,8 +7,13 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = []
+signing = ["dep:acteon-crypto"]
+
 [dependencies]
 acteon-core.workspace = true
+acteon-crypto = { workspace = true, features = ["signing"], optional = true }
 
 chrono.workspace = true
 futures.workspace = true

--- a/crates/client/src/dispatch.rs
+++ b/crates/client/src/dispatch.rs
@@ -78,6 +78,40 @@ impl ActeonClient {
         self.dispatch_inner(action, false).await
     }
 
+    /// Sign an action with an Ed25519 key, then dispatch it.
+    ///
+    /// Computes the action's canonical bytes, signs them, sets the
+    /// `signature` and `signer_id` fields on a cloned action, and
+    /// dispatches the signed copy. Requires the `signing` feature.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # async fn example() -> Result<(), acteon_client::Error> {
+    /// use acteon_client::ActeonClient;
+    /// use acteon_core::Action;
+    ///
+    /// let client = ActeonClient::new("http://localhost:8080");
+    /// let action = Action::new("ns", "tenant", "email", "send", serde_json::json!({}));
+    /// let key = acteon_crypto::signing::parse_signing_key("hex-or-b64-key", "my-signer")
+    ///     .expect("valid key");
+    /// let outcome = client.dispatch_signed(&action, &key).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "signing")]
+    pub async fn dispatch_signed(
+        &self,
+        action: &Action,
+        key: &acteon_crypto::signing::ActionSigningKey,
+    ) -> Result<ActionOutcome, Error> {
+        let mut signed = action.clone();
+        let canonical = signed.canonical_bytes();
+        signed.signature = Some(key.sign(&canonical));
+        signed.signer_id = Some(key.signer_id().to_owned());
+        self.dispatch_inner(&signed, false).await
+    }
+
     /// Dispatch a single action in dry-run mode.
     ///
     /// Evaluates rules and returns the verdict without executing the action,

--- a/docs/book/features/action-signing.md
+++ b/docs/book/features/action-signing.md
@@ -1,0 +1,149 @@
+# Action Signing
+
+Acteon supports **Ed25519 action signing** so dispatched actions carry a cryptographic `signature` and `signer_id` that downstream systems and compliance auditors can verify without trusting the gateway.
+
+The feature is fully opt-in. Deployments without a `[signing]` section in the TOML config operate exactly as before — the two new fields on actions are always optional.
+
+## How it works
+
+1. The **client** computes the action's **canonical bytes** — a compact, sorted-key JSON serialization of every field except `signature` and `signer_id`.
+2. The client signs the canonical bytes with its Ed25519 secret key and sets `signature` (base64) + `signer_id` on the action.
+3. The **server** verifies the signature against its keyring, optionally enforces tenant/namespace scope restrictions, and optionally rejects replays via action-ID deduplication.
+4. The **audit record** stores the `signature`, `signer_id`, and a `canonical_hash` (SHA-256 of the canonical bytes) for post-hoc verification.
+
+## TOML configuration
+
+```toml
+[signing]
+enabled = true
+reject_unsigned = false          # true = reject actions without valid signature
+reject_replay = false            # true = reject action IDs that have been seen before
+replay_ttl_seconds = 86400       # TTL for replay-protection entries (default 24h)
+server_key = "ENC[AES256-GCM,data:...]"   # Ed25519 secret for server-originated actions
+server_signer_id = "acteon-server"         # signer_id for server key
+
+[[signing.keyring]]
+signer_id = "ci-bot"
+public_key = "base64-or-hex-encoded-ed25519-public-key"
+tenants = ["acme"]                   # optional scope restriction (default: ["*"])
+namespaces = ["prod", "staging"]     # optional scope restriction (default: ["*"])
+
+[[signing.keyring]]
+signer_id = "deploy-service"
+public_key = "..."
+# tenants/namespaces omitted = allow all
+```
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `enabled` | No | `false` | Master switch for signing |
+| `reject_unsigned` | No | `false` | Reject actions without a valid `signature` + `signer_id` |
+| `reject_replay` | No | `false` | Reject action IDs already dispatched (uses state store) |
+| `replay_ttl_seconds` | No | `86400` | TTL for replay-protection entries |
+| `server_key` | No | — | Ed25519 secret key for server-originated actions. Supports `ENC[...]` |
+| `server_signer_id` | No | `"acteon-server"` | `signer_id` stamped on server-originated signatures |
+| `keyring[].signer_id` | Yes | — | Must match the `signer_id` field on incoming actions |
+| `keyring[].public_key` | Yes | — | Ed25519 public key (hex or base64) |
+| `keyring[].tenants` | No | `["*"]` | Allowed tenants for this signer |
+| `keyring[].namespaces` | No | `["*"]` | Allowed namespaces for this signer |
+
+## Canonicalization
+
+The canonical byte representation is the input to the Ed25519 signature. It is computed as:
+
+1. Serialize the action to a JSON object.
+2. Remove the `signature` and `signer_id` keys.
+3. Collect the remaining keys into a sorted map (lexicographic order).
+4. Serialize to **compact JSON** (no whitespace).
+
+This format is designed for cross-language reproducibility: any JSON library that can emit compact, sorted-key JSON produces identical bytes.
+
+```python
+# Python example — computing canonical bytes
+import json
+
+action = {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "namespace": "prod",
+    "tenant": "acme",
+    "provider": "email",
+    "action_type": "send",
+    "payload": {"to": "user@example.com"},
+    "created_at": "2026-04-12T00:00:00Z",
+    "metadata": {}
+}
+# Remove signing fields, sort keys, compact
+canonical = json.dumps(action, sort_keys=True, separators=(",", ":")).encode()
+```
+
+## Dispatch payload
+
+A signed action includes the two extra fields:
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "namespace": "prod",
+  "tenant": "acme",
+  "provider": "email",
+  "action_type": "send",
+  "payload": {"to": "user@example.com"},
+  "created_at": "2026-04-12T00:00:00Z",
+  "signature": "base64-encoded-64-byte-ed25519-signature",
+  "signer_id": "ci-bot"
+}
+```
+
+## Verification endpoint
+
+```
+GET /v1/actions/{id}/verify
+```
+
+Looks up the audit record by action ID and returns:
+
+```json
+{
+  "verified": true,
+  "signer_id": "ci-bot",
+  "algorithm": "Ed25519",
+  "canonical_hash": "sha256-hex-of-canonical-bytes"
+}
+```
+
+Callers can independently verify by computing `canonical_bytes` on the original action, hashing with SHA-256, and comparing to `canonical_hash`.
+
+## Error behavior
+
+| Scenario | HTTP status | Error message |
+|----------|-------------|---------------|
+| Invalid signature | 400 | `signature verification failed: invalid signature` |
+| Unknown `signer_id` | 400 | `signature verification failed: unknown signer: X` |
+| Signer not authorized for tenant/namespace | 400 | `signer 'X' is not authorized for tenant=Y namespace=Z` |
+| Unsigned action + `reject_unsigned=true` | 400 | `unsigned action rejected: signing.reject_unsigned is enabled` |
+| Replayed action ID + `reject_replay=true` | 409 | `replay rejected: action ID 'X' has already been dispatched` |
+
+## Rust client
+
+The Rust client supports signing via the `signing` feature flag:
+
+```toml
+[dependencies]
+acteon-client = { version = "0.1", features = ["signing"] }
+```
+
+```rust
+use acteon_client::ActeonClient;
+use acteon_core::Action;
+use acteon_crypto::signing::parse_signing_key;
+
+let client = ActeonClient::new("http://localhost:8080");
+let key = parse_signing_key("hex-or-base64-key", "ci-bot")?;
+let action = Action::new("prod", "acme", "email", "send", payload);
+
+let outcome = client.dispatch_signed(&action, &key).await?;
+```
+
+## Polyglot SDKs
+
+The Python, Node.js, Go, and Java SDKs carry `signature` and `signer_id` as optional fields on the Action model for passthrough to the server. Client-side signing is not implemented in the polyglot SDKs — sign on the server side or use the Rust client.


### PR DESCRIPTION
## Summary

Closes out the action signing feature thread (#95, #96) with the three remaining items.

### 1. Rust client `dispatch_signed()`

New `signing` feature flag on `acteon-client` that pulls in `acteon-crypto/signing`:

```rust
let key = parse_signing_key("hex-or-b64", "ci-bot")?;
let outcome = client.dispatch_signed(&action, &key).await?;
```

One call: compute canonical bytes, sign, set fields on a clone, dispatch.

### 2. Polyglot SDK `signature`/`signer_id` fields

Added to Action models in all four SDKs (Python, Node.js, Go, Java). Passthrough only — no client-side signing, just the fields so signed actions can be constructed and forwarded.

### 3. Feature documentation

`docs/book/features/action-signing.md` with:
- Full TOML config reference
- Canonicalization spec (compact sorted-key JSON) + Python cross-language example
- Signed dispatch payload shape
- Verification endpoint response
- Error behavior table for every rejection scenario
- Rust client usage example

## Test plan

- [x] `cargo fmt --all && cargo clippy --workspace --no-deps -- -D warnings`
- [x] `cargo check -p acteon-client --features signing`
- [x] `npx tsc --noEmit` (Node.js)
- [x] `go vet ./...` (Go)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)