### PR TITLE
feat(audit): cursor-based pagination across all backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "acteon-core",
  "acteon-crypto",
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "serde",
  "serde_json",

--- a/clients/go/acteon/client.go
+++ b/clients/go/acteon/client.go
@@ -343,6 +343,9 @@ func (c *Client) QueryAudit(ctx context.Context, query *AuditQuery) (*AuditPage,
 		if query.Offset > 0 {
 			params.Set("offset", strconv.Itoa(query.Offset))
 		}
+		if query.Cursor != "" {
+			params.Set("cursor", query.Cursor)
+		}
 		if len(params) > 0 {
 			path += "?" + params.Encode()
 		}

--- a/clients/go/acteon/models.go
+++ b/clients/go/acteon/models.go
@@ -348,6 +348,11 @@ type ReloadResult struct {
 }
 
 // AuditQuery contains query parameters for audit search.
+//
+// Prefer Cursor over Offset for deep pagination — large offsets degrade
+// linearly on every backend. Pass the NextCursor returned by a prior
+// AuditPage back in here to fetch the next page in O(limit) time.
+// Treat the cursor as opaque.
 type AuditQuery struct {
 	Namespace  string
 	Tenant     string
@@ -356,6 +361,7 @@ type AuditQuery struct {
 	Outcome    string
 	Limit      int
 	Offset     int
+	Cursor     string
 }
 
 // AuditRecord represents an audit record.
@@ -377,11 +383,16 @@ type AuditRecord struct {
 }
 
 // AuditPage represents paginated audit results.
+//
+// Total is nil when the backend skipped the count (always the case
+// when paginating with a cursor). NextCursor is empty when this page
+// is the last; otherwise pass it into AuditQuery.Cursor to resume.
 type AuditPage struct {
-	Records []AuditRecord `json:"records"`
-	Total   int64         `json:"total"`
-	Limit   int64         `json:"limit"`
-	Offset  int64         `json:"offset"`
+	Records    []AuditRecord `json:"records"`
+	Total      *int64        `json:"total,omitempty"`
+	Limit      int64         `json:"limit"`
+	Offset     int64         `json:"offset"`
+	NextCursor string        `json:"next_cursor,omitempty"`
 }
 
 // =============================================================================

--- a/clients/java/src/main/java/com/acteon/client/ActeonClient.java
+++ b/clients/java/src/main/java/com/acteon/client/ActeonClient.java
@@ -464,6 +464,9 @@ public class ActeonClient implements AutoCloseable {
                 if (query.getOffset() != null) {
                     params.add("offset=" + query.getOffset());
                 }
+                if (query.getCursor() != null) {
+                    params.add("cursor=" + URLEncoder.encode(query.getCursor(), StandardCharsets.UTF_8));
+                }
             }
 
             if (!params.isEmpty()) {

--- a/clients/java/src/main/java/com/acteon/client/models/AuditPage.java
+++ b/clients/java/src/main/java/com/acteon/client/models/AuditPage.java
@@ -1,25 +1,37 @@
 package com.acteon.client.models;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 /**
  * Paginated audit results.
+ *
+ * <p>{@code total} is {@code null} when the backend skipped the count
+ * (always the case when paginating with a cursor). {@code nextCursor}
+ * is {@code null} when this page is the last; otherwise pass it back
+ * into {@link AuditQuery#setCursor(String)} to resume.
  */
 public class AuditPage {
     private List<AuditRecord> records;
-    private long total;
+    private Long total;
     private long limit;
     private long offset;
+
+    @JsonProperty("next_cursor")
+    private String nextCursor;
 
     public List<AuditRecord> getRecords() { return records; }
     public void setRecords(List<AuditRecord> records) { this.records = records; }
 
-    public long getTotal() { return total; }
-    public void setTotal(long total) { this.total = total; }
+    public Long getTotal() { return total; }
+    public void setTotal(Long total) { this.total = total; }
 
     public long getLimit() { return limit; }
     public void setLimit(long limit) { this.limit = limit; }
 
     public long getOffset() { return offset; }
     public void setOffset(long offset) { this.offset = offset; }
+
+    public String getNextCursor() { return nextCursor; }
+    public void setNextCursor(String nextCursor) { this.nextCursor = nextCursor; }
 }

--- a/clients/java/src/main/java/com/acteon/client/models/AuditQuery.java
+++ b/clients/java/src/main/java/com/acteon/client/models/AuditQuery.java
@@ -2,6 +2,11 @@ package com.acteon.client.models;
 
 /**
  * Query parameters for audit search.
+ *
+ * <p>Prefer {@code cursor} over {@code offset} for deep pagination —
+ * large offsets degrade linearly on every backend. Pass the
+ * {@code nextCursor} returned by a prior {@link AuditPage} back in here
+ * to fetch the next page in O(limit) time. Treat the cursor as opaque.
  */
 public class AuditQuery {
     private String namespace;
@@ -11,6 +16,7 @@ public class AuditQuery {
     private String outcome;
     private Integer limit;
     private Integer offset;
+    private String cursor;
 
     public static Builder builder() {
         return new Builder();
@@ -37,6 +43,9 @@ public class AuditQuery {
     public Integer getOffset() { return offset; }
     public void setOffset(Integer offset) { this.offset = offset; }
 
+    public String getCursor() { return cursor; }
+    public void setCursor(String cursor) { this.cursor = cursor; }
+
     public static class Builder {
         private String namespace;
         private String tenant;
@@ -45,6 +54,7 @@ public class AuditQuery {
         private String outcome;
         private Integer limit;
         private Integer offset;
+        private String cursor;
 
         public Builder namespace(String namespace) { this.namespace = namespace; return this; }
         public Builder tenant(String tenant) { this.tenant = tenant; return this; }
@@ -53,6 +63,7 @@ public class AuditQuery {
         public Builder outcome(String outcome) { this.outcome = outcome; return this; }
         public Builder limit(int limit) { this.limit = limit; return this; }
         public Builder offset(int offset) { this.offset = offset; return this; }
+        public Builder cursor(String cursor) { this.cursor = cursor; return this; }
 
         public AuditQuery build() {
             AuditQuery query = new AuditQuery();
@@ -63,6 +74,7 @@ public class AuditQuery {
             query.outcome = this.outcome;
             query.limit = this.limit;
             query.offset = this.offset;
+            query.cursor = this.cursor;
             return query;
         }
     }

--- a/clients/nodejs/src/models.ts
+++ b/clients/nodejs/src/models.ts
@@ -399,6 +399,11 @@ export interface EvaluateRulesResponse {
 
 /**
  * Query parameters for audit search.
+ *
+ * Prefer `cursor` over `offset` for deep pagination — large offsets
+ * degrade linearly on every backend. Pass the `nextCursor` returned by
+ * a prior {@link AuditPage} back in here to fetch the next page in
+ * O(limit) time. Treat the cursor as opaque.
  */
 export interface AuditQuery {
   namespace?: string;
@@ -408,6 +413,7 @@ export interface AuditQuery {
   outcome?: string;
   limit?: number;
   offset?: number;
+  cursor?: string;
 }
 
 /**
@@ -422,6 +428,7 @@ export function auditQueryToParams(query: AuditQuery): URLSearchParams {
   if (query.outcome) params.set("outcome", query.outcome);
   if (query.limit !== undefined) params.set("limit", query.limit.toString());
   if (query.offset !== undefined) params.set("offset", query.offset.toString());
+  if (query.cursor !== undefined) params.set("cursor", query.cursor);
   return params;
 }
 
@@ -472,12 +479,18 @@ export function parseAuditRecord(data: Record<string, unknown>): AuditRecord {
 
 /**
  * Paginated audit results.
+ *
+ * `total` is omitted when the backend skipped the count (always the
+ * case when paginating with a cursor). `nextCursor` is omitted when
+ * this page is the last; otherwise pass it back into
+ * {@link AuditQuery.cursor} to resume.
  */
 export interface AuditPage {
   records: AuditRecord[];
-  total: number;
+  total?: number;
   limit: number;
   offset: number;
+  nextCursor?: string;
 }
 
 /**
@@ -487,9 +500,10 @@ export function parseAuditPage(data: Record<string, unknown>): AuditPage {
   const records = data.records as Record<string, unknown>[];
   return {
     records: records.map(parseAuditRecord),
-    total: data.total as number,
+    total: data.total as number | undefined,
     limit: data.limit as number,
     offset: data.offset as number,
+    nextCursor: data.next_cursor as string | undefined,
   };
 }
 

--- a/clients/python/acteon_client/models.py
+++ b/clients/python/acteon_client/models.py
@@ -470,7 +470,13 @@ class EvaluateRulesResponse:
 
 @dataclass
 class AuditQuery:
-    """Query parameters for audit search."""
+    """Query parameters for audit search.
+
+    Prefer ``cursor`` over ``offset`` for deep pagination — large offsets
+    degrade linearly on every backend. Pass the ``next_cursor`` returned
+    by a prior :class:`AuditPage` back in here to fetch the next page in
+    O(limit) time. Treat the cursor as opaque.
+    """
     namespace: Optional[str] = None
     tenant: Optional[str] = None
     provider: Optional[str] = None
@@ -478,6 +484,7 @@ class AuditQuery:
     outcome: Optional[str] = None
     limit: Optional[int] = None
     offset: Optional[int] = None
+    cursor: Optional[str] = None
 
     def to_params(self) -> dict[str, Any]:
         """Convert to query parameters."""
@@ -496,6 +503,8 @@ class AuditQuery:
             params["limit"] = self.limit
         if self.offset is not None:
             params["offset"] = self.offset
+        if self.cursor is not None:
+            params["cursor"] = self.cursor
         return params
 
 
@@ -539,19 +548,27 @@ class AuditRecord:
 
 @dataclass
 class AuditPage:
-    """Paginated audit results."""
+    """Paginated audit results.
+
+    ``total`` is ``None`` when the backend skipped the count (always the
+    case when paginating with a cursor). ``next_cursor`` is ``None``
+    when this page is the last; otherwise pass it to the next
+    :class:`AuditQuery` to resume.
+    """
     records: list[AuditRecord]
-    total: int
+    total: Optional[int]
     limit: int
     offset: int
+    next_cursor: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "AuditPage":
         return cls(
             records=[AuditRecord.from_dict(r) for r in data["records"]],
-            total=data["total"],
+            total=data.get("total"),
             limit=data["limit"],
             offset=data["offset"],
+            next_cursor=data.get("next_cursor"),
         )
 
 

--- a/crates/audit/audit/Cargo.toml
+++ b/crates/audit/audit/Cargo.toml
@@ -14,6 +14,7 @@ openapi = ["utoipa"]
 acteon-core = { workspace = true }
 acteon-crypto = { workspace = true }
 async-trait = { workspace = true }
+base64 = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/audit/audit/src/analytics.rs
+++ b/crates/audit/audit/src/analytics.rs
@@ -194,10 +194,13 @@ impl<S: AuditStore + ?Sized + 'static> AnalyticsStore for InMemoryAnalytics<S> {
         let to = query.to.unwrap_or(now);
         let top_n = query.top_n.unwrap_or(10);
 
-        // Fetch all matching records in batches.
+        // Fetch all matching records in batches using cursor pagination.
+        // Cursor avoids the O(N²) degradation that offset paging causes
+        // on large audit trails, and lets backends short-circuit the
+        // count query.
         let mut all_records = Vec::new();
         let batch_size = 1000u32;
-        let mut offset = 0u32;
+        let mut cursor: Option<String> = None;
 
         loop {
             let audit_query = AuditQuery {
@@ -209,18 +212,17 @@ impl<S: AuditStore + ?Sized + 'static> AnalyticsStore for InMemoryAnalytics<S> {
                 from: Some(from),
                 to: Some(to),
                 limit: Some(batch_size),
-                offset: Some(offset),
+                cursor: cursor.clone(),
                 ..Default::default()
             };
 
             let page = self.store.query(&audit_query).await?;
-            let fetched = page.records.len();
             all_records.extend(page.records);
 
-            if fetched < batch_size as usize {
-                break;
+            match page.next_cursor {
+                Some(next) => cursor = Some(next),
+                None => break,
             }
-            offset += batch_size;
         }
 
         let total_count = all_records.len() as u64;
@@ -321,7 +323,7 @@ impl<S: AuditStore + ?Sized + 'static> AnalyticsStore for InMemoryAnalytics<S> {
             HashMap::new();
 
         let batch_size = 1000u32;
-        let mut offset = 0u32;
+        let mut cursor: Option<String> = None;
 
         loop {
             let audit_query = AuditQuery {
@@ -330,12 +332,11 @@ impl<S: AuditStore + ?Sized + 'static> AnalyticsStore for InMemoryAnalytics<S> {
                 from: Some(from),
                 to: Some(to),
                 limit: Some(batch_size),
-                offset: Some(offset),
+                cursor: cursor.clone(),
                 ..Default::default()
             };
 
             let page = self.store.query(&audit_query).await?;
-            let fetched = page.records.len();
 
             for record in page.records {
                 let key = (
@@ -348,10 +349,10 @@ impl<S: AuditStore + ?Sized + 'static> AnalyticsStore for InMemoryAnalytics<S> {
                 *matrix.entry(key).or_insert(0) += 1;
             }
 
-            if fetched < batch_size as usize {
-                break;
+            match page.next_cursor {
+                Some(next) => cursor = Some(next),
+                None => break,
             }
-            offset = offset.saturating_add(batch_size);
         }
 
         let mut aggregates: Vec<CoverageAggregate> = matrix
@@ -449,21 +450,67 @@ mod tests {
                 .collect();
 
             let total = filtered.len() as u64;
-            let offset = query.effective_offset();
             let limit = query.effective_limit();
 
-            filtered.sort_by(|a, b| b.dispatched_at.cmp(&a.dispatched_at));
-            let records: Vec<AuditRecord> = filtered
-                .into_iter()
-                .skip(offset as usize)
-                .take(limit as usize)
-                .collect();
+            filtered.sort_by(|a, b| {
+                b.dispatched_at
+                    .cmp(&a.dispatched_at)
+                    .then_with(|| b.id.cmp(&a.id))
+            });
+
+            // Honour cursor pagination so the analytics loops in the
+            // outer module make forward progress against this mock.
+            let (mut page_records, used_cursor): (Vec<AuditRecord>, bool) =
+                if let Some(cursor_str) = query.cursor.as_deref() {
+                    let cursor = crate::cursor::AuditCursor::decode(cursor_str).unwrap();
+                    let cursor_ms = cursor.dispatched_at_ms.unwrap_or(0);
+                    let cursor_id = cursor.id.clone().unwrap_or_default();
+                    let recs = filtered
+                        .into_iter()
+                        .filter(|r| {
+                            let r_ms = r.dispatched_at.timestamp_millis();
+                            r_ms < cursor_ms
+                                || (r_ms == cursor_ms && r.id.as_str() < cursor_id.as_str())
+                        })
+                        .take(limit as usize + 1)
+                        .collect();
+                    (recs, true)
+                } else {
+                    let offset = query.effective_offset();
+                    (
+                        filtered
+                            .into_iter()
+                            .skip(offset as usize)
+                            .take(limit as usize + 1)
+                            .collect(),
+                        false,
+                    )
+                };
+
+            let has_more = page_records.len() > limit as usize;
+            if has_more {
+                page_records.truncate(limit as usize);
+            }
+
+            let next_cursor = if has_more {
+                page_records.last().map(|r| {
+                    crate::cursor::AuditCursor::from_timestamp(
+                        r.dispatched_at.timestamp_millis(),
+                        r.id.clone(),
+                    )
+                    .encode()
+                    .unwrap()
+                })
+            } else {
+                None
+            };
 
             Ok(AuditPage {
-                records,
-                total,
+                records: page_records,
+                total: if used_cursor { None } else { Some(total) },
                 limit,
-                offset,
+                offset: 0,
+                next_cursor,
             })
         }
 

--- a/crates/audit/audit/src/compliance.rs
+++ b/crates/audit/audit/src/compliance.rs
@@ -110,7 +110,7 @@ impl HashChainAuditStore {
         to: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<HashChainVerification, AuditError> {
         let page_size: u32 = 500;
-        let mut offset = 0u32;
+        let mut cursor: Option<String> = None;
         let mut records_checked: u64 = 0;
         let mut previous_hash: Option<String> = None;
         let mut first_record_id: Option<String> = None;
@@ -123,7 +123,7 @@ impl HashChainAuditStore {
                 from,
                 to,
                 limit: Some(page_size),
-                offset: Some(offset),
+                cursor: cursor.clone(),
                 sort_by_sequence_asc: true,
                 ..AuditQuery::default()
             };
@@ -176,7 +176,13 @@ impl HashChainAuditStore {
             if fetched < usize::try_from(page_size).unwrap_or(usize::MAX) {
                 break;
             }
-            offset = offset.saturating_add(page_size);
+            // Resume from the cursor returned with this page. If the
+            // backend didn't supply one (older mock or a backend that
+            // can't keyset-paginate), bail out — we'd otherwise loop.
+            match page.next_cursor {
+                Some(next) => cursor = Some(next),
+                None => break,
+            }
         }
 
         Ok(HashChainVerification {
@@ -445,15 +451,47 @@ mod tests {
             }
 
             let total = filtered.len() as u64;
-            let offset = query.effective_offset() as usize;
             let limit = query.effective_limit() as usize;
-            let records: Vec<AuditRecord> = filtered.into_iter().skip(offset).take(limit).collect();
+
+            // Honour cursor pagination so verify_chain's keyset loop
+            // makes forward progress against this mock.
+            let (records, used_cursor): (Vec<AuditRecord>, bool) =
+                if let Some(cursor_str) = query.cursor.as_deref() {
+                    let cursor = crate::cursor::AuditCursor::decode(cursor_str).unwrap();
+                    let after_seq = cursor.sequence_number.unwrap_or(0);
+                    let recs = filtered
+                        .into_iter()
+                        .filter(|r| r.sequence_number.unwrap_or(0) > after_seq)
+                        .take(limit)
+                        .collect();
+                    (recs, true)
+                } else {
+                    let offset = query.effective_offset() as usize;
+                    (
+                        filtered.into_iter().skip(offset).take(limit).collect(),
+                        false,
+                    )
+                };
+
+            let next_cursor = if records.len() == limit {
+                records.last().map(|r| {
+                    crate::cursor::AuditCursor::from_sequence(
+                        r.sequence_number.unwrap_or(0),
+                        r.id.clone(),
+                    )
+                    .encode()
+                    .unwrap()
+                })
+            } else {
+                None
+            };
 
             Ok(AuditPage {
                 records,
-                total,
+                total: if used_cursor { None } else { Some(total) },
                 limit: limit as u32,
-                offset: offset as u32,
+                offset: 0,
+                next_cursor,
             })
         }
 
@@ -1080,9 +1118,10 @@ mod tests {
             async fn query(&self, _query: &AuditQuery) -> Result<AuditPage, AuditError> {
                 Ok(AuditPage {
                     records: vec![],
-                    total: 0,
+                    total: Some(0),
                     limit: 50,
                     offset: 0,
+                    next_cursor: None,
                 })
             }
 
@@ -1128,9 +1167,10 @@ mod tests {
             async fn query(&self, _query: &AuditQuery) -> Result<AuditPage, AuditError> {
                 Ok(AuditPage {
                     records: vec![],
-                    total: 0,
+                    total: Some(0),
                     limit: 50,
                     offset: 0,
+                    next_cursor: None,
                 })
             }
 

--- a/crates/audit/audit/src/cursor.rs
+++ b/crates/audit/audit/src/cursor.rs
@@ -1,0 +1,149 @@
+//! Opaque pagination cursor for audit query results.
+//!
+//! Cursors encode the sort key of the last record on a page so the next
+//! query can resume from that point without a server-side `OFFSET` scan.
+//! This keeps page latency constant regardless of how deep the caller has
+//! paged.
+//!
+//! The cursor is an opaque base64url-encoded JSON blob — callers should
+//! treat it as an opaque string and round-trip it verbatim.
+
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+
+use crate::error::AuditError;
+
+/// Decoded pagination cursor.
+///
+/// Carries the sort key of the last record on the previous page. The
+/// `kind` field selects which sort key is in use; backends pick the
+/// matching variant based on the query's sort order.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuditCursor {
+    /// Cursor format version. Reserved for future incompatible changes.
+    #[serde(rename = "v")]
+    pub version: u8,
+    /// Sort key in use: `"ts"` for `(dispatched_at, id)` or `"seq"` for
+    /// `sequence_number`.
+    #[serde(rename = "k")]
+    pub kind: CursorKind,
+    /// `dispatched_at` of the last record on the previous page, in
+    /// milliseconds since epoch. Present when `kind == Ts`.
+    #[serde(rename = "t", default, skip_serializing_if = "Option::is_none")]
+    pub dispatched_at_ms: Option<i64>,
+    /// `id` of the last record on the previous page, used as a tiebreaker
+    /// when `dispatched_at` collides. Present when `kind == Ts`.
+    #[serde(rename = "i", default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// `sequence_number` of the last record on the previous page. Present
+    /// when `kind == Seq`.
+    #[serde(rename = "s", default, skip_serializing_if = "Option::is_none")]
+    pub sequence_number: Option<u64>,
+}
+
+/// Which sort key the cursor encodes.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CursorKind {
+    /// `(dispatched_at DESC, id DESC)` — the default audit query order.
+    #[serde(rename = "ts")]
+    Ts,
+    /// `(sequence_number ASC)` — used by hash chain verification.
+    #[serde(rename = "seq")]
+    Seq,
+}
+
+impl AuditCursor {
+    /// Build a `(dispatched_at, id)` cursor pointing at the last record on
+    /// a page.
+    #[must_use]
+    pub fn from_timestamp(dispatched_at_ms: i64, id: impl Into<String>) -> Self {
+        Self {
+            version: 1,
+            kind: CursorKind::Ts,
+            dispatched_at_ms: Some(dispatched_at_ms),
+            id: Some(id.into()),
+            sequence_number: None,
+        }
+    }
+
+    /// Build a `sequence_number` cursor for hash chain ordering.
+    ///
+    /// `id` is carried alongside the sequence number so backends that
+    /// need a tiebreaker (and `DynamoDB`'s `ExclusiveStartKey`, which
+    /// requires the table primary key) can resume cleanly.
+    #[must_use]
+    pub fn from_sequence(sequence_number: u64, id: impl Into<String>) -> Self {
+        Self {
+            version: 1,
+            kind: CursorKind::Seq,
+            dispatched_at_ms: None,
+            id: Some(id.into()),
+            sequence_number: Some(sequence_number),
+        }
+    }
+
+    /// Encode the cursor as an opaque base64url string.
+    pub fn encode(&self) -> Result<String, AuditError> {
+        let json = serde_json::to_vec(self)
+            .map_err(|e| AuditError::Serialization(format!("cursor encode: {e}")))?;
+        Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json))
+    }
+
+    /// Decode an opaque cursor produced by [`AuditCursor::encode`].
+    pub fn decode(s: &str) -> Result<Self, AuditError> {
+        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(s.as_bytes())
+            .map_err(|e| AuditError::Serialization(format!("cursor decode: {e}")))?;
+        let cursor: Self = serde_json::from_slice(&bytes)
+            .map_err(|e| AuditError::Serialization(format!("cursor decode: {e}")))?;
+        if cursor.version != 1 {
+            return Err(AuditError::Serialization(format!(
+                "unsupported cursor version: {}",
+                cursor.version
+            )));
+        }
+        Ok(cursor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timestamp_cursor_roundtrip() {
+        let cursor = AuditCursor::from_timestamp(1_700_000_000_000, "rec-123");
+        let encoded = cursor.encode().unwrap();
+        let decoded = AuditCursor::decode(&encoded).unwrap();
+        assert_eq!(decoded, cursor);
+        assert_eq!(decoded.kind, CursorKind::Ts);
+        assert_eq!(decoded.dispatched_at_ms, Some(1_700_000_000_000));
+        assert_eq!(decoded.id.as_deref(), Some("rec-123"));
+    }
+
+    #[test]
+    fn sequence_cursor_roundtrip() {
+        let cursor = AuditCursor::from_sequence(42, "rec-9");
+        let encoded = cursor.encode().unwrap();
+        let decoded = AuditCursor::decode(&encoded).unwrap();
+        assert_eq!(decoded, cursor);
+        assert_eq!(decoded.kind, CursorKind::Seq);
+        assert_eq!(decoded.sequence_number, Some(42));
+        assert_eq!(decoded.id.as_deref(), Some("rec-9"));
+    }
+
+    #[test]
+    fn decode_rejects_garbage() {
+        assert!(AuditCursor::decode("not-base64!!!").is_err());
+        assert!(AuditCursor::decode("aGVsbG8").is_err()); // valid b64 but not JSON
+    }
+
+    #[test]
+    fn encoded_cursor_is_opaque_url_safe() {
+        let cursor = AuditCursor::from_timestamp(1_700_000_000_000, "rec-123");
+        let encoded = cursor.encode().unwrap();
+        assert!(!encoded.contains('+'));
+        assert!(!encoded.contains('/'));
+        assert!(!encoded.contains('='));
+    }
+}

--- a/crates/audit/audit/src/encrypt.rs
+++ b/crates/audit/audit/src/encrypt.rs
@@ -182,9 +182,10 @@ mod tests {
             let records = self.records.lock().unwrap().clone();
             Ok(AuditPage {
                 records,
-                total: 0,
+                total: Some(0),
                 limit: 100,
                 offset: 0,
+                next_cursor: None,
             })
         }
 

--- a/crates/audit/audit/src/lib.rs
+++ b/crates/audit/audit/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod analytics;
 pub mod compliance;
+pub mod cursor;
 pub mod encrypt;
 pub mod error;
 pub mod record;
@@ -8,6 +9,7 @@ pub mod store;
 
 pub use analytics::{AnalyticsStore, InMemoryAnalytics};
 pub use compliance::{ComplianceAuditStore, HashChainAuditStore};
+pub use cursor::{AuditCursor, CursorKind};
 pub use encrypt::EncryptingAuditStore;
 pub use error::AuditError;
 pub use record::{AuditPage, AuditQuery, AuditRecord};

--- a/crates/audit/audit/src/record.rs
+++ b/crates/audit/audit/src/record.rs
@@ -123,7 +123,19 @@ pub struct AuditQuery {
     /// Maximum number of records to return (default 50, max 1000).
     pub limit: Option<u32>,
     /// Number of records to skip for pagination.
+    ///
+    /// Backends fall back to offset-based pagination only when no
+    /// `cursor` is supplied. Prefer `cursor` for deep pagination — large
+    /// offsets degrade linearly on every backend.
     pub offset: Option<u32>,
+    /// Opaque pagination cursor returned by the previous page.
+    ///
+    /// When set, backends use keyset pagination from the cursor's sort
+    /// key and ignore `offset`. Cursors must be round-tripped verbatim
+    /// from a prior `AuditPage::next_cursor`; do not construct or
+    /// modify them on the client side.
+    #[serde(default)]
+    pub cursor: Option<String>,
     /// When true, sort by `sequence_number ASC` instead of the default
     /// `dispatched_at DESC`. Used by hash chain verification to iterate
     /// records in chain order with bounded memory.
@@ -144,15 +156,47 @@ impl AuditQuery {
 }
 
 /// A paginated page of audit records.
+///
+/// # Detecting the last page
+///
+/// Always rely on `next_cursor`: when `next_cursor.is_none()` you have
+/// reached the end of the result set. `records.len() < limit` is *not*
+/// a reliable end-of-stream signal because filter expressions on
+/// `DynamoDB` and Elasticsearch can produce short-but-not-final pages.
+///
+/// # `total` semantics
+///
+/// `total` is intentionally a *best-effort* field. It is populated only
+/// when the backend can compute it cheaply, and is `None` whenever the
+/// caller paginated with a `cursor` (the count would defeat the
+/// purpose of cursor pagination). Concrete behaviour by backend:
+///
+/// | Backend         | Offset path (`cursor` is `None`) | Cursor path  |
+/// |-----------------|----------------------------------|--------------|
+/// | Memory          | `Some(matches)`                  | `None`       |
+/// | Postgres        | `Some(SELECT COUNT(*))`          | `None`       |
+/// | `ClickHouse`    | `Some(count())`                  | `None`       |
+/// | Elasticsearch   | `Some(track_total_hits)`         | `None`       |
+/// | `DynamoDB`      | `None` (count was the bottleneck)| `None`       |
+///
+/// Treat `total` as a UI hint, not a state-of-the-world fact. Do not
+/// build pagination control flow on it — use `next_cursor`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AuditPage {
     /// The records matching the query.
     pub records: Vec<AuditRecord>,
-    /// Total number of records matching the query (before pagination).
-    pub total: u64,
+    /// Best-effort total number of matching records. See the
+    /// [type-level docs](AuditPage) for when this is populated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total: Option<u64>,
     /// The limit used for this page.
     pub limit: u32,
-    /// The offset used for this page.
+    /// The offset used for this page (0 when cursor pagination is used).
     pub offset: u32,
+    /// Opaque cursor pointing at the next page, or `None` when this is
+    /// the last page. **This is the authoritative end-of-stream
+    /// signal** — `records.len() < limit` is not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
 }

--- a/crates/audit/clickhouse/src/migrations.rs
+++ b/crates/audit/clickhouse/src/migrations.rs
@@ -76,5 +76,17 @@ pub async fn run_migrations(
     );
     client.query(&attachment_stmt).execute().await?;
 
+    // Action signing columns: Ed25519 signature, signer key id, and
+    // canonical hash captured at dispatch time. Nullable so existing
+    // unsigned records remain valid.
+    let signing_stmts = [
+        format!("ALTER TABLE {table} ADD COLUMN IF NOT EXISTS signature Nullable(String)"),
+        format!("ALTER TABLE {table} ADD COLUMN IF NOT EXISTS signer_id Nullable(String)"),
+        format!("ALTER TABLE {table} ADD COLUMN IF NOT EXISTS canonical_hash Nullable(String)"),
+    ];
+    for stmt in &signing_stmts {
+        client.query(stmt).execute().await?;
+    }
+
     Ok(())
 }

--- a/crates/audit/clickhouse/src/store.rs
+++ b/crates/audit/clickhouse/src/store.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 
 use acteon_audit::analytics::AnalyticsStore;
+use acteon_audit::cursor::{AuditCursor, CursorKind};
 use acteon_audit::error::AuditError;
 use acteon_audit::record::{AuditPage, AuditQuery, AuditRecord};
 use acteon_audit::store::AuditStore;
@@ -51,6 +52,9 @@ struct AuditInsertRow {
     sequence_number: Option<u64>,
     /// JSON-serialised `Vec<serde_json::Value>`.
     attachment_metadata: String,
+    signature: Option<String>,
+    signer_id: Option<String>,
+    canonical_hash: Option<String>,
 }
 
 /// Row layout used when reading audit records from `ClickHouse`.
@@ -80,6 +84,9 @@ struct AuditSelectRow {
     previous_hash: Option<String>,
     sequence_number: Option<u64>,
     attachment_metadata: String,
+    signature: Option<String>,
+    signer_id: Option<String>,
+    canonical_hash: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -116,6 +123,9 @@ impl From<AuditRecord> for AuditInsertRow {
             sequence_number: r.sequence_number,
             attachment_metadata: serde_json::to_string(&r.attachment_metadata)
                 .unwrap_or_else(|_| "[]".to_owned()),
+            signature: r.signature,
+            signer_id: r.signer_id,
+            canonical_hash: r.canonical_hash,
         }
     }
 }
@@ -151,9 +161,9 @@ impl From<AuditSelectRow> for AuditRecord {
             previous_hash: row.previous_hash,
             sequence_number: row.sequence_number,
             attachment_metadata: serde_json::from_str(&row.attachment_metadata).unwrap_or_default(),
-            signature: None,
-            signer_id: None,
-            canonical_hash: None,
+            signature: row.signature,
+            signer_id: row.signer_id,
+            canonical_hash: row.canonical_hash,
         }
     }
 }
@@ -174,7 +184,7 @@ const SELECT_COLUMNS: &str = "\
     matched_rule, outcome, action_payload, verdict_details, outcome_details, \
     metadata, dispatched_at, completed_at, duration_ms, expires_at, \
     caller_id, auth_method, record_hash, previous_hash, sequence_number, \
-    attachment_metadata";
+    attachment_metadata, signature, signer_id, canonical_hash";
 
 /// Escape a string value for safe interpolation inside a `ClickHouse` SQL
 /// single-quoted literal.  `ClickHouse` uses backslash escaping by default.
@@ -338,27 +348,80 @@ impl AuditStore for ClickHouseAuditStore {
 
     async fn query(&self, query: &AuditQuery) -> Result<AuditPage, AuditError> {
         let limit = query.effective_limit();
-        let offset = query.effective_offset();
-        let where_clause = build_where_clause(query);
+        let mut where_clause = build_where_clause(query);
 
-        // Count query.
-        let count_sql = format!("SELECT count() FROM {} {where_clause}", self.table,);
+        let cursor = query
+            .cursor
+            .as_deref()
+            .map(AuditCursor::decode)
+            .transpose()?;
 
-        let total = self
-            .client
-            .query(&count_sql)
-            .fetch_one::<u64>()
-            .await
-            .map_err(|e| AuditError::Storage(e.to_string()))?;
+        if let Some(ref cursor) = cursor {
+            let prefix = if where_clause.is_empty() {
+                "WHERE"
+            } else {
+                "AND"
+            };
+            match cursor.kind {
+                CursorKind::Ts => {
+                    if query.sort_by_sequence_asc {
+                        return Err(AuditError::Serialization(
+                            "cursor kind 'ts' does not match sort_by_sequence_asc=true".into(),
+                        ));
+                    }
+                    // ts is i64 (no injection surface). id originated
+                    // server-side from a UUID v7 that we round-tripped
+                    // through the opaque cursor; escape_ch matches the
+                    // rest of build_where_clause and gives us
+                    // belt-and-braces protection against any future
+                    // change in the cursor source.
+                    let ts = cursor.dispatched_at_ms.unwrap_or(0);
+                    let id = escape_ch(cursor.id.as_deref().unwrap_or(""));
+                    where_clause =
+                        format!("{where_clause} {prefix} (dispatched_at, id) < ({ts}, '{id}')");
+                }
+                CursorKind::Seq => {
+                    if !query.sort_by_sequence_asc {
+                        return Err(AuditError::Serialization(
+                            "cursor kind 'seq' requires sort_by_sequence_asc=true".into(),
+                        ));
+                    }
+                    let seq = cursor.sequence_number.unwrap_or(0);
+                    where_clause = format!("{where_clause} {prefix} sequence_number > {seq}");
+                }
+            }
+        }
+
+        // Count query — only on the offset path. Cursor pagination skips
+        // the count for O(limit) page latency.
+        let total = if cursor.is_none() {
+            let count_sql = format!("SELECT count() FROM {} {where_clause}", self.table);
+            let count = self
+                .client
+                .query(&count_sql)
+                .fetch_one::<u64>()
+                .await
+                .map_err(|e| AuditError::Storage(e.to_string()))?;
+            Some(count)
+        } else {
+            None
+        };
 
         // Data query.
         let order_clause = if query.sort_by_sequence_asc {
-            "ORDER BY sequence_number ASC"
+            "ORDER BY sequence_number ASC, id ASC"
         } else {
-            "ORDER BY dispatched_at DESC"
+            "ORDER BY dispatched_at DESC, id DESC"
         };
+        let offset = if cursor.is_some() {
+            0
+        } else {
+            query.effective_offset()
+        };
+        // Fetch limit + 1 to detect whether another page exists.
+        let probe = limit + 1;
         let data_sql = format!(
-            "SELECT {SELECT_COLUMNS} FROM {} {where_clause} {order_clause} LIMIT {limit} OFFSET {offset}",
+            "SELECT {SELECT_COLUMNS} FROM {} {where_clause} {order_clause} LIMIT {probe} OFFSET {offset}",
             self.table,
         );
 
@@ -369,13 +432,37 @@ impl AuditStore for ClickHouseAuditStore {
             .await
             .map_err(|e| AuditError::Storage(e.to_string()))?;
 
-        let records = rows.into_iter().map(Into::into).collect();
+        let mut records: Vec<AuditRecord> = rows.into_iter().map(Into::into).collect();
+        let has_more = records.len() > limit as usize;
+        if has_more {
+            records.truncate(limit as usize);
+        }
+
+        let next_cursor = if has_more {
+            records
+                .last()
+                .map(|rec| {
+                    if query.sort_by_sequence_asc {
+                        AuditCursor::from_sequence(rec.sequence_number.unwrap_or(0), rec.id.clone())
+                    } else {
+                        AuditCursor::from_timestamp(
+                            rec.dispatched_at.timestamp_millis(),
+                            rec.id.clone(),
+                        )
+                    }
+                })
+                .map(|c| c.encode())
+                .transpose()?
+        } else {
+            None
+        };
 
         Ok(AuditPage {
             records,
             total,
             limit,
             offset,
+            next_cursor,
         })
     }
 

--- a/crates/audit/dynamodb/src/store.rs
+++ b/crates/audit/dynamodb/src/store.rs
@@ -5,6 +5,7 @@ use aws_sdk_dynamodb::Client;
 use aws_sdk_dynamodb::types::AttributeValue;
 use chrono::{DateTime, Utc};
 
+use acteon_audit::cursor::{AuditCursor, CursorKind};
 use acteon_audit::error::AuditError;
 use acteon_audit::record::{AuditPage, AuditQuery, AuditRecord};
 use acteon_audit::store::AuditStore;
@@ -243,7 +244,6 @@ impl AuditStore for DynamoDbAuditStore {
 
     async fn query(&self, query: &AuditQuery) -> Result<AuditPage, AuditError> {
         let limit = query.effective_limit();
-        let offset = query.effective_offset();
 
         // Require at least namespace + tenant for GSI queries.
         let (namespace, tenant) = match (&query.namespace, &query.tenant) {
@@ -253,15 +253,22 @@ impl AuditStore for DynamoDbAuditStore {
                 // Return empty for now (a full table scan would be expensive).
                 return Ok(AuditPage {
                     records: Vec::new(),
-                    total: 0,
+                    total: Some(0),
                     limit,
-                    offset,
+                    offset: query.effective_offset(),
+                    next_cursor: None,
                 });
             }
         };
 
         let ns_tenant = Self::ns_tenant(&namespace, &tenant);
         let (filter_parts, filter_values, filter_names) = Self::build_filters(query);
+
+        let cursor = query
+            .cursor
+            .as_deref()
+            .map(AuditCursor::decode)
+            .transpose()?;
 
         // Choose GSI based on sort order.
         let (index_name, key_condition, mut expr_values) = if query.sort_by_sequence_asc {
@@ -316,118 +323,131 @@ impl AuditStore for DynamoDbAuditStore {
             Some(filter_parts.join(" AND "))
         };
 
-        // For total count, run a SELECT COUNT query first.
-        let total = {
-            let mut count_query = self
-                .client
-                .query()
-                .table_name(&self.table_name)
-                .index_name(index_name)
-                .key_condition_expression(&key_condition)
-                .select(aws_sdk_dynamodb::types::Select::Count);
-
-            for (k, v) in &expr_values {
-                count_query = count_query.expression_attribute_values(k, v.clone());
-            }
-            for (k, v) in &filter_names {
-                count_query = count_query.expression_attribute_names(k, v);
-            }
-            if let Some(ref fe) = filter_expression {
-                count_query = count_query.filter_expression(fe);
-            }
-
-            let scan_forward = query.sort_by_sequence_asc;
-            count_query = count_query.scan_index_forward(scan_forward);
-
-            // Paginate through all to get accurate total count.
-            let mut total = 0u64;
-            let mut exclusive_start_key = None;
-            loop {
-                let mut q = count_query.clone();
-                if let Some(key) = exclusive_start_key {
-                    q = q.set_exclusive_start_key(Some(key));
-                }
-                let resp = q
-                    .send()
-                    .await
-                    .map_err(|e| AuditError::Storage(e.to_string()))?;
-                total += u64::try_from(resp.count()).unwrap_or(0);
-                exclusive_start_key = resp.last_evaluated_key().cloned();
-                if exclusive_start_key.is_none() {
-                    break;
-                }
-            }
-            total
-        };
-
-        // Fetch actual records with client-side offset skipping.
-        let mut all_records = Vec::new();
-        let items_needed = offset as usize + limit as usize;
-        let mut exclusive_start_key = None;
-
-        let scan_forward = query.sort_by_sequence_asc;
-
-        loop {
-            let mut q = self
-                .client
-                .query()
-                .table_name(&self.table_name)
-                .index_name(index_name)
-                .key_condition_expression(&key_condition)
-                .scan_index_forward(scan_forward);
-
-            for (k, v) in &expr_values {
-                q = q.expression_attribute_values(k, v.clone());
-            }
-            for (k, v) in &filter_names {
-                q = q.expression_attribute_names(k, v);
-            }
-            if let Some(ref fe) = filter_expression {
-                q = q.filter_expression(fe);
-            }
-            if let Some(key) = exclusive_start_key {
-                q = q.set_exclusive_start_key(Some(key));
-            }
-
-            let resp = q
-                .send()
-                .await
-                .map_err(|e| AuditError::Storage(e.to_string()))?;
-
-            for item in resp.items() {
-                if all_records.len() >= items_needed {
-                    break;
-                }
-                match item_to_record(item) {
-                    Ok(record) => all_records.push(record),
-                    Err(e) => {
-                        tracing::warn!(error = %e, "skipping malformed audit record");
+        // Build the ExclusiveStartKey from the cursor, if any. The
+        // cursor carries the sort key + record id; the ns_tenant comes
+        // from the query.
+        let exclusive_start_key: Option<HashMap<String, AttributeValue>> = match cursor.as_ref() {
+            None => None,
+            Some(cursor) => {
+                let mut start = HashMap::new();
+                start.insert("ns_tenant".to_owned(), AttributeValue::S(ns_tenant.clone()));
+                let id = cursor.id.clone().unwrap_or_default();
+                start.insert("id".to_owned(), AttributeValue::S(id));
+                match cursor.kind {
+                    CursorKind::Ts => {
+                        if query.sort_by_sequence_asc {
+                            return Err(AuditError::Serialization(
+                                "cursor kind 'ts' does not match sort_by_sequence_asc=true".into(),
+                            ));
+                        }
+                        start.insert(
+                            "dispatched_at_ms".to_owned(),
+                            AttributeValue::N(cursor.dispatched_at_ms.unwrap_or(0).to_string()),
+                        );
+                    }
+                    CursorKind::Seq => {
+                        if !query.sort_by_sequence_asc {
+                            return Err(AuditError::Serialization(
+                                "cursor kind 'seq' requires sort_by_sequence_asc=true".into(),
+                            ));
+                        }
+                        start.insert(
+                            "sequence_number".to_owned(),
+                            AttributeValue::N(cursor.sequence_number.unwrap_or(0).to_string()),
+                        );
                     }
                 }
+                Some(start)
             }
+        };
 
-            if all_records.len() >= items_needed {
-                break;
-            }
+        // Skip the count entirely. The previous implementation walked
+        // every page just to compute `total` — that's an O(matching
+        // items) operation per query and was the main source of linear
+        // degradation. Cursor-based pagination treats `total` as
+        // best-effort and leaves it `None`; offset callers also pay no
+        // count here (the prior behaviour was already worse than useful
+        // on large tenants, and offset paging on DynamoDB GSIs is a
+        // bad pattern anyway).
+        let total = None;
 
-            exclusive_start_key = resp.last_evaluated_key().cloned();
-            if exclusive_start_key.is_none() {
-                break;
+        let scan_forward = query.sort_by_sequence_asc;
+        // Fetch limit + 1 so we can detect a definitive last page
+        // without returning an empty trailing cursor. DynamoDB also
+        // exposes LastEvaluatedKey, but it can lag behind filter
+        // expressions: relying on the over-fetch sidesteps those edge
+        // cases.
+        let probe_limit = i32::try_from(limit).unwrap_or(50).saturating_add(1);
+        let mut q = self
+            .client
+            .query()
+            .table_name(&self.table_name)
+            .index_name(index_name)
+            .key_condition_expression(&key_condition)
+            .scan_index_forward(scan_forward)
+            .limit(probe_limit);
+
+        for (k, v) in &expr_values {
+            q = q.expression_attribute_values(k, v.clone());
+        }
+        for (k, v) in &filter_names {
+            q = q.expression_attribute_names(k, v);
+        }
+        if let Some(ref fe) = filter_expression {
+            q = q.filter_expression(fe);
+        }
+        if let Some(key) = exclusive_start_key {
+            q = q.set_exclusive_start_key(Some(key));
+        }
+
+        let resp = q
+            .send()
+            .await
+            .map_err(|e| AuditError::Storage(e.to_string()))?;
+
+        let mut records: Vec<AuditRecord> = Vec::with_capacity(resp.items().len());
+        for item in resp.items() {
+            match item_to_record(item) {
+                Ok(record) => records.push(record),
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping malformed audit record");
+                }
             }
         }
 
-        // Apply client-side offset.
-        let records: Vec<AuditRecord> = all_records
-            .into_iter()
-            .skip(offset as usize)
-            .take(limit as usize)
-            .collect();
+        let has_more = records.len() > limit as usize;
+        if has_more {
+            records.truncate(limit as usize);
+        }
+
+        // Build next_cursor only if the over-fetch detected another
+        // record. We re-encode it as our opaque AuditCursor so the wire
+        // format stays consistent across backends.
+        let next_cursor = if has_more {
+            records
+                .last()
+                .map(|rec| {
+                    if query.sort_by_sequence_asc {
+                        AuditCursor::from_sequence(rec.sequence_number.unwrap_or(0), rec.id.clone())
+                    } else {
+                        AuditCursor::from_timestamp(
+                            rec.dispatched_at.timestamp_millis(),
+                            rec.id.clone(),
+                        )
+                    }
+                })
+                .map(|c| c.encode())
+                .transpose()?
+        } else {
+            None
+        };
 
         Ok(AuditPage {
             records,
             total,
             limit,
-            offset,
+            offset: 0,
+            next_cursor,
         })
     }
 
@@ -566,6 +586,18 @@ fn record_to_item(record: &AuditRecord) -> HashMap<String, AttributeValue> {
         );
     }
 
+    // Action signing fields. Persisted as plain string attributes;
+    // absent attributes round-trip to `None` via `get_s_opt` on read.
+    if let Some(ref sig) = record.signature {
+        item.insert("signature".to_owned(), AttributeValue::S(sig.clone()));
+    }
+    if let Some(ref signer) = record.signer_id {
+        item.insert("signer_id".to_owned(), AttributeValue::S(signer.clone()));
+    }
+    if let Some(ref hash) = record.canonical_hash {
+        item.insert("canonical_hash".to_owned(), AttributeValue::S(hash.clone()));
+    }
+
     item
 }
 
@@ -657,9 +689,9 @@ fn item_to_record(item: &HashMap<String, AttributeValue>) -> Result<AuditRecord,
         attachment_metadata: get_s_opt("attachment_metadata")
             .and_then(|s| serde_json::from_str(&s).ok())
             .unwrap_or_default(),
-        signature: None,
-        signer_id: None,
-        canonical_hash: None,
+        signature: get_s_opt("signature"),
+        signer_id: get_s_opt("signer_id"),
+        canonical_hash: get_s_opt("canonical_hash"),
     })
 }
 

--- a/crates/audit/elasticsearch/src/store.rs
+++ b/crates/audit/elasticsearch/src/store.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use chrono::Utc;
 
+use acteon_audit::cursor::{AuditCursor, CursorKind};
 use acteon_audit::error::AuditError;
 use acteon_audit::record::{AuditPage, AuditQuery, AuditRecord};
 use acteon_audit::store::AuditStore;
@@ -142,11 +143,12 @@ struct SearchResponse {
 
 #[derive(serde::Deserialize)]
 struct SearchHits {
-    total: HitsTotal,
+    #[serde(default)]
+    total: Option<HitsTotal>,
     hits: Vec<SearchHit>,
 }
 
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, Default)]
 struct HitsTotal {
     value: u64,
 }
@@ -155,6 +157,10 @@ struct HitsTotal {
 struct SearchHit {
     #[serde(rename = "_source")]
     source: AuditRecord,
+    /// Sort values for this hit, used to seed `search_after` for the
+    /// next page. Always present when the request specified a `sort`.
+    #[serde(default)]
+    sort: Vec<serde_json::Value>,
 }
 
 #[derive(serde::Deserialize)]
@@ -252,25 +258,76 @@ impl AuditStore for ElasticsearchAuditStore {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn query(&self, query: &AuditQuery) -> Result<AuditPage, AuditError> {
         let limit = query.effective_limit();
-        let offset = query.effective_offset();
 
         let es_query = build_es_query(query);
 
+        // Sort always carries a tiebreaker (`id`) so `search_after` can
+        // resume deterministically even when the primary sort key has
+        // duplicates.
         let sort_clause = if query.sort_by_sequence_asc {
-            serde_json::json!([{ "sequence_number": { "order": "asc", "missing": "_last" } }])
+            serde_json::json!([
+                { "sequence_number": { "order": "asc", "missing": "_last" } },
+                { "id": { "order": "asc" } }
+            ])
         } else {
-            serde_json::json!([{ "dispatched_at": "desc" }])
+            serde_json::json!([
+                { "dispatched_at": "desc" },
+                { "id": "desc" }
+            ])
         };
 
-        let body = serde_json::json!({
+        let cursor = query
+            .cursor
+            .as_deref()
+            .map(AuditCursor::decode)
+            .transpose()?;
+
+        // Fetch limit + 1 so we can tell when this page is the last one
+        // without round-tripping an empty page.
+        let probe = limit + 1;
+        let mut body = serde_json::json!({
             "query": es_query,
             "sort": sort_clause,
-            "size": limit,
-            "from": offset,
-            "track_total_hits": true
+            "size": probe,
         });
+
+        let offset = if let Some(ref cursor) = cursor {
+            let search_after = match cursor.kind {
+                CursorKind::Ts => {
+                    if query.sort_by_sequence_asc {
+                        return Err(AuditError::Serialization(
+                            "cursor kind 'ts' does not match sort_by_sequence_asc=true".into(),
+                        ));
+                    }
+                    serde_json::json!([
+                        cursor.dispatched_at_ms.unwrap_or(0),
+                        cursor.id.clone().unwrap_or_default(),
+                    ])
+                }
+                CursorKind::Seq => {
+                    if !query.sort_by_sequence_asc {
+                        return Err(AuditError::Serialization(
+                            "cursor kind 'seq' requires sort_by_sequence_asc=true".into(),
+                        ));
+                    }
+                    serde_json::json!([
+                        cursor.sequence_number.unwrap_or(0),
+                        cursor.id.clone().unwrap_or_default(),
+                    ])
+                }
+            };
+            body["search_after"] = search_after;
+            // Cursor pagination skips the count for O(limit) latency.
+            0
+        } else {
+            // Legacy offset path — let ES count for backward compat.
+            body["from"] = serde_json::json!(query.effective_offset());
+            body["track_total_hits"] = serde_json::json!(true);
+            query.effective_offset()
+        };
 
         let path = format!("{}/_search", self.index);
 
@@ -291,13 +348,55 @@ impl AuditStore for ElasticsearchAuditStore {
             .await
             .map_err(|e| AuditError::Serialization(e.to_string()))?;
 
-        let records = search.hits.hits.into_iter().map(|h| h.source).collect();
+        let mut hits = search.hits.hits;
+        let has_more = hits.len() > limit as usize;
+        if has_more {
+            hits.truncate(limit as usize);
+        }
+        let last_sort = hits.last().map(|h| h.sort.clone());
+        let records: Vec<AuditRecord> = hits.into_iter().map(|h| h.source).collect();
+
+        let next_cursor = if has_more {
+            // Build the next cursor from the last hit's sort values.
+            // We round-trip via the structured cursor so the wire format
+            // stays consistent across backends.
+            last_sort.and_then(|sort_vals| {
+                let id = sort_vals
+                    .get(1)
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("")
+                    .to_owned();
+                let cursor = if query.sort_by_sequence_asc {
+                    let seq = sort_vals
+                        .first()
+                        .and_then(serde_json::Value::as_u64)
+                        .unwrap_or(0);
+                    AuditCursor::from_sequence(seq, id)
+                } else {
+                    let ts = sort_vals
+                        .first()
+                        .and_then(serde_json::Value::as_i64)
+                        .unwrap_or(0);
+                    AuditCursor::from_timestamp(ts, id)
+                };
+                cursor.encode().ok()
+            })
+        } else {
+            None
+        };
+
+        let total = if cursor.is_none() {
+            Some(search.hits.total.unwrap_or_default().value)
+        } else {
+            None
+        };
 
         Ok(AuditPage {
             records,
-            total: search.hits.total.value,
+            total,
             limit,
             offset,
+            next_cursor,
         })
     }
 

--- a/crates/audit/memory/src/store.rs
+++ b/crates/audit/memory/src/store.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use dashmap::DashMap;
 
+use acteon_audit::cursor::{AuditCursor, CursorKind};
 use acteon_audit::error::AuditError;
 use acteon_audit::record::{AuditPage, AuditQuery, AuditRecord};
 use acteon_audit::store::AuditStore;
@@ -69,9 +70,9 @@ impl AuditStore for MemoryAuditStore {
         Ok(self.records.get(id).map(|r| r.value().clone()))
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn query(&self, query: &AuditQuery) -> Result<AuditPage, AuditError> {
         let limit = query.effective_limit();
-        let offset = query.effective_offset();
 
         // Collect all matching records.
         let mut matching: Vec<AuditRecord> = self
@@ -121,21 +122,78 @@ impl AuditStore for MemoryAuditStore {
             })
             .collect();
 
-        // Sort by dispatched_at descending.
-        matching.sort_by(|a, b| b.dispatched_at.cmp(&a.dispatched_at));
+        // Sort by the requested order. The default is `dispatched_at DESC`
+        // with `id DESC` as a tiebreaker so the cursor key uniquely
+        // identifies a row.
+        if query.sort_by_sequence_asc {
+            matching.sort_by(|a, b| {
+                a.sequence_number
+                    .unwrap_or(u64::MAX)
+                    .cmp(&b.sequence_number.unwrap_or(u64::MAX))
+                    .then_with(|| a.id.cmp(&b.id))
+            });
+        } else {
+            matching.sort_by(|a, b| {
+                b.dispatched_at
+                    .cmp(&a.dispatched_at)
+                    .then_with(|| b.id.cmp(&a.id))
+            });
+        }
 
-        let total = matching.len() as u64;
-        let records: Vec<AuditRecord> = matching
-            .into_iter()
-            .skip(offset as usize)
-            .take(limit as usize)
-            .collect();
+        let total_matches = matching.len() as u64;
+
+        // Cursor takes precedence over offset. When neither is set the
+        // request behaves like the legacy offset path.
+        //
+        // We fetch `limit + 1` rows so we can detect a definitive last
+        // page without round-tripping an empty cursor: if the over-fetch
+        // returned `> limit`, more rows exist and we trim + emit a
+        // cursor; otherwise we know we're done.
+        let probe = limit as usize + 1;
+        let (mut records, used_cursor, offset) = if let Some(cursor_str) = query.cursor.as_deref() {
+            let cursor = AuditCursor::decode(cursor_str)?;
+            let after: Vec<AuditRecord> = matching
+                .into_iter()
+                .filter(|rec| record_after_cursor(rec, &cursor, query.sort_by_sequence_asc))
+                .take(probe)
+                .collect();
+            (after, true, 0u32)
+        } else {
+            let offset = query.effective_offset();
+            let page: Vec<AuditRecord> = matching
+                .into_iter()
+                .skip(offset as usize)
+                .take(probe)
+                .collect();
+            (page, false, offset)
+        };
+
+        let has_more = records.len() > limit as usize;
+        if has_more {
+            records.truncate(limit as usize);
+        }
+
+        let next_cursor = if has_more {
+            records
+                .last()
+                .map(|rec| build_cursor(rec, query.sort_by_sequence_asc).encode())
+                .transpose()?
+        } else {
+            None
+        };
+
+        let total = if used_cursor {
+            None
+        } else {
+            Some(total_matches)
+        };
 
         Ok(AuditPage {
             records,
             total,
             limit,
             offset,
+            next_cursor,
         })
     }
 
@@ -175,6 +233,39 @@ impl AuditStore for MemoryAuditStore {
 /// Check if a filter matches a value. `None` filter matches everything.
 fn matches_filter(filter: Option<&String>, value: &str) -> bool {
     filter.is_none_or(|f| f == value)
+}
+
+/// Build the cursor that points at `rec` for the active sort order.
+fn build_cursor(rec: &AuditRecord, sort_by_sequence_asc: bool) -> AuditCursor {
+    if sort_by_sequence_asc {
+        AuditCursor::from_sequence(rec.sequence_number.unwrap_or(0), rec.id.clone())
+    } else {
+        AuditCursor::from_timestamp(rec.dispatched_at.timestamp_millis(), rec.id.clone())
+    }
+}
+
+/// Filter predicate: keep records strictly after the cursor in the active
+/// sort order.
+fn record_after_cursor(
+    rec: &AuditRecord,
+    cursor: &AuditCursor,
+    sort_by_sequence_asc: bool,
+) -> bool {
+    match (sort_by_sequence_asc, cursor.kind) {
+        (true, CursorKind::Seq) => {
+            let cursor_seq = cursor.sequence_number.unwrap_or(0);
+            rec.sequence_number.is_some_and(|seq| seq > cursor_seq)
+        }
+        (false, CursorKind::Ts) => {
+            let cursor_ms = cursor.dispatched_at_ms.unwrap_or(0);
+            let cursor_id = cursor.id.as_deref().unwrap_or("");
+            let rec_ms = rec.dispatched_at.timestamp_millis();
+            // Default sort is DESC, so "after" means strictly older.
+            rec_ms < cursor_ms || (rec_ms == cursor_ms && rec.id.as_str() < cursor_id)
+        }
+        // Cursor kind mismatch with current sort — treat as no-match.
+        _ => false,
+    }
 }
 
 #[cfg(test)]
@@ -264,7 +355,7 @@ mod tests {
             ..Default::default()
         };
         let page = store.query(&q).await.unwrap();
-        assert_eq!(page.total, 1);
+        assert_eq!(page.total, Some(1));
         assert_eq!(page.records[0].id, "r1");
     }
 
@@ -283,10 +374,65 @@ mod tests {
             ..Default::default()
         };
         let page = store.query(&q).await.unwrap();
-        assert_eq!(page.total, 10);
+        assert_eq!(page.total, Some(10));
         assert_eq!(page.records.len(), 3);
         assert_eq!(page.limit, 3);
         assert_eq!(page.offset, 2);
+    }
+
+    #[tokio::test]
+    async fn query_cursor_pagination_walks_all_records() {
+        let store = MemoryAuditStore::new();
+        for i in 0..10 {
+            let mut rec = make_record(&format!("r{i:02}"), &format!("a{i}"));
+            rec.dispatched_at = Utc::now() + Duration::seconds(i64::from(i));
+            store.record(rec).await.unwrap();
+        }
+
+        let mut cursor: Option<String> = None;
+        let mut seen: Vec<String> = Vec::new();
+        loop {
+            let q = AuditQuery {
+                limit: Some(3),
+                cursor: cursor.clone(),
+                ..Default::default()
+            };
+            let page = store.query(&q).await.unwrap();
+            // Only the cursor-driven follow-up pages skip the count.
+            if cursor.is_some() {
+                assert!(page.total.is_none(), "cursor pagination should skip count");
+            }
+            for rec in &page.records {
+                seen.push(rec.id.clone());
+            }
+            if page.next_cursor.is_none() {
+                break;
+            }
+            cursor = page.next_cursor;
+        }
+        assert_eq!(seen.len(), 10);
+        // Records should be in the default sort: dispatched_at DESC.
+        for w in seen.windows(2) {
+            assert!(w[0] > w[1], "expected DESC order: {:?}", w);
+        }
+    }
+
+    #[tokio::test]
+    async fn query_cursor_first_page_no_cursor() {
+        let store = MemoryAuditStore::new();
+        for i in 0..5 {
+            let mut rec = make_record(&format!("r{i}"), &format!("a{i}"));
+            rec.dispatched_at = Utc::now() + Duration::seconds(i64::from(i));
+            store.record(rec).await.unwrap();
+        }
+        let q = AuditQuery {
+            limit: Some(2),
+            ..Default::default()
+        };
+        let page = store.query(&q).await.unwrap();
+        assert_eq!(page.records.len(), 2);
+        assert!(page.next_cursor.is_some());
+        assert_eq!(page.total, Some(5));
     }
 
     #[tokio::test]
@@ -337,7 +483,7 @@ mod tests {
             ..Default::default()
         };
         let page = store.query(&q).await.unwrap();
-        assert_eq!(page.total, 1);
+        assert_eq!(page.total, Some(1));
         assert_eq!(page.records[0].id, "r2");
     }
 }

--- a/crates/audit/postgres/src/migrations.rs
+++ b/crates/audit/postgres/src/migrations.rs
@@ -100,6 +100,20 @@ pub async fn run_migrations(pool: &PgPool, prefix: &str) -> Result<(), sqlx::Err
     );
     sqlx::query(&attachment_stmt).execute(pool).await?;
 
+    // Action signing columns: Ed25519 signature + signer key id +
+    // canonical hash captured at dispatch time. These are nullable so
+    // existing records without signing data are unaffected; the
+    // signing audit row → AuditRecord conversion populates them when
+    // present.
+    let signing_stmts = [
+        format!("ALTER TABLE {table} ADD COLUMN IF NOT EXISTS signature TEXT"),
+        format!("ALTER TABLE {table} ADD COLUMN IF NOT EXISTS signer_id TEXT"),
+        format!("ALTER TABLE {table} ADD COLUMN IF NOT EXISTS canonical_hash TEXT"),
+    ];
+    for stmt in &signing_stmts {
+        sqlx::query(stmt).execute(pool).await?;
+    }
+
     // Covering index for rule coverage aggregation.
     //
     // `/v1/rules/coverage` issues

--- a/crates/audit/postgres/src/store.rs
+++ b/crates/audit/postgres/src/store.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use sqlx::PgPool;
 
 use acteon_audit::analytics::AnalyticsStore;
+use acteon_audit::cursor::{AuditCursor, CursorKind};
 use acteon_audit::error::AuditError;
 use acteon_audit::record::{AuditPage, AuditQuery, AuditRecord};
 use acteon_audit::store::AuditStore;
@@ -111,7 +112,8 @@ impl AuditStore for PostgresAuditStore {
                 dispatched_at, completed_at, duration_ms, expires_at,
                 caller_id, auth_method,
                 record_hash, previous_hash, sequence_number,
-                attachment_metadata
+                attachment_metadata,
+                signature, signer_id, canonical_hash
             ) VALUES (
                 $1, $2, $3, $4, $5, $6, $7,
                 $8, $9, $10,
@@ -119,7 +121,8 @@ impl AuditStore for PostgresAuditStore {
                 $15, $16, $17, $18,
                 $19, $20,
                 $21, $22, $23,
-                $24
+                $24,
+                $25, $26, $27
             )
             ",
             self.table
@@ -155,6 +158,9 @@ impl AuditStore for PostgresAuditStore {
             .bind(&entry.previous_hash)
             .bind(sequence_number)
             .bind(serde_json::Value::Array(entry.attachment_metadata.clone()))
+            .bind(&entry.signature)
+            .bind(&entry.signer_id)
+            .bind(&entry.canonical_hash)
             .execute(&self.pool)
             .await
             .map_err(|e| AuditError::Storage(e.to_string()))?;
@@ -189,37 +195,99 @@ impl AuditStore for PostgresAuditStore {
         Ok(row.map(Into::into))
     }
 
+    #[allow(clippy::too_many_lines, clippy::similar_names)]
     async fn query(&self, query: &AuditQuery) -> Result<AuditPage, AuditError> {
         let limit = query.effective_limit();
-        let offset = query.effective_offset();
-        let (where_clause, binds, from_idx, to_idx, bind_idx) = build_where_clause(query);
+        let (mut where_clause, binds, from_idx, to_idx, mut bind_idx) = build_where_clause(query);
 
-        // Count query.
-        let count_sql = format!("SELECT COUNT(*) as cnt FROM {} {where_clause}", self.table);
-        let mut count_q = sqlx::query_scalar::<_, i64>(&count_sql);
-        for b in &binds {
-            count_q = count_q.bind(b);
-        }
-        if from_idx.is_some() {
-            count_q = count_q.bind(query.from.unwrap());
-        }
-        if to_idx.is_some() {
-            count_q = count_q.bind(query.to.unwrap());
+        // Decode the cursor up-front so we can fail fast on bad input.
+        let cursor = query
+            .cursor
+            .as_deref()
+            .map(AuditCursor::decode)
+            .transpose()?;
+
+        // Append the keyset condition for the cursor, if any.
+        let cursor_dispatched_idx;
+        let cursor_id_idx;
+        let cursor_seq_idx;
+        if let Some(ref cursor) = cursor {
+            let prefix = if where_clause.is_empty() {
+                "WHERE"
+            } else {
+                "AND"
+            };
+            match cursor.kind {
+                CursorKind::Ts => {
+                    if query.sort_by_sequence_asc {
+                        return Err(AuditError::Serialization(
+                            "cursor kind 'ts' does not match sort_by_sequence_asc=true".into(),
+                        ));
+                    }
+                    let ts_idx = bind_idx;
+                    let id_idx = bind_idx + 1;
+                    where_clause = format!(
+                        "{where_clause} {prefix} (dispatched_at, id) < (${ts_idx}, ${id_idx})"
+                    );
+                    cursor_dispatched_idx = Some(ts_idx);
+                    cursor_id_idx = Some(id_idx);
+                    cursor_seq_idx = None;
+                    bind_idx += 2;
+                }
+                CursorKind::Seq => {
+                    if !query.sort_by_sequence_asc {
+                        return Err(AuditError::Serialization(
+                            "cursor kind 'seq' requires sort_by_sequence_asc=true".into(),
+                        ));
+                    }
+                    let seq_idx = bind_idx;
+                    where_clause = format!("{where_clause} {prefix} sequence_number > ${seq_idx}");
+                    cursor_dispatched_idx = None;
+                    cursor_id_idx = None;
+                    cursor_seq_idx = Some(seq_idx);
+                    bind_idx += 1;
+                }
+            }
+        } else {
+            cursor_dispatched_idx = None;
+            cursor_id_idx = None;
+            cursor_seq_idx = None;
         }
 
-        let total = count_q
-            .fetch_one(&self.pool)
-            .await
-            .map_err(|e| AuditError::Storage(e.to_string()))?;
+        // Count query — only run when no cursor is present (offset path).
+        // Cursor pagination intentionally skips the count to keep page
+        // latency O(limit).
+        let total = if cursor.is_none() {
+            let count_sql = format!("SELECT COUNT(*) as cnt FROM {} {where_clause}", self.table);
+            let mut count_q = sqlx::query_scalar::<_, i64>(&count_sql);
+            for b in &binds {
+                count_q = count_q.bind(b);
+            }
+            if from_idx.is_some() {
+                count_q = count_q.bind(query.from.unwrap());
+            }
+            if to_idx.is_some() {
+                count_q = count_q.bind(query.to.unwrap());
+            }
+            let count = count_q
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e| AuditError::Storage(e.to_string()))?;
+            #[allow(clippy::cast_sign_loss)]
+            let count = count as u64;
+            Some(count)
+        } else {
+            None
+        };
 
         // Data query.
+        let order_clause = if query.sort_by_sequence_asc {
+            "ORDER BY sequence_number ASC NULLS LAST, id ASC"
+        } else {
+            "ORDER BY dispatched_at DESC, id DESC"
+        };
         let limit_idx = bind_idx;
         let offset_idx = bind_idx + 1;
-        let order_clause = if query.sort_by_sequence_asc {
-            "ORDER BY sequence_number ASC NULLS LAST"
-        } else {
-            "ORDER BY dispatched_at DESC"
-        };
         let data_sql = format!(
             "SELECT * FROM {} {where_clause} {order_clause} LIMIT ${limit_idx} OFFSET ${offset_idx}",
             self.table
@@ -235,24 +303,72 @@ impl AuditStore for PostgresAuditStore {
         if to_idx.is_some() {
             data_q = data_q.bind(query.to.unwrap());
         }
-        data_q = data_q.bind(i64::from(limit));
-        data_q = data_q.bind(i64::from(offset));
+        if let Some(ref cursor) = cursor {
+            match cursor.kind {
+                CursorKind::Ts => {
+                    let ts = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(
+                        cursor.dispatched_at_ms.unwrap_or(0),
+                    )
+                    .unwrap_or_default();
+                    data_q = data_q.bind(ts);
+                    data_q = data_q.bind(cursor.id.clone().unwrap_or_default());
+                }
+                CursorKind::Seq => {
+                    #[allow(clippy::cast_possible_wrap)]
+                    let seq = cursor.sequence_number.unwrap_or(0) as i64;
+                    data_q = data_q.bind(seq);
+                }
+            }
+        }
+        let _ = (cursor_dispatched_idx, cursor_id_idx, cursor_seq_idx);
+        // Fetch limit + 1 so we can detect whether another page exists
+        // without returning an empty trailing cursor to the caller.
+        data_q = data_q.bind(i64::from(limit) + 1);
+        // Cursor pagination always uses offset 0; offset is only used in
+        // the legacy non-cursor path.
+        let offset_value = if cursor.is_some() {
+            0
+        } else {
+            query.effective_offset()
+        };
+        data_q = data_q.bind(i64::from(offset_value));
 
         let rows: Vec<AuditRow> = data_q
             .fetch_all(&self.pool)
             .await
             .map_err(|e| AuditError::Storage(e.to_string()))?;
 
-        let records = rows.into_iter().map(Into::into).collect();
+        let mut records: Vec<AuditRecord> = rows.into_iter().map(Into::into).collect();
+        let has_more = records.len() > limit as usize;
+        if has_more {
+            records.truncate(limit as usize);
+        }
 
-        #[allow(clippy::cast_sign_loss)]
-        let total = total as u64;
+        let next_cursor = if has_more {
+            records
+                .last()
+                .map(|rec| {
+                    if query.sort_by_sequence_asc {
+                        AuditCursor::from_sequence(rec.sequence_number.unwrap_or(0), rec.id.clone())
+                    } else {
+                        AuditCursor::from_timestamp(
+                            rec.dispatched_at.timestamp_millis(),
+                            rec.id.clone(),
+                        )
+                    }
+                })
+                .map(|c| c.encode())
+                .transpose()?
+        } else {
+            None
+        };
 
         Ok(AuditPage {
             records,
             total,
             limit,
-            offset,
+            offset: offset_value,
+            next_cursor,
         })
     }
 
@@ -358,6 +474,12 @@ struct AuditRow {
     previous_hash: Option<String>,
     sequence_number: Option<i64>,
     attachment_metadata: serde_json::Value,
+    #[sqlx(default)]
+    signature: Option<String>,
+    #[sqlx(default)]
+    signer_id: Option<String>,
+    #[sqlx(default)]
+    canonical_hash: Option<String>,
 }
 
 impl From<AuditRow> for AuditRecord {
@@ -396,9 +518,9 @@ impl From<AuditRow> for AuditRecord {
             #[allow(clippy::cast_sign_loss)]
             sequence_number: row.sequence_number.map(|n| n as u64),
             attachment_metadata,
-            signature: None,
-            signer_id: None,
-            canonical_hash: None,
+            signature: row.signature,
+            signer_id: row.signer_id,
+            canonical_hash: row.canonical_hash,
         }
     }
 }

--- a/crates/cli/src/commands/audit.rs
+++ b/crates/cli/src/commands/audit.rs
@@ -30,6 +30,20 @@ pub enum AuditCommand {
         /// Maximum records to return.
         #[arg(long, default_value = "20")]
         limit: u32,
+        /// Opaque pagination cursor returned by a previous query.
+        ///
+        /// Pass the `next_cursor` from the previous page's JSON output
+        /// (or the value printed in the text footer) to fetch the next
+        /// page in O(limit) time. Prefer this over `--offset` for deep
+        /// pagination — large offsets degrade linearly.
+        #[arg(long)]
+        cursor: Option<String>,
+        /// Walk every page automatically, printing each record exactly
+        /// once. Equivalent to repeatedly invoking `audit query` with
+        /// the previous response's `next_cursor`. Useful for exporting
+        /// the entire audit trail without burning offset scans.
+        #[arg(long, conflicts_with = "cursor")]
+        all: bool,
     },
     /// Get a single audit record by action ID.
     Get {
@@ -69,6 +83,8 @@ pub async fn run(ops: &OpsClient, args: &AuditArgs, format: &OutputFormat) -> an
             provider,
             action_type,
             limit,
+            cursor,
+            all,
         } => {
             run_query(
                 ops,
@@ -77,6 +93,8 @@ pub async fn run(ops: &OpsClient, args: &AuditArgs, format: &OutputFormat) -> an
                 provider.as_ref(),
                 action_type.as_ref(),
                 *limit,
+                cursor.clone(),
+                *all,
                 format,
             )
             .await
@@ -104,6 +122,7 @@ pub async fn run(ops: &OpsClient, args: &AuditArgs, format: &OutputFormat) -> an
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_query(
     ops: &OpsClient,
     tenant: Option<&String>,
@@ -111,42 +130,68 @@ async fn run_query(
     provider: Option<&String>,
     action_type: Option<&String>,
     limit: u32,
+    cursor: Option<String>,
+    walk_all: bool,
     format: &OutputFormat,
 ) -> anyhow::Result<()> {
-    let query = AuditQuery {
-        tenant: tenant.cloned(),
-        namespace: namespace.cloned(),
-        provider: provider.cloned(),
-        action_type: action_type.cloned(),
-        outcome: None,
-        limit: Some(limit),
-        offset: None,
-    };
+    let mut current_cursor = cursor;
+    let mut printed_records: u64 = 0;
 
-    let page = ops.query_audit(query).await?;
+    loop {
+        let query = AuditQuery {
+            tenant: tenant.cloned(),
+            namespace: namespace.cloned(),
+            provider: provider.cloned(),
+            action_type: action_type.cloned(),
+            outcome: None,
+            limit: Some(limit),
+            offset: None,
+            cursor: current_cursor.clone(),
+        };
 
-    match format {
-        OutputFormat::Json => {
-            info!("{}", serde_json::to_string_pretty(&page)?);
-        }
-        OutputFormat::Text => {
-            info!(
-                total = page.total,
-                showing = page.records.len(),
-                "Audit query results"
-            );
-            for rec in &page.records {
+        let page = ops.query_audit(query).await?;
+        let page_len = page.records.len() as u64;
+
+        match format {
+            OutputFormat::Json => {
+                // In --all mode we emit one JSON object per page so the
+                // stream is parseable line-by-line by jq -c style tools.
+                info!("{}", serde_json::to_string_pretty(&page)?);
+            }
+            OutputFormat::Text => {
                 info!(
-                    timestamp = %rec.dispatched_at,
-                    action_type = %rec.action_type,
-                    provider = %rec.provider,
-                    verdict = %rec.verdict,
-                    outcome = %rec.outcome,
-                    id = %&rec.action_id[..8.min(rec.action_id.len())],
-                    "Audit record"
+                    total = ?page.total,
+                    showing = page.records.len(),
+                    next_cursor = ?page.next_cursor,
+                    "Audit query results"
                 );
+                for rec in &page.records {
+                    info!(
+                        timestamp = %rec.dispatched_at,
+                        action_type = %rec.action_type,
+                        provider = %rec.provider,
+                        verdict = %rec.verdict,
+                        outcome = %rec.outcome,
+                        id = %&rec.action_id[..8.min(rec.action_id.len())],
+                        "Audit record"
+                    );
+                }
             }
         }
+
+        printed_records += page_len;
+
+        if !walk_all {
+            break;
+        }
+        match page.next_cursor {
+            Some(next) => current_cursor = Some(next),
+            None => break,
+        }
+    }
+
+    if walk_all {
+        info!(records = printed_records, "Audit walk complete");
     }
     Ok(())
 }

--- a/crates/client/src/audit.rs
+++ b/crates/client/src/audit.rs
@@ -24,8 +24,18 @@ pub struct AuditQuery {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
     /// Number of records to skip.
+    ///
+    /// Prefer `cursor` for deep pagination — large offsets degrade
+    /// linearly on every backend.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<u32>,
+    /// Opaque pagination cursor returned by the previous page.
+    ///
+    /// Pass a `next_cursor` from a prior `AuditPage` to fetch the next
+    /// page in O(limit) time. Treat this as opaque — never construct
+    /// or modify the value on the client side.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
 }
 
 /// Paginated audit results.
@@ -33,12 +43,19 @@ pub struct AuditQuery {
 pub struct AuditPage {
     /// Audit records.
     pub records: Vec<AuditRecord>,
-    /// Total number of matching records.
-    pub total: u64,
+    /// Total number of matching records, when the backend computed it.
+    /// Cursor pagination intentionally skips the count, so this is
+    /// `None` after the first cursor-driven request.
+    #[serde(default)]
+    pub total: Option<u64>,
     /// Limit used in the query.
     pub limit: u64,
     /// Offset used in the query.
     pub offset: u64,
+    /// Opaque cursor pointing at the next page, or `None` if this is
+    /// the last page. Pass into [`AuditQuery::cursor`] to resume.
+    #[serde(default)]
+    pub next_cursor: Option<String>,
 }
 
 /// An audit record.
@@ -155,7 +172,11 @@ impl ActeonClient {
     /// };
     ///
     /// let page = client.query_audit(&query).await?;
-    /// println!("Found {} records (total: {})", page.records.len(), page.total);
+    /// println!(
+    ///     "Found {} records (total: {:?})",
+    ///     page.records.len(),
+    ///     page.total
+    /// );
     /// # Ok(())
     /// # }
     /// ```

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -358,6 +358,9 @@ pub struct QueryAuditParams {
     /// Maximum number of records (default 20).
     #[serde(default)]
     pub limit: Option<u32>,
+    /// Opaque pagination cursor returned by the previous page.
+    #[serde(default)]
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -887,6 +890,7 @@ impl ActeonMcpServer {
             outcome: p.outcome,
             limit: Some(p.limit.unwrap_or(20)),
             offset: None,
+            cursor: p.cursor,
         };
 
         match self.ops.query_audit(query).await {

--- a/crates/server/src/api/audit.rs
+++ b/crates/server/src/api/audit.rs
@@ -29,7 +29,8 @@ use super::schemas::ErrorResponse;
         ("from" = Option<String>, Query, description = "Start of time range (RFC 3339)"),
         ("to" = Option<String>, Query, description = "End of time range (RFC 3339)"),
         ("limit" = Option<u32>, Query, description = "Max records to return (default 50, max 1000)"),
-        ("offset" = Option<u32>, Query, description = "Number of records to skip"),
+        ("offset" = Option<u32>, Query, description = "Number of records to skip — prefer `cursor` for deep pagination"),
+        ("cursor" = Option<String>, Query, description = "Opaque pagination cursor returned by the previous page"),
     ),
     responses(
         (status = 200, description = "Audit records matching query", body = acteon_audit::AuditPage),

--- a/crates/simulation/examples/chain_simulation.rs
+++ b/crates/simulation/examples/chain_simulation.rs
@@ -177,7 +177,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
         .await?;
 
-    info!("\n  Audit records for chain {chain_id}: {}", page.total);
+    info!(
+        "\n  Audit records for chain {chain_id}: {}",
+        page.total.unwrap_or(0)
+    );
     for rec in &page.records {
         info!(
             "    [{:>22}] provider={:<12} outcome={}",
@@ -336,7 +339,7 @@ rules:
             ..Default::default()
         })
         .await?;
-    info!("\n  Audit records for chain: {}", page.total);
+    info!("\n  Audit records for chain: {}", page.total.unwrap_or(0));
     for rec in &page.records {
         info!(
             "    [{:>22}] provider={:<16} action_type={}",
@@ -490,7 +493,7 @@ rules:
             ..Default::default()
         })
         .await?;
-    info!("\n  Audit records for chain: {}", page.total);
+    info!("\n  Audit records for chain: {}", page.total.unwrap_or(0));
     for rec in &page.records {
         info!(
             "    [{:>22}] provider={:<10} action_type={}",
@@ -630,7 +633,7 @@ rules:
             ..Default::default()
         })
         .await?;
-    info!("\n  Audit records for chain: {}", page.total);
+    info!("\n  Audit records for chain: {}", page.total.unwrap_or(0));
     for rec in &page.records {
         info!(
             "    [{:>22}] provider={:<10} action_type={}",
@@ -763,7 +766,10 @@ rules:
 
     // Query all audit records.
     let all_page = audit.query(&AuditQuery::default()).await?;
-    info!("  Total audit records (all chains): {}", all_page.total);
+    info!(
+        "  Total audit records (all chains): {}",
+        all_page.total.unwrap_or(0)
+    );
 
     // Query only chain-alpha records.
     let alpha_page = audit
@@ -774,7 +780,8 @@ rules:
         .await?;
     info!(
         "  Records for chain-alpha ({}): {}",
-        chain_id_a, alpha_page.total
+        chain_id_a,
+        alpha_page.total.unwrap_or(0)
     );
     for rec in &alpha_page.records {
         info!(
@@ -792,7 +799,8 @@ rules:
         .await?;
     info!(
         "  Records for chain-beta  ({}): {}",
-        chain_id_b, beta_page.total
+        chain_id_b,
+        beta_page.total.unwrap_or(0)
     );
     for rec in &beta_page.records {
         info!(
@@ -804,11 +812,13 @@ rules:
     // chain-alpha: 1 dispatch + 2 steps + 1 terminal = 4 records.
     // chain-beta:  1 dispatch + 1 step  + 1 terminal = 3 records.
     assert_eq!(
-        alpha_page.total, 4,
+        alpha_page.total.unwrap_or(0),
+        4,
         "chain-alpha: 1 dispatch + 2 step + 1 terminal"
     );
     assert_eq!(
-        beta_page.total, 3,
+        beta_page.total.unwrap_or(0),
+        3,
         "chain-beta: 1 dispatch + 1 step + 1 terminal"
     );
 

--- a/crates/simulation/examples/http_client_simulation.rs
+++ b/crates/simulation/examples/http_client_simulation.rs
@@ -228,12 +228,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match client.query_audit(&audit_query).await {
         Ok(page) => {
-            if page.total == 0 {
+            if page.total.unwrap_or(0) == 0 && page.records.is_empty() {
                 info!("  No audit records (audit may not be enabled)\n");
                 info!("  To enable audit, use a config with [audit] section:");
                 info!("    cargo run -p acteon-server -- -c examples/postgres.toml\n");
             } else {
-                info!("  Found {} audit records for tenant-http-test:", page.total);
+                info!(
+                    "  Found {} audit records for tenant-http-test:",
+                    page.total.unwrap_or(0)
+                );
                 for record in &page.records {
                     info!(
                         "    {} | {} | {} | {}",

--- a/crates/simulation/examples/mixed_backends_simulation.rs
+++ b/crates/simulation/examples/mixed_backends_simulation.rs
@@ -551,7 +551,7 @@ async fn run_simulation(config: MixedBackendConfig) -> Result<(), Box<dyn std::e
     let tenant2_page = audit.query(&tenant2_query).await?;
     info!(
         "\n  Unified audit for tenant-2: {} records",
-        tenant2_page.total
+        tenant2_page.total.unwrap_or(0)
     );
     for record in &tenant2_page.records {
         info!(
@@ -653,7 +653,7 @@ async fn run_simulation(config: MixedBackendConfig) -> Result<(), Box<dyn std::e
         ..Default::default()
     };
     let bench_page = audit.query(&bench_query).await?;
-    info!("  Audit records created: {}", bench_page.total);
+    info!("  Audit records created: {}", bench_page.total.unwrap_or(0));
 
     // =========================================================================
     // SCENARIO 7: Failure Injection
@@ -1171,7 +1171,7 @@ async fn run_simulation(config: MixedBackendConfig) -> Result<(), Box<dyn std::e
         .filter(|r| r.outcome == "throttled")
         .count();
 
-    info!("  Total audit records: {}", all_page.total);
+    info!("  Total audit records: {}", all_page.total.unwrap_or(0));
     info!("    - Executed: {}", executed_count);
     info!("    - Suppressed: {}", suppressed_count);
     info!("    - Deduplicated: {}", deduplicated_count);

--- a/crates/simulation/examples/postgres_chain_simulation.rs
+++ b/crates/simulation/examples/postgres_chain_simulation.rs
@@ -204,7 +204,7 @@ rules:
 
     info!(
         "\n  Audit records in Postgres for chain {chain_id}: {}",
-        page.total
+        page.total.unwrap_or(0)
     );
     for rec in &page.records {
         info!(
@@ -361,7 +361,10 @@ rules:
             ..Default::default()
         })
         .await?;
-    info!("\n  Audit records in Postgres for chain: {}", page.total);
+    info!(
+        "\n  Audit records in Postgres for chain: {}",
+        page.total.unwrap_or(0)
+    );
     for rec in &page.records {
         info!(
             "    [{:>22}] provider={:<16} action_type={}",
@@ -505,7 +508,10 @@ rules:
             ..Default::default()
         })
         .await?;
-    info!("\n  Audit records in Postgres for chain: {}", page.total);
+    info!(
+        "\n  Audit records in Postgres for chain: {}",
+        page.total.unwrap_or(0)
+    );
     for rec in &page.records {
         info!(
             "    [{:>22}] provider={:<10} action_type={}",
@@ -641,7 +647,10 @@ rules:
             ..Default::default()
         })
         .await?;
-    info!("\n  Audit records in Postgres for chain: {}", page.total);
+    info!(
+        "\n  Audit records in Postgres for chain: {}",
+        page.total.unwrap_or(0)
+    );
     for rec in &page.records {
         info!(
             "    [{:>22}] provider={:<10} action_type={}",
@@ -776,7 +785,10 @@ rules:
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     let all_page = audit.query(&AuditQuery::default()).await?;
-    info!("\n  Total audit records (all chains): {}", all_page.total);
+    info!(
+        "\n  Total audit records (all chains): {}",
+        all_page.total.unwrap_or(0)
+    );
 
     let alpha_page = audit
         .query(&AuditQuery {
@@ -786,7 +798,7 @@ rules:
         .await?;
     info!(
         "  Records for chain-alpha: {} (expected 4: 1 dispatch + 2 step + 1 terminal)",
-        alpha_page.total
+        alpha_page.total.unwrap_or(0)
     );
     for rec in &alpha_page.records {
         info!(
@@ -803,7 +815,7 @@ rules:
         .await?;
     info!(
         "  Records for chain-beta:  {} (expected 3: 1 dispatch + 1 step + 1 terminal)",
-        beta_page.total
+        beta_page.total.unwrap_or(0)
     );
     for rec in &beta_page.records {
         info!(
@@ -815,11 +827,13 @@ rules:
     // chain-alpha: 1 dispatch + 2 steps + 1 terminal = 4.
     // chain-beta:  1 dispatch + 1 step  + 1 terminal = 3.
     assert_eq!(
-        alpha_page.total, 4,
+        alpha_page.total.unwrap_or(0),
+        4,
         "chain-alpha: 1 dispatch + 2 step + 1 terminal"
     );
     assert_eq!(
-        beta_page.total, 3,
+        beta_page.total.unwrap_or(0),
+        3,
         "chain-beta: 1 dispatch + 1 step + 1 terminal"
     );
 

--- a/crates/simulation/examples/postgres_simulation.rs
+++ b/crates/simulation/examples/postgres_simulation.rs
@@ -251,7 +251,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("→ Querying all audit records for tenant-1...");
     let page = audit.query(&query).await?;
-    info!("  Total records: {}", page.total);
+    info!("  Total records: {}", page.total.unwrap_or(0));
     info!("  Records in page: {}\n", page.records.len());
 
     for record in &page.records {
@@ -272,7 +272,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ..Default::default()
     };
     let suppressed_page = audit.query(&suppressed_query).await?;
-    info!("  Suppressed actions: {}", suppressed_page.total);
+    info!(
+        "  Suppressed actions: {}",
+        suppressed_page.total.unwrap_or(0)
+    );
 
     // Query executed actions only
     info!("\n→ Querying only EXECUTED actions...");
@@ -282,7 +285,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ..Default::default()
     };
     let executed_page = audit.query(&executed_query).await?;
-    info!("  Executed actions: {}", executed_page.total);
+    info!("  Executed actions: {}", executed_page.total.unwrap_or(0));
 
     // =========================================================================
     // DEMO 5: Throughput with Audit
@@ -330,7 +333,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ..Default::default()
     };
     let bulk_page = audit.query(&bulk_query).await?;
-    info!("  Audit records created: {}", bulk_page.total);
+    info!("  Audit records created: {}", bulk_page.total.unwrap_or(0));
 
     // =========================================================================
     // Summary
@@ -361,7 +364,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .filter(|r| r.outcome == "deduplicated")
         .count();
 
-    info!("  Total audit records: {}", all_page.total);
+    info!("  Total audit records: {}", all_page.total.unwrap_or(0));
     info!("    - Executed: {}", executed_count);
     info!("    - Suppressed: {}", suppressed_count);
     info!("    - Deduplicated: {}", deduplicated_count);

--- a/crates/simulation/examples/replay_simulation.rs
+++ b/crates/simulation/examples/replay_simulation.rs
@@ -103,14 +103,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let page = match client.query_audit(&audit_query).await {
         Ok(page) => {
-            if page.total == 0 {
+            if page.total.unwrap_or(0) == 0 && page.records.is_empty() {
                 info!("  No audit records found. Audit may not be enabled.");
                 info!("  Use a config with [audit] section:");
                 info!("    cargo run -p acteon-server -- -c examples/postgres.toml\n");
                 return Ok(());
             }
 
-            info!("  Found {} audit records:", page.total);
+            info!("  Found {} audit records:", page.total.unwrap_or(0));
             for record in &page.records {
                 info!(
                     "    {} | {} | {} | {}",
@@ -214,7 +214,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let original_count = dispatched_ids.len();
             info!(
                 "  Total audit records now: {} (was {original_count} originals)",
-                page.total
+                page.total.unwrap_or(0)
             );
             info!("  Replayed actions have 'replayed_from' in their metadata.\n");
         }

--- a/crates/simulation/examples/retry_chain_simulation.rs
+++ b/crates/simulation/examples/retry_chain_simulation.rs
@@ -278,7 +278,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             ..Default::default()
         })
         .await?;
-    info!("\n  Audit records: {}", page.total);
+    info!("\n  Audit records: {}", page.total.unwrap_or(0));
     for rec in &page.records {
         info!("    [{:>22}] {}", rec.outcome, rec.action_type);
     }

--- a/docs/book/features/audit-trail.md
+++ b/docs/book/features/audit-trail.md
@@ -114,7 +114,59 @@ curl "http://localhost:8080/v1/audit?from=2026-01-01T00:00:00Z&to=2026-01-31T23:
 | `from` | datetime | Start of date range |
 | `to` | datetime | End of date range |
 | `limit` | u32 | Max records (default 50, max 1000) |
-| `offset` | u32 | Pagination offset |
+| `offset` | u32 | Legacy pagination offset — prefer `cursor` for deep pagination |
+| `cursor` | string | Opaque pagination cursor returned by the previous page (see below) |
+
+### Cursor Pagination
+
+Audit pages return an opaque `next_cursor` string when more records are
+available. Pass it back as `cursor` on the next request to fetch the
+following page:
+
+```bash
+# First page
+curl "http://localhost:8080/v1/audit?tenant=tenant-1&limit=50"
+# -> { "records": [...], "limit": 50, "offset": 0, "total": ..., "next_cursor": "eyJ2..." }
+
+# Resume from the cursor — no offset scan, no count query
+curl "http://localhost:8080/v1/audit?tenant=tenant-1&limit=50&cursor=eyJ2..."
+# -> { "records": [...], "limit": 50, "offset": 0, "next_cursor": "eyJ3..." }
+```
+
+Cursor pagination is **O(limit)** on every backend — Postgres and
+ClickHouse use keyset `WHERE (dispatched_at, id) < (...)` predicates,
+Elasticsearch uses `search_after`, DynamoDB uses native
+`ExclusiveStartKey`, and the in-memory store keyset-filters after sort.
+Every backend over-fetches one row internally so the response signals
+"definitely no more" the moment the page's `next_cursor` is omitted —
+you never round-trip an empty trailing page.
+
+#### `total` is best-effort
+
+The `total` field is **not guaranteed**. It is `null` whenever you
+paginate with a cursor (computing it per page would defeat the
+purpose), and DynamoDB always returns `null` even on the first page
+because its count query previously walked every matching item. Use it
+as a UI hint, never as control flow.
+
+| Backend       | First page (no cursor) | Cursor pages |
+|---------------|------------------------|--------------|
+| Memory        | populated              | `null`       |
+| PostgreSQL    | populated              | `null`       |
+| ClickHouse    | populated              | `null`       |
+| Elasticsearch | populated              | `null`       |
+| DynamoDB      | `null`                 | `null`       |
+
+#### Detecting the last page
+
+**Always rely on `next_cursor`.** When `next_cursor` is missing or
+`null`, the stream is exhausted. Do **not** branch on
+`records.length < limit` — DynamoDB and Elasticsearch filter
+expressions can return short-but-not-final pages, and you will lose
+data.
+
+Cursors are opaque — round-trip them verbatim. The encoding is an
+implementation detail and may change between releases.
 
 ### Get Record by Action ID
 
@@ -143,9 +195,13 @@ curl "http://localhost:8080/v1/audit/{action_id}"
   ],
   "total": 150,
   "limit": 50,
-  "offset": 0
+  "offset": 0,
+  "next_cursor": "eyJ2IjoxLCJrIjoidHMiLCJ0IjoxNzAwMDAwMDAwMDAwLCJpIjoiYXVkLTEyMyJ9"
 }
 ```
+
+`total` is omitted on cursor-driven follow-up pages. `next_cursor` is
+omitted when the page is the last.
 
 ## Audit Backends
 
@@ -176,7 +232,20 @@ See [Audit Backends](../backends/audit-backends.md) for detailed backend compari
         ..Default::default()
     }).await?;
 
-    println!("Found {} records", page.total);
+    println!("Found {} records", page.records.len());
+
+    // Walk every page with a cursor — O(limit) per request.
+    let mut cursor = page.next_cursor;
+    while let Some(c) = cursor {
+        let next = client.query_audit(&AuditQuery {
+            tenant: Some("tenant-1".into()),
+            limit: Some(100),
+            cursor: Some(c),
+            ..Default::default()
+        }).await?;
+        // ... process next.records ...
+        cursor = next.next_cursor;
+    }
 
     // Get specific record
     if let Some(record) = client.get_audit_record("action-id").await? {

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -117,9 +117,19 @@ export interface AuditRecord {
 
 export interface AuditPage {
   records: AuditRecord[]
-  total: number
+  /**
+   * Total matching records, when the backend computed it. Cursor
+   * pagination skips the count, so this is `undefined` after the first
+   * cursor-driven request.
+   */
+  total?: number
   limit: number
   offset: number
+  /**
+   * Opaque cursor pointing at the next page, or `undefined` when this
+   * page is the last. Pass into `AuditQuery.cursor` to resume.
+   */
+  next_cursor?: string
 }
 
 export interface AuditQuery {
@@ -135,7 +145,13 @@ export interface AuditQuery {
   from?: string
   to?: string
   limit?: number
+  /**
+   * Legacy offset pagination — prefer `cursor` for deep pagination.
+   * Large offsets degrade linearly on every backend.
+   */
   offset?: number
+  /** Opaque pagination cursor returned by the previous page. */
+  cursor?: string
 }
 
 export interface ReplayResult {


### PR DESCRIPTION
## Summary

- Replace offset-based audit pagination with opaque keyset cursors so deep pagination is **O(limit)** on every backend (Memory keyset, Postgres/ClickHouse `WHERE (dispatched_at, id) < (...)`, Elasticsearch `search_after`, DynamoDB native `ExclusiveStartKey`).
- Skip the per-query COUNT scan on the cursor path — `AuditPage::total` is now `Option<u64>` and best-effort. `next_cursor` is the **only** authoritative end-of-stream signal; backends over-fetch `limit + 1` so the final page never round-trips an empty trailing cursor.
- Fix `InMemoryAnalytics::query_analytics` + `rule_coverage` and `HashChainAuditStore::verify_chain` to walk audit history via cursor — eliminating the O(N²) "ghost offset" crawl that previously negated cursor benefits for analytics workloads.
- CLI: `acteon audit query` gains `--cursor <opaque>` and `--all` for cursor-driven walks.
- Polyglot SDKs (Rust, Python, Node.js, Go, Java), MCP server, and React UI all carry `cursor` / `next_cursor`.
- **Bonus fix:** persist action signing fields (`signature`, `signer_id`, `canonical_hash`) that were silently dropped by Postgres, ClickHouse, and DynamoDB stores. Idempotent column migrations + row-conversion round-trip.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --no-deps -- -D warnings`
- [x] `cargo test --workspace --lib --bins --tests` — all green
- [x] `cargo test -p acteon-aws --features full --lib --tests` — 87 passed
- [x] `cd ui && npm run lint && npm run build`
- [x] New memory backend tests cover cursor walk and first-page-without-cursor
- [x] `analytics::tests::rule_coverage_pages_through_large_result_sets` (1500 records) exercises the cursor-driven analytics loop end-to-end
- [ ] Manual smoke on a populated Postgres-backed deployment (cursor-paged `/v1/audit` walk + signing field persistence) — recommended before tagging a release

## Notes for reviewers

- `AuditPage::total` is `Option<u64>` — see the `AuditPage` rustdoc and `docs/book/features/audit-trail.md` for the per-backend matrix. Existing offset callers still get a populated `total` on the first page (except DynamoDB, where the count was the bottleneck).
- DynamoDB cursor uses `ExclusiveStartKey` shape derived from the opaque cursor; ns_tenant comes from the query, sort key + id come from the cursor.
- Action signing fields persistence is bundled in this PR rather than ticketed separately because the bug shipped in the same release window as #95–#98 and silently breaks compliance posture on Postgres/ClickHouse/DynamoDB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)