### PR TITLE
feat(metrics): silenced + muted counters end-to-end

### DIFF
--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -653,6 +653,7 @@ impl Gateway {
         //     verdict. This preserves the rule verdict in the audit record
         //     while preventing actual provider delivery.
         if let Some(silence_id) = self.check_silence(&action) {
+            self.metrics.increment_silenced();
             let outcome = ActionOutcome::Silenced {
                 silence_id,
                 matched_rule: matched_rule_name(&verdict),
@@ -713,6 +714,7 @@ impl Gateway {
             Utc::now(),
         );
         if let Some(interval_name) = ti_decision.interval_name() {
+            self.metrics.increment_muted();
             let outcome = ActionOutcome::Muted {
                 interval: interval_name.to_owned(),
                 reason: ti_decision.reason().to_owned(),

--- a/crates/gateway/src/metrics.rs
+++ b/crates/gateway/src/metrics.rs
@@ -20,6 +20,11 @@ pub struct GatewayMetrics {
     pub deduplicated: AtomicU64,
     /// Actions that were suppressed by a rule.
     pub suppressed: AtomicU64,
+    /// Actions that were silenced by a matching silence (label-pattern mute).
+    pub silenced: AtomicU64,
+    /// Actions that were muted by a referenced time interval (mute or
+    /// inactive active window).
+    pub muted: AtomicU64,
     /// Actions that were rerouted to a different provider.
     pub rerouted: AtomicU64,
     /// Actions that were throttled.
@@ -95,6 +100,16 @@ impl GatewayMetrics {
     /// Increment the suppressed counter.
     pub fn increment_suppressed(&self) {
         self.suppressed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the silenced counter.
+    pub fn increment_silenced(&self) {
+        self.silenced.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the muted counter.
+    pub fn increment_muted(&self) {
+        self.muted.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Increment the rerouted counter.
@@ -250,6 +265,8 @@ impl GatewayMetrics {
             executed: self.executed.load(Ordering::Relaxed),
             deduplicated: self.deduplicated.load(Ordering::Relaxed),
             suppressed: self.suppressed.load(Ordering::Relaxed),
+            silenced: self.silenced.load(Ordering::Relaxed),
+            muted: self.muted.load(Ordering::Relaxed),
             rerouted: self.rerouted.load(Ordering::Relaxed),
             throttled: self.throttled.load(Ordering::Relaxed),
             failed: self.failed.load(Ordering::Relaxed),
@@ -292,6 +309,10 @@ pub struct MetricsSnapshot {
     pub deduplicated: u64,
     /// Actions that were suppressed by a rule.
     pub suppressed: u64,
+    /// Actions that were silenced by a matching silence (label-pattern mute).
+    pub silenced: u64,
+    /// Actions that were muted by a referenced time interval.
+    pub muted: u64,
     /// Actions that were rerouted to a different provider.
     pub rerouted: u64,
     /// Actions that were throttled.
@@ -670,6 +691,8 @@ mod tests {
         assert_eq!(snap.executed, 0);
         assert_eq!(snap.deduplicated, 0);
         assert_eq!(snap.suppressed, 0);
+        assert_eq!(snap.silenced, 0);
+        assert_eq!(snap.muted, 0);
         assert_eq!(snap.rerouted, 0);
         assert_eq!(snap.throttled, 0);
         assert_eq!(snap.failed, 0);
@@ -707,6 +730,8 @@ mod tests {
         m.increment_executed();
         m.increment_deduplicated();
         m.increment_suppressed();
+        m.increment_silenced();
+        m.increment_muted();
         m.increment_rerouted();
         m.increment_throttled();
         m.increment_failed();
@@ -740,6 +765,8 @@ mod tests {
         assert_eq!(snap.executed, 1);
         assert_eq!(snap.deduplicated, 1);
         assert_eq!(snap.suppressed, 1);
+        assert_eq!(snap.silenced, 1);
+        assert_eq!(snap.muted, 1);
         assert_eq!(snap.rerouted, 1);
         assert_eq!(snap.throttled, 1);
         assert_eq!(snap.failed, 1);

--- a/crates/server/src/api/health.rs
+++ b/crates/server/src/api/health.rs
@@ -27,6 +27,8 @@ fn build_metrics_response(
         executed: snap.executed,
         deduplicated: snap.deduplicated,
         suppressed: snap.suppressed,
+        silenced: snap.silenced,
+        muted: snap.muted,
         rerouted: snap.rerouted,
         throttled: snap.throttled,
         failed: snap.failed,

--- a/crates/server/src/api/prometheus.rs
+++ b/crates/server/src/api/prometheus.rs
@@ -149,6 +149,18 @@ fn render_snapshot(snap: &MetricsSnapshot) -> String {
     );
     write_counter(
         &mut buf,
+        "acteon_actions_silenced_total",
+        "Actions silenced by a matching silence (label-pattern mute).",
+        snap.silenced,
+    );
+    write_counter(
+        &mut buf,
+        "acteon_actions_muted_total",
+        "Actions muted by a referenced time interval (mute or inactive active window).",
+        snap.muted,
+    );
+    write_counter(
+        &mut buf,
         "acteon_actions_rerouted_total",
         "Actions rerouted to a different provider.",
         snap.rerouted,
@@ -507,6 +519,8 @@ mod tests {
             executed: 0,
             deduplicated: 0,
             suppressed: 0,
+            silenced: 0,
+            muted: 0,
             rerouted: 0,
             throttled: 0,
             failed: 0,
@@ -543,6 +557,8 @@ mod tests {
             executed: 80,
             deduplicated: 5,
             suppressed: 3,
+            silenced: 8,
+            muted: 6,
             rerouted: 2,
             throttled: 1,
             failed: 4,
@@ -738,12 +754,14 @@ mod tests {
 
     // -- render_snapshot tests --
 
-    /// All 31 gateway counter metric names that must appear in the output.
+    /// All 33 gateway counter metric names that must appear in the output.
     const EXPECTED_COUNTER_METRICS: &[&str] = &[
         "acteon_actions_dispatched_total",
         "acteon_actions_executed_total",
         "acteon_actions_deduplicated_total",
         "acteon_actions_suppressed_total",
+        "acteon_actions_silenced_total",
+        "acteon_actions_muted_total",
         "acteon_actions_rerouted_total",
         "acteon_actions_throttled_total",
         "acteon_actions_failed_total",
@@ -774,7 +792,7 @@ mod tests {
     ];
 
     #[test]
-    fn render_snapshot_contains_all_31_counter_metrics() {
+    fn render_snapshot_contains_all_33_counter_metrics() {
         let snap = zero_snapshot();
         let output = render_snapshot(&snap);
 
@@ -825,6 +843,8 @@ mod tests {
         assert!(output.contains("acteon_actions_executed_total 80"));
         assert!(output.contains("acteon_actions_deduplicated_total 5"));
         assert!(output.contains("acteon_actions_suppressed_total 3"));
+        assert!(output.contains("acteon_actions_silenced_total 8"));
+        assert!(output.contains("acteon_actions_muted_total 6"));
         assert!(output.contains("acteon_actions_rerouted_total 2"));
         assert!(output.contains("acteon_actions_throttled_total 1"));
         assert!(output.contains("acteon_actions_failed_total 4"));
@@ -1069,7 +1089,7 @@ mod tests {
     // -- Full render (snapshot + provider) integration test --
 
     #[test]
-    fn full_render_snapshot_plus_providers_all_37_metrics() {
+    fn full_render_snapshot_plus_providers_all_metric_families() {
         let snap = nonzero_snapshot();
         let mut output = render_snapshot(&snap);
 
@@ -1077,7 +1097,7 @@ mod tests {
         providers.insert("email".to_string(), sample_provider_stats());
         render_provider_metrics(&mut output, &providers);
 
-        // 31 counter metrics from the snapshot
+        // 33 counter metrics from the snapshot
         for metric in EXPECTED_COUNTER_METRICS {
             assert!(output.contains(metric), "Missing snapshot metric: {metric}");
         }
@@ -1087,16 +1107,16 @@ mod tests {
             assert!(output.contains(name), "Missing provider metric: {name}");
         }
 
-        // Total: 31 + 8 = 39 unique metric families
+        // Total: 33 + 8 = 41 unique metric families
         let type_lines: Vec<&str> = output
             .lines()
             .filter(|l| l.starts_with("# TYPE "))
             .collect();
-        assert_eq!(type_lines.len(), 39, "Expected 39 TYPE declarations");
+        assert_eq!(type_lines.len(), 41, "Expected 41 TYPE declarations");
     }
 
     #[test]
-    fn full_render_no_providers_has_31_type_lines() {
+    fn full_render_no_providers_has_33_type_lines() {
         let snap = zero_snapshot();
         let mut output = render_snapshot(&snap);
         let empty: HashMap<String, ProviderStatsSnapshot> = HashMap::new();
@@ -1108,8 +1128,8 @@ mod tests {
             .collect();
         assert_eq!(
             type_lines.len(),
-            31,
-            "Expected 31 TYPE declarations without providers"
+            33,
+            "Expected 33 TYPE declarations without providers"
         );
     }
 }

--- a/crates/server/src/api/schemas.rs
+++ b/crates/server/src/api/schemas.rs
@@ -26,6 +26,15 @@ pub struct MetricsResponse {
     /// Actions suppressed by rules.
     #[schema(example = 3)]
     pub suppressed: u64,
+    /// Actions silenced by a matching silence (label-pattern mute).
+    #[schema(example = 0)]
+    #[serde(default)]
+    pub silenced: u64,
+    /// Actions muted by a referenced time interval (`mute_time_intervals`
+    /// matching, or `active_time_intervals` not currently active).
+    #[schema(example = 0)]
+    #[serde(default)]
+    pub muted: u64,
     /// Actions rerouted to another provider.
     #[schema(example = 2)]
     pub rerouted: u64,

--- a/deploy/grafana/dashboards/acteon-overview.json
+++ b/deploy/grafana/dashboards/acteon-overview.json
@@ -89,6 +89,16 @@
           "refId": "B"
         },
         {
+          "expr": "rate(acteon_actions_silenced_total[5m])",
+          "legendFormat": "silenced",
+          "refId": "B2"
+        },
+        {
+          "expr": "rate(acteon_actions_muted_total[5m])",
+          "legendFormat": "muted (time interval)",
+          "refId": "B3"
+        },
+        {
           "expr": "rate(acteon_actions_deduplicated_total[5m])",
           "legendFormat": "deduplicated",
           "refId": "C"
@@ -133,6 +143,8 @@
         { "expr": "acteon_actions_dispatched_total", "legendFormat": "Dispatched", "refId": "A" },
         { "expr": "acteon_actions_executed_total", "legendFormat": "Executed", "refId": "B" },
         { "expr": "acteon_actions_suppressed_total", "legendFormat": "Suppressed", "refId": "C" },
+        { "expr": "acteon_actions_silenced_total", "legendFormat": "Silenced", "refId": "C2" },
+        { "expr": "acteon_actions_muted_total", "legendFormat": "Muted", "refId": "C3" },
         { "expr": "acteon_actions_deduplicated_total", "legendFormat": "Deduplicated", "refId": "D" },
         { "expr": "acteon_actions_rerouted_total", "legendFormat": "Rerouted", "refId": "E" },
         { "expr": "acteon_actions_throttled_total", "legendFormat": "Throttled", "refId": "F" },

--- a/ui/src/pages/Analytics.tsx
+++ b/ui/src/pages/Analytics.tsx
@@ -30,6 +30,8 @@ const INTERVAL_OPTIONS: { value: AnalyticsInterval; label: string }[] = [
 const OUTCOME_COLORS: Record<string, string> = {
   executed: '#22c55e',
   suppressed: '#f59e0b',
+  silenced: '#06b6d4',
+  muted: '#a855f7',
   deduplicated: '#3b82f6',
   rerouted: '#8b5cf6',
   throttled: '#f97316',

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -66,6 +66,8 @@ export function Dashboard() {
                 { key: 'executed', color: '#10B981', label: 'Executed' },
                 { key: 'failed', color: '#EF4444', label: 'Failed' },
                 { key: 'suppressed', color: '#F59E0B', label: 'Suppressed' },
+                { key: 'silenced', color: '#06B6D4', label: 'Silenced' },
+                { key: 'muted', color: '#A855F7', label: 'Muted' },
                 { key: 'deduplicated', color: '#64647A', label: 'Deduplicated' },
               ]}
             />
@@ -121,6 +123,8 @@ function buildStatCards(m: MetricsResponse) {
     { label: 'Failed', value: m.failed, link: '/audit?outcome=Failed' },
     { label: 'Deduplicated', value: m.deduplicated },
     { label: 'Suppressed', value: m.suppressed },
+    { label: 'Silenced', value: m.silenced ?? 0, link: '/silences' },
+    { label: 'Muted', value: m.muted ?? 0, link: '/time-intervals' },
     { label: 'Pending Approval', value: m.pending_approval ?? 0, link: '/approvals' },
     { label: 'Circuit Open', value: m.circuit_open ?? 0, link: '/circuit-breakers' },
     { label: 'Scheduled', value: m.scheduled ?? 0, link: '/scheduled' },

--- a/ui/src/stores/events.ts
+++ b/ui/src/stores/events.ts
@@ -7,6 +7,8 @@ export type MetricsPoint = Record<string, unknown> & {
   executed: number
   failed: number
   suppressed: number
+  silenced: number
+  muted: number
   deduplicated: number
 }
 
@@ -51,6 +53,8 @@ export const useEventStore = create<EventState>((set) => ({
       executed: m.executed,
       failed: m.failed,
       suppressed: m.suppressed,
+      silenced: m.silenced ?? 0,
+      muted: m.muted ?? 0,
       deduplicated: m.deduplicated,
     }
     return {

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -4,6 +4,8 @@ export interface MetricsResponse {
   executed: number
   deduplicated: number
   suppressed: number
+  silenced?: number
+  muted?: number
   rerouted: number
   throttled: number
   failed: number


### PR DESCRIPTION
## Summary
The `Silenced` and `Muted` dispatch outcomes existed in code (audit records, stream events, the audit query string filters) but were invisible to operators on the observability surfaces — gateway counters, the JSON/Prometheus metrics endpoints, the UI Dashboard, the Analytics legend, and the Grafana overview dashboard all skipped them. An operator who silenced a noisy alert or scoped a rule to a `business-hours` time interval would see traffic disappear with no on-dashboard signal.

This PR plumbs the two outcomes through every observability layer:

- **Gateway** (\`crates/gateway/src/metrics.rs\`): new \`silenced\` and \`muted\` \`AtomicU64\` counters + \`MetricsSnapshot\` fields + \`increment_silenced()\` / \`increment_muted()\`. The dispatch path's silence and time-interval branches now bump them before short-circuiting.
- **HTTP API** (\`crates/server/src/api/{schemas,health,prometheus}.rs\`): new \`silenced\` / \`muted\` fields on \`MetricsResponse\` with \`#[serde(default)]\` for old clients; new \`acteon_actions_silenced_total\` / \`acteon_actions_muted_total\` Prometheus counters; all counter-name and TYPE-line counts in the prometheus tests updated (33 counter metrics, 41 families with providers).
- **UI** (\`ui/src/{types,stores/events,pages/{Dashboard,Analytics}}\`): \`MetricsResponse\` gets the optional fields, the Dashboard adds Silenced/Muted stat cards (linking to /silences and /time-intervals respectively) plus chart series, the Analytics legend gets matching colors, and the in-memory metrics history carries both counters.
- **Grafana** (\`deploy/grafana/dashboards/acteon-overview.json\`): Silenced and Muted lines added to the \"Action Outcomes\" stacked time-series and the \"Totals\" stat panel.

## Test plan
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --no-deps -- -D warnings\`
- [x] \`cargo test --workspace --lib --bins --tests\` — gateway metrics test pinned, prometheus test counts updated, no failures
- [x] \`(cd ui && npm run lint && npm run build)\`
- [x] JSON validity check on the Grafana dashboard
- [ ] Manual smoke: dispatch a silenced action and a muted action, check \`/metrics\`, \`/metrics/prometheus\`, and the Dashboard reflect the new counters