### PR TITLE
fix(simulation): patch pre-existing example rot surfaced by --all-targets

### DIFF
--- a/crates/simulation/examples/adversarial_swarm_simulation.rs
+++ b/crates/simulation/examples/adversarial_swarm_simulation.rs
@@ -103,7 +103,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "swarm",
             "project-alpha",
             "primary-swarm",
-            action_type,
+            *action_type,
             payload.clone(),
         );
 
@@ -183,7 +183,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "swarm",
             "project-alpha",
             "adversarial-reviewer",
-            action_type,
+            *action_type,
             payload.clone(),
         );
 
@@ -265,7 +265,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "swarm",
             "project-alpha",
             "primary-swarm",
-            action_type,
+            *action_type,
             payload.clone(),
         );
 

--- a/crates/simulation/examples/analytics_simulation.rs
+++ b/crates/simulation/examples/analytics_simulation.rs
@@ -55,6 +55,7 @@ fn make_record(
         attachment_metadata: Vec::new(),
         signature: None,
         signer_id: None,
+        canonical_hash: None,
     }
 }
 

--- a/crates/simulation/examples/grouping_simulation.rs
+++ b/crates/simulation/examples/grouping_simulation.rs
@@ -50,7 +50,10 @@ rules:
       max_group_size: 50
 "#;
 
-/// State machine for ticket lifecycle
+/// State machine for ticket lifecycle. Kept as reference material for
+/// readers comparing grouping against state-machine-based lifecycle
+/// tracking — the example doesn't actually wire it in.
+#[allow(dead_code)]
 const TICKET_STATE_MACHINE_RULE: &str = r#"
 rules:
   - name: ticket-lifecycle

--- a/crates/simulation/examples/mixed_backends_simulation.rs
+++ b/crates/simulation/examples/mixed_backends_simulation.rs
@@ -1,3 +1,15 @@
+// This example is only meaningful when at least one backend feature
+// (`redis`, `postgres`, or `clickhouse`) is enabled. Without any, the
+// `match scenario` arms all resolve to the help-and-return fallback,
+// which makes `config`/`state`/`lock`/`audit` appear unreachable to
+// the compiler. Silence the cascade of unreachable + unused warnings
+// in that degenerate case without hiding real bugs in the feature-
+// enabled builds.
+#![cfg_attr(
+    not(any(feature = "redis", feature = "postgres", feature = "clickhouse")),
+    allow(unused_variables, unreachable_code, unreachable_patterns, dead_code)
+)]
+
 //! Demonstration of Acteon with mixed backends for state and audit.
 //!
 //! This example shows realistic production configurations where you might want:

--- a/crates/simulation/examples/payload_encryption_simulation.rs
+++ b/crates/simulation/examples/payload_encryption_simulation.rs
@@ -211,6 +211,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         attachment_metadata: Vec::new(),
         signature: None,
         signer_id: None,
+        canonical_hash: None,
     };
 
     encrypting_audit.record(record).await?;
@@ -269,6 +270,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         attachment_metadata: Vec::new(),
         signature: None,
         signer_id: None,
+        canonical_hash: None,
     };
     encrypting_audit.record(no_payload).await?;
     let fetched_none = encrypting_audit
@@ -309,6 +311,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         attachment_metadata: Vec::new(),
         signature: None,
         signer_id: None,
+        canonical_hash: None,
     };
     // Insert directly into inner store (bypass encryption).
     inner_audit.record(plain_record).await?;
@@ -491,7 +494,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .add_to_group(
             &group_action1,
             &["action_type".to_string()],
-            300,
+            300,  // group_wait_seconds
+            300,  // group_interval_seconds
+            None, // repeat_interval_seconds — ephemeral
+            100,  // max_group_size
             &state_store,
             Some(&group_enc),
         )
@@ -503,6 +509,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             &group_action2,
             &["action_type".to_string()],
             300,
+            300,
+            None,
+            100,
             &state_store,
             Some(&group_enc),
         )

--- a/crates/simulation/examples/polyglot_client_simulation.rs
+++ b/crates/simulation/examples/polyglot_client_simulation.rs
@@ -70,6 +70,9 @@ impl TestServer {
             config: acteon_server::config::ConfigSnapshot::default(),
             ui_path: None,
             ui_enabled: false,
+            cors_allowed_origins: Vec::new(),
+            signature_verifier: None,
+            replay_protection: None,
         };
 
         // Build router

--- a/crates/simulation/examples/rule_coverage_simulation.rs
+++ b/crates/simulation/examples/rule_coverage_simulation.rs
@@ -64,6 +64,7 @@ fn make_record(
         attachment_metadata: Vec::new(),
         signature: None,
         signer_id: None,
+        canonical_hash: None,
     }
 }
 


### PR DESCRIPTION
## Summary
`cargo check --all-targets` was broken on main before this PR because the standard pre-commit (`cargo test --workspace --lib --bins --tests`) skips `--examples`. Six simulation examples had accumulated drift from earlier merged PRs — the broken builds only surfaced during PR #102's post-merge review. This PR brings every example back to clean compilation so future enum-variant and API-signature drift surfaces immediately.

## What's fixed

| File | Issue |
|---|---|
| `analytics_simulation.rs` | Missing `canonical_hash: None` on `AuditRecord` (action-signing drift) |
| `rule_coverage_simulation.rs` | Same |
| `payload_encryption_simulation.rs` | Same × 3 sites, plus `GroupManager::add_to_group` signature grew from 5 → 8 params (`group_interval_seconds`, `repeat_interval_seconds`, `max_group_size`). Supplied sensible defaults (300s / None / 100). |
| `polyglot_client_simulation.rs` | `AppState` grew three fields (`cors_allowed_origins`, `signature_verifier`, `replay_protection`) during signing + CORS work. Added the defaults. |
| `adversarial_swarm_simulation.rs` | Three `Action::new` calls passed `&&str` after an iteration binding was changed. Derefed to `*action_type`. |
| `grouping_simulation.rs` | `TICKET_STATE_MACHINE_RULE` is reference material kept alongside the grouping rules but never wired in. Annotated `#[allow(dead_code)]` so the warning stops re-triggering. |
| `mixed_backends_simulation.rs` | Only meaningful with at least one of `redis`/`postgres`/`clickhouse`. Without any, all match arms are `#[cfg]`-gated and the fallback returns early, producing cascading `unreachable_code` + `unused_variables` + `dead_code` warnings. Added a file-level `cfg_attr` allow that only fires in the no-feature case — feature-enabled builds still get real-bug detection. |

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --no-deps -- -D warnings`
- [x] `cargo test --workspace --lib --bins --tests` (52 test groups, no failures)
- [x] **`cargo check --all-targets`** — **zero errors, zero warnings** (previously 4 errors, 8 warnings)
- [x] `(cd ui && npm run lint && npm run build)`

## Follow-up

After this PR ships, I'd recommend either adding `cargo check --all-targets` to the project's pre-commit recipe in CLAUDE.md, or adding a dedicated CI job so future drift fails fast instead of accumulating for months.