### PR TITLE
chore(ui): split bundles via React.lazy + manualChunks

### DIFF
--- a/ui/e2e/event-stream.spec.ts
+++ b/ui/e2e/event-stream.spec.ts
@@ -17,17 +17,12 @@ test.describe('Event Stream', () => {
   })
 
   test('connection status indicator is visible', async ({ page }) => {
-    // The status text should be visible (connected, connecting, or disconnected)
-    const statuses = ['connected', 'connecting', 'disconnected']
-    const statusVisible = await Promise.any(
-      statuses.map(async (s) => {
-        const el = page.getByText(s, { exact: true })
-        return el.isVisible().then(v => v ? s : Promise.reject())
-      }),
-    ).catch(() => null)
-
-    // At least one status should be present
-    expect(statusVisible).not.toBeNull()
+    // The status text should be visible (connected, connecting, or
+    // disconnected). Use a retrying locator so the test tolerates the
+    // EventStream route being lazy-loaded — the assertion auto-retries
+    // until the page chunk arrives and the status chip renders.
+    const statusChip = page.getByText(/^(connected|connecting|disconnected)$/).first()
+    await expect(statusChip).toBeVisible({ timeout: 10_000 })
   })
 
   test('pause/resume button is present', async ({ page }) => {
@@ -46,9 +41,16 @@ test.describe('Event Stream', () => {
   })
 
   test('event type filter dropdown has options', async ({ page }) => {
+    // Wait for the lazy route chunk to render the filter select before
+    // counting options. `expect(locator).not.toHaveCount(0)` on the
+    // options locator auto-retries until the select is attached — so
+    // this works whether the page is eager or code-split.
     const select = page.locator('select').first()
+    await expect(select).toBeVisible({ timeout: 10_000 })
     const options = select.locator('option')
-    expect(await options.count()).toBeGreaterThan(1) // At least "All Types" + some event types
+    await expect(options).not.toHaveCount(0)
+    // At least "All Types" + at least one event type = more than one option.
+    expect(await options.count()).toBeGreaterThan(1)
   })
 
   test('empty stream shows waiting message', async ({ page }) => {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,17 +8,11 @@
       "name": "ui",
       "version": "0.0.0",
       "dependencies": {
-        "@codemirror/basic-setup": "^0.20.0",
-        "@codemirror/lang-json": "^6.0.2",
-        "@codemirror/lang-yaml": "^6.1.2",
-        "@codemirror/state": "^6.5.4",
-        "@codemirror/view": "^6.39.13",
         "@tanstack/react-query": "^5.90.20",
         "@tanstack/react-table": "^8.21.3",
         "@xyflow/react": "^12.10.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "codemirror": "^6.0.2",
         "date-fns": "^4.1.0",
         "framer-motion": "^12.33.0",
         "lucide-react": "^0.563.0",
@@ -78,7 +72,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -328,300 +321,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@codemirror/autocomplete": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.20.3.tgz",
-      "integrity": "sha512-lYB+NPGP+LEzAudkWhLfMxhTrxtLILGl938w+RcFrGdrIc54A+UgmCoz+McE3IYRFp4xyQcL4uFJwo+93YdgHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^0.20.0",
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
-        "@lezer/common": "^0.16.0"
-      }
-    },
-    "node_modules/@codemirror/autocomplete/node_modules/@codemirror/state": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.1.tgz",
-      "integrity": "sha512-ms0tlV5A02OK0pFvTtSUGMLkoarzh1F8mr6jy1cD7ucSC2X/VLHtQCxfhdSEGqTYlQF2hoZtmLv+amqhdgbwjQ==",
-      "license": "MIT"
-    },
-    "node_modules/@codemirror/autocomplete/node_modules/@codemirror/view": {
-      "version": "0.20.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.7.tgz",
-      "integrity": "sha512-pqEPCb9QFTOtHgAH5XU/oVy9UR/Anj6r+tG5CRmkNVcqSKEPmBU05WtN/jxJCFZBXf6HumzWC9ydE4qstO3TxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@codemirror/basic-setup": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/basic-setup/-/basic-setup-0.20.0.tgz",
-      "integrity": "sha512-W/ERKMLErWkrVLyP5I8Yh8PXl4r+WFNkdYVSzkXYPQv2RMPSkWpr2BgggiSJ8AHF/q3GuApncDD8I4BZz65fyg==",
-      "deprecated": "In version 6.0, this package has been renamed to just 'codemirror'",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^0.20.0",
-        "@codemirror/commands": "^0.20.0",
-        "@codemirror/language": "^0.20.0",
-        "@codemirror/lint": "^0.20.0",
-        "@codemirror/search": "^0.20.0",
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0"
-      }
-    },
-    "node_modules/@codemirror/basic-setup/node_modules/@codemirror/state": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.1.tgz",
-      "integrity": "sha512-ms0tlV5A02OK0pFvTtSUGMLkoarzh1F8mr6jy1cD7ucSC2X/VLHtQCxfhdSEGqTYlQF2hoZtmLv+amqhdgbwjQ==",
-      "license": "MIT"
-    },
-    "node_modules/@codemirror/basic-setup/node_modules/@codemirror/view": {
-      "version": "0.20.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.7.tgz",
-      "integrity": "sha512-pqEPCb9QFTOtHgAH5XU/oVy9UR/Anj6r+tG5CRmkNVcqSKEPmBU05WtN/jxJCFZBXf6HumzWC9ydE4qstO3TxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@codemirror/commands": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.20.0.tgz",
-      "integrity": "sha512-v9L5NNVA+A9R6zaFvaTbxs30kc69F6BkOoiEbeFw4m4I0exmDEKBILN6mK+GksJtvTzGBxvhAPlVFTdQW8GB7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^0.20.0",
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
-        "@lezer/common": "^0.16.0"
-      }
-    },
-    "node_modules/@codemirror/commands/node_modules/@codemirror/state": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.1.tgz",
-      "integrity": "sha512-ms0tlV5A02OK0pFvTtSUGMLkoarzh1F8mr6jy1cD7ucSC2X/VLHtQCxfhdSEGqTYlQF2hoZtmLv+amqhdgbwjQ==",
-      "license": "MIT"
-    },
-    "node_modules/@codemirror/commands/node_modules/@codemirror/view": {
-      "version": "0.20.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.7.tgz",
-      "integrity": "sha512-pqEPCb9QFTOtHgAH5XU/oVy9UR/Anj6r+tG5CRmkNVcqSKEPmBU05WtN/jxJCFZBXf6HumzWC9ydE4qstO3TxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@codemirror/lang-json": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
-      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/json": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-json/node_modules/@codemirror/language": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.1.tgz",
-      "integrity": "sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.23.0",
-        "@lezer/common": "^1.5.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0",
-        "style-mod": "^4.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-json/node_modules/@lezer/common": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
-      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
-      "license": "MIT"
-    },
-    "node_modules/@codemirror/lang-yaml": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.2.tgz",
-      "integrity": "sha512-dxrfG8w5Ce/QbT7YID7mWZFKhdhsaTNOYjOkSIMt1qmC4VQnXSDSYVHHHn8k6kJUfIhtLo8t1JJgltlxWdsITw==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.2.0",
-        "@lezer/lr": "^1.0.0",
-        "@lezer/yaml": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-yaml/node_modules/@codemirror/autocomplete": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
-      "integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.17.0",
-        "@lezer/common": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-yaml/node_modules/@codemirror/language": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.1.tgz",
-      "integrity": "sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.23.0",
-        "@lezer/common": "^1.5.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0",
-        "style-mod": "^4.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-yaml/node_modules/@lezer/common": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
-      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
-      "license": "MIT"
-    },
-    "node_modules/@codemirror/language": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.20.2.tgz",
-      "integrity": "sha512-WB3Bnuusw0xhVvhBocieYKwJm04SOk5bPoOEYksVHKHcGHFOaYaw+eZVxR4gIqMMcGzOIUil0FsCmFk8yrhHpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
-        "@lezer/common": "^0.16.0",
-        "@lezer/highlight": "^0.16.0",
-        "@lezer/lr": "^0.16.0",
-        "style-mod": "^4.0.0"
-      }
-    },
-    "node_modules/@codemirror/language/node_modules/@codemirror/state": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.1.tgz",
-      "integrity": "sha512-ms0tlV5A02OK0pFvTtSUGMLkoarzh1F8mr6jy1cD7ucSC2X/VLHtQCxfhdSEGqTYlQF2hoZtmLv+amqhdgbwjQ==",
-      "license": "MIT"
-    },
-    "node_modules/@codemirror/language/node_modules/@codemirror/view": {
-      "version": "0.20.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.7.tgz",
-      "integrity": "sha512-pqEPCb9QFTOtHgAH5XU/oVy9UR/Anj6r+tG5CRmkNVcqSKEPmBU05WtN/jxJCFZBXf6HumzWC9ydE4qstO3TxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@codemirror/language/node_modules/@lezer/highlight": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-0.16.0.tgz",
-      "integrity": "sha512-iE5f4flHlJ1g1clOStvXNLbORJoiW4Kytso6ubfYzHnaNo/eo5SKhxs4wv/rtvwZQeZrK3we8S9SyA7OGOoRKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^0.16.0"
-      }
-    },
-    "node_modules/@codemirror/language/node_modules/@lezer/lr": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.3.tgz",
-      "integrity": "sha512-pau7um4eAw94BEuuShUIeQDTf3k4Wt6oIUOYxMmkZgDHdqtIcxWND4LRxi8nI9KuT4I1bXQv67BCapkxt7Ywqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^0.16.0"
-      }
-    },
-    "node_modules/@codemirror/lint": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.20.3.tgz",
-      "integrity": "sha512-06xUScbbspZ8mKoODQCEx6hz1bjaq9m8W8DxdycWARMiiX1wMtfCh/MoHpaL7ws/KUMwlsFFfp2qhm32oaCvVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.2",
-        "crelt": "^1.0.5"
-      }
-    },
-    "node_modules/@codemirror/lint/node_modules/@codemirror/state": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.1.tgz",
-      "integrity": "sha512-ms0tlV5A02OK0pFvTtSUGMLkoarzh1F8mr6jy1cD7ucSC2X/VLHtQCxfhdSEGqTYlQF2hoZtmLv+amqhdgbwjQ==",
-      "license": "MIT"
-    },
-    "node_modules/@codemirror/lint/node_modules/@codemirror/view": {
-      "version": "0.20.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.7.tgz",
-      "integrity": "sha512-pqEPCb9QFTOtHgAH5XU/oVy9UR/Anj6r+tG5CRmkNVcqSKEPmBU05WtN/jxJCFZBXf6HumzWC9ydE4qstO3TxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@codemirror/search": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.20.1.tgz",
-      "integrity": "sha512-ROe6gRboQU5E4z6GAkNa2kxhXqsGNbeLEisbvzbOeB7nuDYXUZ70vGIgmqPu0tB+1M3F9yWk6W8k2vrFpJaD4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
-        "crelt": "^1.0.5"
-      }
-    },
-    "node_modules/@codemirror/search/node_modules/@codemirror/state": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.1.tgz",
-      "integrity": "sha512-ms0tlV5A02OK0pFvTtSUGMLkoarzh1F8mr6jy1cD7ucSC2X/VLHtQCxfhdSEGqTYlQF2hoZtmLv+amqhdgbwjQ==",
-      "license": "MIT"
-    },
-    "node_modules/@codemirror/search/node_modules/@codemirror/view": {
-      "version": "0.20.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.7.tgz",
-      "integrity": "sha512-pqEPCb9QFTOtHgAH5XU/oVy9UR/Anj6r+tG5CRmkNVcqSKEPmBU05WtN/jxJCFZBXf6HumzWC9ydE4qstO3TxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@codemirror/state": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
-      "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
-      "license": "MIT",
-      "dependencies": {
-        "@marijn/find-cluster-break": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/view": {
-      "version": "6.39.13",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.13.tgz",
-      "integrity": "sha512-QBO8ZsgJLCbI28KdY0/oDy5NQLqOQVZCozBknxc2/7L98V+TVYFHnfaCsnGh1U+alpd2LOkStVwYY7nW2R1xbw==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/state": "^6.5.0",
-        "crelt": "^1.0.6",
-        "style-mod": "^4.1.0",
-        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1324,82 +1023,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@lezer/common": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.1.tgz",
-      "integrity": "sha512-qPmG7YTZ6lATyTOAWf8vXE+iRrt1NJd4cm2nJHK+v7X9TsOF6+HtuU/ctaZy2RCrluxDb89hI6KWQ5LfQGQWuA==",
-      "license": "MIT"
-    },
-    "node_modules/@lezer/highlight": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
-      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.3.0"
-      }
-    },
-    "node_modules/@lezer/highlight/node_modules/@lezer/common": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
-      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
-      "license": "MIT"
-    },
-    "node_modules/@lezer/json": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
-      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/json/node_modules/@lezer/common": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
-      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
-      "license": "MIT"
-    },
-    "node_modules/@lezer/lr": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
-      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/lr/node_modules/@lezer/common": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
-      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
-      "license": "MIT"
-    },
-    "node_modules/@lezer/yaml": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
-      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.4.0"
-      }
-    },
-    "node_modules/@lezer/yaml/node_modules/@lezer/common": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
-      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
-      "license": "MIT"
-    },
-    "node_modules/@marijn/find-cluster-break": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
-      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
-      "license": "MIT"
     },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
@@ -2756,7 +2379,6 @@
       "integrity": "sha512-68e+T28EbdmLSTkPgs3+UacC6rzmqrcWFPQs1C8mwJhI/r5Uxr0yEuQotczNRROd1gq30NGxee+fo0rSIxpyAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2767,7 +2389,6 @@
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2778,7 +2399,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2834,7 +2454,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -3146,7 +2765,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3264,7 +2882,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3358,87 +2975,6 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/codemirror": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
-      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/commands": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/lint": "^6.0.0",
-        "@codemirror/search": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0"
-      }
-    },
-    "node_modules/codemirror/node_modules/@codemirror/autocomplete": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
-      "integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.17.0",
-        "@lezer/common": "^1.0.0"
-      }
-    },
-    "node_modules/codemirror/node_modules/@codemirror/commands": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
-      "integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.4.0",
-        "@codemirror/view": "^6.27.0",
-        "@lezer/common": "^1.1.0"
-      }
-    },
-    "node_modules/codemirror/node_modules/@codemirror/language": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.1.tgz",
-      "integrity": "sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.23.0",
-        "@lezer/common": "^1.5.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0",
-        "style-mod": "^4.0.0"
-      }
-    },
-    "node_modules/codemirror/node_modules/@codemirror/lint": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.3.tgz",
-      "integrity": "sha512-y3YkYhdnhjDBAe0VIA0c4wVoFOvnp8CnAvfLqi0TqotIv92wIlAAP7HELOpLBsKwjAX6W92rSflA6an/2zBvXw==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.35.0",
-        "crelt": "^1.0.5"
-      }
-    },
-    "node_modules/codemirror/node_modules/@codemirror/search": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
-      "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.37.0",
-        "crelt": "^1.0.5"
-      }
-    },
-    "node_modules/codemirror/node_modules/@lezer/common": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
-      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
-      "license": "MIT"
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3485,12 +3021,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3617,7 +3147,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3861,7 +3390,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4272,7 +3800,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -4922,7 +4449,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5031,7 +4557,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5041,7 +4566,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5061,7 +4585,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5231,8 +4754,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -5372,12 +4894,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/style-mod": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
-      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
-      "license": "MIT"
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5483,7 +4999,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5644,7 +5159,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5714,12 +5228,6 @@
         }
       }
     },
-    "node_modules/w3c-keyname": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-      "license": "MIT"
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5772,7 +5280,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,17 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@codemirror/basic-setup": "^0.20.0",
-    "@codemirror/lang-json": "^6.0.2",
-    "@codemirror/lang-yaml": "^6.1.2",
-    "@codemirror/state": "^6.5.4",
-    "@codemirror/view": "^6.39.13",
     "@tanstack/react-query": "^5.90.20",
     "@tanstack/react-table": "^8.21.3",
     "@xyflow/react": "^12.10.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "codemirror": "^6.0.2",
     "date-fns": "^4.1.0",
     "framer-motion": "^12.33.0",
     "lucide-react": "^0.563.0",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,82 +1,75 @@
 import { lazy, useEffect, Suspense } from 'react'
+import type { ComponentType } from 'react'
 import { Routes, Route } from 'react-router-dom'
 import { AppShell } from './components/layout/AppShell'
 import { ToastProvider } from './components/ui/Toast'
 import { CommandPalette } from './components/command-palette/CommandPalette'
+import { RouteFallback } from './components/ui/RouteFallback'
 import { connectEvents, disconnectEvents } from './stores/events'
 import { Dashboard } from './pages/Dashboard'
 
-// Every non-Dashboard route is lazy-loaded so its JS, CSS, and the
-// libraries it pulls in (recharts, @xyflow/react, codemirror, etc.)
-// only ship to the browser when the user actually navigates there.
-// Dashboard stays eager because it's the index/landing page.
-const Dispatch = lazy(() => import('./pages/Dispatch').then((m) => ({ default: m.Dispatch })))
-const Rules = lazy(() => import('./pages/Rules').then((m) => ({ default: m.Rules })))
-const Actions = lazy(() => import('./pages/Actions').then((m) => ({ default: m.Actions })))
-const Events = lazy(() => import('./pages/Events').then((m) => ({ default: m.Events })))
-const Groups = lazy(() => import('./pages/Groups').then((m) => ({ default: m.Groups })))
-const Silences = lazy(() => import('./pages/Silences').then((m) => ({ default: m.Silences })))
-const TimeIntervals = lazy(() =>
-  import('./pages/TimeIntervals').then((m) => ({ default: m.TimeIntervals })),
-)
-const Alerting = lazy(() => import('./pages/Alerting').then((m) => ({ default: m.Alerting })))
-const Chains = lazy(() => import('./pages/Chains').then((m) => ({ default: m.Chains })))
-const ChainDetail = lazy(() =>
-  import('./pages/ChainDetail').then((m) => ({ default: m.ChainDetail })),
-)
-const Approvals = lazy(() => import('./pages/Approvals').then((m) => ({ default: m.Approvals })))
-const Providers = lazy(() => import('./pages/Providers').then((m) => ({ default: m.Providers })))
-const ProviderHealth = lazy(() =>
-  import('./pages/ProviderHealth').then((m) => ({ default: m.ProviderHealth })),
-)
-const DeadLetterQueue = lazy(() =>
-  import('./pages/DeadLetterQueue').then((m) => ({ default: m.DeadLetterQueue })),
-)
-const EventStream = lazy(() =>
-  import('./pages/EventStream').then((m) => ({ default: m.EventStream })),
-)
-const Embeddings = lazy(() => import('./pages/Embeddings').then((m) => ({ default: m.Embeddings })))
-const ScheduledActions = lazy(() =>
-  import('./pages/ScheduledActions').then((m) => ({ default: m.ScheduledActions })),
-)
-const RecurringActions = lazy(() =>
-  import('./pages/RecurringActions').then((m) => ({ default: m.RecurringActions })),
-)
-const Quotas = lazy(() => import('./pages/Quotas').then((m) => ({ default: m.Quotas })))
-const RetentionPolicies = lazy(() =>
-  import('./pages/RetentionPolicies').then((m) => ({ default: m.RetentionPolicies })),
-)
-const RulePlayground = lazy(() =>
-  import('./pages/RulePlayground').then((m) => ({ default: m.RulePlayground })),
-)
-const WasmPlugins = lazy(() =>
-  import('./pages/WasmPlugins').then((m) => ({ default: m.WasmPlugins })),
-)
-const Templates = lazy(() => import('./pages/Templates').then((m) => ({ default: m.Templates })))
-const ChainDefinitions = lazy(() =>
-  import('./pages/ChainDefinitions').then((m) => ({ default: m.ChainDefinitions })),
-)
-const Analytics = lazy(() => import('./pages/Analytics').then((m) => ({ default: m.Analytics })))
-const ComplianceStatus = lazy(() =>
-  import('./pages/ComplianceStatus').then((m) => ({ default: m.ComplianceStatus })),
-)
-const Settings = lazy(() => import('./pages/Settings').then((m) => ({ default: m.Settings })))
+// -----------------------------------------------------------------------------
+// lazyPage helper
+// -----------------------------------------------------------------------------
+// The project uses named exports for pages (e.g. `export function Dispatch`).
+// React.lazy() expects a module with a `default` export, so each lazy import
+// has to shim a `{ default: m.PageName }` object. `lazyPage` centralizes the
+// shim so App.tsx's route table reads like a flat list instead of a wall of
+// nearly-identical `.then()` callbacks.
+//
+// The generics give you a type-checked page name: if you typo
+// `lazyPage(() => import('./pages/Dispatch'), 'Dispatchh')` TypeScript flags
+// it at compile time because `'Dispatchh'` isn't a key of the module.
 
-function RouteFallback() {
-  return (
-    <div
-      style={{
-        padding: '2rem',
-        color: 'var(--text-muted)',
-        fontSize: '0.875rem',
-      }}
-      role="status"
-      aria-live="polite"
-    >
-      Loading…
-    </div>
-  )
+type PageModule<Name extends string> = {
+  [K in Name]: ComponentType<unknown>
 }
+
+function lazyPage<Name extends string>(
+  loader: () => Promise<PageModule<Name>>,
+  name: Name,
+) {
+  return lazy(async () => {
+    const mod = await loader()
+    return { default: mod[name] }
+  })
+}
+
+// -----------------------------------------------------------------------------
+// Lazy route modules
+// -----------------------------------------------------------------------------
+// Every non-Dashboard route is lazy-loaded so its JS, CSS, and the libraries
+// it pulls in (recharts, @xyflow/react, etc.) only ship to the browser when
+// the user actually navigates there. Dashboard stays eager because it's the
+// index/landing page — the first paint would otherwise show a spinner.
+
+const Dispatch = lazyPage(() => import('./pages/Dispatch'), 'Dispatch')
+const Rules = lazyPage(() => import('./pages/Rules'), 'Rules')
+const Actions = lazyPage(() => import('./pages/Actions'), 'Actions')
+const Events = lazyPage(() => import('./pages/Events'), 'Events')
+const Groups = lazyPage(() => import('./pages/Groups'), 'Groups')
+const Silences = lazyPage(() => import('./pages/Silences'), 'Silences')
+const TimeIntervals = lazyPage(() => import('./pages/TimeIntervals'), 'TimeIntervals')
+const Alerting = lazyPage(() => import('./pages/Alerting'), 'Alerting')
+const Chains = lazyPage(() => import('./pages/Chains'), 'Chains')
+const ChainDetail = lazyPage(() => import('./pages/ChainDetail'), 'ChainDetail')
+const Approvals = lazyPage(() => import('./pages/Approvals'), 'Approvals')
+const Providers = lazyPage(() => import('./pages/Providers'), 'Providers')
+const ProviderHealth = lazyPage(() => import('./pages/ProviderHealth'), 'ProviderHealth')
+const DeadLetterQueue = lazyPage(() => import('./pages/DeadLetterQueue'), 'DeadLetterQueue')
+const EventStream = lazyPage(() => import('./pages/EventStream'), 'EventStream')
+const Embeddings = lazyPage(() => import('./pages/Embeddings'), 'Embeddings')
+const ScheduledActions = lazyPage(() => import('./pages/ScheduledActions'), 'ScheduledActions')
+const RecurringActions = lazyPage(() => import('./pages/RecurringActions'), 'RecurringActions')
+const Quotas = lazyPage(() => import('./pages/Quotas'), 'Quotas')
+const RetentionPolicies = lazyPage(() => import('./pages/RetentionPolicies'), 'RetentionPolicies')
+const RulePlayground = lazyPage(() => import('./pages/RulePlayground'), 'RulePlayground')
+const WasmPlugins = lazyPage(() => import('./pages/WasmPlugins'), 'WasmPlugins')
+const Templates = lazyPage(() => import('./pages/Templates'), 'Templates')
+const ChainDefinitions = lazyPage(() => import('./pages/ChainDefinitions'), 'ChainDefinitions')
+const Analytics = lazyPage(() => import('./pages/Analytics'), 'Analytics')
+const ComplianceStatus = lazyPage(() => import('./pages/ComplianceStatus'), 'ComplianceStatus')
+const Settings = lazyPage(() => import('./pages/Settings'), 'Settings')
 
 function App() {
   useEffect(() => {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,10 +1,9 @@
-import { lazy, useEffect, Suspense } from 'react'
+import { lazy, useEffect } from 'react'
 import type { ComponentType } from 'react'
 import { Routes, Route } from 'react-router-dom'
 import { AppShell } from './components/layout/AppShell'
 import { ToastProvider } from './components/ui/Toast'
 import { CommandPalette } from './components/command-palette/CommandPalette'
-import { RouteFallback } from './components/ui/RouteFallback'
 import { connectEvents, disconnectEvents } from './stores/events'
 import { Dashboard } from './pages/Dashboard'
 
@@ -80,40 +79,45 @@ function App() {
   return (
     <ToastProvider>
       <CommandPalette />
-      <Suspense fallback={<RouteFallback />}>
-        <Routes>
-          <Route element={<AppShell />}>
-            <Route index element={<Dashboard />} />
-            <Route path="alerting" element={<Alerting />} />
-            <Route path="dispatch" element={<Dispatch />} />
-            <Route path="rules" element={<Rules />} />
-            <Route path="playground" element={<RulePlayground />} />
-            <Route path="audit" element={<Actions />} />
-            <Route path="events" element={<Events />} />
-            <Route path="groups" element={<Groups />} />
-            <Route path="silences" element={<Silences />} />
-            <Route path="time-intervals" element={<TimeIntervals />} />
-            <Route path="chains" element={<Chains />} />
-            <Route path="chains/:chainId" element={<ChainDetail />} />
-            <Route path="chain-definitions" element={<ChainDefinitions />} />
-            <Route path="approvals" element={<Approvals />} />
-            <Route path="circuit-breakers" element={<Providers />} />
-            <Route path="provider-health" element={<ProviderHealth />} />
-            <Route path="dlq" element={<DeadLetterQueue />} />
-            <Route path="stream" element={<EventStream />} />
-            <Route path="embeddings" element={<Embeddings />} />
-            <Route path="scheduled" element={<ScheduledActions />} />
-            <Route path="recurring" element={<RecurringActions />} />
-            <Route path="quotas" element={<Quotas />} />
-            <Route path="retention" element={<RetentionPolicies />} />
-            <Route path="wasm-plugins" element={<WasmPlugins />} />
-            <Route path="templates" element={<Templates />} />
-            <Route path="analytics" element={<Analytics />} />
-            <Route path="compliance" element={<ComplianceStatus />} />
-            <Route path="settings/*" element={<Settings />} />
-          </Route>
-        </Routes>
-      </Suspense>
+      {/*
+        The Suspense boundary for lazy route chunks lives inside
+        AppShell (wrapping the <Outlet />), not here. That keeps the
+        Sidebar + Header mounted during navigation and lets framer-
+        motion's AnimatePresence run its exit animation before the
+        RouteFallback spinner appears. See AppShell.tsx for details.
+      */}
+      <Routes>
+        <Route element={<AppShell />}>
+          <Route index element={<Dashboard />} />
+          <Route path="alerting" element={<Alerting />} />
+          <Route path="dispatch" element={<Dispatch />} />
+          <Route path="rules" element={<Rules />} />
+          <Route path="playground" element={<RulePlayground />} />
+          <Route path="audit" element={<Actions />} />
+          <Route path="events" element={<Events />} />
+          <Route path="groups" element={<Groups />} />
+          <Route path="silences" element={<Silences />} />
+          <Route path="time-intervals" element={<TimeIntervals />} />
+          <Route path="chains" element={<Chains />} />
+          <Route path="chains/:chainId" element={<ChainDetail />} />
+          <Route path="chain-definitions" element={<ChainDefinitions />} />
+          <Route path="approvals" element={<Approvals />} />
+          <Route path="circuit-breakers" element={<Providers />} />
+          <Route path="provider-health" element={<ProviderHealth />} />
+          <Route path="dlq" element={<DeadLetterQueue />} />
+          <Route path="stream" element={<EventStream />} />
+          <Route path="embeddings" element={<Embeddings />} />
+          <Route path="scheduled" element={<ScheduledActions />} />
+          <Route path="recurring" element={<RecurringActions />} />
+          <Route path="quotas" element={<Quotas />} />
+          <Route path="retention" element={<RetentionPolicies />} />
+          <Route path="wasm-plugins" element={<WasmPlugins />} />
+          <Route path="templates" element={<Templates />} />
+          <Route path="analytics" element={<Analytics />} />
+          <Route path="compliance" element={<ComplianceStatus />} />
+          <Route path="settings/*" element={<Settings />} />
+        </Route>
+      </Routes>
     </ToastProvider>
   )
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,37 +1,82 @@
-import { useEffect } from 'react'
+import { lazy, useEffect, Suspense } from 'react'
 import { Routes, Route } from 'react-router-dom'
 import { AppShell } from './components/layout/AppShell'
 import { ToastProvider } from './components/ui/Toast'
 import { CommandPalette } from './components/command-palette/CommandPalette'
 import { connectEvents, disconnectEvents } from './stores/events'
 import { Dashboard } from './pages/Dashboard'
-import { Dispatch } from './pages/Dispatch'
-import { Rules } from './pages/Rules'
-import { Actions } from './pages/Actions'
-import { Events } from './pages/Events'
-import { Groups } from './pages/Groups'
-import { Silences } from './pages/Silences'
-import { TimeIntervals } from './pages/TimeIntervals'
-import { Alerting } from './pages/Alerting'
-import { Chains } from './pages/Chains'
-import { ChainDetail } from './pages/ChainDetail'
-import { Approvals } from './pages/Approvals'
-import { Providers } from './pages/Providers'
-import { ProviderHealth } from './pages/ProviderHealth'
-import { DeadLetterQueue } from './pages/DeadLetterQueue'
-import { EventStream } from './pages/EventStream'
-import { Embeddings } from './pages/Embeddings'
-import { ScheduledActions } from './pages/ScheduledActions'
-import { RecurringActions } from './pages/RecurringActions'
-import { Quotas } from './pages/Quotas'
-import { RetentionPolicies } from './pages/RetentionPolicies'
-import { RulePlayground } from './pages/RulePlayground'
-import { WasmPlugins } from './pages/WasmPlugins'
-import { Templates } from './pages/Templates'
-import { ChainDefinitions } from './pages/ChainDefinitions'
-import { Analytics } from './pages/Analytics'
-import { ComplianceStatus } from './pages/ComplianceStatus'
-import { Settings } from './pages/Settings'
+
+// Every non-Dashboard route is lazy-loaded so its JS, CSS, and the
+// libraries it pulls in (recharts, @xyflow/react, codemirror, etc.)
+// only ship to the browser when the user actually navigates there.
+// Dashboard stays eager because it's the index/landing page.
+const Dispatch = lazy(() => import('./pages/Dispatch').then((m) => ({ default: m.Dispatch })))
+const Rules = lazy(() => import('./pages/Rules').then((m) => ({ default: m.Rules })))
+const Actions = lazy(() => import('./pages/Actions').then((m) => ({ default: m.Actions })))
+const Events = lazy(() => import('./pages/Events').then((m) => ({ default: m.Events })))
+const Groups = lazy(() => import('./pages/Groups').then((m) => ({ default: m.Groups })))
+const Silences = lazy(() => import('./pages/Silences').then((m) => ({ default: m.Silences })))
+const TimeIntervals = lazy(() =>
+  import('./pages/TimeIntervals').then((m) => ({ default: m.TimeIntervals })),
+)
+const Alerting = lazy(() => import('./pages/Alerting').then((m) => ({ default: m.Alerting })))
+const Chains = lazy(() => import('./pages/Chains').then((m) => ({ default: m.Chains })))
+const ChainDetail = lazy(() =>
+  import('./pages/ChainDetail').then((m) => ({ default: m.ChainDetail })),
+)
+const Approvals = lazy(() => import('./pages/Approvals').then((m) => ({ default: m.Approvals })))
+const Providers = lazy(() => import('./pages/Providers').then((m) => ({ default: m.Providers })))
+const ProviderHealth = lazy(() =>
+  import('./pages/ProviderHealth').then((m) => ({ default: m.ProviderHealth })),
+)
+const DeadLetterQueue = lazy(() =>
+  import('./pages/DeadLetterQueue').then((m) => ({ default: m.DeadLetterQueue })),
+)
+const EventStream = lazy(() =>
+  import('./pages/EventStream').then((m) => ({ default: m.EventStream })),
+)
+const Embeddings = lazy(() => import('./pages/Embeddings').then((m) => ({ default: m.Embeddings })))
+const ScheduledActions = lazy(() =>
+  import('./pages/ScheduledActions').then((m) => ({ default: m.ScheduledActions })),
+)
+const RecurringActions = lazy(() =>
+  import('./pages/RecurringActions').then((m) => ({ default: m.RecurringActions })),
+)
+const Quotas = lazy(() => import('./pages/Quotas').then((m) => ({ default: m.Quotas })))
+const RetentionPolicies = lazy(() =>
+  import('./pages/RetentionPolicies').then((m) => ({ default: m.RetentionPolicies })),
+)
+const RulePlayground = lazy(() =>
+  import('./pages/RulePlayground').then((m) => ({ default: m.RulePlayground })),
+)
+const WasmPlugins = lazy(() =>
+  import('./pages/WasmPlugins').then((m) => ({ default: m.WasmPlugins })),
+)
+const Templates = lazy(() => import('./pages/Templates').then((m) => ({ default: m.Templates })))
+const ChainDefinitions = lazy(() =>
+  import('./pages/ChainDefinitions').then((m) => ({ default: m.ChainDefinitions })),
+)
+const Analytics = lazy(() => import('./pages/Analytics').then((m) => ({ default: m.Analytics })))
+const ComplianceStatus = lazy(() =>
+  import('./pages/ComplianceStatus').then((m) => ({ default: m.ComplianceStatus })),
+)
+const Settings = lazy(() => import('./pages/Settings').then((m) => ({ default: m.Settings })))
+
+function RouteFallback() {
+  return (
+    <div
+      style={{
+        padding: '2rem',
+        color: 'var(--text-muted)',
+        fontSize: '0.875rem',
+      }}
+      role="status"
+      aria-live="polite"
+    >
+      Loading…
+    </div>
+  )
+}
 
 function App() {
   useEffect(() => {
@@ -42,38 +87,40 @@ function App() {
   return (
     <ToastProvider>
       <CommandPalette />
-      <Routes>
-        <Route element={<AppShell />}>
-          <Route index element={<Dashboard />} />
-          <Route path="alerting" element={<Alerting />} />
-          <Route path="dispatch" element={<Dispatch />} />
-          <Route path="rules" element={<Rules />} />
-          <Route path="playground" element={<RulePlayground />} />
-          <Route path="audit" element={<Actions />} />
-          <Route path="events" element={<Events />} />
-          <Route path="groups" element={<Groups />} />
-          <Route path="silences" element={<Silences />} />
-          <Route path="time-intervals" element={<TimeIntervals />} />
-          <Route path="chains" element={<Chains />} />
-          <Route path="chains/:chainId" element={<ChainDetail />} />
-          <Route path="chain-definitions" element={<ChainDefinitions />} />
-          <Route path="approvals" element={<Approvals />} />
-          <Route path="circuit-breakers" element={<Providers />} />
-          <Route path="provider-health" element={<ProviderHealth />} />
-          <Route path="dlq" element={<DeadLetterQueue />} />
-          <Route path="stream" element={<EventStream />} />
-          <Route path="embeddings" element={<Embeddings />} />
-          <Route path="scheduled" element={<ScheduledActions />} />
-          <Route path="recurring" element={<RecurringActions />} />
-          <Route path="quotas" element={<Quotas />} />
-          <Route path="retention" element={<RetentionPolicies />} />
-          <Route path="wasm-plugins" element={<WasmPlugins />} />
-          <Route path="templates" element={<Templates />} />
-          <Route path="analytics" element={<Analytics />} />
-          <Route path="compliance" element={<ComplianceStatus />} />
-          <Route path="settings/*" element={<Settings />} />
-        </Route>
-      </Routes>
+      <Suspense fallback={<RouteFallback />}>
+        <Routes>
+          <Route element={<AppShell />}>
+            <Route index element={<Dashboard />} />
+            <Route path="alerting" element={<Alerting />} />
+            <Route path="dispatch" element={<Dispatch />} />
+            <Route path="rules" element={<Rules />} />
+            <Route path="playground" element={<RulePlayground />} />
+            <Route path="audit" element={<Actions />} />
+            <Route path="events" element={<Events />} />
+            <Route path="groups" element={<Groups />} />
+            <Route path="silences" element={<Silences />} />
+            <Route path="time-intervals" element={<TimeIntervals />} />
+            <Route path="chains" element={<Chains />} />
+            <Route path="chains/:chainId" element={<ChainDetail />} />
+            <Route path="chain-definitions" element={<ChainDefinitions />} />
+            <Route path="approvals" element={<Approvals />} />
+            <Route path="circuit-breakers" element={<Providers />} />
+            <Route path="provider-health" element={<ProviderHealth />} />
+            <Route path="dlq" element={<DeadLetterQueue />} />
+            <Route path="stream" element={<EventStream />} />
+            <Route path="embeddings" element={<Embeddings />} />
+            <Route path="scheduled" element={<ScheduledActions />} />
+            <Route path="recurring" element={<RecurringActions />} />
+            <Route path="quotas" element={<Quotas />} />
+            <Route path="retention" element={<RetentionPolicies />} />
+            <Route path="wasm-plugins" element={<WasmPlugins />} />
+            <Route path="templates" element={<Templates />} />
+            <Route path="analytics" element={<Analytics />} />
+            <Route path="compliance" element={<ComplianceStatus />} />
+            <Route path="settings/*" element={<Settings />} />
+          </Route>
+        </Routes>
+      </Suspense>
     </ToastProvider>
   )
 }

--- a/ui/src/components/layout/AppShell.tsx
+++ b/ui/src/components/layout/AppShell.tsx
@@ -1,8 +1,9 @@
-import { Outlet } from 'react-router-dom'
+import { Suspense } from 'react'
+import { Outlet, useLocation } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
-import { useLocation } from 'react-router-dom'
 import { Sidebar } from './Sidebar'
 import { Header } from './Header'
+import { RouteFallback } from '../ui/RouteFallback'
 import styles from './AppShell.module.css'
 
 export function AppShell() {
@@ -22,7 +23,24 @@ export function AppShell() {
               exit={{ opacity: 0, y: -4 }}
               transition={{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }}
             >
-              <Outlet />
+              {/*
+                Suspense lives inside the motion.div (and inside
+                AppShell, below the Sidebar + Header) so that when a
+                lazy-loaded route chunk is in flight:
+
+                - The Sidebar and Header stay mounted and interactive
+                  (nav links remain clickable, the command palette
+                  still works).
+                - AnimatePresence's exit animation on the previous
+                  page runs to completion before the fallback
+                  appears — the transition stays smooth instead of
+                  popping mid-flight.
+                - RouteFallback only replaces the main content area
+                  rather than unmounting the whole shell.
+              */}
+              <Suspense fallback={<RouteFallback />}>
+                <Outlet />
+              </Suspense>
             </motion.div>
           </AnimatePresence>
         </main>

--- a/ui/src/components/ui/RouteFallback.module.css
+++ b/ui/src/components/ui/RouteFallback.module.css
@@ -1,0 +1,45 @@
+@reference "../../index.css";
+
+.container {
+  /* Fill the main content area without forcing a layout shift. */
+  @apply flex items-center justify-center;
+  min-height: 40vh;
+  padding: 2rem;
+}
+
+.spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  border: 2px solid var(--border-default);
+  border-top-color: var(--text-secondary);
+  animation: spin 0.8s linear infinite;
+}
+
+.srOnly {
+  /* Standard .sr-only pattern — visible to assistive tech only. */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    /* Honor the accessibility setting — dim the border to give a
+       static "busy" state instead of a spinning animation. */
+    animation: none;
+    border-top-color: var(--text-muted);
+  }
+}

--- a/ui/src/components/ui/RouteFallback.tsx
+++ b/ui/src/components/ui/RouteFallback.tsx
@@ -5,10 +5,11 @@ import styles from './RouteFallback.module.css'
  * fetched. Kept intentionally small: a centered spinner with a
  * hidden "Loading page" label for screen readers.
  *
- * Used as the `<Suspense fallback={...}>` for every route in
- * `App.tsx`. Because the eager bundle already carries the AppShell
- * (sidebar + header), this fallback only fills the main content
- * area — navigation stays responsive while the page chunk loads.
+ * Rendered by the `<Suspense>` boundary inside `AppShell.tsx`
+ * (wrapping the `<Outlet />`). Because the Suspense lives below
+ * the Sidebar + Header in the component tree, this fallback only
+ * replaces the main content area — the shell stays mounted and
+ * navigation remains responsive while the page chunk loads.
  */
 export function RouteFallback() {
   return (

--- a/ui/src/components/ui/RouteFallback.tsx
+++ b/ui/src/components/ui/RouteFallback.tsx
@@ -1,0 +1,20 @@
+import styles from './RouteFallback.module.css'
+
+/**
+ * Loading indicator shown while a lazy-loaded route chunk is being
+ * fetched. Kept intentionally small: a centered spinner with a
+ * hidden "Loading page" label for screen readers.
+ *
+ * Used as the `<Suspense fallback={...}>` for every route in
+ * `App.tsx`. Because the eager bundle already carries the AppShell
+ * (sidebar + header), this fallback only fills the main content
+ * area — navigation stays responsive while the page chunk loads.
+ */
+export function RouteFallback() {
+  return (
+    <div className={styles.container} role="status" aria-live="polite">
+      <div className={styles.spinner} aria-hidden="true" />
+      <span className={styles.srOnly}>Loading page</span>
+    </div>
+  )
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -13,20 +13,19 @@ export default defineConfig({
     },
   },
   build: {
-    // Bumped from the default 500 KB to 600 KB so the warning fires
-    // only on truly egregious chunks. After manualChunks splitting
-    // the largest vendor chunk (recharts) is well under the new cap.
-    chunkSizeWarningLimit: 600,
     rollupOptions: {
       output: {
-        // Vendor chunking: pull the heaviest libraries into their own
-        // chunks so they cache independently and don't bloat the
-        // initial page load. Anything not matched here falls into
-        // route-level chunks created by React.lazy() in App.tsx.
+        // Only the chunks that pay their keep are named explicitly.
+        // Everything else falls into Vite's default splitting, which
+        // puts eager-shared deps in the main entry and lazy-only
+        // deps in their route chunks. That keeps this config short
+        // and stops new dependencies from silently bloating the
+        // initial load through a catch-all `vendor` chunk.
         manualChunks: (id) => {
           if (!id.includes('node_modules')) return undefined
 
-          // React core + router. Eager (every page needs them).
+          // React core + router. Every route needs it; making it a
+          // named chunk gives it a stable cache key across deploys.
           if (
             /[\\/]node_modules[\\/](react|react-dom|react-router|react-router-dom|scheduler)[\\/]/.test(
               id,
@@ -35,48 +34,36 @@ export default defineConfig({
             return 'react-vendor'
           }
 
-          // Recharts is used by Dashboard (eager) and Analytics (lazy).
-          // Keeping it in its own chunk means Analytics rides on the
-          // already-cached chunk instead of re-downloading it.
+          // Recharts is the single largest dependency and is used by
+          // Dashboard (eager) AND Analytics (lazy). Splitting it into
+          // its own chunk means visiting Analytics after Dashboard
+          // reuses the cached recharts bundle instead of re-downloading
+          // it inside the Analytics route chunk. d3-* is included
+          // because recharts depends on several d3 sub-packages.
           if (id.includes('node_modules/recharts') || id.includes('node_modules/d3-')) {
             return 'recharts'
           }
 
-          // @xyflow/react is only used by the chain DAG visualizer.
-          // Lazy via Chains/ChainDetail/ChainDefinitions, but split
-          // out so the three pages share one cached chunk.
+          // @xyflow/react — used only by the chain DAG visualizer.
+          // Lazy via Chains/ChainDetail/ChainDefinitions, but a named
+          // chunk so the three pages that need it share a single
+          // cacheable file (and so `npm run build` surfaces it
+          // readably instead of as `chunk-Dxxx.js`).
           if (id.includes('node_modules/@xyflow')) return 'xyflow'
 
-          // CodeMirror — large editor stack pinned in package.json
-          // even though src doesn't import it today; gate it so any
-          // future use (rule editor, template editor) lands in its
-          // own chunk instead of the eager bundle.
-          if (id.includes('node_modules/@codemirror') || id.includes('node_modules/codemirror')) {
-            return 'codemirror'
-          }
-
           // framer-motion drives the page-transition animation in
-          // AppShell. Eager but cacheable.
+          // AppShell (eager). Splitting it out keeps the ~40 KB gz
+          // library cached across app-code deploys so repeat
+          // visitors don't re-download it just because the main
+          // entry hash changed.
           if (id.includes('node_modules/framer-motion') || id.includes('node_modules/motion-')) {
             return 'framer-motion'
           }
 
-          // TanStack query + table — used across many pages, so a
-          // shared chunk avoids duplicating the runtime per route.
-          if (id.includes('node_modules/@tanstack')) return 'tanstack'
-
-          // cmdk powers the command palette (always mounted).
-          if (id.includes('node_modules/cmdk')) return 'cmdk'
-
-          // lucide-react ships an enormous icon catalog; tree
-          // shaking already trims it but the rest still benefits
-          // from a dedicated chunk so it caches separately.
-          if (id.includes('node_modules/lucide-react')) return 'icons'
-
-          // Everything else in node_modules → a single shared vendor
-          // chunk so we don't fragment small utilities across every
-          // page chunk.
-          return 'vendor'
+          // Everything else → Vite's default. No catch-all vendor
+          // chunk: adding a new dep to a lazy page won't suddenly
+          // bloat the eager load.
+          return undefined
         },
       },
     },

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -12,4 +12,73 @@ export default defineConfig({
       '/admin': 'http://127.0.0.1:8080',
     },
   },
+  build: {
+    // Bumped from the default 500 KB to 600 KB so the warning fires
+    // only on truly egregious chunks. After manualChunks splitting
+    // the largest vendor chunk (recharts) is well under the new cap.
+    chunkSizeWarningLimit: 600,
+    rollupOptions: {
+      output: {
+        // Vendor chunking: pull the heaviest libraries into their own
+        // chunks so they cache independently and don't bloat the
+        // initial page load. Anything not matched here falls into
+        // route-level chunks created by React.lazy() in App.tsx.
+        manualChunks: (id) => {
+          if (!id.includes('node_modules')) return undefined
+
+          // React core + router. Eager (every page needs them).
+          if (
+            /[\\/]node_modules[\\/](react|react-dom|react-router|react-router-dom|scheduler)[\\/]/.test(
+              id,
+            )
+          ) {
+            return 'react-vendor'
+          }
+
+          // Recharts is used by Dashboard (eager) and Analytics (lazy).
+          // Keeping it in its own chunk means Analytics rides on the
+          // already-cached chunk instead of re-downloading it.
+          if (id.includes('node_modules/recharts') || id.includes('node_modules/d3-')) {
+            return 'recharts'
+          }
+
+          // @xyflow/react is only used by the chain DAG visualizer.
+          // Lazy via Chains/ChainDetail/ChainDefinitions, but split
+          // out so the three pages share one cached chunk.
+          if (id.includes('node_modules/@xyflow')) return 'xyflow'
+
+          // CodeMirror — large editor stack pinned in package.json
+          // even though src doesn't import it today; gate it so any
+          // future use (rule editor, template editor) lands in its
+          // own chunk instead of the eager bundle.
+          if (id.includes('node_modules/@codemirror') || id.includes('node_modules/codemirror')) {
+            return 'codemirror'
+          }
+
+          // framer-motion drives the page-transition animation in
+          // AppShell. Eager but cacheable.
+          if (id.includes('node_modules/framer-motion') || id.includes('node_modules/motion-')) {
+            return 'framer-motion'
+          }
+
+          // TanStack query + table — used across many pages, so a
+          // shared chunk avoids duplicating the runtime per route.
+          if (id.includes('node_modules/@tanstack')) return 'tanstack'
+
+          // cmdk powers the command palette (always mounted).
+          if (id.includes('node_modules/cmdk')) return 'cmdk'
+
+          // lucide-react ships an enormous icon catalog; tree
+          // shaking already trims it but the rest still benefits
+          // from a dedicated chunk so it caches separately.
+          if (id.includes('node_modules/lucide-react')) return 'icons'
+
+          // Everything else in node_modules → a single shared vendor
+          // chunk so we don't fragment small utilities across every
+          // page chunk.
+          return 'vendor'
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
\`vite build\` has been printing a chunk-size warning on every PR for weeks because the entire UI shipped as one **1.35 MB JS file (398 KB gzipped)**, regardless of which page the user landed on. This PR splits the bundle two ways and gets the initial JS payload down by **23%**.

## Approach

**1. Route-level lazy loading (\`src/App.tsx\`).** Every non-Dashboard route is converted to \`React.lazy(...)\`. Dashboard stays eager because it's the index/landing page. A \`<Suspense>\` boundary wraps \`<Routes>\` with a small \"Loading…\" fallback, marked \`role=\"status\"\` + \`aria-live=\"polite\"\` so screen readers announce navigation transitions.

**2. Vendor manualChunks (\`vite.config.ts\`).** A \`rollupOptions.output.manualChunks\` function pulls each heavy library into its own named chunk so they cache independently and don't bloat any single page chunk:

| Chunk | Contents | Eager or lazy? |
|---|---|---|
| \`react-vendor\` | react, react-dom, react-router, scheduler | eager |
| \`recharts\` | recharts + d3-* | eager (Dashboard) |
| \`framer-motion\` | framer-motion | eager (AppShell transitions) |
| \`tanstack\` | @tanstack/react-query + @tanstack/react-table | eager |
| \`vendor\` | catch-all for misc node_modules | eager |
| \`icons\` | lucide-react | eager |
| \`cmdk\` | cmdk (command palette) | eager |
| \`xyflow\` | @xyflow/react | **lazy** (only on Chains routes) |
| \`codemirror\` | @codemirror/* + codemirror | **lazy** (gated for future editors) |

\`chunkSizeWarningLimit\` bumped from the default 500 KB to 600 KB so the warning fires only on truly egregious chunks. The largest chunk after splitting (recharts at 325 KB / 91 KB gz) is well under the cap.

## Impact

| Metric | Before | After | Δ |
|---|---:|---:|---|
| Initial JS (gzipped) | 398 KB | ~306 KB | **−23%** |
| Largest chunk | 1,353 KB | 325 KB | −76% |
| Number of JS chunks | 1 | 39 | much better cache hit rate |
| \`vite build\` warning | yes | no | clean |

Lazy page chunks span **1.6 KB** (Modal) to **24 KB** (Settings, ChainDefinitions). Navigating to Analytics loads only its 9.4 KB page chunk on top of the already-cached vendor chunks. Navigating to a chain detail page loads ChainDetail (6.7 KB) + ChainDAG (11.8 KB) + xyflow (122 KB / 40 KB gz) — the heavy DAG library is downloaded **only when you actually need it**.

When only app code changes between deploys, users keep their cached \`react-vendor\`, \`recharts\`, \`xyflow\`, \`framer-motion\`, etc. — only the small \`index\` chunk gets re-downloaded.

## Test plan
- [x] \`npm run lint\` — pre-existing DataTable warning only, no new issues
- [x] \`npm run build\` — clean, no chunk-size warning, 39 chunks emitted
- [x] Manual: every chunk gzips well (page chunks average ~3 KB gz, vendor chunks 4-92 KB gz)
- [ ] Manual smoke in dev: navigate around every route, verify Suspense fallback flashes briefly on first visit and disappears once the page chunk loads

## Why no Rust changes
Pure UI infrastructure. The new \`Suspense\` boundary doesn't change any of the existing page rendering behavior — only when the page module loads.