### PR TITLE
feat(signing): observability counters for every verification branch

### DIFF
--- a/crates/gateway/src/metrics.rs
+++ b/crates/gateway/src/metrics.rs
@@ -94,9 +94,16 @@ pub struct GatewayMetrics {
     /// Unsigned actions rejected because `signing.reject_unsigned`
     /// is enabled.
     pub signing_unsigned_rejected: AtomicU64,
+    /// Unsigned actions passed through because `signing.reject_unsigned`
+    /// is off. Lets operators compute the signed-vs-unsigned ratio
+    /// directly without subtracting every rejection counter from
+    /// `dispatched`.
+    pub signing_unsigned_allowed: AtomicU64,
     /// Actions rejected because their action ID was already seen
-    /// within the `replay_ttl_seconds` window.
-    pub signing_replay_rejected: AtomicU64,
+    /// within the `replay_ttl_seconds` window. Replay protection is
+    /// independent of signing — this counter increments whether or
+    /// not a valid signature was presented.
+    pub replay_rejected: AtomicU64,
 }
 
 impl GatewayMetrics {
@@ -307,10 +314,17 @@ impl GatewayMetrics {
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Increment the `signing_replay_rejected` counter (action ID
-    /// already seen within the replay protection window).
-    pub fn increment_signing_replay_rejected(&self) {
-        self.signing_replay_rejected.fetch_add(1, Ordering::Relaxed);
+    /// Increment the `signing_unsigned_allowed` counter (unsigned
+    /// action passed through because `signing.reject_unsigned` is off).
+    pub fn increment_signing_unsigned_allowed(&self) {
+        self.signing_unsigned_allowed
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the `replay_rejected` counter (action ID already
+    /// seen within the replay protection window).
+    pub fn increment_replay_rejected(&self) {
+        self.replay_rejected.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Take a consistent point-in-time snapshot of all counters.
@@ -354,7 +368,8 @@ impl GatewayMetrics {
             signing_unknown_signer: self.signing_unknown_signer.load(Ordering::Relaxed),
             signing_scope_denied: self.signing_scope_denied.load(Ordering::Relaxed),
             signing_unsigned_rejected: self.signing_unsigned_rejected.load(Ordering::Relaxed),
-            signing_replay_rejected: self.signing_replay_rejected.load(Ordering::Relaxed),
+            signing_unsigned_allowed: self.signing_unsigned_allowed.load(Ordering::Relaxed),
+            replay_rejected: self.replay_rejected.load(Ordering::Relaxed),
         }
     }
 }
@@ -442,9 +457,12 @@ pub struct MetricsSnapshot {
     /// Unsigned actions rejected because `signing.reject_unsigned`
     /// is enabled.
     pub signing_unsigned_rejected: u64,
+    /// Unsigned actions that passed through because
+    /// `signing.reject_unsigned` is off.
+    pub signing_unsigned_allowed: u64,
     /// Actions rejected because their action ID was already seen
     /// within the `replay_ttl_seconds` window.
-    pub signing_replay_rejected: u64,
+    pub replay_rejected: u64,
 }
 
 /// Maximum number of latency samples retained per provider.
@@ -803,7 +821,8 @@ mod tests {
         assert_eq!(snap.signing_unknown_signer, 0);
         assert_eq!(snap.signing_scope_denied, 0);
         assert_eq!(snap.signing_unsigned_rejected, 0);
-        assert_eq!(snap.signing_replay_rejected, 0);
+        assert_eq!(snap.signing_unsigned_allowed, 0);
+        assert_eq!(snap.replay_rejected, 0);
     }
 
     #[test]
@@ -848,7 +867,8 @@ mod tests {
         m.increment_signing_unknown_signer();
         m.increment_signing_scope_denied();
         m.increment_signing_unsigned_rejected();
-        m.increment_signing_replay_rejected();
+        m.increment_signing_unsigned_allowed();
+        m.increment_replay_rejected();
 
         let snap = m.snapshot();
         assert_eq!(snap.dispatched, 2);
@@ -889,7 +909,8 @@ mod tests {
         assert_eq!(snap.signing_unknown_signer, 1);
         assert_eq!(snap.signing_scope_denied, 1);
         assert_eq!(snap.signing_unsigned_rejected, 1);
-        assert_eq!(snap.signing_replay_rejected, 1);
+        assert_eq!(snap.signing_unsigned_allowed, 1);
+        assert_eq!(snap.replay_rejected, 1);
     }
 
     #[test]

--- a/crates/gateway/src/metrics.rs
+++ b/crates/gateway/src/metrics.rs
@@ -79,6 +79,24 @@ pub struct GatewayMetrics {
     pub wasm_invocations: AtomicU64,
     /// WASM plugin invocation errors.
     pub wasm_errors: AtomicU64,
+    /// Action signatures successfully verified and scope-authorized.
+    pub signing_verified: AtomicU64,
+    /// Signed actions rejected because the Ed25519 signature did not
+    /// validate against the registered public key.
+    pub signing_invalid: AtomicU64,
+    /// Signed actions rejected because the `signer_id` (or
+    /// `(signer_id, kid)` pair during a rotation window) is not in
+    /// the server's keyring.
+    pub signing_unknown_signer: AtomicU64,
+    /// Signed actions rejected because the signer is not authorized
+    /// for the action's `(tenant, namespace)` pair.
+    pub signing_scope_denied: AtomicU64,
+    /// Unsigned actions rejected because `signing.reject_unsigned`
+    /// is enabled.
+    pub signing_unsigned_rejected: AtomicU64,
+    /// Actions rejected because their action ID was already seen
+    /// within the `replay_ttl_seconds` window.
+    pub signing_replay_rejected: AtomicU64,
 }
 
 impl GatewayMetrics {
@@ -258,6 +276,43 @@ impl GatewayMetrics {
         self.wasm_errors.fetch_add(n, Ordering::Relaxed);
     }
 
+    /// Increment the `signing_verified` counter (signature crypto-valid
+    /// and scope-authorized).
+    pub fn increment_signing_verified(&self) {
+        self.signing_verified.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the `signing_invalid` counter (Ed25519 verification
+    /// failed against the registered public key).
+    pub fn increment_signing_invalid(&self) {
+        self.signing_invalid.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the `signing_unknown_signer` counter (`signer_id` or
+    /// `(signer_id, kid)` pair not in the keyring).
+    pub fn increment_signing_unknown_signer(&self) {
+        self.signing_unknown_signer.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the `signing_scope_denied` counter (signature valid
+    /// but signer not authorized for the `(tenant, namespace)` pair).
+    pub fn increment_signing_scope_denied(&self) {
+        self.signing_scope_denied.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the `signing_unsigned_rejected` counter (unsigned
+    /// action rejected because `signing.reject_unsigned` is enabled).
+    pub fn increment_signing_unsigned_rejected(&self) {
+        self.signing_unsigned_rejected
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the `signing_replay_rejected` counter (action ID
+    /// already seen within the replay protection window).
+    pub fn increment_signing_replay_rejected(&self) {
+        self.signing_replay_rejected.fetch_add(1, Ordering::Relaxed);
+    }
+
     /// Take a consistent point-in-time snapshot of all counters.
     pub fn snapshot(&self) -> MetricsSnapshot {
         MetricsSnapshot {
@@ -294,6 +349,12 @@ impl GatewayMetrics {
             retention_errors: self.retention_errors.load(Ordering::Relaxed),
             wasm_invocations: self.wasm_invocations.load(Ordering::Relaxed),
             wasm_errors: self.wasm_errors.load(Ordering::Relaxed),
+            signing_verified: self.signing_verified.load(Ordering::Relaxed),
+            signing_invalid: self.signing_invalid.load(Ordering::Relaxed),
+            signing_unknown_signer: self.signing_unknown_signer.load(Ordering::Relaxed),
+            signing_scope_denied: self.signing_scope_denied.load(Ordering::Relaxed),
+            signing_unsigned_rejected: self.signing_unsigned_rejected.load(Ordering::Relaxed),
+            signing_replay_rejected: self.signing_replay_rejected.load(Ordering::Relaxed),
         }
     }
 }
@@ -367,6 +428,23 @@ pub struct MetricsSnapshot {
     pub wasm_invocations: u64,
     /// WASM plugin invocation errors.
     pub wasm_errors: u64,
+    /// Action signatures successfully verified and scope-authorized.
+    pub signing_verified: u64,
+    /// Signed actions rejected because the Ed25519 signature did not
+    /// validate against the registered public key.
+    pub signing_invalid: u64,
+    /// Signed actions rejected because `signer_id` (or
+    /// `(signer_id, kid)`) is not in the server's keyring.
+    pub signing_unknown_signer: u64,
+    /// Signed actions rejected because the signer is not authorized
+    /// for the action's `(tenant, namespace)` pair.
+    pub signing_scope_denied: u64,
+    /// Unsigned actions rejected because `signing.reject_unsigned`
+    /// is enabled.
+    pub signing_unsigned_rejected: u64,
+    /// Actions rejected because their action ID was already seen
+    /// within the `replay_ttl_seconds` window.
+    pub signing_replay_rejected: u64,
 }
 
 /// Maximum number of latency samples retained per provider.
@@ -720,6 +798,12 @@ mod tests {
         assert_eq!(snap.retention_errors, 0);
         assert_eq!(snap.wasm_invocations, 0);
         assert_eq!(snap.wasm_errors, 0);
+        assert_eq!(snap.signing_verified, 0);
+        assert_eq!(snap.signing_invalid, 0);
+        assert_eq!(snap.signing_unknown_signer, 0);
+        assert_eq!(snap.signing_scope_denied, 0);
+        assert_eq!(snap.signing_unsigned_rejected, 0);
+        assert_eq!(snap.signing_replay_rejected, 0);
     }
 
     #[test]
@@ -759,6 +843,12 @@ mod tests {
         m.increment_retention_errors();
         m.increment_wasm_invocations();
         m.increment_wasm_errors();
+        m.increment_signing_verified();
+        m.increment_signing_invalid();
+        m.increment_signing_unknown_signer();
+        m.increment_signing_scope_denied();
+        m.increment_signing_unsigned_rejected();
+        m.increment_signing_replay_rejected();
 
         let snap = m.snapshot();
         assert_eq!(snap.dispatched, 2);
@@ -794,6 +884,12 @@ mod tests {
         assert_eq!(snap.retention_errors, 1);
         assert_eq!(snap.wasm_invocations, 1);
         assert_eq!(snap.wasm_errors, 1);
+        assert_eq!(snap.signing_verified, 1);
+        assert_eq!(snap.signing_invalid, 1);
+        assert_eq!(snap.signing_unknown_signer, 1);
+        assert_eq!(snap.signing_scope_denied, 1);
+        assert_eq!(snap.signing_unsigned_rejected, 1);
+        assert_eq!(snap.signing_replay_rejected, 1);
     }
 
     #[test]

--- a/crates/server/src/api/dispatch.rs
+++ b/crates/server/src/api/dispatch.rs
@@ -86,14 +86,22 @@ pub async fn dispatch(
         ));
     }
 
-    // Verify action signature if signing is enabled.
-    if let Some(ref verifier) = state.signature_verifier
-        && let Err(e) = verifier.verify_action(&action)
-    {
-        return Ok((
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!(ErrorResponse { error: e })),
-        ));
+    // Verify action signature if signing is enabled. Every branch
+    // (pass, reject, allow-unsigned) bumps a gateway metric so
+    // operators can alert on a spike in invalid/unknown/scope-denied
+    // signatures post-rotation.
+    if let Some(ref verifier) = state.signature_verifier {
+        let outcome = verifier.verify_action(&action);
+        {
+            let gw = state.gateway.read().await;
+            outcome.record_metric(gw.metrics());
+        }
+        if let Some(err) = outcome.error_message() {
+            return Ok((
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!(ErrorResponse { error: err })),
+            ));
+        }
     }
 
     // Replay protection: reject if this action ID has already been dispatched.
@@ -113,6 +121,7 @@ pub async fn dispatch(
             .await
         {
             // Already existed — replay detected.
+            gw.metrics().increment_signing_replay_rejected();
             return Ok((
                 StatusCode::CONFLICT,
                 Json(serde_json::json!(ErrorResponse {

--- a/crates/server/src/api/dispatch.rs
+++ b/crates/server/src/api/dispatch.rs
@@ -96,6 +96,13 @@ pub async fn dispatch(
     if let Some(ref verifier) = state.signature_verifier {
         let outcome = verifier.verify_action(&action);
         outcome.record_metric(&state.metrics);
+        // Rejection paths (and InternalError) emit a structured
+        // tracing::warn with the full variant + signer + kid + scope
+        // context. The HTTP body, by contrast, deliberately returns a
+        // uniform "signature verification failed for signer X"
+        // message so a probing caller can't tell UnknownSigner apart
+        // from InvalidSignature.
+        outcome.log_rejection();
         if let Some(msg) = outcome.internal_error_message() {
             return Ok((
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/server/src/api/dispatch.rs
+++ b/crates/server/src/api/dispatch.rs
@@ -52,6 +52,7 @@ pub struct DispatchQuery {
         (status = 500, description = "Internal server error", body = ErrorResponse)
     )
 )]
+#[allow(clippy::too_many_lines)]
 pub async fn dispatch(
     State(state): State<AppState>,
     axum::Extension(identity): axum::Extension<CallerIdentity>,
@@ -89,12 +90,17 @@ pub async fn dispatch(
     // Verify action signature if signing is enabled. Every branch
     // (pass, reject, allow-unsigned) bumps a gateway metric so
     // operators can alert on a spike in invalid/unknown/scope-denied
-    // signatures post-rotation.
+    // signatures post-rotation. Metric bumps hit `state.metrics`
+    // directly (atomic counters) so the signing check never has to
+    // take the gateway RwLock.
     if let Some(ref verifier) = state.signature_verifier {
         let outcome = verifier.verify_action(&action);
-        {
-            let gw = state.gateway.read().await;
-            outcome.record_metric(gw.metrics());
+        outcome.record_metric(&state.metrics);
+        if let Some(msg) = outcome.internal_error_message() {
+            return Ok((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!(ErrorResponse { error: msg })),
+            ));
         }
         if let Some(err) = outcome.error_message() {
             return Ok((
@@ -107,6 +113,8 @@ pub async fn dispatch(
     // Replay protection: reject if this action ID has already been dispatched.
     // Uses check_and_set (atomic set-if-not-exists) to close the race window
     // between checking and marking. Returns false if the key already existed.
+    // Replay protection is independent of signing — this path increments
+    // `replay_rejected`, not any `signing_*` counter.
     if let Some((true, ttl)) = state.replay_protection {
         let gw = state.gateway.read().await;
         let replay_key = acteon_state::StateKey::new(
@@ -121,7 +129,8 @@ pub async fn dispatch(
             .await
         {
             // Already existed — replay detected.
-            gw.metrics().increment_signing_replay_rejected();
+            drop(gw);
+            state.metrics.increment_replay_rejected();
             return Ok((
                 StatusCode::CONFLICT,
                 Json(serde_json::json!(ErrorResponse {

--- a/crates/server/src/api/health.rs
+++ b/crates/server/src/api/health.rs
@@ -61,7 +61,9 @@ fn build_metrics_response(
         signing_unknown_signer: snap.signing_unknown_signer,
         signing_scope_denied: snap.signing_scope_denied,
         signing_unsigned_rejected: snap.signing_unsigned_rejected,
-        signing_replay_rejected: snap.signing_replay_rejected,
+        signing_unsigned_allowed: snap.signing_unsigned_allowed,
+        replay_rejected: snap.replay_rejected,
+        signing_enabled: state.signature_verifier.is_some(),
         embedding,
     }
 }

--- a/crates/server/src/api/health.rs
+++ b/crates/server/src/api/health.rs
@@ -56,6 +56,12 @@ fn build_metrics_response(
         retention_errors: snap.retention_errors,
         wasm_invocations: snap.wasm_invocations,
         wasm_errors: snap.wasm_errors,
+        signing_verified: snap.signing_verified,
+        signing_invalid: snap.signing_invalid,
+        signing_unknown_signer: snap.signing_unknown_signer,
+        signing_scope_denied: snap.signing_scope_denied,
+        signing_unsigned_rejected: snap.signing_unsigned_rejected,
+        signing_replay_rejected: snap.signing_replay_rejected,
         embedding,
     }
 }

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -46,7 +46,7 @@ use utoipa_swagger_ui::SwaggerUi;
 use acteon_audit::AnalyticsStore;
 use acteon_audit::store::AuditStore;
 use acteon_embedding::EmbeddingMetrics;
-use acteon_gateway::Gateway;
+use acteon_gateway::{Gateway, GatewayMetrics};
 use acteon_rules::EmbeddingEvalSupport;
 
 use self::stream::ConnectionRegistry;
@@ -66,6 +66,10 @@ use self::openapi::ApiDoc;
 pub struct AppState {
     /// The gateway instance.
     pub gateway: Arc<RwLock<Gateway>>,
+    /// Shared handle to the gateway's metric counters. Lets hot-path
+    /// handlers bump counters without acquiring the gateway `RwLock`
+    /// — the inner counters are `AtomicU64`, so no lock is required.
+    pub metrics: Arc<GatewayMetrics>,
     /// Optional audit store (None when audit is disabled).
     pub audit: Option<Arc<dyn AuditStore>>,
     /// Optional analytics store (None when audit is disabled).

--- a/crates/server/src/api/prometheus.rs
+++ b/crates/server/src/api/prometheus.rs
@@ -334,6 +334,44 @@ fn render_snapshot(snap: &MetricsSnapshot) -> String {
         snap.wasm_errors,
     );
 
+    // -- Action signing counters --
+    write_counter(
+        &mut buf,
+        "acteon_signing_verified_total",
+        "Action signatures successfully verified and scope-authorized.",
+        snap.signing_verified,
+    );
+    write_counter(
+        &mut buf,
+        "acteon_signing_invalid_total",
+        "Signed actions rejected because the Ed25519 signature did not validate.",
+        snap.signing_invalid,
+    );
+    write_counter(
+        &mut buf,
+        "acteon_signing_unknown_signer_total",
+        "Signed actions rejected because the signer_id (or signer_id/kid pair) is not in the keyring.",
+        snap.signing_unknown_signer,
+    );
+    write_counter(
+        &mut buf,
+        "acteon_signing_scope_denied_total",
+        "Signed actions rejected because the signer is not authorized for the (tenant, namespace) pair.",
+        snap.signing_scope_denied,
+    );
+    write_counter(
+        &mut buf,
+        "acteon_signing_unsigned_rejected_total",
+        "Unsigned actions rejected because signing.reject_unsigned is enabled.",
+        snap.signing_unsigned_rejected,
+    );
+    write_counter(
+        &mut buf,
+        "acteon_signing_replay_rejected_total",
+        "Actions rejected because their action ID was already seen within the replay protection window.",
+        snap.signing_replay_rejected,
+    );
+
     buf
 }
 
@@ -548,6 +586,12 @@ mod tests {
             retention_errors: 0,
             wasm_invocations: 0,
             wasm_errors: 0,
+            signing_verified: 0,
+            signing_invalid: 0,
+            signing_unknown_signer: 0,
+            signing_scope_denied: 0,
+            signing_unsigned_rejected: 0,
+            signing_replay_rejected: 0,
         }
     }
 
@@ -586,6 +630,12 @@ mod tests {
             retention_errors: 1,
             wasm_invocations: 6,
             wasm_errors: 2,
+            signing_verified: 42,
+            signing_invalid: 2,
+            signing_unknown_signer: 3,
+            signing_scope_denied: 1,
+            signing_unsigned_rejected: 5,
+            signing_replay_rejected: 4,
         }
     }
 
@@ -754,7 +804,7 @@ mod tests {
 
     // -- render_snapshot tests --
 
-    /// All 33 gateway counter metric names that must appear in the output.
+    /// All 39 gateway counter metric names that must appear in the output.
     const EXPECTED_COUNTER_METRICS: &[&str] = &[
         "acteon_actions_dispatched_total",
         "acteon_actions_executed_total",
@@ -789,10 +839,16 @@ mod tests {
         "acteon_retention_errors_total",
         "acteon_wasm_invocations_total",
         "acteon_wasm_errors_total",
+        "acteon_signing_verified_total",
+        "acteon_signing_invalid_total",
+        "acteon_signing_unknown_signer_total",
+        "acteon_signing_scope_denied_total",
+        "acteon_signing_unsigned_rejected_total",
+        "acteon_signing_replay_rejected_total",
     ];
 
     #[test]
-    fn render_snapshot_contains_all_33_counter_metrics() {
+    fn render_snapshot_contains_all_39_counter_metrics() {
         let snap = zero_snapshot();
         let output = render_snapshot(&snap);
 
@@ -872,6 +928,12 @@ mod tests {
         assert!(output.contains("acteon_retention_errors_total 1"));
         assert!(output.contains("acteon_wasm_invocations_total 6"));
         assert!(output.contains("acteon_wasm_errors_total 2"));
+        assert!(output.contains("acteon_signing_verified_total 42"));
+        assert!(output.contains("acteon_signing_invalid_total 2"));
+        assert!(output.contains("acteon_signing_unknown_signer_total 3"));
+        assert!(output.contains("acteon_signing_scope_denied_total 1"));
+        assert!(output.contains("acteon_signing_unsigned_rejected_total 5"));
+        assert!(output.contains("acteon_signing_replay_rejected_total 4"));
     }
 
     #[test]
@@ -1097,7 +1159,7 @@ mod tests {
         providers.insert("email".to_string(), sample_provider_stats());
         render_provider_metrics(&mut output, &providers);
 
-        // 33 counter metrics from the snapshot
+        // 39 counter metrics from the snapshot
         for metric in EXPECTED_COUNTER_METRICS {
             assert!(output.contains(metric), "Missing snapshot metric: {metric}");
         }
@@ -1107,16 +1169,16 @@ mod tests {
             assert!(output.contains(name), "Missing provider metric: {name}");
         }
 
-        // Total: 33 + 8 = 41 unique metric families
+        // Total: 39 + 8 = 47 unique metric families
         let type_lines: Vec<&str> = output
             .lines()
             .filter(|l| l.starts_with("# TYPE "))
             .collect();
-        assert_eq!(type_lines.len(), 41, "Expected 41 TYPE declarations");
+        assert_eq!(type_lines.len(), 47, "Expected 47 TYPE declarations");
     }
 
     #[test]
-    fn full_render_no_providers_has_33_type_lines() {
+    fn full_render_no_providers_has_39_type_lines() {
         let snap = zero_snapshot();
         let mut output = render_snapshot(&snap);
         let empty: HashMap<String, ProviderStatsSnapshot> = HashMap::new();
@@ -1128,8 +1190,8 @@ mod tests {
             .collect();
         assert_eq!(
             type_lines.len(),
-            33,
-            "Expected 33 TYPE declarations without providers"
+            39,
+            "Expected 39 TYPE declarations without providers"
         );
     }
 }

--- a/crates/server/src/api/prometheus.rs
+++ b/crates/server/src/api/prometheus.rs
@@ -367,9 +367,17 @@ fn render_snapshot(snap: &MetricsSnapshot) -> String {
     );
     write_counter(
         &mut buf,
-        "acteon_signing_replay_rejected_total",
+        "acteon_signing_unsigned_allowed_total",
+        "Unsigned actions passed through because signing.reject_unsigned is off.",
+        snap.signing_unsigned_allowed,
+    );
+
+    // -- Replay protection counter (independent of signing) --
+    write_counter(
+        &mut buf,
+        "acteon_replay_rejected_total",
         "Actions rejected because their action ID was already seen within the replay protection window.",
-        snap.signing_replay_rejected,
+        snap.replay_rejected,
     );
 
     buf
@@ -591,7 +599,8 @@ mod tests {
             signing_unknown_signer: 0,
             signing_scope_denied: 0,
             signing_unsigned_rejected: 0,
-            signing_replay_rejected: 0,
+            signing_unsigned_allowed: 0,
+            replay_rejected: 0,
         }
     }
 
@@ -635,7 +644,8 @@ mod tests {
             signing_unknown_signer: 3,
             signing_scope_denied: 1,
             signing_unsigned_rejected: 5,
-            signing_replay_rejected: 4,
+            signing_unsigned_allowed: 7,
+            replay_rejected: 4,
         }
     }
 
@@ -804,7 +814,7 @@ mod tests {
 
     // -- render_snapshot tests --
 
-    /// All 39 gateway counter metric names that must appear in the output.
+    /// All 40 gateway counter metric names that must appear in the output.
     const EXPECTED_COUNTER_METRICS: &[&str] = &[
         "acteon_actions_dispatched_total",
         "acteon_actions_executed_total",
@@ -844,11 +854,12 @@ mod tests {
         "acteon_signing_unknown_signer_total",
         "acteon_signing_scope_denied_total",
         "acteon_signing_unsigned_rejected_total",
-        "acteon_signing_replay_rejected_total",
+        "acteon_signing_unsigned_allowed_total",
+        "acteon_replay_rejected_total",
     ];
 
     #[test]
-    fn render_snapshot_contains_all_39_counter_metrics() {
+    fn render_snapshot_contains_all_40_counter_metrics() {
         let snap = zero_snapshot();
         let output = render_snapshot(&snap);
 
@@ -933,7 +944,8 @@ mod tests {
         assert!(output.contains("acteon_signing_unknown_signer_total 3"));
         assert!(output.contains("acteon_signing_scope_denied_total 1"));
         assert!(output.contains("acteon_signing_unsigned_rejected_total 5"));
-        assert!(output.contains("acteon_signing_replay_rejected_total 4"));
+        assert!(output.contains("acteon_signing_unsigned_allowed_total 7"));
+        assert!(output.contains("acteon_replay_rejected_total 4"));
     }
 
     #[test]
@@ -1159,7 +1171,7 @@ mod tests {
         providers.insert("email".to_string(), sample_provider_stats());
         render_provider_metrics(&mut output, &providers);
 
-        // 39 counter metrics from the snapshot
+        // 40 counter metrics from the snapshot
         for metric in EXPECTED_COUNTER_METRICS {
             assert!(output.contains(metric), "Missing snapshot metric: {metric}");
         }
@@ -1169,16 +1181,16 @@ mod tests {
             assert!(output.contains(name), "Missing provider metric: {name}");
         }
 
-        // Total: 39 + 8 = 47 unique metric families
+        // Total: 40 + 8 = 48 unique metric families
         let type_lines: Vec<&str> = output
             .lines()
             .filter(|l| l.starts_with("# TYPE "))
             .collect();
-        assert_eq!(type_lines.len(), 47, "Expected 47 TYPE declarations");
+        assert_eq!(type_lines.len(), 48, "Expected 48 TYPE declarations");
     }
 
     #[test]
-    fn full_render_no_providers_has_39_type_lines() {
+    fn full_render_no_providers_has_40_type_lines() {
         let snap = zero_snapshot();
         let mut output = render_snapshot(&snap);
         let empty: HashMap<String, ProviderStatsSnapshot> = HashMap::new();
@@ -1190,8 +1202,8 @@ mod tests {
             .collect();
         assert_eq!(
             type_lines.len(),
-            39,
-            "Expected 39 TYPE declarations without providers"
+            40,
+            "Expected 40 TYPE declarations without providers"
         );
     }
 }

--- a/crates/server/src/api/schemas.rs
+++ b/crates/server/src/api/schemas.rs
@@ -116,6 +116,36 @@ pub struct MetricsResponse {
     /// WASM plugin invocation errors.
     #[schema(example = 0)]
     pub wasm_errors: u64,
+    /// Action signatures successfully verified and scope-authorized.
+    #[schema(example = 0)]
+    #[serde(default)]
+    pub signing_verified: u64,
+    /// Signed actions rejected because the Ed25519 signature did not
+    /// validate against the registered public key.
+    #[schema(example = 0)]
+    #[serde(default)]
+    pub signing_invalid: u64,
+    /// Signed actions rejected because the `signer_id` (or
+    /// `(signer_id, kid)` pair during a rotation window) is not in
+    /// the server's keyring.
+    #[schema(example = 0)]
+    #[serde(default)]
+    pub signing_unknown_signer: u64,
+    /// Signed actions rejected because the signer is not authorized
+    /// for the action's `(tenant, namespace)` pair.
+    #[schema(example = 0)]
+    #[serde(default)]
+    pub signing_scope_denied: u64,
+    /// Unsigned actions rejected because `signing.reject_unsigned`
+    /// is enabled.
+    #[schema(example = 0)]
+    #[serde(default)]
+    pub signing_unsigned_rejected: u64,
+    /// Actions rejected because their action ID was already seen
+    /// within the replay protection window.
+    #[schema(example = 0)]
+    #[serde(default)]
+    pub signing_replay_rejected: u64,
     /// Embedding cache metrics (present when embedding provider is enabled).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub embedding: Option<EmbeddingMetricsResponse>,

--- a/crates/server/src/api/schemas.rs
+++ b/crates/server/src/api/schemas.rs
@@ -141,11 +141,26 @@ pub struct MetricsResponse {
     #[schema(example = 0)]
     #[serde(default)]
     pub signing_unsigned_rejected: u64,
-    /// Actions rejected because their action ID was already seen
-    /// within the replay protection window.
+    /// Unsigned actions passed through because
+    /// `signing.reject_unsigned` is off. Lets operators compute the
+    /// signed-vs-unsigned traffic ratio without subtracting every
+    /// rejection counter from `dispatched`.
     #[schema(example = 0)]
     #[serde(default)]
-    pub signing_replay_rejected: u64,
+    pub signing_unsigned_allowed: u64,
+    /// Actions rejected because their action ID was already seen
+    /// within the replay protection window. Replay protection is
+    /// independent of signing — this counter increments whether or
+    /// not a valid signature was presented.
+    #[schema(example = 0)]
+    #[serde(default)]
+    pub replay_rejected: u64,
+    /// Whether signing is enabled on the server. Lets the dashboard
+    /// distinguish "signing configured but idle" (show the cards with
+    /// zeros) from "signing not configured" (hide the cards).
+    #[schema(example = false)]
+    #[serde(default)]
+    pub signing_enabled: bool,
     /// Embedding cache metrics (present when embedding provider is enabled).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub embedding: Option<EmbeddingMetricsResponse>,

--- a/crates/server/src/api/verify.rs
+++ b/crates/server/src/api/verify.rs
@@ -100,8 +100,11 @@ impl SignatureVerifier {
 
     /// Verify an action's signature inline during dispatch.
     ///
-    /// Returns `Ok(())` if the action passes verification, or an
-    /// error string suitable for an HTTP 400 response body.
+    /// Returns a [`VerifyOutcome`] describing which branch was
+    /// taken. Callers bump the corresponding gateway metric via
+    /// [`VerifyOutcome::record_metric`] and translate the outcome
+    /// into an HTTP 400 response via [`VerifyOutcome::error_message`]
+    /// when appropriate.
     ///
     /// When the action carries a `kid`, the verifier looks up the
     /// exact `(signer_id, kid)` pair — fail-fast on stale or
@@ -110,38 +113,146 @@ impl SignatureVerifier {
     /// accepts the first match (legacy single-key behavior, plus
     /// the rotation overlap window where neither client nor server
     /// has fully migrated to `kid`).
-    pub fn verify_action(&self, action: &Action) -> Result<(), String> {
-        if let (Some(sig), Some(signer_id)) = (&action.signature, &action.signer_id) {
-            // 1. Cryptographic verification.
-            let canonical = action.canonical_bytes();
-            let verify_result = if let Some(ref kid) = action.kid {
-                self.keyring
-                    .verify_with_kid(signer_id, kid, sig, &canonical)
+    pub fn verify_action(&self, action: &Action) -> VerifyOutcome {
+        let (Some(sig), Some(signer_id)) = (&action.signature, &action.signer_id) else {
+            return if self.reject_unsigned {
+                VerifyOutcome::UnsignedRejected
             } else {
-                self.keyring.verify(signer_id, sig, &canonical)
+                VerifyOutcome::UnsignedAllowed
             };
-            verify_result.map_err(|e| format!("signature verification failed: {e}"))?;
+        };
 
-            // 2. Scope enforcement.
-            if let Some(scope) = self.scopes.get(signer_id.as_str())
-                && !scope.allows(&action.tenant, &action.namespace)
-            {
-                return Err(format!(
-                    "signer '{signer_id}' is not authorized for \
-                     tenant={} namespace={}",
-                    action.tenant, action.namespace
-                ));
-            }
+        // 1. Cryptographic verification.
+        let canonical = action.canonical_bytes();
+        let crypto_result = if let Some(ref kid) = action.kid {
+            self.keyring
+                .verify_with_kid(signer_id, kid, sig, &canonical)
+        } else {
+            self.keyring.verify(signer_id, sig, &canonical)
+        };
 
-            Ok(())
-        } else if self.reject_unsigned {
-            Err(
+        if let Err(e) = crypto_result {
+            return match e {
+                acteon_crypto::CryptoError::UnknownSigner(_) => VerifyOutcome::UnknownSigner {
+                    signer_id: signer_id.clone(),
+                    kid: action.kid.clone(),
+                },
+                _ => VerifyOutcome::InvalidSignature {
+                    signer_id: signer_id.clone(),
+                    kid: action.kid.clone(),
+                },
+            };
+        }
+
+        // 2. Scope enforcement.
+        if let Some(scope) = self.scopes.get(signer_id.as_str())
+            && !scope.allows(&action.tenant, &action.namespace)
+        {
+            return VerifyOutcome::ScopeDenied {
+                signer_id: signer_id.clone(),
+                tenant: action.tenant.to_string(),
+                namespace: action.namespace.to_string(),
+            };
+        }
+
+        VerifyOutcome::Verified {
+            signer_id: signer_id.clone(),
+            kid: action.kid.clone(),
+        }
+    }
+}
+
+/// Outcome of verifying an action's signature.
+///
+/// Lets the dispatch handler distinguish between the branches the
+/// verifier took so it can bump the right metric and — for rejection
+/// paths — emit a targeted HTTP 400 error message.
+#[derive(Debug, Clone)]
+pub enum VerifyOutcome {
+    /// Action carries no signature and `reject_unsigned` is off —
+    /// dispatch proceeds without signing validation.
+    UnsignedAllowed,
+    /// Action carries a signature that is cryptographically valid
+    /// and passes scope enforcement.
+    Verified {
+        signer_id: String,
+        kid: Option<String>,
+    },
+    /// Action carries no signature and `reject_unsigned` is on.
+    UnsignedRejected,
+    /// The `signer_id` (or `(signer_id, kid)` pair during a rotation
+    /// window) is not registered in the keyring.
+    UnknownSigner {
+        signer_id: String,
+        kid: Option<String>,
+    },
+    /// Cryptographic verification failed — the signature does not
+    /// match the canonical bytes under the registered public key.
+    InvalidSignature {
+        signer_id: String,
+        kid: Option<String>,
+    },
+    /// Signature is cryptographically valid but the signer is not
+    /// authorized for the action's `(tenant, namespace)` pair.
+    ScopeDenied {
+        signer_id: String,
+        tenant: String,
+        namespace: String,
+    },
+}
+
+impl VerifyOutcome {
+    /// Whether the outcome allows dispatch to proceed.
+    #[must_use]
+    pub fn is_ok(&self) -> bool {
+        matches!(self, Self::UnsignedAllowed | Self::Verified { .. })
+    }
+
+    /// HTTP 400 body message for rejection outcomes, or `None` when
+    /// dispatch should proceed.
+    #[must_use]
+    pub fn error_message(&self) -> Option<String> {
+        match self {
+            Self::UnsignedAllowed | Self::Verified { .. } => None,
+            Self::UnsignedRejected => Some(
                 "unsigned action rejected: signing.reject_unsigned is enabled; \
                  provide both 'signature' and 'signer_id' fields"
                     .to_owned(),
-            )
-        } else {
-            Ok(())
+            ),
+            Self::UnknownSigner { signer_id, kid } => Some(match kid {
+                Some(k) => format!(
+                    "signature verification failed: unknown signer '{signer_id}' \
+                     with kid '{k}' — check /.well-known/acteon-signing-keys"
+                ),
+                None => format!(
+                    "signature verification failed: unknown signer '{signer_id}' — \
+                     check /.well-known/acteon-signing-keys"
+                ),
+            }),
+            Self::InvalidSignature { signer_id, kid: _ } => Some(format!(
+                "signature verification failed: signature did not validate \
+                 under the registered public key for signer '{signer_id}'"
+            )),
+            Self::ScopeDenied {
+                signer_id,
+                tenant,
+                namespace,
+            } => Some(format!(
+                "signer '{signer_id}' is not authorized for tenant={tenant} \
+                 namespace={namespace}"
+            )),
+        }
+    }
+
+    /// Bump the gateway counter that corresponds to this outcome.
+    pub fn record_metric(&self, metrics: &acteon_gateway::GatewayMetrics) {
+        match self {
+            Self::UnsignedAllowed => {}
+            Self::Verified { .. } => metrics.increment_signing_verified(),
+            Self::UnsignedRejected => metrics.increment_signing_unsigned_rejected(),
+            Self::UnknownSigner { .. } => metrics.increment_signing_unknown_signer(),
+            Self::InvalidSignature { .. } => metrics.increment_signing_invalid(),
+            Self::ScopeDenied { .. } => metrics.increment_signing_scope_denied(),
         }
     }
 }

--- a/crates/server/src/api/verify.rs
+++ b/crates/server/src/api/verify.rs
@@ -14,6 +14,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use base64::Engine;
 use serde::Serialize;
+use tracing::warn;
 use utoipa::ToSchema;
 
 use super::AppState;
@@ -224,6 +225,18 @@ impl VerifyOutcome {
     /// HTTP 400 body message for rejection outcomes, or `None` when
     /// dispatch should proceed. `InternalError` is handled separately
     /// via [`Self::internal_error_message`] since it maps to a 500.
+    ///
+    /// `UnknownSigner` and `InvalidSignature` return the same wire
+    /// message on purpose: distinguishing them would let an attacker
+    /// enumerate which `(signer_id, kid)` pairs exist on the server.
+    /// The JWKS discovery endpoint already exposes the public
+    /// verifier set to anyone who asks, but we don't need to give
+    /// away additional signal per dispatch attempt. Operators can
+    /// still tell the two apart via the [`record_metric`] counters
+    /// and the structured tracing log emitted by [`log_rejection`].
+    ///
+    /// [`record_metric`]: Self::record_metric
+    /// [`log_rejection`]: Self::log_rejection
     #[must_use]
     pub fn error_message(&self) -> Option<String> {
         match self {
@@ -233,20 +246,11 @@ impl VerifyOutcome {
                  provide both 'signature' and 'signer_id' fields"
                     .to_owned(),
             ),
-            Self::UnknownSigner { signer_id, kid } => Some(match kid {
-                Some(k) => format!(
-                    "signature verification failed: unknown signer '{signer_id}' \
-                     with kid '{k}' — check /.well-known/acteon-signing-keys"
-                ),
-                None => format!(
-                    "signature verification failed: unknown signer '{signer_id}' — \
-                     check /.well-known/acteon-signing-keys"
-                ),
-            }),
-            Self::InvalidSignature { signer_id, kid: _ } => Some(format!(
-                "signature verification failed: signature did not validate \
-                 under the registered public key for signer '{signer_id}'"
-            )),
+            Self::UnknownSigner { signer_id, .. } | Self::InvalidSignature { signer_id, .. } => {
+                Some(format!(
+                    "signature verification failed for signer '{signer_id}'"
+                ))
+            }
             Self::ScopeDenied {
                 signer_id,
                 tenant,
@@ -255,6 +259,59 @@ impl VerifyOutcome {
                 "signer '{signer_id}' is not authorized for tenant={tenant} \
                  namespace={namespace}"
             )),
+        }
+    }
+
+    /// Emit a structured `tracing::warn` line describing a rejection
+    /// outcome. Operators debugging a failed dispatch get the full
+    /// variant, `kid`, and scope context in logs — which the
+    /// generic HTTP 400 body deliberately omits. No-ops on the
+    /// success and `UnsignedAllowed` branches.
+    pub fn log_rejection(&self) {
+        match self {
+            Self::UnsignedAllowed | Self::Verified { .. } => {}
+            Self::UnsignedRejected => {
+                warn!(
+                    outcome = "unsigned_rejected",
+                    "signature verification rejected: unsigned action with reject_unsigned enabled"
+                );
+            }
+            Self::UnknownSigner { signer_id, kid } => {
+                warn!(
+                    outcome = "unknown_signer",
+                    signer_id = signer_id.as_str(),
+                    kid = kid.as_deref(),
+                    "signature verification rejected: signer (or signer/kid pair) not in keyring"
+                );
+            }
+            Self::InvalidSignature { signer_id, kid } => {
+                warn!(
+                    outcome = "invalid_signature",
+                    signer_id = signer_id.as_str(),
+                    kid = kid.as_deref(),
+                    "signature verification rejected: Ed25519 signature did not validate"
+                );
+            }
+            Self::ScopeDenied {
+                signer_id,
+                tenant,
+                namespace,
+            } => {
+                warn!(
+                    outcome = "scope_denied",
+                    signer_id = signer_id.as_str(),
+                    tenant = tenant.as_str(),
+                    namespace = namespace.as_str(),
+                    "signature verification rejected: signer not authorized for tenant/namespace"
+                );
+            }
+            Self::InternalError { message } => {
+                warn!(
+                    outcome = "internal_error",
+                    error = message.as_str(),
+                    "signature verification hit an unexpected crypto error"
+                );
+            }
         }
     }
 

--- a/crates/server/src/api/verify.rs
+++ b/crates/server/src/api/verify.rs
@@ -137,9 +137,18 @@ impl SignatureVerifier {
                     signer_id: signer_id.clone(),
                     kid: action.kid.clone(),
                 },
-                _ => VerifyOutcome::InvalidSignature {
+                acteon_crypto::CryptoError::SignatureInvalid => VerifyOutcome::InvalidSignature {
                     signer_id: signer_id.clone(),
                     kid: action.kid.clone(),
+                },
+                // Any other CryptoError variant (InvalidKey, InvalidFormat,
+                // DecryptionFailed, EncryptionFailed) is an internal fault
+                // — those error types are for the encryption path, not
+                // signature verification, and shouldn't reach this arm in
+                // normal operation. Surface as a 500 so operators notice
+                // instead of mislabeling them as "invalid signature".
+                other => VerifyOutcome::InternalError {
+                    message: other.to_string(),
                 },
             };
         }
@@ -199,6 +208,10 @@ pub enum VerifyOutcome {
         tenant: String,
         namespace: String,
     },
+    /// An unexpected crypto error was returned during verification.
+    /// Indicates a bug or misconfiguration rather than a rejected
+    /// signature — the dispatch handler maps this to HTTP 500.
+    InternalError { message: String },
 }
 
 impl VerifyOutcome {
@@ -209,11 +222,12 @@ impl VerifyOutcome {
     }
 
     /// HTTP 400 body message for rejection outcomes, or `None` when
-    /// dispatch should proceed.
+    /// dispatch should proceed. `InternalError` is handled separately
+    /// via [`Self::internal_error_message`] since it maps to a 500.
     #[must_use]
     pub fn error_message(&self) -> Option<String> {
         match self {
-            Self::UnsignedAllowed | Self::Verified { .. } => None,
+            Self::UnsignedAllowed | Self::Verified { .. } | Self::InternalError { .. } => None,
             Self::UnsignedRejected => Some(
                 "unsigned action rejected: signing.reject_unsigned is enabled; \
                  provide both 'signature' and 'signer_id' fields"
@@ -244,15 +258,30 @@ impl VerifyOutcome {
         }
     }
 
+    /// HTTP 500 body message when an unexpected crypto error surfaced
+    /// during verification (none otherwise).
+    #[must_use]
+    pub fn internal_error_message(&self) -> Option<String> {
+        match self {
+            Self::InternalError { message } => Some(format!(
+                "signature verification failed with an unexpected crypto error: {message}"
+            )),
+            _ => None,
+        }
+    }
+
     /// Bump the gateway counter that corresponds to this outcome.
     pub fn record_metric(&self, metrics: &acteon_gateway::GatewayMetrics) {
         match self {
-            Self::UnsignedAllowed => {}
+            Self::UnsignedAllowed => metrics.increment_signing_unsigned_allowed(),
             Self::Verified { .. } => metrics.increment_signing_verified(),
             Self::UnsignedRejected => metrics.increment_signing_unsigned_rejected(),
             Self::UnknownSigner { .. } => metrics.increment_signing_unknown_signer(),
             Self::InvalidSignature { .. } => metrics.increment_signing_invalid(),
             Self::ScopeDenied { .. } => metrics.increment_signing_scope_denied(),
+            // InternalError is a bug, not a signing event — don't
+            // count it against the verification metrics.
+            Self::InternalError { .. } => {}
         }
     }
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1548,6 +1548,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let gateway = Arc::new(RwLock::new(gateway));
+    // Snapshot the Arc<GatewayMetrics> at startup so hot-path metric
+    // increments can skip the gateway RwLock entirely. The inner
+    // counters are AtomicU64 — no lock needed once we hold the Arc.
+    let gateway_metrics = gateway.read().await.metrics_arc();
 
     // Spawn background processor for group flushing and timeout processing.
     // This must be after gateway Arc is created so handlers can dispatch notifications.
@@ -2205,6 +2209,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let state = AppState {
         gateway: Arc::clone(&gateway),
+        metrics: gateway_metrics,
         audit: audit_store,
         analytics: analytics_store,
         auth: auth_provider,

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -90,6 +90,7 @@ fn build_test_state_with_audit_and_analytics(
     }
 
     let gw = builder.build().expect("gateway should build");
+    let metrics = gw.metrics_arc();
 
     let analytics: Option<Arc<dyn AnalyticsStore>> = if with_analytics {
         audit
@@ -101,6 +102,7 @@ fn build_test_state_with_audit_and_analytics(
 
     AppState {
         gateway: Arc::new(RwLock::new(gw)),
+        metrics,
         audit,
         analytics,
         auth: None,
@@ -928,9 +930,11 @@ fn build_approval_state_with_providers(
     }
 
     let gw = builder.build().expect("gateway should build");
+    let metrics = gw.metrics_arc();
 
     AppState {
         gateway: Arc::new(RwLock::new(gw)),
+        metrics,
         audit: None,
         analytics: None,
         auth: None,

--- a/crates/server/tests/ui_tests.rs
+++ b/crates/server/tests/ui_tests.rs
@@ -27,6 +27,7 @@ async fn ui_serves_index_html() {
         .executor_config(ExecutorConfig::default())
         .build()
         .expect("gateway should build");
+    let metrics = gw.metrics_arc();
 
     let ui_config = UiConfig {
         enabled: true,
@@ -35,6 +36,7 @@ async fn ui_serves_index_html() {
 
     let state = AppState {
         gateway: Arc::new(RwLock::new(gw)),
+        metrics,
         audit: None,
         analytics: None,
         auth: None,

--- a/crates/simulation/examples/polyglot_client_simulation.rs
+++ b/crates/simulation/examples/polyglot_client_simulation.rs
@@ -55,10 +55,12 @@ impl TestServer {
             .build()?;
 
         let gateway = Arc::new(RwLock::new(gateway));
+        let metrics = gateway.read().await.metrics_arc();
 
         // Create app state
         let app_state = acteon_server::api::AppState {
             gateway,
+            metrics,
             audit: Some(audit),
             analytics: None,
             auth: None,

--- a/deploy/grafana/dashboards/acteon-overview.json
+++ b/deploy/grafana/dashboards/acteon-overview.json
@@ -505,11 +505,12 @@
       "title": "Signature Verification Rate",
       "targets": [
         { "expr": "rate(acteon_signing_verified_total[5m])", "legendFormat": "verified", "refId": "A" },
-        { "expr": "rate(acteon_signing_invalid_total[5m])", "legendFormat": "invalid", "refId": "B" },
-        { "expr": "rate(acteon_signing_unknown_signer_total[5m])", "legendFormat": "unknown signer", "refId": "C" },
-        { "expr": "rate(acteon_signing_scope_denied_total[5m])", "legendFormat": "scope denied", "refId": "D" },
-        { "expr": "rate(acteon_signing_unsigned_rejected_total[5m])", "legendFormat": "unsigned rejected", "refId": "E" },
-        { "expr": "rate(acteon_signing_replay_rejected_total[5m])", "legendFormat": "replay rejected", "refId": "F" }
+        { "expr": "rate(acteon_signing_unsigned_allowed_total[5m])", "legendFormat": "unsigned allowed", "refId": "B" },
+        { "expr": "rate(acteon_signing_invalid_total[5m])", "legendFormat": "invalid", "refId": "C" },
+        { "expr": "rate(acteon_signing_unknown_signer_total[5m])", "legendFormat": "unknown signer", "refId": "D" },
+        { "expr": "rate(acteon_signing_scope_denied_total[5m])", "legendFormat": "scope denied", "refId": "E" },
+        { "expr": "rate(acteon_signing_unsigned_rejected_total[5m])", "legendFormat": "unsigned rejected", "refId": "F" },
+        { "expr": "rate(acteon_replay_rejected_total[5m])", "legendFormat": "replay rejected", "refId": "G" }
       ],
       "type": "timeseries"
     },
@@ -531,11 +532,12 @@
       "title": "Signing Totals",
       "targets": [
         { "expr": "acteon_signing_verified_total", "legendFormat": "Verified", "refId": "A" },
-        { "expr": "acteon_signing_invalid_total", "legendFormat": "Invalid", "refId": "B" },
-        { "expr": "acteon_signing_unknown_signer_total", "legendFormat": "Unknown signer", "refId": "C" },
-        { "expr": "acteon_signing_scope_denied_total", "legendFormat": "Scope denied", "refId": "D" },
-        { "expr": "acteon_signing_unsigned_rejected_total", "legendFormat": "Unsigned rejected", "refId": "E" },
-        { "expr": "acteon_signing_replay_rejected_total", "legendFormat": "Replay rejected", "refId": "F" }
+        { "expr": "acteon_signing_unsigned_allowed_total", "legendFormat": "Unsigned allowed", "refId": "B" },
+        { "expr": "acteon_signing_invalid_total", "legendFormat": "Invalid", "refId": "C" },
+        { "expr": "acteon_signing_unknown_signer_total", "legendFormat": "Unknown signer", "refId": "D" },
+        { "expr": "acteon_signing_scope_denied_total", "legendFormat": "Scope denied", "refId": "E" },
+        { "expr": "acteon_signing_unsigned_rejected_total", "legendFormat": "Unsigned rejected", "refId": "F" },
+        { "expr": "acteon_replay_rejected_total", "legendFormat": "Replay rejected", "refId": "G" }
       ],
       "type": "stat"
     }

--- a/deploy/grafana/dashboards/acteon-overview.json
+++ b/deploy/grafana/dashboards/acteon-overview.json
@@ -482,6 +482,62 @@
         { "expr": "acteon_embedding_fail_open_total", "legendFormat": "Fail-Open", "refId": "B" }
       ],
       "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 57 },
+      "id": 200,
+      "title": "Action Signing",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "lineWidth": 2, "showPoints": "never" },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 58 },
+      "id": 201,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "title": "Signature Verification Rate",
+      "targets": [
+        { "expr": "rate(acteon_signing_verified_total[5m])", "legendFormat": "verified", "refId": "A" },
+        { "expr": "rate(acteon_signing_invalid_total[5m])", "legendFormat": "invalid", "refId": "B" },
+        { "expr": "rate(acteon_signing_unknown_signer_total[5m])", "legendFormat": "unknown signer", "refId": "C" },
+        { "expr": "rate(acteon_signing_scope_denied_total[5m])", "legendFormat": "scope denied", "refId": "D" },
+        { "expr": "rate(acteon_signing_unsigned_rejected_total[5m])", "legendFormat": "unsigned rejected", "refId": "E" },
+        { "expr": "rate(acteon_signing_replay_rejected_total[5m])", "legendFormat": "replay rejected", "refId": "F" }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "thresholds": { "steps": [{ "color": "green", "value": null }] } },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Invalid" }, "properties": [{ "id": "thresholds", "value": { "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] } }] },
+          { "matcher": { "id": "byName", "options": "Unknown signer" }, "properties": [{ "id": "thresholds", "value": { "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }] } }] },
+          { "matcher": { "id": "byName", "options": "Scope denied" }, "properties": [{ "id": "thresholds", "value": { "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] } }] },
+          { "matcher": { "id": "byName", "options": "Unsigned rejected" }, "properties": [{ "id": "thresholds", "value": { "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }] } }] },
+          { "matcher": { "id": "byName", "options": "Replay rejected" }, "properties": [{ "id": "thresholds", "value": { "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }] } }] }
+        ]
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 58 },
+      "id": 202,
+      "options": { "colorMode": "background", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Signing Totals",
+      "targets": [
+        { "expr": "acteon_signing_verified_total", "legendFormat": "Verified", "refId": "A" },
+        { "expr": "acteon_signing_invalid_total", "legendFormat": "Invalid", "refId": "B" },
+        { "expr": "acteon_signing_unknown_signer_total", "legendFormat": "Unknown signer", "refId": "C" },
+        { "expr": "acteon_signing_scope_denied_total", "legendFormat": "Scope denied", "refId": "D" },
+        { "expr": "acteon_signing_unsigned_rejected_total", "legendFormat": "Unsigned rejected", "refId": "E" },
+        { "expr": "acteon_signing_replay_rejected_total", "legendFormat": "Replay rejected", "refId": "F" }
+      ],
+      "type": "stat"
     }
   ],
   "refresh": "30s",

--- a/docs/book/features/action-signing.md
+++ b/docs/book/features/action-signing.md
@@ -216,12 +216,21 @@ Callers can independently verify by computing `canonical_bytes` on the original 
 
 | Scenario | HTTP status | Error message |
 |----------|-------------|---------------|
-| Invalid signature | 400 | `signature verification failed: signature did not validate under the registered public key for signer 'X'` |
-| Unknown `signer_id` or `(signer_id, kid)` | 400 | `signature verification failed: unknown signer 'X'` (or `'X' with kid 'Y'` when kid is present) — the error message points at `/.well-known/acteon-signing-keys` |
+| Invalid signature **or** unknown `(signer_id, kid)` | 400 | `signature verification failed for signer 'X'` |
 | Signer not authorized for tenant/namespace | 400 | `signer 'X' is not authorized for tenant=Y namespace=Z` |
 | Unsigned action + `reject_unsigned=true` | 400 | `unsigned action rejected: signing.reject_unsigned is enabled` |
 | Replayed action ID + `reject_replay=true` | 409 | `replay rejected: action ID 'X' has already been dispatched` |
 | Unexpected crypto error (bug or misconfig) | 500 | `signature verification failed with an unexpected crypto error: <detail>` |
+
+Note that `InvalidSignature` and `UnknownSigner` return the **same**
+wire message. This is intentional: a probing client should not be
+able to use error responses to distinguish "this signer doesn't
+exist" from "this signer exists but the signature is wrong". The
+full variant (along with `signer_id`, `kid`, and scope) is written
+to the server's `tracing::warn` log so operators can still debug a
+failed dispatch from logs, and each variant still increments its
+own Prometheus counter (`signing_unknown_signer_total` vs.
+`signing_invalid_total`) for alerting.
 
 ## Metrics
 

--- a/docs/book/features/action-signing.md
+++ b/docs/book/features/action-signing.md
@@ -221,6 +221,7 @@ Callers can independently verify by computing `canonical_bytes` on the original 
 | Signer not authorized for tenant/namespace | 400 | `signer 'X' is not authorized for tenant=Y namespace=Z` |
 | Unsigned action + `reject_unsigned=true` | 400 | `unsigned action rejected: signing.reject_unsigned is enabled` |
 | Replayed action ID + `reject_replay=true` | 409 | `replay rejected: action ID 'X' has already been dispatched` |
+| Unexpected crypto error (bug or misconfig) | 500 | `signature verification failed with an unexpected crypto error: <detail>` |
 
 ## Metrics
 
@@ -232,11 +233,18 @@ as a Prometheus counter. They're exposed at `GET /metrics/prometheus`
 | Metric | Counted on |
 |---|---|
 | `acteon_signing_verified_total` | Cryptographically valid signature + scope-authorized |
+| `acteon_signing_unsigned_allowed_total` | Unsigned action passed through because `signing.reject_unsigned` is off |
 | `acteon_signing_invalid_total` | Signature present but Ed25519 verification failed |
 | `acteon_signing_unknown_signer_total` | `signer_id` (or `(signer_id, kid)` during a rotation) not in the keyring |
 | `acteon_signing_scope_denied_total` | Crypto valid but signer not authorized for the action's tenant/namespace |
 | `acteon_signing_unsigned_rejected_total` | Unsigned action blocked by `signing.reject_unsigned` |
-| `acteon_signing_replay_rejected_total` | Action ID already seen inside the replay TTL window |
+| `acteon_replay_rejected_total` | Action ID already seen inside the replay TTL window (independent of signing) |
+
+Note that `acteon_replay_rejected_total` does **not** carry a
+`signing_` prefix. Replay protection is driven by
+`signing.reject_replay` in the config but runs independently of
+signature verification — unsigned actions are subject to the same
+deduplication window.
 
 **What to alert on.** Verified signatures are the happy path — a
 healthy deployment should see them trend with dispatch volume.
@@ -256,19 +264,29 @@ as a security signal and page on it:
 increase(acteon_signing_scope_denied_total[15m]) > 0
 ```
 
-`signing_replay_rejected` fires when a client retries a
+`acteon_replay_rejected_total` fires when a client retries a
 previously-dispatched action id within the TTL. Low rates are
 noise (e.g. clients with misconfigured retries), sudden bursts
 can indicate a replay attack.
 
+To compute the signed-vs-unsigned traffic ratio during a rollout:
+
+```promql
+rate(acteon_signing_verified_total[5m])
+  /
+(rate(acteon_signing_verified_total[5m]) + rate(acteon_signing_unsigned_allowed_total[5m]))
+```
+
 **Grafana**: the bundled `acteon-overview` dashboard has an
-"Action Signing" row with a time-series panel of all six rates
-and a stat panel for the totals.
+"Action Signing" row with a time-series panel of the verification
+rates and a stat panel for the totals.
 
 **Dashboard UI**: the admin UI dashboard renders a compact "Sig
-Verified / Sig Rejected" stat-card pair — but only when at least
-one of the signing counters is non-zero, so operators who haven't
-enabled signing don't see empty cards.
+Verified / Sig Rejected" stat-card pair whenever signing is
+configured on the server — including the first run with zero
+traffic — so operators can confirm the config was picked up
+without having to dispatch a test action first. The cards stay
+hidden on deployments that don't enable signing at all.
 
 ## Rust client
 

--- a/docs/book/features/action-signing.md
+++ b/docs/book/features/action-signing.md
@@ -216,11 +216,59 @@ Callers can independently verify by computing `canonical_bytes` on the original 
 
 | Scenario | HTTP status | Error message |
 |----------|-------------|---------------|
-| Invalid signature | 400 | `signature verification failed: invalid signature` |
-| Unknown `signer_id` | 400 | `signature verification failed: unknown signer: X` |
+| Invalid signature | 400 | `signature verification failed: signature did not validate under the registered public key for signer 'X'` |
+| Unknown `signer_id` or `(signer_id, kid)` | 400 | `signature verification failed: unknown signer 'X'` (or `'X' with kid 'Y'` when kid is present) — the error message points at `/.well-known/acteon-signing-keys` |
 | Signer not authorized for tenant/namespace | 400 | `signer 'X' is not authorized for tenant=Y namespace=Z` |
 | Unsigned action + `reject_unsigned=true` | 400 | `unsigned action rejected: signing.reject_unsigned is enabled` |
 | Replayed action ID + `reject_replay=true` | 409 | `replay rejected: action ID 'X' has already been dispatched` |
+
+## Metrics
+
+The gateway tracks every branch of the signature verification path
+as a Prometheus counter. They're exposed at `GET /metrics/prometheus`
+(scraped by the Docker-compose monitoring profile) and as JSON at
+`GET /metrics` / `GET /health`.
+
+| Metric | Counted on |
+|---|---|
+| `acteon_signing_verified_total` | Cryptographically valid signature + scope-authorized |
+| `acteon_signing_invalid_total` | Signature present but Ed25519 verification failed |
+| `acteon_signing_unknown_signer_total` | `signer_id` (or `(signer_id, kid)` during a rotation) not in the keyring |
+| `acteon_signing_scope_denied_total` | Crypto valid but signer not authorized for the action's tenant/namespace |
+| `acteon_signing_unsigned_rejected_total` | Unsigned action blocked by `signing.reject_unsigned` |
+| `acteon_signing_replay_rejected_total` | Action ID already seen inside the replay TTL window |
+
+**What to alert on.** Verified signatures are the happy path — a
+healthy deployment should see them trend with dispatch volume.
+Spikes in `signing_invalid` or `signing_unknown_signer` after a
+rotation usually mean a client didn't pick up the new `kid` yet;
+monitor with:
+
+```promql
+rate(acteon_signing_unknown_signer_total[5m]) > 0.1
+```
+
+Sustained non-zero `signing_scope_denied` suggests a scoping
+misconfiguration or an attempted cross-tenant attack — treat it
+as a security signal and page on it:
+
+```promql
+increase(acteon_signing_scope_denied_total[15m]) > 0
+```
+
+`signing_replay_rejected` fires when a client retries a
+previously-dispatched action id within the TTL. Low rates are
+noise (e.g. clients with misconfigured retries), sudden bursts
+can indicate a replay attack.
+
+**Grafana**: the bundled `acteon-overview` dashboard has an
+"Action Signing" row with a time-series panel of all six rates
+and a stat panel for the totals.
+
+**Dashboard UI**: the admin UI dashboard renders a compact "Sig
+Verified / Sig Rejected" stat-card pair — but only when at least
+one of the signing counters is non-zero, so operators who haven't
+enabled signing don't see empty cards.
 
 ## Rust client
 

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -116,8 +116,14 @@ export function Dashboard() {
   )
 }
 
-function buildStatCards(m: MetricsResponse) {
-  return [
+interface StatCard {
+  label: string
+  value: number
+  link?: string
+}
+
+function buildStatCards(m: MetricsResponse): StatCard[] {
+  const cards: StatCard[] = [
     { label: 'Dispatched', value: m.dispatched, link: '/audit' },
     { label: 'Executed', value: m.executed, link: '/audit?outcome=Executed' },
     { label: 'Failed', value: m.failed, link: '/audit?outcome=Failed' },
@@ -129,4 +135,22 @@ function buildStatCards(m: MetricsResponse) {
     { label: 'Circuit Open', value: m.circuit_open ?? 0, link: '/circuit-breakers' },
     { label: 'Scheduled', value: m.scheduled ?? 0, link: '/scheduled' },
   ]
+
+  // Signing cards render only when signing is actually in use on the
+  // server. The signing.reject_* counters all start at 0 on a fresh
+  // server; if any of them (or signing_verified) is non-zero, signing
+  // is enabled and operators want visibility.
+  const sigVerified = m.signing_verified ?? 0
+  const sigRejected =
+    (m.signing_invalid ?? 0) +
+    (m.signing_unknown_signer ?? 0) +
+    (m.signing_scope_denied ?? 0) +
+    (m.signing_unsigned_rejected ?? 0) +
+    (m.signing_replay_rejected ?? 0)
+  if (sigVerified > 0 || sigRejected > 0) {
+    cards.push({ label: 'Sig Verified', value: sigVerified })
+    cards.push({ label: 'Sig Rejected', value: sigRejected })
+  }
+
+  return cards
 }

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -136,18 +136,18 @@ function buildStatCards(m: MetricsResponse): StatCard[] {
     { label: 'Scheduled', value: m.scheduled ?? 0, link: '/scheduled' },
   ]
 
-  // Signing cards render only when signing is actually in use on the
-  // server. The signing.reject_* counters all start at 0 on a fresh
-  // server; if any of them (or signing_verified) is non-zero, signing
-  // is enabled and operators want visibility.
+  // Signing cards render whenever the server reports signing is
+  // configured (`signing_enabled`), OR when any signing counter has
+  // ticked on older servers that predate the flag. This way an
+  // operator who just turned on signing sees the cards with zeros
+  // instead of wondering whether the config was actually picked up.
   const sigVerified = m.signing_verified ?? 0
   const sigRejected =
     (m.signing_invalid ?? 0) +
     (m.signing_unknown_signer ?? 0) +
     (m.signing_scope_denied ?? 0) +
-    (m.signing_unsigned_rejected ?? 0) +
-    (m.signing_replay_rejected ?? 0)
-  if (sigVerified > 0 || sigRejected > 0) {
+    (m.signing_unsigned_rejected ?? 0)
+  if (m.signing_enabled || sigVerified > 0 || sigRejected > 0) {
     cards.push({ label: 'Sig Verified', value: sigVerified })
     cards.push({ label: 'Sig Rejected', value: sigRejected })
   }

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -33,6 +33,15 @@ export interface MetricsResponse {
   retention_errors?: number
   wasm_invocations?: number
   wasm_errors?: number
+  // Action signing observability. All optional for backward compat
+  // with older servers that haven't shipped the signing observability
+  // PR yet.
+  signing_verified?: number
+  signing_invalid?: number
+  signing_unknown_signer?: number
+  signing_scope_denied?: number
+  signing_unsigned_rejected?: number
+  signing_replay_rejected?: number
   embedding?: EmbeddingMetrics
 }
 

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -41,7 +41,14 @@ export interface MetricsResponse {
   signing_unknown_signer?: number
   signing_scope_denied?: number
   signing_unsigned_rejected?: number
-  signing_replay_rejected?: number
+  signing_unsigned_allowed?: number
+  // Replay protection is independent of signing — this counter
+  // increments whether or not a valid signature was presented.
+  replay_rejected?: number
+  // `true` when the server has `[signing]` configured, even if no
+  // signed traffic has flowed yet. Lets the dashboard show the
+  // signing cards on day zero instead of waiting for the first event.
+  signing_enabled?: boolean
   embedding?: EmbeddingMetrics
 }
 


### PR DESCRIPTION
## Summary
PR #107 shipped kid-based key rotation + JWKS discovery but left no signal on the metrics side. Operators rotating a key had no way to spot a spike in \`unknown_signer\` rejections post-rotation without tailing logs. This PR adds end-to-end observability for every signature verification branch.

## Typed VerifyOutcome

\`SignatureVerifier::verify_action\` used to return \`Result<(), String>\` which collapsed six distinct failure modes into a single opaque error string. Replaced with a typed \`VerifyOutcome\` enum so the dispatch handler can bump the right counter, emit a tailored HTTP 400 body, and let future callers (batch dispatch, etc.) hook the same states cleanly:

| Variant | Meaning |
|---|---|
| \`UnsignedAllowed\` | No signature, \`reject_unsigned\` off |
| \`Verified { signer_id, kid }\` | Crypto valid + scope authorized |
| \`UnsignedRejected\` | No signature, \`reject_unsigned\` on |
| \`UnknownSigner { signer_id, kid }\` | Signer/kid not in keyring (error message points at \`/.well-known/acteon-signing-keys\`) |
| \`InvalidSignature { signer_id, kid }\` | Ed25519 verification failed |
| \`ScopeDenied { signer_id, tenant, namespace }\` | Crypto valid, scope violation |

\`is_ok()\`, \`error_message()\`, and \`record_metric(gw)\` are the three helpers the dispatch handler uses.

## Six new counters

| Metric | Counted on |
|---|---|
| \`acteon_signing_verified_total\` | Successful path (crypto + scope) |
| \`acteon_signing_invalid_total\` | Ed25519 verification failed |
| \`acteon_signing_unknown_signer_total\` | \`signer_id\` (or \`(signer_id, kid)\`) not in keyring |
| \`acteon_signing_scope_denied_total\` | Signer not authorized for tenant/namespace |
| \`acteon_signing_unsigned_rejected_total\` | \`reject_unsigned\` blocked an unsigned action |
| \`acteon_signing_replay_rejected_total\` | Replay protection caught a duplicate action id (pre-existing branch, previously untracked) |

## Plumbing

- **Gateway** (\`crates/gateway/src/metrics.rs\`): 6 \`AtomicU64\` fields, matching \`increment_*\` methods, wired into \`snapshot()\` and both metrics tests.
- **SignatureVerifier** (\`crates/server/src/api/verify.rs\`): typed \`VerifyOutcome\` enum, \`error_message()\` formatting, \`record_metric()\` helper.
- **Dispatch handler** (\`crates/server/src/api/dispatch.rs\`): calls \`verify_action\`, bumps via \`outcome.record_metric(gw.metrics())\`, returns 400 from \`outcome.error_message()\`. Replay rejection path also bumps \`signing_replay_rejected\`.
- **HTTP API** (\`schemas.rs\`, \`health.rs\`, \`prometheus.rs\`): 6 new \`#[serde(default)]\` fields on \`MetricsResponse\`, JSON wiring, and \`acteon_signing_*_total\` Prometheus counters. Prometheus tests updated: EXPECTED_COUNTER_METRICS grew 33 → 39, TYPE-line counts 41 → 47 / 33 → 39.
- **UI** (\`Dashboard.tsx\`, \`types/index.ts\`): 6 optional fields, plus a conditional \"Sig Verified\" + \"Sig Rejected\" stat-card pair on Dashboard. The cards only render when any signing counter is non-zero, so operators who don't use signing don't see empty cards.
- **Grafana** (\`deploy/grafana/dashboards/acteon-overview.json\`): new \"Action Signing\" row with a rate time-series panel (6 series) and a totals stat panel with threshold overrides that turn Invalid/ScopeDenied red and Unknown/Replay/Unsigned orange.
- **Docs** (\`docs/book/features/action-signing.md\`): new \"Metrics\" section with the counter table, PromQL alerting examples, and pointers to the Grafana + UI surfaces. The \"Error behavior\" table is updated to match the tailored error messages (the JWKS endpoint pointer in the unknown-signer message is a nice side effect of the typed outcome).

## Out of scope (deferred)

- **Batch dispatch signature verification** — \`POST /v1/dispatch/batch\` doesn't call \`verify_action\` today, a pre-existing gap worth its own PR.
- **Audit query filters for \`signer_id\` / \`kid\`** — nice-to-have for \"show me everything signed by ci-bot/k1 post-rotation\" but requires per-backend WHERE clause updates.
- **Analytics outcome integration** — signing failures are HTTP 400s before rule evaluation and never produce an ActionOutcome, so they intentionally don't flow through the Analytics axis.

## Test plan
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --no-deps -- -D warnings\`
- [x] \`cargo test --workspace --lib --bins --tests\` — 52 test groups, 0 failures; new metrics + prometheus cases covered
- [x] \`cargo check --all-targets\` — clean, 0 errors, 0 warnings
- [x] \`(cd ui && npm run lint && npm run build)\` — clean
- [ ] Manual smoke against a live server with signing enabled: dispatch a valid signed action, a stale-kid signed action, an unsigned action with \`reject_unsigned=true\`, and a replay — confirm each bumps the expected counter