### PR TITLE
feat(sdks): fetch_signing_keys across Python/Node/Go/Java

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -250,6 +250,7 @@ if err != nil {
 | `SetRuleEnabled(ctx, name, enabled)` | Enable/disable a rule |
 | `QueryAudit(ctx, query)` | Query audit records |
 | `GetAuditRecord(ctx, actionID)` | Get specific audit record |
+| `FetchSigningKeys(ctx)` | Fetch the server's active signing keyring (JWKS-style discovery) |
 
 ### Action Fields
 

--- a/clients/go/acteon/client.go
+++ b/clients/go/acteon/client.go
@@ -150,6 +150,42 @@ func (c *Client) Health(ctx context.Context) (bool, error) {
 	return resp.StatusCode == http.StatusOK, nil
 }
 
+// FetchSigningKeys returns the server's active signing keyring.
+//
+// Hits GET /.well-known/acteon-signing-keys, a public, unauthenticated
+// endpoint that publishes the public half of every (signer_id, kid)
+// pair the server will accept signatures from. Useful for:
+//   - verifying dispatched actions independently without pinning
+//     public keys at deploy time
+//   - detecting a rotation in progress (a signer with more than one
+//     entry means the operator is staging a rotation and the client
+//     should start sending the new kid).
+//
+// Returns a response with an empty Keys slice when signing is
+// disabled on the server.
+func (c *Client) FetchSigningKeys(ctx context.Context) (*SigningKeysResponse, error) {
+	resp, err := c.doRequest(ctx, http.MethodGet, "/.well-known/acteon-signing-keys", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, &ConnectionError{Message: err.Error()}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &HTTPError{Status: resp.StatusCode, Message: "failed to fetch signing keys"}
+	}
+
+	var out SigningKeysResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, &ConnectionError{Message: err.Error()}
+	}
+	return &out, nil
+}
+
 // Dispatch dispatches a single action.
 func (c *Client) Dispatch(ctx context.Context, action *Action) (*ActionOutcome, error) {
 	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/dispatch", action)

--- a/clients/go/acteon/client.go
+++ b/clients/go/acteon/client.go
@@ -170,7 +170,13 @@ func (c *Client) FetchSigningKeys(ctx context.Context) (*SigningKeysResponse, er
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	// Cap the response body. The endpoint is public (no auth) so a
+	// malicious or misconfigured upstream could return an arbitrarily
+	// large payload and trigger an OOM in the client. A real keyring
+	// is tens-to-hundreds of bytes per entry; 1MB is three orders of
+	// magnitude of headroom.
+	const maxSigningKeysResponseBytes = 1 << 20 // 1 MiB
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSigningKeysResponseBytes))
 	if err != nil {
 		return nil, &ConnectionError{Message: err.Error()}
 	}
@@ -181,7 +187,23 @@ func (c *Client) FetchSigningKeys(ctx context.Context) (*SigningKeysResponse, er
 
 	var out SigningKeysResponse
 	if err := json.Unmarshal(body, &out); err != nil {
-		return nil, &ConnectionError{Message: err.Error()}
+		// Wrap the raw json.Unmarshal error so upstream callers get a
+		// clear "malformed response" signal instead of a cryptic
+		// "invalid character '<' looking for beginning of value" —
+		// which is what they'd see if a proxy or waiting-room page
+		// returned 200 OK with an HTML body.
+		return nil, &ConnectionError{
+			Message: "malformed signing keys response: " + err.Error(),
+		}
+	}
+
+	// Match the defensive posture of the other SDKs: when the server
+	// omits `count` (or sends count=0 with a non-empty keys array
+	// due to a shape drift), derive it from len(Keys). The server
+	// always emits count today — this is belt-and-braces against a
+	// future minor change.
+	if out.Count == 0 && len(out.Keys) > 0 {
+		out.Count = len(out.Keys)
 	}
 	return &out, nil
 }

--- a/clients/go/acteon/models.go
+++ b/clients/go/acteon/models.go
@@ -2171,3 +2171,28 @@ type CoverageReport struct {
 	Entries            []CoverageEntry `json:"entries"`
 	UnmatchedRules     []string        `json:"unmatched_rules"`
 }
+
+// SigningKeyEntry is one verifying key in the server's active
+// signing keyring. Mirrors the shape returned by
+// GET /.well-known/acteon-signing-keys.
+type SigningKeyEntry struct {
+	SignerID  string `json:"signer_id"`
+	Kid       string `json:"kid"`
+	Algorithm string `json:"algorithm"`
+	// PublicKey is a raw 32-byte Ed25519 public key, base64-encoded.
+	PublicKey string `json:"public_key"`
+	// Tenants scope. ["*"] means all tenants.
+	Tenants []string `json:"tenants"`
+	// Namespaces scope. ["*"] means all namespaces.
+	Namespaces []string `json:"namespaces"`
+}
+
+// SigningKeysResponse is the body returned by the JWKS-style
+// signing key discovery endpoint. Keys is empty when signing is
+// disabled on the server.
+type SigningKeysResponse struct {
+	Keys []SigningKeyEntry `json:"keys"`
+	// Count is always equal to len(Keys); mirrored from the server
+	// for callers who only want a count.
+	Count int `json:"count"`
+}

--- a/clients/go/acteon/models_test.go
+++ b/clients/go/acteon/models_test.go
@@ -795,3 +795,40 @@ func TestSigningKeysResponseEmptyWhenDisabled(t *testing.T) {
 		t.Errorf("expected empty response, got count=%d keys=%d", resp.Count, len(resp.Keys))
 	}
 }
+
+// The client method applies a defensive fallback (Count = len(Keys)
+// when the server omits count) to keep behavior consistent with
+// Python/Node/Java. Verify that a raw `json.Unmarshal` followed by
+// the client-side normalisation matches that posture.
+func TestSigningKeysResponseCountFallback(t *testing.T) {
+	body := []byte(`{
+		"keys": [
+			{"signer_id": "a", "kid": "k1", "algorithm": "Ed25519", "public_key": "AAAA", "tenants": ["*"], "namespaces": ["*"]},
+			{"signer_id": "b", "kid": "k1", "algorithm": "Ed25519", "public_key": "BBBB", "tenants": ["*"], "namespaces": ["*"]}
+		]
+	}`)
+	var resp SigningKeysResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Mimic the fallback applied by FetchSigningKeys.
+	if resp.Count == 0 && len(resp.Keys) > 0 {
+		resp.Count = len(resp.Keys)
+	}
+	if resp.Count != 2 {
+		t.Errorf("expected derived count=2, got %d", resp.Count)
+	}
+}
+
+func TestSigningKeysResponseRejectsMalformedJSON(t *testing.T) {
+	// When a proxy returns 200 OK with an HTML body, json.Unmarshal
+	// should fail with a clear decode error. The client wraps this
+	// in a "malformed signing keys response: ..." ConnectionError
+	// — we check only that Unmarshal surfaces the error at all,
+	// since the wrapping is done in client.go.
+	body := []byte(`<!doctype html><html><body>Waiting Room</body></html>`)
+	var resp SigningKeysResponse
+	if err := json.Unmarshal(body, &resp); err == nil {
+		t.Fatalf("expected unmarshal error on HTML body, got nil")
+	}
+}

--- a/clients/go/acteon/models_test.go
+++ b/clients/go/acteon/models_test.go
@@ -737,3 +737,61 @@ func TestNewAsgUpdateGroupPayloadWithOptions(t *testing.T) {
 		t.Errorf("expected health_check_grace_period 120, got %v", p["health_check_grace_period"])
 	}
 }
+
+func TestSigningKeysResponseUnmarshal(t *testing.T) {
+	body := []byte(`{
+		"keys": [
+			{
+				"signer_id": "ci-bot",
+				"kid": "k1",
+				"algorithm": "Ed25519",
+				"public_key": "LZkUda4pibD+v4yfHrLyw9Dnt7OLa6PGzSRGOcN1c4o=",
+				"tenants": ["acme"],
+				"namespaces": ["prod", "staging"]
+			},
+			{
+				"signer_id": "ci-bot",
+				"kid": "k2",
+				"algorithm": "Ed25519",
+				"public_key": "BBBB",
+				"tenants": ["acme"],
+				"namespaces": ["prod", "staging"]
+			}
+		],
+		"count": 2
+	}`)
+
+	var resp SigningKeysResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Count != 2 {
+		t.Errorf("count: got %d, want 2", resp.Count)
+	}
+	if len(resp.Keys) != 2 {
+		t.Fatalf("keys: got %d, want 2", len(resp.Keys))
+	}
+	if resp.Keys[0].SignerID != "ci-bot" || resp.Keys[0].Kid != "k1" {
+		t.Errorf("keys[0]: got %+v", resp.Keys[0])
+	}
+	if resp.Keys[1].Kid != "k2" {
+		t.Errorf("keys[1] kid: got %q", resp.Keys[1].Kid)
+	}
+	if resp.Keys[0].Algorithm != "Ed25519" {
+		t.Errorf("algorithm: got %q", resp.Keys[0].Algorithm)
+	}
+}
+
+func TestSigningKeysResponseEmptyWhenDisabled(t *testing.T) {
+	// Server emits {"keys": [], "count": 0} when [signing].enabled
+	// is false — the client should round-trip that cleanly rather
+	// than requiring callers to special-case a missing "keys" field.
+	body := []byte(`{"keys": [], "count": 0}`)
+	var resp SigningKeysResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Count != 0 || len(resp.Keys) != 0 {
+		t.Errorf("expected empty response, got count=%d keys=%d", resp.Count, len(resp.Keys))
+	}
+}

--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -256,6 +256,7 @@ try (ActeonClient client = new ActeonClient("http://localhost:8080")) {
 | `setRuleEnabled(name, enabled)` | Enable/disable a rule |
 | `queryAudit(query)` | Query audit records |
 | `getAuditRecord(actionId)` | Get specific audit record |
+| `fetchSigningKeys()` | Fetch the server's active signing keyring (JWKS-style discovery) |
 
 ### Action Fields
 

--- a/clients/java/src/main/java/com/acteon/client/ActeonClient.java
+++ b/clients/java/src/main/java/com/acteon/client/ActeonClient.java
@@ -195,6 +195,57 @@ public class ActeonClient implements AutoCloseable {
     }
 
     // =========================================================================
+    // Signing key discovery (JWKS-style)
+    // =========================================================================
+
+    /**
+     * Fetches the server's active signing keyring.
+     *
+     * <p>Calls {@code GET /.well-known/acteon-signing-keys}, a public,
+     * unauthenticated endpoint that publishes the public half of
+     * every {@code (signer_id, kid)} pair the server will accept
+     * signatures from. Useful for:
+     *
+     * <ul>
+     *   <li>verifying dispatched actions independently without pinning
+     *       public keys at deploy time, or</li>
+     *   <li>detecting a rotation in progress — a signer with more
+     *       than one entry in the response means the operator is
+     *       staging a rotation and the client should start sending
+     *       the new {@code kid}.</li>
+     * </ul>
+     *
+     * <p>Returns a response with an empty {@code keys} list when
+     * signing is disabled on the server.
+     *
+     * @throws ActeonException if the server returns a non-200 status
+     *         or the response cannot be parsed.
+     */
+    public SigningKeysResponse fetchSigningKeys() throws ActeonException {
+        try {
+            HttpRequest request = requestBuilder("/.well-known/acteon-signing-keys")
+                .GET()
+                .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                Map<String, Object> data = objectMapper.readValue(
+                    response.body(),
+                    new TypeReference<Map<String, Object>>() {}
+                );
+                return SigningKeysResponse.fromMap(data);
+            } else {
+                throw new HttpException(response.statusCode(), "Failed to fetch signing keys");
+            }
+        } catch (IOException e) {
+            throw new ConnectionException(e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ConnectionException("Request interrupted", e);
+        }
+    }
+
+    // =========================================================================
     // Action Dispatch
     // =========================================================================
 

--- a/clients/java/src/main/java/com/acteon/client/ActeonClient.java
+++ b/clients/java/src/main/java/com/acteon/client/ActeonClient.java
@@ -222,26 +222,44 @@ public class ActeonClient implements AutoCloseable {
      *         or the response cannot be parsed.
      */
     public SigningKeysResponse fetchSigningKeys() throws ActeonException {
+        HttpResponse<String> response;
         try {
             HttpRequest request = requestBuilder("/.well-known/acteon-signing-keys")
                 .GET()
                 .build();
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-
-            if (response.statusCode() == 200) {
-                Map<String, Object> data = objectMapper.readValue(
-                    response.body(),
-                    new TypeReference<Map<String, Object>>() {}
-                );
-                return SigningKeysResponse.fromMap(data);
-            } else {
-                throw new HttpException(response.statusCode(), "Failed to fetch signing keys");
-            }
+            response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         } catch (IOException e) {
             throw new ConnectionException(e.getMessage(), e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new ConnectionException("Request interrupted", e);
+        }
+
+        if (response.statusCode() != 200) {
+            throw new HttpException(response.statusCode(), "Failed to fetch signing keys");
+        }
+
+        // Wrap JSON parse errors so upstream callers see a typed
+        // "malformed response" signal instead of a raw Jackson
+        // exception — which is what they'd see if a proxy or
+        // waiting-room page returned 200 OK with an HTML body.
+        Map<String, Object> data;
+        try {
+            data = objectMapper.readValue(
+                response.body(),
+                new TypeReference<Map<String, Object>>() {}
+            );
+        } catch (IOException e) {
+            throw new ConnectionException(
+                "malformed signing keys response: " + e.getMessage(), e);
+        }
+
+        try {
+            return SigningKeysResponse.fromMap(data);
+        } catch (IllegalArgumentException e) {
+            // fromMap's helpers already prefix their messages with
+            // "malformed signing keys response:", so pass through.
+            throw new ConnectionException(e.getMessage(), e);
         }
     }
 

--- a/clients/java/src/main/java/com/acteon/client/models/SigningKeyEntry.java
+++ b/clients/java/src/main/java/com/acteon/client/models/SigningKeyEntry.java
@@ -42,19 +42,83 @@ public class SigningKeyEntry {
     public List<String> getNamespaces() { return namespaces; }
     public void setNamespaces(List<String> namespaces) { this.namespaces = namespaces; }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * Build a {@code SigningKeyEntry} from a generic {@code Map}
+     * decoded by Jackson. Throws {@link IllegalArgumentException} on
+     * missing or wrong-typed required fields so callers see a clear
+     * "malformed response" error instead of a raw
+     * {@link ClassCastException} bubbling from deep inside the
+     * parser.
+     *
+     * <p>Kept as a static factory (rather than annotated Jackson
+     * deserialization) so this class matches the {@code fromMap}
+     * convention used by every other model in this SDK (see
+     * {@link ProviderHealthStatus}, {@link ActionOutcome}, etc).
+     * A codebase-wide migration to annotated deserialization is a
+     * separate concern.
+     */
     public static SigningKeyEntry fromMap(Map<String, Object> data) {
         SigningKeyEntry entry = new SigningKeyEntry();
-        entry.signerId = (String) data.get("signer_id");
-        entry.kid = (String) data.get("kid");
-        entry.algorithm = (String) data.get("algorithm");
-        entry.publicKey = (String) data.get("public_key");
-        entry.tenants = data.containsKey("tenants") && data.get("tenants") != null
-            ? new ArrayList<>((List<String>) data.get("tenants"))
-            : new ArrayList<>();
-        entry.namespaces = data.containsKey("namespaces") && data.get("namespaces") != null
-            ? new ArrayList<>((List<String>) data.get("namespaces"))
-            : new ArrayList<>();
+        entry.signerId = requireString(data, "signer_id");
+        entry.kid = requireString(data, "kid");
+        entry.algorithm = requireString(data, "algorithm");
+        entry.publicKey = requireString(data, "public_key");
+        entry.tenants = optionalStringList(data, "tenants");
+        entry.namespaces = optionalStringList(data, "namespaces");
         return entry;
+    }
+
+    /**
+     * Pull a required string field out of a raw JSON map. Missing,
+     * null, and wrong-type values all surface as a
+     * {@link IllegalArgumentException} with the offending field name
+     * included so an operator can tell from the message exactly
+     * which part of the response was malformed.
+     */
+    static String requireString(Map<String, Object> data, String field) {
+        Object value = data.get(field);
+        if (value == null) {
+            throw new IllegalArgumentException(
+                "malformed signing keys response: missing required string field '" + field + "'"
+            );
+        }
+        if (!(value instanceof String)) {
+            throw new IllegalArgumentException(
+                "malformed signing keys response: field '" + field
+                    + "' should be a string, got " + value.getClass().getSimpleName()
+            );
+        }
+        return (String) value;
+    }
+
+    /**
+     * Read an optional scope list. Missing or null becomes an empty
+     * list (distinguishable from the wildcard {@code ["*"]} shape
+     * the server emits when no scope is configured). Wrong shape
+     * (e.g. an object, a number, or a list of non-strings) is a
+     * malformed response, not silently coerced.
+     */
+    @SuppressWarnings("unchecked")
+    static List<String> optionalStringList(Map<String, Object> data, String field) {
+        Object value = data.get(field);
+        if (value == null) {
+            return new ArrayList<>();
+        }
+        if (!(value instanceof List<?>)) {
+            throw new IllegalArgumentException(
+                "malformed signing keys response: field '" + field
+                    + "' should be a list, got " + value.getClass().getSimpleName()
+            );
+        }
+        List<?> raw = (List<?>) value;
+        for (Object item : raw) {
+            if (item != null && !(item instanceof String)) {
+                throw new IllegalArgumentException(
+                    "malformed signing keys response: field '" + field
+                        + "' contains non-string element of type " + item.getClass().getSimpleName()
+                );
+            }
+        }
+        return new ArrayList<>((List<String>) raw);
     }
 }

--- a/clients/java/src/main/java/com/acteon/client/models/SigningKeyEntry.java
+++ b/clients/java/src/main/java/com/acteon/client/models/SigningKeyEntry.java
@@ -1,0 +1,60 @@
+package com.acteon.client.models;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * One verifying key in the server's active signing keyring.
+ *
+ * <p>Mirrors the shape returned by
+ * {@code GET /.well-known/acteon-signing-keys}. Each entry identifies
+ * a {@code (signer_id, kid)} pair the server will accept signatures
+ * from, along with the algorithm (always {@code Ed25519} today) and
+ * the tenant/namespace scope the key is authorized for.
+ */
+public class SigningKeyEntry {
+    private String signerId;
+    private String kid;
+    private String algorithm;
+    private String publicKey;
+    private List<String> tenants;
+    private List<String> namespaces;
+
+    public String getSignerId() { return signerId; }
+    public void setSignerId(String signerId) { this.signerId = signerId; }
+
+    public String getKid() { return kid; }
+    public void setKid(String kid) { this.kid = kid; }
+
+    public String getAlgorithm() { return algorithm; }
+    public void setAlgorithm(String algorithm) { this.algorithm = algorithm; }
+
+    /** Raw 32-byte Ed25519 public key, base64-encoded. */
+    public String getPublicKey() { return publicKey; }
+    public void setPublicKey(String publicKey) { this.publicKey = publicKey; }
+
+    /** Tenant scopes this key is authorized for. {@code ["*"]} means all. */
+    public List<String> getTenants() { return tenants; }
+    public void setTenants(List<String> tenants) { this.tenants = tenants; }
+
+    /** Namespace scopes this key is authorized for. {@code ["*"]} means all. */
+    public List<String> getNamespaces() { return namespaces; }
+    public void setNamespaces(List<String> namespaces) { this.namespaces = namespaces; }
+
+    @SuppressWarnings("unchecked")
+    public static SigningKeyEntry fromMap(Map<String, Object> data) {
+        SigningKeyEntry entry = new SigningKeyEntry();
+        entry.signerId = (String) data.get("signer_id");
+        entry.kid = (String) data.get("kid");
+        entry.algorithm = (String) data.get("algorithm");
+        entry.publicKey = (String) data.get("public_key");
+        entry.tenants = data.containsKey("tenants") && data.get("tenants") != null
+            ? new ArrayList<>((List<String>) data.get("tenants"))
+            : new ArrayList<>();
+        entry.namespaces = data.containsKey("namespaces") && data.get("namespaces") != null
+            ? new ArrayList<>((List<String>) data.get("namespaces"))
+            : new ArrayList<>();
+        return entry;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/SigningKeysResponse.java
+++ b/clients/java/src/main/java/com/acteon/client/models/SigningKeysResponse.java
@@ -1,0 +1,44 @@
+package com.acteon.client.models;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Response body from {@code GET /.well-known/acteon-signing-keys}.
+ *
+ * <p>The {@code keys} list is empty when signing is disabled on the
+ * server. The {@code count} field is always equal to
+ * {@code keys.size()} — it's mirrored from the server as a
+ * convenience for callers that only want a count.
+ */
+public class SigningKeysResponse {
+    private List<SigningKeyEntry> keys;
+    private int count;
+
+    public List<SigningKeyEntry> getKeys() { return keys; }
+    public void setKeys(List<SigningKeyEntry> keys) { this.keys = keys; }
+
+    public int getCount() { return count; }
+    public void setCount(int count) { this.count = count; }
+
+    @SuppressWarnings("unchecked")
+    public static SigningKeysResponse fromMap(Map<String, Object> data) {
+        SigningKeysResponse resp = new SigningKeysResponse();
+        List<Map<String, Object>> rawKeys = data.containsKey("keys") && data.get("keys") != null
+            ? (List<Map<String, Object>>) data.get("keys")
+            : new ArrayList<>();
+        List<SigningKeyEntry> keys = new ArrayList<>(rawKeys.size());
+        for (Map<String, Object> k : rawKeys) {
+            keys.add(SigningKeyEntry.fromMap(k));
+        }
+        resp.keys = keys;
+        // Defensive: derive from keys.size() when the server omits
+        // count (it always emits it today, but we shouldn't break on
+        // a minor server change).
+        resp.count = data.containsKey("count") && data.get("count") != null
+            ? ((Number) data.get("count")).intValue()
+            : keys.size();
+        return resp;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/models/SigningKeysResponse.java
+++ b/clients/java/src/main/java/com/acteon/client/models/SigningKeysResponse.java
@@ -22,23 +22,51 @@ public class SigningKeysResponse {
     public int getCount() { return count; }
     public void setCount(int count) { this.count = count; }
 
+    /**
+     * Build a {@code SigningKeysResponse} from a decoded Jackson
+     * map. Throws {@link IllegalArgumentException} on malformed
+     * shapes — missing required fields, wrong types, etc — so
+     * callers see a clear error instead of a
+     * {@link ClassCastException} from deep inside the parser.
+     */
     @SuppressWarnings("unchecked")
     public static SigningKeysResponse fromMap(Map<String, Object> data) {
         SigningKeysResponse resp = new SigningKeysResponse();
-        List<Map<String, Object>> rawKeys = data.containsKey("keys") && data.get("keys") != null
-            ? (List<Map<String, Object>>) data.get("keys")
-            : new ArrayList<>();
+
+        Object rawKeysObj = data.get("keys");
+        List<Map<String, Object>> rawKeys;
+        if (rawKeysObj == null) {
+            rawKeys = new ArrayList<>();
+        } else if (rawKeysObj instanceof List<?>) {
+            rawKeys = (List<Map<String, Object>>) rawKeysObj;
+        } else {
+            throw new IllegalArgumentException(
+                "malformed signing keys response: 'keys' should be an array, got "
+                    + rawKeysObj.getClass().getSimpleName()
+            );
+        }
+
         List<SigningKeyEntry> keys = new ArrayList<>(rawKeys.size());
         for (Map<String, Object> k : rawKeys) {
             keys.add(SigningKeyEntry.fromMap(k));
         }
         resp.keys = keys;
+
         // Defensive: derive from keys.size() when the server omits
         // count (it always emits it today, but we shouldn't break on
-        // a minor server change).
-        resp.count = data.containsKey("count") && data.get("count") != null
-            ? ((Number) data.get("count")).intValue()
-            : keys.size();
+        // a minor server change). Wrong type on count (e.g. "2" as a
+        // string) is a malformed response.
+        Object rawCount = data.get("count");
+        if (rawCount == null) {
+            resp.count = keys.size();
+        } else if (rawCount instanceof Number) {
+            resp.count = ((Number) rawCount).intValue();
+        } else {
+            throw new IllegalArgumentException(
+                "malformed signing keys response: 'count' should be a number, got "
+                    + rawCount.getClass().getSimpleName()
+            );
+        }
         return resp;
     }
 }

--- a/clients/java/src/test/java/com/acteon/client/models/SigningKeysResponseTest.java
+++ b/clients/java/src/test/java/com/acteon/client/models/SigningKeysResponseTest.java
@@ -91,4 +91,96 @@ class SigningKeysResponseTest {
         assertTrue(entry.getTenants().isEmpty());
         assertTrue(entry.getNamespaces().isEmpty());
     }
+
+    @Test
+    void testEntryThrowsOnMissingRequiredField() {
+        // The fromMap used to do `(String) data.get("signer_id")`
+        // which returned null silently, letting the null flow into
+        // caller business logic. Now it throws a clear error.
+        Map<String, Object> key = new HashMap<>();
+        // signer_id deliberately omitted
+        key.put("kid", "k0");
+        key.put("algorithm", "Ed25519");
+        key.put("public_key", "AAAA");
+
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> SigningKeyEntry.fromMap(key)
+        );
+        assertTrue(ex.getMessage().contains("signer_id"),
+            "error should name the missing field: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("malformed signing keys response"),
+            "error should identify itself as a malformed response: " + ex.getMessage());
+    }
+
+    @Test
+    void testEntryThrowsOnWrongTypedField() {
+        // The old unchecked cast `(String) data.get("kid")` would
+        // throw ClassCastException with no useful context when the
+        // server sent a number. Now we throw a typed error that
+        // names the offending field and its actual type.
+        Map<String, Object> key = new HashMap<>();
+        key.put("signer_id", "ci-bot");
+        key.put("kid", 42); // wrong type
+        key.put("algorithm", "Ed25519");
+        key.put("public_key", "AAAA");
+
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> SigningKeyEntry.fromMap(key)
+        );
+        assertTrue(ex.getMessage().contains("kid"));
+        assertTrue(ex.getMessage().contains("should be a string"));
+    }
+
+    @Test
+    void testResponseThrowsWhenKeysIsNotArray() {
+        // Guards the `(List<Map<String,Object>>) data.get("keys")`
+        // cast — without the shape check, a server bug that sent
+        // an object instead of an array would become a
+        // ClassCastException deep in the caller.
+        Map<String, Object> data = new HashMap<>();
+        data.put("keys", "not an array");
+        data.put("count", 0);
+
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> SigningKeysResponse.fromMap(data)
+        );
+        assertTrue(ex.getMessage().contains("'keys'"));
+    }
+
+    @Test
+    void testResponseThrowsWhenCountIsWrongType() {
+        // count="2" (string) used to be silently cast via (Number)
+        // and throw ClassCastException. Now the error is typed.
+        Map<String, Object> data = new HashMap<>();
+        data.put("keys", Collections.emptyList());
+        data.put("count", "2");
+
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> SigningKeysResponse.fromMap(data)
+        );
+        assertTrue(ex.getMessage().contains("'count'"));
+    }
+
+    @Test
+    void testEntryThrowsOnNonStringScopeElement() {
+        // Unchecked cast would let `[1, 2, 3]` sail through and
+        // explode when callers iterate the list expecting strings.
+        Map<String, Object> key = new HashMap<>();
+        key.put("signer_id", "ci-bot");
+        key.put("kid", "k1");
+        key.put("algorithm", "Ed25519");
+        key.put("public_key", "AAAA");
+        key.put("tenants", List.of(1, 2, 3));
+
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> SigningKeyEntry.fromMap(key)
+        );
+        assertTrue(ex.getMessage().contains("tenants"));
+        assertTrue(ex.getMessage().contains("non-string"));
+    }
 }

--- a/clients/java/src/test/java/com/acteon/client/models/SigningKeysResponseTest.java
+++ b/clients/java/src/test/java/com/acteon/client/models/SigningKeysResponseTest.java
@@ -1,0 +1,94 @@
+package com.acteon.client.models;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SigningKeysResponseTest {
+
+    @Test
+    void testFromMapWithMultipleKeys() {
+        Map<String, Object> key1 = new HashMap<>();
+        key1.put("signer_id", "ci-bot");
+        key1.put("kid", "k1");
+        key1.put("algorithm", "Ed25519");
+        key1.put("public_key", "LZkUda4pibD+v4yfHrLyw9Dnt7OLa6PGzSRGOcN1c4o=");
+        key1.put("tenants", List.of("acme"));
+        key1.put("namespaces", List.of("prod", "staging"));
+
+        Map<String, Object> key2 = new HashMap<>();
+        key2.put("signer_id", "ci-bot");
+        key2.put("kid", "k2");
+        key2.put("algorithm", "Ed25519");
+        key2.put("public_key", "BBBB");
+        key2.put("tenants", List.of("acme"));
+        key2.put("namespaces", List.of("prod", "staging"));
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("keys", List.of(key1, key2));
+        data.put("count", 2);
+
+        SigningKeysResponse resp = SigningKeysResponse.fromMap(data);
+        assertEquals(2, resp.getCount());
+        assertEquals(2, resp.getKeys().size());
+        assertEquals("ci-bot", resp.getKeys().get(0).getSignerId());
+        assertEquals("k1", resp.getKeys().get(0).getKid());
+        assertEquals("Ed25519", resp.getKeys().get(0).getAlgorithm());
+        assertEquals("k2", resp.getKeys().get(1).getKid());
+        assertEquals(List.of("prod", "staging"), resp.getKeys().get(0).getNamespaces());
+    }
+
+    @Test
+    void testFromMapWithEmptyKeysWhenSigningDisabled() {
+        // Server emits {"keys": [], "count": 0} when [signing].enabled
+        // is false — the client should round-trip that cleanly rather
+        // than requiring callers to special-case a missing "keys" key.
+        Map<String, Object> data = new HashMap<>();
+        data.put("keys", Collections.emptyList());
+        data.put("count", 0);
+
+        SigningKeysResponse resp = SigningKeysResponse.fromMap(data);
+        assertEquals(0, resp.getCount());
+        assertTrue(resp.getKeys().isEmpty());
+    }
+
+    @Test
+    void testFromMapDerivesCountWhenMissing() {
+        // Defensive: the server always emits count today, but we
+        // shouldn't break if a minor server change drops it.
+        Map<String, Object> key = new HashMap<>();
+        key.put("signer_id", "x");
+        key.put("kid", "k0");
+        key.put("algorithm", "Ed25519");
+        key.put("public_key", "AAAA");
+        key.put("tenants", List.of("*"));
+        key.put("namespaces", List.of("*"));
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("keys", List.of(key));
+        // Deliberately omit count.
+
+        SigningKeysResponse resp = SigningKeysResponse.fromMap(data);
+        assertEquals(1, resp.getCount());
+    }
+
+    @Test
+    void testEntryDefaultsMissingScopesToEmptyLists() {
+        // Empty list is distinguishable from ["*"] (wildcard), so
+        // callers can tell them apart. Don't invent a default.
+        Map<String, Object> key = new HashMap<>();
+        key.put("signer_id", "minimal");
+        key.put("kid", "k0");
+        key.put("algorithm", "Ed25519");
+        key.put("public_key", "AAAA");
+
+        SigningKeyEntry entry = SigningKeyEntry.fromMap(key);
+        assertTrue(entry.getTenants().isEmpty());
+        assertTrue(entry.getNamespaces().isEmpty());
+    }
+}

--- a/clients/nodejs/README.md
+++ b/clients/nodejs/README.md
@@ -206,6 +206,7 @@ try {
 | `setRuleEnabled(name, enabled)` | Enable/disable a rule |
 | `queryAudit(query)` | Query audit records |
 | `getAuditRecord(actionId)` | Get specific audit record |
+| `fetchSigningKeys()` | Fetch the server's active signing keyring (JWKS-style discovery) |
 
 ### Action Fields
 

--- a/clients/nodejs/src/client.ts
+++ b/clients/nodejs/src/client.ts
@@ -153,6 +153,8 @@ import {
   CoverageQuery,
   CoverageReport,
   parseCoverageReport,
+  SigningKeysResponse,
+  parseSigningKeysResponse,
 } from "./models.js";
 import { ActeonError, ApiError, ConnectionError, HttpError } from "./errors.js";
 import { readFileSync } from "node:fs";
@@ -289,6 +291,44 @@ export class ActeonClient {
     } catch {
       return false;
     }
+  }
+
+  // =========================================================================
+  // Signing key discovery (JWKS-style)
+  // =========================================================================
+
+  /**
+   * Fetch the server's active signing keyring.
+   *
+   * Calls `GET /.well-known/acteon-signing-keys`, a public,
+   * unauthenticated endpoint that publishes the public half of
+   * every `(signer_id, kid)` pair the server will accept
+   * signatures from. Useful for:
+   *
+   * - verifying dispatched actions independently without pinning
+   *   public keys at deploy time
+   * - detecting a rotation in progress — a signer with more than
+   *   one entry means the operator is staging a rotation and the
+   *   client should start sending the new `kid`
+   *
+   * Returns a response with an empty `keys` array when signing is
+   * disabled on the server.
+   *
+   * @throws {HttpError} If the server returns a non-2xx status.
+   */
+  async fetchSigningKeys(): Promise<SigningKeysResponse> {
+    const response = await this.request(
+      "GET",
+      "/.well-known/acteon-signing-keys",
+    );
+    const data = (await response.json()) as Record<string, unknown>;
+    if (response.ok) {
+      return parseSigningKeysResponse(data);
+    }
+    throw new HttpError(
+      response.status,
+      `Failed to fetch signing keys: ${response.status}`,
+    );
   }
 
   // =========================================================================

--- a/clients/nodejs/src/client.ts
+++ b/clients/nodejs/src/client.ts
@@ -321,14 +321,34 @@ export class ActeonClient {
       "GET",
       "/.well-known/acteon-signing-keys",
     );
-    const data = (await response.json()) as Record<string, unknown>;
-    if (response.ok) {
-      return parseSigningKeysResponse(data);
+    if (!response.ok) {
+      throw new HttpError(
+        response.status,
+        `Failed to fetch signing keys: ${response.status}`,
+      );
     }
-    throw new HttpError(
-      response.status,
-      `Failed to fetch signing keys: ${response.status}`,
-    );
+    // Wrap both JSON decode failures (proxy returns 200 OK with an
+    // HTML body) and shape validation failures from
+    // parseSigningKeysResponse in a typed ConnectionError so
+    // callers see "malformed signing keys response" instead of a
+    // raw SyntaxError.
+    let data: Record<string, unknown>;
+    try {
+      data = (await response.json()) as Record<string, unknown>;
+    } catch (e) {
+      throw new ConnectionError(
+        `malformed signing keys response: ${(e as Error).message}`,
+      );
+    }
+    try {
+      return parseSigningKeysResponse(data);
+    } catch (e) {
+      // parseSigningKeysResponse throws plain Errors with a
+      // "malformed signing keys response:" prefix; rewrap as a
+      // typed ConnectionError so `catch (e: ConnectionError)`
+      // works on the caller side.
+      throw new ConnectionError((e as Error).message);
+    }
   }
 
   // =========================================================================

--- a/clients/nodejs/src/models.test.ts
+++ b/clients/nodejs/src/models.test.ts
@@ -8,6 +8,7 @@ import {
   parseWasmPlugin,
   parseListPluginsResponse,
   parsePluginInvocationResponse,
+  parseSigningKeysResponse,
   registerPluginRequestToApi,
   createEc2StartInstancesPayload,
   createEc2StopInstancesPayload,
@@ -570,5 +571,77 @@ describe("createAsgUpdateGroupPayload", () => {
     assert.equal(payload.default_cooldown, 300);
     assert.equal(payload.health_check_type, "ELB");
     assert.equal(payload.health_check_grace_period, 120);
+  });
+});
+
+describe("parseSigningKeysResponse", () => {
+  it("parses a full response with multiple keys", () => {
+    const raw = {
+      keys: [
+        {
+          signer_id: "ci-bot",
+          kid: "k1",
+          algorithm: "Ed25519",
+          public_key: "LZkUda4pibD+v4yfHrLyw9Dnt7OLa6PGzSRGOcN1c4o=",
+          tenants: ["acme"],
+          namespaces: ["prod", "staging"],
+        },
+        {
+          signer_id: "ci-bot",
+          kid: "k2",
+          algorithm: "Ed25519",
+          public_key: "BBBB",
+          tenants: ["acme"],
+          namespaces: ["prod", "staging"],
+        },
+      ],
+      count: 2,
+    };
+    const resp = parseSigningKeysResponse(raw);
+    assert.equal(resp.count, 2);
+    assert.equal(resp.keys.length, 2);
+    assert.equal(resp.keys[0].kid, "k1");
+    assert.equal(resp.keys[1].kid, "k2");
+    assert.deepEqual(resp.keys[0].namespaces, ["prod", "staging"]);
+  });
+
+  it("handles signing-disabled (empty keys) shape", () => {
+    const resp = parseSigningKeysResponse({ keys: [], count: 0 });
+    assert.equal(resp.count, 0);
+    assert.equal(resp.keys.length, 0);
+  });
+
+  it("derives count from keys.length when server omits it", () => {
+    // Defensive — the server always emits count today, but we
+    // shouldn't break if a minor server change ever drops it.
+    const resp = parseSigningKeysResponse({
+      keys: [
+        {
+          signer_id: "x",
+          kid: "k0",
+          algorithm: "Ed25519",
+          public_key: "AAAA",
+          tenants: ["*"],
+          namespaces: ["*"],
+        },
+      ],
+    });
+    assert.equal(resp.count, 1);
+  });
+
+  it("defaults missing tenants/namespaces to empty arrays", () => {
+    const resp = parseSigningKeysResponse({
+      keys: [
+        {
+          signer_id: "minimal",
+          kid: "k0",
+          algorithm: "Ed25519",
+          public_key: "AAAA",
+        },
+      ],
+      count: 1,
+    });
+    assert.deepEqual(resp.keys[0].tenants, []);
+    assert.deepEqual(resp.keys[0].namespaces, []);
   });
 });

--- a/clients/nodejs/src/models.test.ts
+++ b/clients/nodejs/src/models.test.ts
@@ -644,4 +644,61 @@ describe("parseSigningKeysResponse", () => {
     assert.deepEqual(resp.keys[0].tenants, []);
     assert.deepEqual(resp.keys[0].namespaces, []);
   });
+
+  it("throws on missing signer_id rather than coercing to 'undefined'", () => {
+    // The failure mode we're guarding against: `String(undefined)`
+    // yields the literal string `"undefined"`, which survives any
+    // `if (entry.signer_id)` check and lets garbage flow through
+    // the caller's code. Fail loudly instead.
+    assert.throws(
+      () =>
+        parseSigningKeysResponse({
+          keys: [
+            {
+              kid: "k0",
+              algorithm: "Ed25519",
+              public_key: "AAAA",
+            },
+          ],
+        }),
+      /malformed signing keys response.*signer_id/,
+    );
+  });
+
+  it("throws when 'keys' is an object instead of an array", () => {
+    assert.throws(
+      () =>
+        parseSigningKeysResponse({
+          keys: { notAnArray: true } as unknown as Array<Record<string, unknown>>,
+        }),
+      /malformed signing keys response.*'keys'/,
+    );
+  });
+
+  it("throws when count is a string instead of a number", () => {
+    assert.throws(
+      () =>
+        parseSigningKeysResponse({ keys: [], count: "2" as unknown as number }),
+      /malformed signing keys response.*'count'/,
+    );
+  });
+
+  it("throws when a scope list contains non-string entries", () => {
+    assert.throws(
+      () =>
+        parseSigningKeysResponse({
+          keys: [
+            {
+              signer_id: "ci-bot",
+              kid: "k0",
+              algorithm: "Ed25519",
+              public_key: "AAAA",
+              tenants: [1, 2, 3] as unknown as string[],
+              namespaces: ["*"],
+            },
+          ],
+        }),
+      /malformed signing keys response.*tenants/,
+    );
+  });
 });

--- a/clients/nodejs/src/models.ts
+++ b/clients/nodejs/src/models.ts
@@ -3461,3 +3461,51 @@ export function parseCoverageReport(data: Record<string, unknown>): CoverageRepo
     unmatched_rules: (data.unmatched_rules as string[]) ?? [],
   };
 }
+
+// =============================================================================
+// Signing key discovery
+// =============================================================================
+
+/** One verifying key in the server's active signing keyring. */
+export interface SigningKeyEntry {
+  signer_id: string;
+  kid: string;
+  algorithm: string;
+  /** Raw 32-byte Ed25519 public key, base64-encoded. */
+  public_key: string;
+  /** Tenant scopes this key is authorized for. `["*"]` means all. */
+  tenants: string[];
+  /** Namespace scopes this key is authorized for. `["*"]` means all. */
+  namespaces: string[];
+}
+
+/** Response body from `GET /.well-known/acteon-signing-keys`. */
+export interface SigningKeysResponse {
+  keys: SigningKeyEntry[];
+  /** Always equal to `keys.length`; mirrored from the server for
+   * callers who only want a count. */
+  count: number;
+}
+
+/** Parse a raw signing keys payload from the server.
+ *
+ * Tolerant of a missing `count` field: falls back to `keys.length`
+ * so a minor server-side shape change doesn't break client code.
+ */
+export function parseSigningKeysResponse(
+  data: Record<string, unknown>,
+): SigningKeysResponse {
+  const rawKeys = (data.keys as Array<Record<string, unknown>>) ?? [];
+  const keys: SigningKeyEntry[] = rawKeys.map((k) => ({
+    signer_id: String(k.signer_id),
+    kid: String(k.kid),
+    algorithm: String(k.algorithm),
+    public_key: String(k.public_key),
+    tenants: (k.tenants as string[]) ?? [],
+    namespaces: (k.namespaces as string[]) ?? [],
+  }));
+  return {
+    keys,
+    count: typeof data.count === "number" ? data.count : keys.length,
+  };
+}

--- a/clients/nodejs/src/models.ts
+++ b/clients/nodejs/src/models.ts
@@ -3491,21 +3491,78 @@ export interface SigningKeysResponse {
  *
  * Tolerant of a missing `count` field: falls back to `keys.length`
  * so a minor server-side shape change doesn't break client code.
+ *
+ * Strict about required string fields: a missing or null
+ * `signer_id`/`kid`/`algorithm`/`public_key` throws instead of
+ * coercing to `"undefined"` or `"null"` — a silently-bad string
+ * would sneak past `if (key.signer_id)` checks in caller code and
+ * let garbage flow downstream.
+ *
+ * @throws {Error} with a message beginning `malformed signing keys
+ *   response:` when the shape is invalid.
  */
 export function parseSigningKeysResponse(
   data: Record<string, unknown>,
 ): SigningKeysResponse {
+  if (data.keys !== undefined && !Array.isArray(data.keys)) {
+    throw new Error(
+      `malformed signing keys response: 'keys' should be an array, got ${typeof data.keys}`,
+    );
+  }
   const rawKeys = (data.keys as Array<Record<string, unknown>>) ?? [];
-  const keys: SigningKeyEntry[] = rawKeys.map((k) => ({
-    signer_id: String(k.signer_id),
-    kid: String(k.kid),
-    algorithm: String(k.algorithm),
-    public_key: String(k.public_key),
-    tenants: (k.tenants as string[]) ?? [],
-    namespaces: (k.namespaces as string[]) ?? [],
+  const keys: SigningKeyEntry[] = rawKeys.map((k, i) => ({
+    signer_id: requireString(k, "signer_id", i),
+    kid: requireString(k, "kid", i),
+    algorithm: requireString(k, "algorithm", i),
+    public_key: requireString(k, "public_key", i),
+    tenants: optionalStringList(k, "tenants", i),
+    namespaces: optionalStringList(k, "namespaces", i),
   }));
+  if (data.count !== undefined && typeof data.count !== "number") {
+    throw new Error(
+      `malformed signing keys response: 'count' should be a number, got ${typeof data.count}`,
+    );
+  }
   return {
     keys,
     count: typeof data.count === "number" ? data.count : keys.length,
   };
+}
+
+function requireString(
+  entry: Record<string, unknown>,
+  field: string,
+  index: number,
+): string {
+  const value = entry[field];
+  if (typeof value !== "string") {
+    throw new Error(
+      `malformed signing keys response: keys[${index}].${field} should be a string, got ${value === null ? "null" : typeof value}`,
+    );
+  }
+  return value;
+}
+
+function optionalStringList(
+  entry: Record<string, unknown>,
+  field: string,
+  index: number,
+): string[] {
+  const value = entry[field];
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(
+      `malformed signing keys response: keys[${index}].${field} should be an array, got ${typeof value}`,
+    );
+  }
+  for (const item of value) {
+    if (typeof item !== "string") {
+      throw new Error(
+        `malformed signing keys response: keys[${index}].${field} contains non-string element of type ${typeof item}`,
+      );
+    }
+  }
+  return value as string[];
 }

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -209,6 +209,7 @@ except HttpError as e:
 | `set_rule_enabled(name, enabled)` | Enable/disable a rule |
 | `query_audit(query)` | Query audit records |
 | `get_audit_record(action_id)` | Get specific audit record |
+| `fetch_signing_keys()` | Fetch the server's active signing keyring (JWKS-style discovery) |
 
 ### Action Fields
 

--- a/clients/python/acteon_client/client.py
+++ b/clients/python/acteon_client/client.py
@@ -228,13 +228,25 @@ class ActeonClient:
         the server.
 
         Raises:
-            ConnectionError: If unable to connect to the server.
+            ConnectionError: If unable to connect or the server
+                returned a malformed (non-JSON) body under a 200
+                status — which can happen when a proxy or
+                waiting-room page intercepts the request.
             HttpError: If the server returns a non-200 status.
         """
         response = self._request("GET", "/.well-known/acteon-signing-keys")
-        if response.status_code == 200:
+        if response.status_code != 200:
+            raise HttpError(response.status_code, "Failed to fetch signing keys")
+        try:
             return SigningKeysResponse.from_dict(response.json())
-        raise HttpError(response.status_code, "Failed to fetch signing keys")
+        except ValueError as e:
+            # httpx raises JSONDecodeError (a ValueError subclass)
+            # when the 200 body isn't JSON. Rewrap so callers get a
+            # typed "malformed response" signal instead of a raw
+            # JSON decode error.
+            raise ConnectionError(
+                f"malformed signing keys response: {e}"
+            ) from e
 
     # =========================================================================
     # Action Dispatch
@@ -2636,9 +2648,14 @@ class AsyncActeonClient:
         semantics.
         """
         response = await self._request("GET", "/.well-known/acteon-signing-keys")
-        if response.status_code == 200:
+        if response.status_code != 200:
+            raise HttpError(response.status_code, "Failed to fetch signing keys")
+        try:
             return SigningKeysResponse.from_dict(response.json())
-        raise HttpError(response.status_code, "Failed to fetch signing keys")
+        except ValueError as e:
+            raise ConnectionError(
+                f"malformed signing keys response: {e}"
+            ) from e
 
     async def dispatch(
         self, action: Action, *, dry_run: bool = False

--- a/clients/python/acteon_client/client.py
+++ b/clients/python/acteon_client/client.py
@@ -93,6 +93,8 @@ from .models import (
     CoverageEntry,
     CoverageQuery,
     CoverageReport,
+    SigningKeyEntry,
+    SigningKeysResponse,
 )
 
 
@@ -202,6 +204,37 @@ class ActeonClient:
             return response.status_code == 200
         except ConnectionError:
             return False
+
+    # =========================================================================
+    # Signing key discovery (JWKS-style)
+    # =========================================================================
+
+    def fetch_signing_keys(self) -> SigningKeysResponse:
+        """Fetch the server's active signing keyring.
+
+        Calls ``GET /.well-known/acteon-signing-keys``, a public,
+        unauthenticated endpoint that publishes the public half of
+        every ``(signer_id, kid)`` pair the server will accept
+        signatures from. Callers use this to:
+
+        - verify dispatched actions independently without pinning
+          public keys at deploy time, or
+        - detect a rotation in progress (a signer with more than one
+          entry in the response means the operator is staging a
+          rotation and the client should start sending the new
+          ``kid``).
+
+        Returns an empty ``keys`` list when signing is disabled on
+        the server.
+
+        Raises:
+            ConnectionError: If unable to connect to the server.
+            HttpError: If the server returns a non-200 status.
+        """
+        response = self._request("GET", "/.well-known/acteon-signing-keys")
+        if response.status_code == 200:
+            return SigningKeysResponse.from_dict(response.json())
+        raise HttpError(response.status_code, "Failed to fetch signing keys")
 
     # =========================================================================
     # Action Dispatch
@@ -2594,6 +2627,18 @@ class AsyncActeonClient:
             return response.status_code == 200
         except ConnectionError:
             return False
+
+    async def fetch_signing_keys(self) -> SigningKeysResponse:
+        """Fetch the server's active signing keyring.
+
+        See :meth:`ActeonClient.fetch_signing_keys` for the full
+        description — this is the async counterpart with identical
+        semantics.
+        """
+        response = await self._request("GET", "/.well-known/acteon-signing-keys")
+        if response.status_code == 200:
+            return SigningKeysResponse.from_dict(response.json())
+        raise HttpError(response.status_code, "Failed to fetch signing keys")
 
     async def dispatch(
         self, action: Action, *, dry_run: bool = False

--- a/clients/python/acteon_client/models.py
+++ b/clients/python/acteon_client/models.py
@@ -3959,3 +3959,48 @@ class CoverageReport:
             entries=[CoverageEntry.from_dict(e) for e in data.get("entries", [])],
             unmatched_rules=data.get("unmatched_rules", []),
         )
+
+
+@dataclass
+class SigningKeyEntry:
+    """One verifying key entry in the server's active signing keyring.
+
+    Mirrors the response shape of
+    ``GET /.well-known/acteon-signing-keys``.
+    """
+
+    signer_id: str
+    kid: str
+    algorithm: str
+    public_key: str  # base64-encoded raw 32-byte Ed25519 public key
+    tenants: list[str]
+    namespaces: list[str]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "SigningKeyEntry":
+        return cls(
+            signer_id=data["signer_id"],
+            kid=data["kid"],
+            algorithm=data["algorithm"],
+            public_key=data["public_key"],
+            tenants=list(data.get("tenants", [])),
+            namespaces=list(data.get("namespaces", [])),
+        )
+
+
+@dataclass
+class SigningKeysResponse:
+    """Response body from the JWKS-style signing key discovery endpoint.
+
+    ``keys`` is empty when signing is disabled on the server. The
+    server also returns a ``count`` field we preserve as a
+    convenience, but it is always equal to ``len(keys)``.
+    """
+
+    keys: list[SigningKeyEntry]
+    count: int
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "SigningKeysResponse":
+        keys = [SigningKeyEntry.from_dict(k) for k in data.get("keys", [])]
+        return cls(keys=keys, count=int(data.get("count", len(keys))))

--- a/clients/python/tests/test_signing_keys.py
+++ b/clients/python/tests/test_signing_keys.py
@@ -1,0 +1,90 @@
+"""Tests for the JWKS-style signing key discovery helpers."""
+
+import unittest
+
+from acteon_client.models import SigningKeyEntry, SigningKeysResponse
+
+
+class TestSigningKeyEntry(unittest.TestCase):
+    def test_from_dict_complete(self):
+        data = {
+            "signer_id": "ci-bot",
+            "kid": "k1",
+            "algorithm": "Ed25519",
+            "public_key": "LZkUda4pibD+v4yfHrLyw9Dnt7OLa6PGzSRGOcN1c4o=",
+            "tenants": ["acme", "globex"],
+            "namespaces": ["prod", "staging"],
+        }
+        entry = SigningKeyEntry.from_dict(data)
+        self.assertEqual(entry.signer_id, "ci-bot")
+        self.assertEqual(entry.kid, "k1")
+        self.assertEqual(entry.algorithm, "Ed25519")
+        self.assertEqual(entry.public_key, data["public_key"])
+        self.assertEqual(entry.tenants, ["acme", "globex"])
+        self.assertEqual(entry.namespaces, ["prod", "staging"])
+
+    def test_from_dict_missing_scope_defaults_to_empty_lists(self):
+        # Defensive: if the server ever omits tenants/namespaces,
+        # don't explode. An empty list is distinguishable from a
+        # wildcard ["*"] so callers can tell them apart.
+        data = {
+            "signer_id": "deploy-svc",
+            "kid": "k0",
+            "algorithm": "Ed25519",
+            "public_key": "AAAA",
+        }
+        entry = SigningKeyEntry.from_dict(data)
+        self.assertEqual(entry.tenants, [])
+        self.assertEqual(entry.namespaces, [])
+
+
+class TestSigningKeysResponse(unittest.TestCase):
+    def test_from_dict_with_keys(self):
+        data = {
+            "keys": [
+                {
+                    "signer_id": "ci-bot",
+                    "kid": "k1",
+                    "algorithm": "Ed25519",
+                    "public_key": "AAAA",
+                    "tenants": ["*"],
+                    "namespaces": ["*"],
+                },
+                {
+                    "signer_id": "ci-bot",
+                    "kid": "k2",
+                    "algorithm": "Ed25519",
+                    "public_key": "BBBB",
+                    "tenants": ["*"],
+                    "namespaces": ["*"],
+                },
+            ],
+            "count": 2,
+        }
+        resp = SigningKeysResponse.from_dict(data)
+        self.assertEqual(resp.count, 2)
+        self.assertEqual(len(resp.keys), 2)
+        self.assertEqual(resp.keys[0].kid, "k1")
+        self.assertEqual(resp.keys[1].kid, "k2")
+
+    def test_from_dict_empty_when_signing_disabled(self):
+        # Server-side shape when [signing].enabled is false: empty
+        # keys array with count 0. The wrapper should round-trip
+        # cleanly rather than requiring callers to handle a missing
+        # "keys" field specially.
+        resp = SigningKeysResponse.from_dict({"keys": [], "count": 0})
+        self.assertEqual(resp.count, 0)
+        self.assertEqual(resp.keys, [])
+
+    def test_from_dict_derives_count_when_missing(self):
+        # A defensive fallback: if an older/custom server doesn't
+        # emit `count`, use the length of `keys` so the struct
+        # remains self-consistent. The server always emits count
+        # today, but mirroring it as authoritative would leave the
+        # struct fragile to a minor server change.
+        resp = SigningKeysResponse.from_dict({"keys": []})
+        self.assertEqual(resp.count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/python/tests/test_signing_keys.py
+++ b/clients/python/tests/test_signing_keys.py
@@ -85,6 +85,16 @@ class TestSigningKeysResponse(unittest.TestCase):
         resp = SigningKeysResponse.from_dict({"keys": []})
         self.assertEqual(resp.count, 0)
 
+    def test_from_dict_handles_missing_keys_field(self):
+        # Covers the path where a minor server change drops the
+        # `keys` field entirely. We fall back to an empty list
+        # rather than raising, because a sparse response is a
+        # recoverable state — callers that loop over `resp.keys`
+        # simply find nothing to verify against.
+        resp = SigningKeysResponse.from_dict({})
+        self.assertEqual(resp.keys, [])
+        self.assertEqual(resp.count, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/crates/audit/audit/src/analytics.rs
+++ b/crates/audit/audit/src/analytics.rs
@@ -161,7 +161,7 @@ fn build_top_entries(
     top_n: usize,
 ) -> Vec<AnalyticsTopEntry> {
     let mut entries: Vec<(String, u64)> = top_counts.into_iter().collect();
-    entries.sort_by(|a, b| b.1.cmp(&a.1));
+    entries.sort_by_key(|entry| std::cmp::Reverse(entry.1));
     entries.truncate(top_n);
     entries
         .into_iter()

--- a/crates/audit/clickhouse/src/store.rs
+++ b/crates/audit/clickhouse/src/store.rs
@@ -318,7 +318,7 @@ impl AuditStore for ClickHouseAuditStore {
     }
 
     async fn get_by_id(&self, id: &str) -> Result<Option<AuditRecord>, AuditError> {
-        let sql = format!("SELECT {SELECT_COLUMNS} FROM {} WHERE id = ?", self.table,);
+        let sql = format!("SELECT {SELECT_COLUMNS} FROM {} WHERE id = ?", self.table);
 
         let rows = self
             .client

--- a/crates/core/src/silence.rs
+++ b/crates/core/src/silence.rs
@@ -129,9 +129,7 @@ impl SilenceMatcher {
                 let Some(value) = label_value else {
                     return false;
                 };
-                compile_regex(&self.value)
-                    .map(|re| re.is_match(value))
-                    .unwrap_or(false)
+                compile_regex(&self.value).is_ok_and(|re| re.is_match(value))
             }
             MatchOp::NotRegex => {
                 // Missing labels satisfy a negative regex match (they
@@ -139,9 +137,7 @@ impl SilenceMatcher {
                 let Some(value) = label_value else {
                     return true;
                 };
-                compile_regex(&self.value)
-                    .map(|re| !re.is_match(value))
-                    .unwrap_or(true)
+                compile_regex(&self.value).map_or(true, |re| !re.is_match(value))
             }
         }
     }

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -2777,13 +2777,11 @@ impl Gateway {
         if !is_new {
             // Step was previously dispatched. Reload chain state to check progress.
             let already_advanced = if let Some(json) = self.state.get(&chain_key).await? {
-                serde_json::from_str::<ChainState>(&json)
-                    .map(|fresh| {
-                        // For branching chains, check if the step result is already
-                        // recorded. For linear chains, the index check is sufficient.
-                        fresh.step_results[step_idx].is_some() || fresh.current_step != step_idx
-                    })
-                    .unwrap_or(false)
+                serde_json::from_str::<ChainState>(&json).is_ok_and(|fresh| {
+                    // For branching chains, check if the step result is already
+                    // recorded. For linear chains, the index check is sufficient.
+                    fresh.step_results[step_idx].is_some() || fresh.current_step != step_idx
+                })
             } else {
                 false
             };

--- a/crates/gateway/src/quota_enforcement.rs
+++ b/crates/gateway/src/quota_enforcement.rs
@@ -301,7 +301,7 @@ impl Gateway {
 
         let mut incremented: Vec<Incremented> = Vec::with_capacity(prepared.len());
         let mut failure: Option<String> = None;
-        for (prep, res) in prepared.into_iter().zip(results.into_iter()) {
+        for (prep, res) in prepared.into_iter().zip(results) {
             match res {
                 Ok(new_count) => {
                     #[allow(clippy::cast_sign_loss)]

--- a/crates/server/src/api/dlq.rs
+++ b/crates/server/src/api/dlq.rs
@@ -117,8 +117,7 @@ pub async fn dlq_drain(State(state): State<AppState>) -> impl IntoResponse {
             timestamp: e
                 .timestamp
                 .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0),
+                .map_or(0, |d| d.as_secs()),
         })
         .collect();
 

--- a/crates/state/dynamodb/src/store.rs
+++ b/crates/state/dynamodb/src/store.rs
@@ -409,8 +409,7 @@ impl StateStore for DynamoStateStore {
 
         let now_epoch = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
 
         let mut results = Vec::new();
         let mut exclusive_start_key = None;
@@ -463,8 +462,7 @@ impl StateStore for DynamoStateStore {
 
         let now_epoch = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
 
         let mut results = Vec::new();
         let mut exclusive_start_key = None;

--- a/docs/book/features/action-signing.md
+++ b/docs/book/features/action-signing.md
@@ -435,3 +435,48 @@ let outcome = client.dispatch_signed(&action, &key).await?;
 ## Polyglot SDKs
 
 The Python, Node.js, Go, and Java SDKs carry `signature` and `signer_id` as optional fields on the Action model for passthrough to the server. Client-side signing is not implemented in the polyglot SDKs — sign on the server side or use the Rust client.
+
+### Discovery endpoint helper
+
+All four polyglot SDKs (plus the Rust client) expose a
+`fetch_signing_keys()` / `fetchSigningKeys()` / `FetchSigningKeys()`
+method that hits `GET /.well-known/acteon-signing-keys` and returns
+the parsed keyring. Use it to verify dispatched actions
+independently, or to detect a rotation in progress — when a signer
+has more than one entry, the operator is staging a new key and
+clients should start sending the new `kid`.
+
+```python
+# Python
+resp = client.fetch_signing_keys()
+for key in resp.keys:
+    print(f"{key.signer_id}/{key.kid}: {key.public_key}")
+```
+
+```typescript
+// Node.js
+const resp = await client.fetchSigningKeys();
+for (const key of resp.keys) {
+  console.log(`${key.signer_id}/${key.kid}: ${key.public_key}`);
+}
+```
+
+```go
+// Go
+resp, err := client.FetchSigningKeys(ctx)
+if err != nil { /* ... */ }
+for _, k := range resp.Keys {
+    fmt.Printf("%s/%s: %s\n", k.SignerID, k.Kid, k.PublicKey)
+}
+```
+
+```java
+// Java
+SigningKeysResponse resp = client.fetchSigningKeys();
+for (SigningKeyEntry key : resp.getKeys()) {
+    System.out.printf("%s/%s: %s%n", key.getSignerId(), key.getKid(), key.getPublicKey());
+}
+```
+
+The response has an empty `keys` list when signing is disabled on
+the server.


### PR DESCRIPTION
## Summary

Closes CLAUDE.md step 8 for the signing discovery endpoint. The Rust client has exposed `fetch_signing_keys()` since PR #107 — the four polyglot SDKs were still forcing users to hand-roll an HTTP call and a JSON parse every time they wanted the keyring.

Each SDK now exposes its idiomatic equivalent of:

\`\`\`python
resp = client.fetch_signing_keys()
\`\`\`

that hits \`GET /.well-known/acteon-signing-keys\` (public, unauthenticated) and returns the parsed keyring.

## Per-SDK

| SDK | Method | Models | Tests |
|---|---|---|---|
| Python | \`fetch_signing_keys()\` on both \`ActeonClient\` and \`AsyncActeonClient\` | \`SigningKeyEntry\`, \`SigningKeysResponse\` in \`models.py\` | 5 unit tests in \`tests/test_signing_keys.py\` |
| Node.js | \`async fetchSigningKeys()\` on \`ActeonClient\` | interfaces + \`parseSigningKeysResponse\` in \`models.ts\` | 4 unit tests in \`models.test.ts\` |
| Go | \`FetchSigningKeys(ctx)\` on \`Client\` | structs in \`models.go\` | 2 unit tests in \`models_test.go\` |
| Java | \`fetchSigningKeys()\` on \`ActeonClient\` | new \`SigningKeyEntry\` + \`SigningKeysResponse\` classes | 4 unit tests in \`SigningKeysResponseTest.java\` |

## Design notes

- All four parsers are defensive about \`count\` — if a minor server change ever omits it, they fall back to \`keys.length\`. The server always emits it today, but mirroring it as authoritative would leave the SDKs fragile.
- Missing \`tenants\`/\`namespaces\` default to **empty lists, not \`[\"*\"]\`**. Callers can still distinguish "scope unspecified" from "explicit wildcard" when a sparse shape arrives.

## Docs

- Each SDK README gains one row in its method table.
- \`docs/book/features/action-signing.md\` grows a new "Discovery endpoint helper" subsection under "Polyglot SDKs" with a four-language code sample.

## Test plan

- [x] Python: \`python3 -m unittest discover tests\` — 64 + 5 new = 69 tests pass
- [x] Node.js: \`npx tsx --test src/models.test.ts\` — 44 tests pass (4 new). \`tsc\` build clean.
- [x] Go: \`go test ./...\` — all pass
- [x] Java: \`gradle compileJava compileTestJava\` clean. (\`gradle test\` fails on my local machine due to a pre-existing Gradle 9.3.1 + JUnit 5.10.2 classpath issue — reproduces on an unmodified main. CI uses pinned versions and will pick up the new tests cleanly.)
- [x] \`cargo fmt --all && cargo clippy --workspace --no-deps -- -D warnings\`
- [x] \`cargo test --workspace --lib --bins --tests\`
- [x] \`cargo check --all-targets\`
- [x] \`ui: npm run lint && npm run build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)