### PR TITLE
feat(observability): expose acteon_recurring_active gauge

### DIFF
--- a/crates/gateway/src/background/mod.rs
+++ b/crates/gateway/src/background/mod.rs
@@ -1147,6 +1147,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn recurring_active_gauge_tracks_pending_count() {
+        let group_manager = Arc::new(GroupManager::new());
+        let state: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+        let metrics = Arc::new(GatewayMetrics::default());
+        let namespace = "test-ns";
+        let tenant = "test-tenant";
+
+        // Index three pending recurring actions across two tenants — none of
+        // them are due yet, but the gauge should still see them.
+        let future = Utc::now() + chrono::Duration::hours(1);
+        for (id, t) in [("rec-a", "t1"), ("rec-b", "t1"), ("rec-c", "t2")] {
+            let pending_key = StateKey::new(namespace, t, KeyKind::PendingRecurring, id);
+            state
+                .set(&pending_key, &future.timestamp_millis().to_string(), None)
+                .await
+                .unwrap();
+            state
+                .index_timeout(&pending_key, future.timestamp_millis())
+                .await
+                .unwrap();
+        }
+
+        let (rec_tx, _rec_rx) = mpsc::channel(10);
+        let (mut processor, shutdown_tx) = BackgroundProcessorBuilder::new()
+            .metrics(Arc::clone(&metrics))
+            .config(BackgroundConfig {
+                enable_group_flush: false,
+                enable_timeout_processing: false,
+                enable_approval_retry: false,
+                enable_chain_advancement: false,
+                enable_scheduled_actions: false,
+                enable_recurring_actions: true,
+                recurring_check_interval: Duration::from_millis(50),
+                namespace: namespace.to_owned(),
+                tenant: tenant.to_owned(),
+                ..BackgroundConfig::default()
+            })
+            .group_manager(group_manager)
+            .state(Arc::clone(&state))
+            .recurring_action_channel(rec_tx)
+            .build()
+            .unwrap();
+
+        let handle = tokio::spawn(async move { processor.run().await });
+
+        // Poll until the worker has refreshed the gauge at least once.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            if metrics.snapshot().recurring_active == 3 {
+                break;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!(
+                    "gauge never reached 3, last value = {}",
+                    metrics.snapshot().recurring_active
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let _ = shutdown_tx.send(()).await;
+        let _ = tokio::time::timeout(Duration::from_secs(1), handle).await;
+    }
+
+    #[tokio::test]
     async fn builder_with_recurring_channel() {
         let group_manager = Arc::new(GroupManager::new());
         let state = Arc::new(MemoryStateStore::new());

--- a/crates/gateway/src/background/workers/recurring.rs
+++ b/crates/gateway/src/background/workers/recurring.rs
@@ -6,6 +6,28 @@ use acteon_state::{KeyKind, StateKey};
 use super::super::{BackgroundProcessor, RecurringActionDueEvent};
 
 impl BackgroundProcessor {
+    /// Refresh the `recurring_active` gauge by counting entries in the
+    /// pending-recurring index. Called once per recurring tick before
+    /// dispatching due actions, so the gauge reflects the steady-state
+    /// number of scheduled recurring actions even when no dispatches
+    /// are happening.
+    pub(crate) async fn refresh_recurring_active_gauge(&self) {
+        match self
+            .state
+            .scan_keys_by_kind(KeyKind::PendingRecurring)
+            .await
+        {
+            Ok(entries) => {
+                self.metrics.set_recurring_active(entries.len() as u64);
+            }
+            Err(e) => {
+                debug!(error = %e, "failed to refresh recurring_active gauge");
+            }
+        }
+    }
+}
+
+impl BackgroundProcessor {
     /// Process recurring actions that are due for dispatch.
     ///
     /// Uses the timeout index to efficiently find expired `PendingRecurring`
@@ -25,6 +47,10 @@ impl BackgroundProcessor {
         let Some(ref tx) = self.recurring_action_tx else {
             return Ok(());
         };
+
+        // Refresh the active gauge first so it stays current even when no
+        // recurring actions are due in this tick.
+        self.refresh_recurring_active_gauge().await;
 
         let now = Utc::now();
         let now_ms = now.timestamp_millis();

--- a/crates/gateway/src/metrics.rs
+++ b/crates/gateway/src/metrics.rs
@@ -61,6 +61,10 @@ pub struct GatewayMetrics {
     pub recurring_errors: AtomicU64,
     /// Recurring actions skipped (disabled, expired, etc.).
     pub recurring_skipped: AtomicU64,
+    /// Recurring actions currently scheduled and eligible for dispatch.
+    /// Refreshed once per `recurring_check_interval` tick by counting
+    /// the pending-recurring index.
+    pub recurring_active: AtomicU64,
     /// Actions blocked by tenant quota.
     pub quota_exceeded: AtomicU64,
     /// Actions that passed with a quota warning.
@@ -227,6 +231,12 @@ impl GatewayMetrics {
         self.recurring_skipped.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Set the recurring active gauge to the current count of scheduled
+    /// recurring actions. Called from the recurring worker tick.
+    pub fn set_recurring_active(&self, value: u64) {
+        self.recurring_active.store(value, Ordering::Relaxed);
+    }
+
     /// Increment the quota exceeded (blocked) counter.
     pub fn increment_quota_exceeded(&self) {
         self.quota_exceeded.fetch_add(1, Ordering::Relaxed);
@@ -354,6 +364,7 @@ impl GatewayMetrics {
             recurring_dispatched: self.recurring_dispatched.load(Ordering::Relaxed),
             recurring_errors: self.recurring_errors.load(Ordering::Relaxed),
             recurring_skipped: self.recurring_skipped.load(Ordering::Relaxed),
+            recurring_active: self.recurring_active.load(Ordering::Relaxed),
             quota_exceeded: self.quota_exceeded.load(Ordering::Relaxed),
             quota_warned: self.quota_warned.load(Ordering::Relaxed),
             quota_degraded: self.quota_degraded.load(Ordering::Relaxed),
@@ -425,6 +436,8 @@ pub struct MetricsSnapshot {
     pub recurring_errors: u64,
     /// Recurring actions skipped (disabled, expired, etc.).
     pub recurring_skipped: u64,
+    /// Recurring actions currently scheduled and eligible for dispatch.
+    pub recurring_active: u64,
     /// Actions blocked by tenant quota.
     pub quota_exceeded: u64,
     /// Actions that passed with a quota warning.
@@ -807,6 +820,7 @@ mod tests {
         assert_eq!(snap.recurring_dispatched, 0);
         assert_eq!(snap.recurring_errors, 0);
         assert_eq!(snap.recurring_skipped, 0);
+        assert_eq!(snap.recurring_active, 0);
         assert_eq!(snap.quota_exceeded, 0);
         assert_eq!(snap.quota_warned, 0);
         assert_eq!(snap.quota_degraded, 0);
@@ -853,6 +867,7 @@ mod tests {
         m.increment_recurring_dispatched();
         m.increment_recurring_errors();
         m.increment_recurring_skipped();
+        m.set_recurring_active(7);
         m.increment_quota_exceeded();
         m.increment_quota_warned();
         m.increment_quota_degraded();
@@ -895,6 +910,7 @@ mod tests {
         assert_eq!(snap.recurring_dispatched, 1);
         assert_eq!(snap.recurring_errors, 1);
         assert_eq!(snap.recurring_skipped, 1);
+        assert_eq!(snap.recurring_active, 7);
         assert_eq!(snap.quota_exceeded, 1);
         assert_eq!(snap.quota_warned, 1);
         assert_eq!(snap.quota_degraded, 1);

--- a/crates/server/src/api/health.rs
+++ b/crates/server/src/api/health.rs
@@ -47,6 +47,7 @@ fn build_metrics_response(
         recurring_dispatched: snap.recurring_dispatched,
         recurring_errors: snap.recurring_errors,
         recurring_skipped: snap.recurring_skipped,
+        recurring_active: snap.recurring_active,
         quota_exceeded: snap.quota_exceeded,
         quota_warned: snap.quota_warned,
         quota_degraded: snap.quota_degraded,

--- a/crates/server/src/api/prometheus.rs
+++ b/crates/server/src/api/prometheus.rs
@@ -275,6 +275,12 @@ fn render_snapshot(snap: &MetricsSnapshot) -> String {
         "Recurring actions skipped (disabled, expired, etc.).",
         snap.recurring_skipped,
     );
+    write_gauge(
+        &mut buf,
+        "acteon_recurring_active",
+        "Recurring actions currently scheduled and eligible for dispatch.",
+        snap.recurring_active,
+    );
 
     // -- Quota counters --
     write_counter(
@@ -507,6 +513,15 @@ fn write_counter(buf: &mut String, name: &str, help: &str, value: u64) {
     buf.push('\n');
 }
 
+/// Write a single gauge metric with HELP and TYPE annotations.
+fn write_gauge(buf: &mut String, name: &str, help: &str, value: u64) {
+    use std::fmt::Write;
+    let _ = writeln!(buf, "# HELP {name} {help}");
+    let _ = writeln!(buf, "# TYPE {name} gauge");
+    let _ = writeln!(buf, "{name} {value}");
+    buf.push('\n');
+}
+
 /// Write HELP and TYPE header for a counter with provider labels.
 fn write_provider_counter_header(buf: &mut String, name: &str, help: &str) {
     use std::fmt::Write;
@@ -585,6 +600,7 @@ mod tests {
             recurring_dispatched: 0,
             recurring_errors: 0,
             recurring_skipped: 0,
+            recurring_active: 0,
             quota_exceeded: 0,
             quota_warned: 0,
             quota_degraded: 0,
@@ -630,6 +646,7 @@ mod tests {
             recurring_dispatched: 4,
             recurring_errors: 1,
             recurring_skipped: 2,
+            recurring_active: 9,
             quota_exceeded: 3,
             quota_warned: 2,
             quota_degraded: 1,
@@ -930,6 +947,8 @@ mod tests {
         assert!(output.contains("acteon_recurring_dispatched_total 4"));
         assert!(output.contains("acteon_recurring_errors_total 1"));
         assert!(output.contains("acteon_recurring_skipped_total 2"));
+        assert!(output.contains("acteon_recurring_active 9"));
+        assert!(output.contains("# TYPE acteon_recurring_active gauge"));
         assert!(output.contains("acteon_quota_exceeded_total 3"));
         assert!(output.contains("acteon_quota_warned_total 2"));
         assert!(output.contains("acteon_quota_degraded_total 1"));
@@ -1181,12 +1200,12 @@ mod tests {
             assert!(output.contains(name), "Missing provider metric: {name}");
         }
 
-        // Total: 40 + 8 = 48 unique metric families
+        // 40 counters + 1 gauge from the snapshot + 8 provider families = 49.
         let type_lines: Vec<&str> = output
             .lines()
             .filter(|l| l.starts_with("# TYPE "))
             .collect();
-        assert_eq!(type_lines.len(), 48, "Expected 48 TYPE declarations");
+        assert_eq!(type_lines.len(), 49, "Expected 49 TYPE declarations");
     }
 
     #[test]
@@ -1202,8 +1221,18 @@ mod tests {
             .collect();
         assert_eq!(
             type_lines.len(),
-            40,
-            "Expected 40 TYPE declarations without providers"
+            41,
+            "Expected 41 TYPE declarations without providers (40 counters + 1 gauge)"
         );
+    }
+
+    #[test]
+    fn write_gauge_format() {
+        let mut buf = String::new();
+        write_gauge(&mut buf, "acteon_test_gauge", "A test gauge.", 42);
+        let lines: Vec<&str> = buf.lines().collect();
+        assert_eq!(lines[0], "# HELP acteon_test_gauge A test gauge.");
+        assert_eq!(lines[1], "# TYPE acteon_test_gauge gauge");
+        assert_eq!(lines[2], "acteon_test_gauge 42");
     }
 }

--- a/crates/server/src/api/schemas.rs
+++ b/crates/server/src/api/schemas.rs
@@ -89,6 +89,12 @@ pub struct MetricsResponse {
     /// Recurring actions skipped (disabled, expired, etc.).
     #[schema(example = 0)]
     pub recurring_skipped: u64,
+    /// Recurring actions currently scheduled and eligible for dispatch.
+    /// Refreshed once per `recurring_check_interval` tick by counting
+    /// the pending-recurring index.
+    #[schema(example = 0)]
+    #[serde(default)]
+    pub recurring_active: u64,
     /// Actions blocked by tenant quota.
     #[schema(example = 0)]
     pub quota_exceeded: u64,

--- a/deploy/grafana/dashboards/acteon-overview.json
+++ b/deploy/grafana/dashboards/acteon-overview.json
@@ -311,12 +311,25 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "short", "thresholds": { "steps": [{ "color": "blue", "value": null }] } } },
+      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 35 },
+      "id": 19,
+      "options": { "colorMode": "background", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Recurring Actions Active",
+      "description": "Recurring actions currently scheduled and eligible for dispatch. Refreshed once per recurring_check_interval tick.",
+      "targets": [
+        { "expr": "acteon_recurring_active", "legendFormat": "Active", "refId": "A" }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": { "defaults": { "unit": "short", "thresholds": { "steps": [{ "color": "green", "value": null }] } },
         "overrides": [
           { "matcher": { "id": "byName", "options": "Errors" }, "properties": [{ "id": "thresholds", "value": { "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] } }] }
         ]
       },
-      "gridPos": { "h": 5, "w": 12, "x": 0, "y": 35 },
+      "gridPos": { "h": 5, "w": 8, "x": 8, "y": 35 },
       "id": 11,
       "options": { "colorMode": "background", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "title": "Recurring Action Totals",
@@ -336,7 +349,7 @@
           "unit": "ops"
         }
       },
-      "gridPos": { "h": 5, "w": 12, "x": 12, "y": 35 },
+      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 35 },
       "id": 12,
       "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
       "title": "Recurring Action Rate",

--- a/docs/book/features/grafana-dashboards.md
+++ b/docs/book/features/grafana-dashboards.md
@@ -100,6 +100,7 @@ All metrics use the `acteon_` prefix. Counters are monotonically increasing from
 | `acteon_recurring_dispatched_total` | counter | Recurring actions dispatched |
 | `acteon_recurring_errors_total` | counter | Recurring action dispatch errors |
 | `acteon_recurring_skipped_total` | counter | Recurring actions skipped |
+| `acteon_recurring_active` | gauge | Recurring actions currently scheduled and eligible for dispatch |
 
 ### Quota Counters
 

--- a/docs/book/features/recurring-actions.md
+++ b/docs/book/features/recurring-actions.md
@@ -591,18 +591,19 @@ The drawer includes **Pause/Resume** and **Delete** buttons.
 
 ### Prometheus Metrics
 
-Recurring action processing exports three counters via
-`GET /metrics/prometheus` (and as JSON at `GET /metrics`):
+Recurring action processing exports three counters and one gauge
+via `GET /metrics/prometheus` (and as JSON at `GET /metrics`):
 
-| Metric | Counted on |
-|---|---|
-| `acteon_recurring_dispatched_total` | Every successful recurring occurrence dispatched through the gateway |
-| `acteon_recurring_errors_total` | Dispatch failures — cron parse error, state store unavailable, claim refused for a genuine reason, etc. |
-| `acteon_recurring_skipped_total` | Occurrences skipped because another replica claimed them first (normal behavior under the CAS claim pattern — **not** an error signal) |
+| Metric | Type | Counted on |
+|---|---|---|
+| `acteon_recurring_dispatched_total` | counter | Every successful recurring occurrence dispatched through the gateway |
+| `acteon_recurring_errors_total` | counter | Dispatch failures — cron parse error, state store unavailable, claim refused for a genuine reason, etc. |
+| `acteon_recurring_skipped_total` | counter | Occurrences skipped because another replica claimed them first (normal behavior under the CAS claim pattern — **not** an error signal) |
+| `acteon_recurring_active` | gauge | Recurring actions currently scheduled and eligible for dispatch. Refreshed once per `recurring_check_interval` tick by counting the pending-recurring index. |
 
 **Grafana.** The bundled `acteon-overview` dashboard has a
-"Recurring Actions" row with a rate timeseries and a stat panel
-for the totals.
+"Recurring Actions" row with stat panels for active count and
+totals plus a rate timeseries.
 
 **What to alert on.** A sustained error rate is the primary
 signal:
@@ -614,11 +615,11 @@ rate(acteon_recurring_errors_total[5m]) > 0.1
 A drop in dispatch rate when recurring actions are configured
 often means the background processor is wedged — the claim TTL
 (120s) expired without progress. Compare the dispatched rate
-against the count of active recurring actions from
-`GET /v1/recurring`:
+against `acteon_recurring_active` to spot a stuck worker without
+hitting `GET /v1/recurring`:
 
 ```promql
-rate(acteon_recurring_dispatched_total[5m]) == 0
+acteon_recurring_active > 0 and rate(acteon_recurring_dispatched_total[5m]) == 0
 ```
 
 **Do not alert on `acteon_recurring_skipped_total`**: it fires

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -24,6 +24,7 @@ export interface MetricsResponse {
   recurring_dispatched?: number
   recurring_errors?: number
   recurring_skipped?: number
+  recurring_active?: number
   quota_exceeded?: number
   quota_warned?: number
   quota_degraded?: number


### PR DESCRIPTION
## Summary

- Adds `acteon_recurring_active` gauge to `GatewayMetrics`, refreshed once per `recurring_check_interval` tick by counting `PendingRecurring` keys via `scan_keys_by_kind`.
- Exposes the gauge via `GET /metrics/prometheus`, the JSON `/metrics` response, and a new stat panel in the "Recurring Actions" row of the bundled `acteon-overview` Grafana dashboard.
- Updates docs in `docs/book/features/recurring-actions.md` (with a new alert recipe combining the gauge with the dispatch rate) and `docs/book/features/grafana-dashboards.md`.

Closes #115. Follow-up filed for the DynamoDB scan cost — see comment below.

## Test plan

- [x] `cargo test --workspace --lib --bins --tests` (new test `recurring_active_gauge_tracks_pending_count` indexes three pending entries across two tenants and asserts the gauge converges to 3 within the worker tick window)
- [x] `cargo clippy --workspace --no-deps -- -D warnings`
- [x] `cargo check --all-targets`
- [x] `cd ui && npm run lint && npm run build`
- [ ] Manual scrape of `GET /metrics/prometheus` against a server with `enable_recurring_actions = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)