### PR TITLE
fix(security): default LLM guardrail to fail-closed

### DIFF
--- a/crates/gateway/src/builder.rs
+++ b/crates/gateway/src/builder.rs
@@ -94,7 +94,11 @@ impl GatewayBuilder {
             llm_evaluator: None,
             llm_policy: String::new(),
             llm_policies: HashMap::new(),
-            llm_fail_open: true,
+            // Fail closed by default: when the LLM evaluator errors,
+            // deny the action rather than silently letting it
+            // through. Operators who explicitly accept the bypass
+            // risk can flip this with `.llm_fail_open(true)`.
+            llm_fail_open: false,
             chains: HashMap::new(),
             completed_chain_ttl: None,
             embedding: None,
@@ -283,10 +287,19 @@ impl GatewayBuilder {
         self
     }
 
-    /// Set whether the LLM guardrail fails open (default: `true`).
+    /// Set whether the LLM guardrail fails open (default: `false`).
     ///
-    /// When `true`, LLM evaluation errors allow the action to proceed.
-    /// When `false`, errors cause the action to be denied.
+    /// When `false` (the default, fail-closed), LLM evaluation errors
+    /// cause the action to be denied — the guardrail is treated as a
+    /// hard gate that must succeed for the action to proceed. This is
+    /// the safer default for security-oriented deployments because an
+    /// attacker who can force evaluator timeouts (oversized prompts,
+    /// upstream slowness) cannot quietly bypass the check.
+    ///
+    /// When `true` (fail-open), evaluator errors allow the action
+    /// through. Use this when availability matters more than the
+    /// guarantee that every action was evaluated — for example, when
+    /// the guardrail is an advisory check on a low-stakes flow.
     #[must_use]
     pub fn llm_fail_open(mut self, fail_open: bool) -> Self {
         self.llm_fail_open = fail_open;
@@ -924,6 +937,20 @@ mod tests {
         async fn health_check(&self) -> Result<(), acteon_provider::ProviderError> {
             Ok(())
         }
+    }
+
+    #[test]
+    fn llm_fail_open_default_is_false() {
+        // The builder defaults to fail-closed so a deployment that
+        // wires an LLM evaluator without explicitly setting
+        // fail_open does not silently bypass the guardrail when the
+        // evaluator errors. Operators who want fail-open behavior
+        // must opt in via .llm_fail_open(true). See issue #120.
+        let builder = GatewayBuilder::new();
+        assert!(
+            !builder.llm_fail_open,
+            "GatewayBuilder default for llm_fail_open must remain false (fail-closed)"
+        );
     }
 
     #[test]

--- a/crates/server/src/config/llm.rs
+++ b/crates/server/src/config/llm.rs
@@ -40,7 +40,13 @@ pub struct LlmGuardrailServerConfig {
     /// metadata `llm_policy` entries.
     #[serde(default)]
     pub policies: HashMap<String, String>,
-    /// Whether to allow actions when the LLM is unreachable.
+    /// Whether to allow actions when the LLM is unreachable
+    /// (default: `false`, fail-closed).
+    ///
+    /// Fail-closed is the safer default: evaluator errors deny the
+    /// action rather than silently letting it through. Set this to
+    /// `true` only when availability matters more than the guarantee
+    /// that every action was evaluated.
     #[serde(default = "default_llm_fail_open")]
     pub fail_open: bool,
     /// Request timeout in seconds.
@@ -77,7 +83,8 @@ fn default_llm_model() -> String {
 }
 
 fn default_llm_fail_open() -> bool {
-    true
+    // Fail closed by default — see the field doc comment for rationale.
+    false
 }
 
 /// Configuration for the embedding provider used by semantic routing.

--- a/docs/admin-ui/specs/ui-specification.md
+++ b/docs/admin-ui/specs/ui-specification.md
@@ -1167,7 +1167,7 @@ Authorization = "Bearer token"
 | | api_key | string | "" | API key (supports ENC[...]) |
 | | policy | string | "" | Global system prompt |
 | | policies | map | {} | Per-action-type policies |
-| | fail_open | bool | true | Allow on LLM failure |
+| | fail_open | bool | false | Allow on LLM failure (default fail-closed) |
 | | timeout_seconds | u64? | 10 | Request timeout |
 | | temperature | f64? | 0.0 | Sampling temperature |
 | | max_tokens | u32? | 256 | Max response tokens |
@@ -1254,8 +1254,8 @@ evaluate(action, policy) -> LlmGuardrailResponse { allowed: bool, reason: string
 | `temperature` | f64 | 0.0 | Sampling temperature |
 | `max_tokens` | u32 | 256 | Max response tokens |
 
-### Fail-Open Behavior
-When `fail_open = true` (default), actions are allowed through when the LLM is unreachable.
+### Failure Handling
+When `fail_open = false` (default, fail-closed), actions are denied when the LLM is unreachable. Set `fail_open = true` only for advisory checks where availability matters more than the guarantee that every action was evaluated.
 
 ### Metrics
 - `llm_guardrail_allowed` -- actions allowed

--- a/docs/book/features/llm-guardrails.md
+++ b/docs/book/features/llm-guardrails.md
@@ -148,6 +148,54 @@ Protect LLM-targeted actions from prompt injection:
     block_on_flag: true
 ```
 
+## Failure Handling
+
+When the LLM evaluator errors — timeout, HTTP failure, JSON parse error,
+provider rate limit — the gateway must decide whether to let the action
+through or block it. The `fail_open` parameter on `[llm_guardrail]`
+controls that choice:
+
+| Mode | Behavior on evaluator error | Counter that increments |
+|---|---|---|
+| `fail_open = false` (**default**, **fail-closed**) | Action is denied (`ActionOutcome::Suppressed`) with reason `"LLM guardrail unavailable: <error>"` | `acteon_llm_guardrail_errors_total` |
+| `fail_open = true` (fail-open) | Action proceeds as if the guardrail allowed it | `acteon_llm_guardrail_errors_total` |
+
+Either way, `acteon_llm_guardrail_errors_total` increments — the
+counter measures evaluator availability, not the dispatch outcome. The
+deny vs. allow decision is what `fail_open` flips.
+
+**Why fail-closed is the default.** Operators who turn the guardrail on
+are explicitly opting into a content-safety check. If the evaluator is
+unreachable, the natural mental model is "the check didn't run, so the
+action should be blocked." Fail-open delivers the opposite: the check
+silently doesn't run and the action proceeds. An attacker who can force
+evaluator timeouts (oversized prompts, prompt-injection that triggers a
+long thought chain, regional outages) gets a free pass past the guard.
+
+**When to set `fail_open = true`.** Override the default if the cost of
+a missed action exceeds the cost of a security bypass — for example,
+when the guardrail is an advisory check on an internal-only flow that
+must not stall on third-party LLM availability. Document the choice in
+your config (with a comment) so a future operator can tell the
+deviation from default was deliberate.
+
+```toml title="acteon.toml — explicit fail-open opt-in"
+[llm_guardrail]
+enabled = true
+endpoint = "https://api.openai.com/v1/chat/completions"
+api_key = "ENC[...]"
+policy = "Internal advisory only — availability over correctness."
+fail_open = true   # Deliberately fail-open: this guardrail is advisory
+                   # and must not block the action if the LLM is down.
+```
+
+!!! warning "Migration note"
+    Acteon ≤ 0.1.x defaulted `fail_open` to `true`. This release flips
+    the default to `false` to align with the principle of least
+    surprise for security-oriented deployments. If you were relying on
+    the implicit fail-open behavior, set `fail_open = true` explicitly
+    in your `acteon.toml` to preserve the old behavior.
+
 ## Monitoring
 
 ### Prometheus Metrics


### PR DESCRIPTION
## Summary

Closes #120. Flips the default of \`llm_fail_open\` from \`true\` to \`false\` in both \`GatewayBuilder\` and the server's \`[llm_guardrail]\` config block.

**Behavior change**: when the LLM evaluator errors (timeout, 5xx, JSON parse error), the action is now denied (\`ActionOutcome::Suppressed\` with reason \`\"LLM guardrail unavailable: <error>\"\`) instead of being allowed through.

## Why

An attacker who can force evaluator timeouts (oversized prompts, prompt-injection that stalls the LLM, regional outages they can amplify) got a free pass past the safety check under the old default. \`docs/book/features/llm-guardrails.md\` already alluded to this in the alerting section but didn't document the parameter or call out the default. Operators turning the guardrail on are explicitly opting into a content-safety check; the natural mental model is \"the check didn't run, so the action should be blocked.\" Fail-closed delivers that.

## Migration

This is a behavior change for any deployment that relied on the implicit \`true\` default.

- **To preserve fail-open** (advisory checks, low-stakes flows where availability matters more than the guarantee): set explicitly in your \`acteon.toml\`:
  \`\`\`toml
  [llm_guardrail]
  fail_open = true
  \`\`\`
- **To get the new behavior**: do nothing — \`fail_open\` defaults to \`false\` after this PR.

The new docs section includes a TOML example with a comment showing the deliberate opt-in pattern. The warning callout in the docs flags the change.

## Out of scope (follow-ups)

- A dedicated \`acteon_llm_guardrail_blocked_on_error_total\` counter to make fail-closed denials trivially separable from verdict denials in dashboards. The existing \`denied_total\` is already strictly verdict-deny and \`errors_total\` is already strictly evaluator-error, so the AC is technically met — but a third counter would let dashboards show \"block-on-error rate\" without operators needing to know which mode the gateway runs in. Worth filing separately if a maintainer agrees.

## Files changed

- \`crates/gateway/src/builder.rs\` — flip default + new test \`llm_fail_open_default_is_false\` that locks the new default + updated docstring on \`llm_fail_open()\`
- \`crates/server/src/config/llm.rs\` — flip server config default + field docs
- \`docs/book/features/llm-guardrails.md\` — new \"Failure Handling\" section with the table, rationale, opt-in example, and migration callout
- \`docs/admin-ui/specs/ui-specification.md\` — table default + section title flipped from \"Fail-Open Behavior\" to \"Failure Handling\"

UI requires no changes — \`ui/src/pages/settings/Llm.tsx\` already renders \`fail_open=true\` as a yellow \"Enabled\" badge and \`fail_open=false\` as a green \"Disabled\" badge, so the new default lights up the safer state visually.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --no-deps -- -D warnings\`
- [x] \`cargo test --workspace --lib --bins --tests\` — new \`llm_fail_open_default_is_false\` test passes; existing \`llm_guardrail_fail_open\` and \`llm_guardrail_fail_closed\` tests pass an explicit boolean and are unaffected
- [x] \`cargo check --all-targets\`
- [x] \`cd ui && npm run lint && npm run build\`
- [ ] Smoke against a deployment with the LLM guardrail enabled and an unreachable endpoint — confirm actions are denied with the new reason string

🤖 Generated with [Claude Code](https://claude.com/claude-code)