### PR TITLE
feat(bus): Phase 2 — durable subscriptions + ack + lag + DLQ

### DIFF
--- a/crates/bus/src/backend.rs
+++ b/crates/bus/src/backend.rs
@@ -4,10 +4,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::Stream;
 
-use acteon_core::Topic;
+use acteon_core::{PartitionLag, Topic};
 
 use crate::error::BusError;
-use crate::message::{BusMessage, DeliveryReceipt, StartOffset};
+use crate::message::{BusMessage, DeliveryReceipt, OffsetPosition, StartOffset};
 
 /// Stream yielded by [`BusBackend::subscribe`]. Items are individual
 /// `BusMessage`s; a transport error ends the stream.
@@ -40,6 +40,25 @@ pub trait BusBackend: Send + Sync + 'static {
         group_id: &str,
         from: StartOffset,
     ) -> Result<SubscribeStream, BusError>;
+
+    /// Commit a `(partition, offset)` pair for the given consumer group.
+    /// Phase 2 manual-ack subscriptions call this after the caller
+    /// finishes processing each record.
+    async fn commit_offset(
+        &self,
+        kafka_topic: &str,
+        group_id: &str,
+        position: OffsetPosition,
+    ) -> Result<(), BusError>;
+
+    /// Report per-partition consumer-group lag
+    /// (`high_water_mark − committed`). Partitions with no committed
+    /// offset report `committed = -1`.
+    async fn consumer_lag(
+        &self,
+        kafka_topic: &str,
+        group_id: &str,
+    ) -> Result<Vec<PartitionLag>, BusError>;
 }
 
 /// Shared-ownership handle for consumers that want to stash a backend

--- a/crates/bus/src/kafka.rs
+++ b/crates/bus/src/kafka.rs
@@ -22,12 +22,12 @@ use rdkafka::message::{Header, Headers, Message, OwnedHeaders};
 use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::util::Timeout;
 
-use acteon_core::Topic;
+use acteon_core::{PartitionLag, Topic};
 
 use crate::backend::{BusBackend, SubscribeStream};
 use crate::config::KafkaBusConfig;
 use crate::error::BusError;
-use crate::message::{BusMessage, DeliveryReceipt, StartOffset};
+use crate::message::{BusMessage, DeliveryReceipt, OffsetPosition, StartOffset};
 
 /// `BusBackend` impl that talks to a real Kafka cluster.
 pub struct KafkaBackend {
@@ -275,5 +275,109 @@ impl BusBackend for KafkaBackend {
             }
         };
         Ok(Box::pin(stream))
+    }
+
+    async fn commit_offset(
+        &self,
+        kafka_topic: &str,
+        group_id: &str,
+        position: OffsetPosition,
+    ) -> Result<(), BusError> {
+        // Out-of-band commits need a consumer that has actually joined
+        // the group (otherwise the broker returns `UnknownMemberId`).
+        // We use `subscribe` + a single `recv` with a short timeout to
+        // force a JoinGroup round-trip; once assignment lands we can
+        // commit and drop. This is expensive per-ack (JoinGroup is
+        // hundreds of milliseconds on a warm broker) — a future phase
+        // introduces a stateful subscription registry so commits flow
+        // through the already-attached consumer.
+        let cfg = self.consumer_config(group_id, StartOffset::Latest);
+        let consumer: StreamConsumer = cfg
+            .create()
+            .map_err(|e| BusError::Transport(format!("commit consumer: {e}")))?;
+        consumer
+            .subscribe(&[kafka_topic])
+            .map_err(|e| BusError::Transport(format!("commit subscribe: {e}")))?;
+
+        // Wait up to 5 s for the group-join to complete. We don't care
+        // about the message — a timeout (= no record waiting) is fine,
+        // because the subscribe poll itself triggers the JoinGroup
+        // protocol and assignment.
+        let _ = tokio::time::timeout(
+            Duration::from_secs(5),
+            futures::StreamExt::next(&mut consumer.stream()),
+        )
+        .await;
+
+        let mut tpl = TopicPartitionList::new();
+        // Kafka's commit API expects the offset of the *next* record to
+        // consume, hence `+1`.
+        tpl.add_partition_offset(
+            kafka_topic,
+            position.partition,
+            rdkafka::Offset::Offset(position.offset + 1),
+        )
+        .map_err(|e| BusError::Transport(format!("tpl: {e}")))?;
+        consumer
+            .commit(&tpl, rdkafka::consumer::CommitMode::Sync)
+            .map_err(map_kafka_error)
+    }
+
+    async fn consumer_lag(
+        &self,
+        kafka_topic: &str,
+        group_id: &str,
+    ) -> Result<Vec<PartitionLag>, BusError> {
+        let cfg = self.consumer_config(group_id, StartOffset::Latest);
+        let consumer: StreamConsumer = cfg
+            .create()
+            .map_err(|e| BusError::Transport(format!("lag consumer: {e}")))?;
+        let metadata = consumer
+            .fetch_metadata(Some(kafka_topic), Duration::from_secs(10))
+            .map_err(map_kafka_error)?;
+        let topic_meta = metadata
+            .topics()
+            .iter()
+            .find(|t| t.name() == kafka_topic)
+            .ok_or_else(|| BusError::TopicNotFound(kafka_topic.into()))?;
+
+        let mut request_tpl = TopicPartitionList::new();
+        for p in topic_meta.partitions() {
+            request_tpl
+                .add_partition_offset(kafka_topic, p.id(), rdkafka::Offset::Invalid)
+                .map_err(|e| BusError::Transport(format!("tpl: {e}")))?;
+        }
+        let committed = consumer
+            .committed_offsets(request_tpl, Duration::from_secs(10))
+            .map_err(map_kafka_error)?;
+
+        let mut out = Vec::with_capacity(topic_meta.partitions().len());
+        for p in topic_meta.partitions() {
+            let (_low, high) = consumer
+                .fetch_watermarks(kafka_topic, p.id(), Duration::from_secs(10))
+                .map_err(map_kafka_error)?;
+            // Kafka stores the "next" offset the group will read; our
+            // public `committed` field is the "last consumed" offset so
+            // memory + Kafka backends report the same numbers.
+            let committed_offset =
+                committed
+                    .find_partition(kafka_topic, p.id())
+                    .map_or(-1, |elt| match elt.offset() {
+                        rdkafka::Offset::Offset(next) => next - 1,
+                        _ => -1,
+                    });
+            let lag = if committed_offset < 0 {
+                high
+            } else {
+                (high - committed_offset - 1).max(0)
+            };
+            out.push(PartitionLag {
+                partition: p.id(),
+                committed: committed_offset,
+                high_water_mark: high,
+                lag,
+            });
+        }
+        Ok(out)
     }
 }

--- a/crates/bus/src/lib.rs
+++ b/crates/bus/src/lib.rs
@@ -27,4 +27,6 @@ pub use config::{BusConfig, KafkaBusConfig};
 pub use error::BusError;
 pub use kafka::KafkaBackend;
 pub use memory::MemoryBackend;
-pub use message::{BusMessage, DeliveryReceipt, StartOffset};
+pub use message::{BusMessage, DeliveryReceipt, OffsetPosition, StartOffset};
+
+pub use acteon_core::PartitionLag;

--- a/crates/bus/src/memory.rs
+++ b/crates/bus/src/memory.rs
@@ -17,8 +17,10 @@ use tokio::sync::broadcast;
 use acteon_core::Topic;
 
 use crate::backend::{BusBackend, SubscribeStream};
+use acteon_core::PartitionLag;
+
 use crate::error::BusError;
-use crate::message::{BusMessage, DeliveryReceipt, StartOffset};
+use crate::message::{BusMessage, DeliveryReceipt, OffsetPosition, StartOffset};
 
 struct TopicState {
     log: VecDeque<BusMessage>,
@@ -30,6 +32,8 @@ struct TopicState {
 #[derive(Default)]
 pub struct MemoryBackend {
     topics: Mutex<HashMap<String, TopicState>>,
+    /// `(topic, group) → committed offset`. Phase 2 commit semantics.
+    committed: Mutex<HashMap<(String, String), i64>>,
 }
 
 impl MemoryBackend {
@@ -122,6 +126,56 @@ impl BusBackend for MemoryBackend {
         };
         Ok(Box::pin(stream))
     }
+
+    async fn commit_offset(
+        &self,
+        kafka_topic: &str,
+        group_id: &str,
+        position: OffsetPosition,
+    ) -> Result<(), BusError> {
+        // Require the topic to exist so tests with typos fail loudly.
+        if !self.topics.lock().contains_key(kafka_topic) {
+            return Err(BusError::TopicNotFound(kafka_topic.into()));
+        }
+        self.committed.lock().insert(
+            (kafka_topic.to_string(), group_id.to_string()),
+            position.offset,
+        );
+        Ok(())
+    }
+
+    async fn consumer_lag(
+        &self,
+        kafka_topic: &str,
+        group_id: &str,
+    ) -> Result<Vec<PartitionLag>, BusError> {
+        let high_water_mark = {
+            let topics = self.topics.lock();
+            topics
+                .get(kafka_topic)
+                .ok_or_else(|| BusError::TopicNotFound(kafka_topic.into()))?
+                .next_offset
+        };
+        let committed = self
+            .committed
+            .lock()
+            .get(&(kafka_topic.to_string(), group_id.to_string()))
+            .copied()
+            .unwrap_or(-1);
+        // Contract: `committed` = last consumed offset. `lag` = number
+        // of records not yet consumed.
+        let lag = if committed < 0 {
+            high_water_mark
+        } else {
+            (high_water_mark - committed - 1).max(0)
+        };
+        Ok(vec![PartitionLag {
+            partition: 0,
+            committed,
+            high_water_mark,
+            lag,
+        }])
+    }
 }
 
 #[cfg(test)]
@@ -209,6 +263,60 @@ mod tests {
     async fn delete_is_idempotent_on_absent() {
         let backend = MemoryBackend::new();
         let err = backend.delete_topic("nope").await.unwrap_err();
+        assert!(matches!(err, BusError::TopicNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn commit_and_lag_roundtrip() {
+        let backend = MemoryBackend::new();
+        let topic = Topic::new("t1", "ns", "tn");
+        backend.create_topic(&topic).await.unwrap();
+        let name = topic.kafka_topic_name();
+
+        for i in 0..5 {
+            backend
+                .produce(BusMessage::new(name.clone(), serde_json::json!({ "n": i })))
+                .await
+                .unwrap();
+        }
+
+        // Before any commit: committed=-1, lag = full log.
+        let lag = backend.consumer_lag(&name, "g1").await.unwrap();
+        assert_eq!(lag[0].committed, -1);
+        assert_eq!(lag[0].high_water_mark, 5);
+        assert_eq!(lag[0].lag, 5); // uncommitted = full log.
+
+        // Commit offset 2 → consumed through record 2 → lag = 2 (records 3, 4).
+        backend
+            .commit_offset(
+                &name,
+                "g1",
+                OffsetPosition {
+                    partition: 0,
+                    offset: 2,
+                },
+            )
+            .await
+            .unwrap();
+        let lag = backend.consumer_lag(&name, "g1").await.unwrap();
+        assert_eq!(lag[0].committed, 2);
+        assert_eq!(lag[0].lag, 2);
+    }
+
+    #[tokio::test]
+    async fn commit_to_unknown_topic_fails() {
+        let backend = MemoryBackend::new();
+        let err = backend
+            .commit_offset(
+                "ghost",
+                "g",
+                OffsetPosition {
+                    partition: 0,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap_err();
         assert!(matches!(err, BusError::TopicNotFound(_)));
     }
 }

--- a/crates/bus/src/message.rs
+++ b/crates/bus/src/message.rs
@@ -94,6 +94,13 @@ pub struct DeliveryReceipt {
     pub timestamp: DateTime<Utc>,
 }
 
+/// Position within a Kafka topic that a consumer can commit.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct OffsetPosition {
+    pub partition: i32,
+    pub offset: i64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bus/tests/kafka_integration.rs
+++ b/crates/bus/tests/kafka_integration.rs
@@ -82,6 +82,76 @@ async fn produce_and_subscribe_end_to_end() {
 }
 
 #[tokio::test]
+async fn commit_and_lag_survive_reconnect() {
+    let Some(_) = brokers() else {
+        eprintln!("skipping: ACTEON_KAFKA_BOOTSTRAP not set");
+        return;
+    };
+    use acteon_bus::{BusBackend, BusMessage, OffsetPosition, StartOffset};
+    let backend = make_backend("acteon-bus-it-commit");
+    let topic = unique_topic("commit");
+    backend.create_topic(&topic).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let name = topic.kafka_topic_name();
+    let group = format!("g-{}", uuid::Uuid::new_v4().simple());
+
+    // Seed 5 records, consume 3, commit, then reconnect — the new
+    // consumer should only see records 3 and 4.
+    for i in 0..5 {
+        backend
+            .produce(BusMessage::new(name.clone(), serde_json::json!({ "n": i })))
+            .await
+            .unwrap();
+    }
+
+    // Commit offset 2 out-of-band (records 0..=2 consumed).
+    backend
+        .commit_offset(
+            &name,
+            &group,
+            OffsetPosition {
+                partition: 0,
+                offset: 2,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Fresh consumer in the same group; use Latest so auto.offset.reset
+    // doesn't interfere — since we committed, Kafka uses that.
+    let mut stream = backend
+        .subscribe(&name, &group, StartOffset::Latest)
+        .await
+        .unwrap();
+
+    let mut seen = Vec::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while seen.len() < 2 {
+        match tokio::time::timeout_at(deadline, futures::StreamExt::next(&mut stream)).await {
+            Ok(Some(Ok(msg))) => seen.push(msg.payload["n"].as_i64().unwrap_or(-1)),
+            _ => break,
+        }
+    }
+    assert_eq!(
+        seen,
+        vec![3, 4],
+        "reconnected consumer should resume after committed offset"
+    );
+
+    // Lag should now report the correct high-water mark and committed
+    // offset (last consumed = 2, so lag = 2 = records 3, 4).
+    let lag = backend.consumer_lag(&name, &group).await.unwrap();
+    assert!(!lag.is_empty());
+    let p0 = lag.iter().find(|e| e.partition == 0).expect("p0");
+    assert_eq!(p0.committed, 2);
+    assert_eq!(p0.high_water_mark, 5);
+    assert_eq!(p0.lag, 2);
+
+    backend.delete_topic(&name).await.ok();
+}
+
+#[tokio::test]
 async fn delete_missing_topic_returns_not_found() {
     let Some(_) = brokers() else {
         eprintln!("skipping: ACTEON_KAFKA_BOOTSTRAP not set");

--- a/crates/client/src/bus.rs
+++ b/crates/client/src/bus.rs
@@ -105,6 +105,105 @@ pub struct PublishReceipt {
     pub produced_at: String,
 }
 
+// ----- Phase 2: subscriptions -----
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct CreateSubscription {
+    pub id: String,
+    pub topic: String,
+    pub namespace: String,
+    pub tenant: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub starting_offset: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ack_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dead_letter_topic: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ack_timeout_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub labels: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BusSubscription {
+    pub id: String,
+    pub topic: String,
+    pub namespace: String,
+    pub tenant: String,
+    pub starting_offset: String,
+    pub ack_mode: String,
+    #[serde(default)]
+    pub dead_letter_topic: Option<String>,
+    pub ack_timeout_ms: u64,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListBusSubscriptionsResponse {
+    pub subscriptions: Vec<BusSubscription>,
+    pub count: usize,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct BusSubscriptionFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct AckOffset {
+    pub partition: i32,
+    pub offset: i64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LagPartition {
+    pub partition: i32,
+    pub committed: i64,
+    pub high_water_mark: i64,
+    pub lag: i64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BusLag {
+    pub subscription_id: String,
+    pub topic: String,
+    pub partitions: Vec<LagPartition>,
+    pub total_lag: i64,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct DeadLetterRequest {
+    pub partition: i32,
+    pub offset: i64,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeadLetterReceipt {
+    pub dlq_topic: String,
+    pub partition: i32,
+    pub offset: i64,
+}
+
 impl ActeonClient {
     /// Create a bus topic (persists in Acteon state and creates the
     /// backing Kafka topic).
@@ -174,6 +273,129 @@ impl ActeonClient {
             .map_err(|e| Error::Connection(e.to_string()))?;
         if resp.status().is_success() {
             resp.json::<PublishReceipt>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    // ---------------- Phase 2 subscription helpers ----------------
+
+    /// Create a durable subscription (Kafka consumer group).
+    pub async fn create_bus_subscription(
+        &self,
+        req: &CreateSubscription,
+    ) -> Result<BusSubscription, Error> {
+        let url = format!("{}/v1/bus/subscriptions", self.base_url);
+        let resp = self
+            .add_auth(self.client.post(&url))
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusSubscription>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// List durable subscriptions.
+    pub async fn list_bus_subscriptions(
+        &self,
+        filter: &BusSubscriptionFilter,
+    ) -> Result<ListBusSubscriptionsResponse, Error> {
+        let url = format!("{}/v1/bus/subscriptions", self.base_url);
+        let resp = self
+            .add_auth(self.client.get(&url))
+            .query(filter)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<ListBusSubscriptionsResponse>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Delete a subscription.
+    pub async fn delete_bus_subscription(&self, id: &str) -> Result<(), Error> {
+        let encoded = encode_segment(id);
+        let url = format!("{}/v1/bus/subscriptions/{encoded}", self.base_url);
+        let resp = self
+            .add_auth(self.client.delete(&url))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::NO_CONTENT || status == reqwest::StatusCode::NOT_FOUND {
+            Ok(())
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Commit an offset on behalf of a subscription's consumer group.
+    pub async fn ack_bus_subscription(&self, id: &str, position: AckOffset) -> Result<(), Error> {
+        let encoded = encode_segment(id);
+        let url = format!("{}/v1/bus/subscriptions/{encoded}/ack", self.base_url);
+        let resp = self
+            .add_auth(self.client.post(&url))
+            .json(&position)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Report per-partition lag for a subscription's consumer group.
+    pub async fn get_bus_lag(&self, id: &str) -> Result<BusLag, Error> {
+        let encoded = encode_segment(id);
+        let url = format!("{}/v1/bus/subscriptions/{encoded}/lag", self.base_url);
+        let resp = self
+            .add_auth(self.client.get(&url))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusLag>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Route a failed record to the subscription's configured dead-letter
+    /// topic.
+    pub async fn deadletter_bus_message(
+        &self,
+        id: &str,
+        req: &DeadLetterRequest,
+    ) -> Result<DeadLetterReceipt, Error> {
+        let encoded = encode_segment(id);
+        let url = format!(
+            "{}/v1/bus/subscriptions/{encoded}/deadletter",
+            self.base_url
+        );
+        let resp = self
+            .add_auth(self.client.post(&url))
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<DeadLetterReceipt>()
                 .await
                 .map_err(|e| Error::Deserialization(e.to_string()))
         } else {

--- a/crates/core/src/bus_subscription.rs
+++ b/crates/core/src/bus_subscription.rs
@@ -1,0 +1,225 @@
+//! Bus subscription — durable Kafka consumer-group binding.
+//!
+//! A `Subscription` is Acteon's record of a long-lived consumer group
+//! plus the operator-facing metadata around it (filter, DLQ, ack
+//! semantics). Kafka owns offsets and partition assignment; Acteon
+//! owns identity, DLQ routing, and policy.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Where a fresh subscription should begin reading if the group has no
+/// committed offset yet.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StartOffset {
+    /// Start at the earliest retained record.
+    Earliest,
+    /// Start at the broker's high-water mark (default).
+    #[default]
+    Latest,
+}
+
+/// How the subscription acknowledges messages it has processed.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AckMode {
+    /// Offset is committed automatically after each message is delivered
+    /// to a consumer. Lower safety, highest throughput.
+    AutoOnDelivery,
+    /// Consumer must explicitly call `ack` for each offset it accepts.
+    /// Default; survives consumer crashes.
+    #[default]
+    Manual,
+}
+
+/// Operator-visible state of the durable consumer behind a subscription.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubscriptionStatus {
+    /// Consumer task is idle — no one has attached to the stream yet.
+    #[default]
+    Inactive,
+    /// Consumer task is running and delivering records.
+    Active,
+    /// Consumer task terminated with an error; the registry will try to
+    /// revive it on the next attach.
+    Errored,
+}
+
+/// Durable Kafka-backed subscription tracked by Acteon.
+///
+/// Not `ToSchema` — the API layer has its own DTOs. Keeping the
+/// internal state type free of `OpenAPI` derives lets us evolve it
+/// independently.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Subscription {
+    /// Stable identifier; doubles as the Kafka `group.id`.
+    pub id: String,
+    /// Target Kafka topic (full `namespace.tenant.name` form).
+    pub topic: String,
+    /// Namespace / tenant the subscription belongs to (for ACL + state
+    /// scoping). Must match the topic's namespace/tenant.
+    pub namespace: String,
+    pub tenant: String,
+    /// Starting offset if the consumer group has no committed offset.
+    #[serde(default)]
+    pub starting_offset: StartOffset,
+    /// Ack model.
+    #[serde(default)]
+    pub ack_mode: AckMode,
+    /// Optional Kafka-name of the dead-letter topic to route failures to.
+    /// When `None`, a failed delivery is retried by Kafka's rebalance.
+    #[serde(default)]
+    pub dead_letter_topic: Option<String>,
+    /// Per-delivery ack timeout. Messages un-acked after this much time
+    /// are routed to the DLQ (if configured) and marked failed.
+    #[serde(default = "default_ack_timeout_ms")]
+    pub ack_timeout_ms: u64,
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Arbitrary operator labels.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub labels: HashMap<String, String>,
+    /// Created / updated timestamps for the state row.
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+fn default_ack_timeout_ms() -> u64 {
+    // 30s matches the executor's per-provider default — long enough for
+    // most LLM calls, short enough that stuck consumers don't hold up
+    // an entire partition.
+    30_000
+}
+
+impl Subscription {
+    /// Construct a subscription with sensible defaults.
+    #[must_use]
+    pub fn new(
+        id: impl Into<String>,
+        topic: impl Into<String>,
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: id.into(),
+            topic: topic.into(),
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            starting_offset: StartOffset::default(),
+            ack_mode: AckMode::default(),
+            dead_letter_topic: None,
+            ack_timeout_ms: default_ack_timeout_ms(),
+            description: None,
+            labels: HashMap::new(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Valid characters: same rules as topic fragments — the subscription
+    /// ID is also used as the Kafka `group.id`, which accepts a superset
+    /// but Acteon tightens to the topic-fragment rule for consistency.
+    pub fn validate_id(s: &str) -> Result<(), SubscriptionValidationError> {
+        if s.is_empty() {
+            return Err(SubscriptionValidationError::EmptyId);
+        }
+        if s.len() > 120 {
+            return Err(SubscriptionValidationError::IdTooLong);
+        }
+        if !s
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(SubscriptionValidationError::InvalidIdChar(s.into()));
+        }
+        Ok(())
+    }
+
+    /// Validate the subscription end-to-end.
+    pub fn validate(&self) -> Result<(), SubscriptionValidationError> {
+        Self::validate_id(&self.id)?;
+        if self.ack_timeout_ms == 0 {
+            return Err(SubscriptionValidationError::ZeroAckTimeout);
+        }
+        if self.topic.is_empty() {
+            return Err(SubscriptionValidationError::EmptyTopic);
+        }
+        Ok(())
+    }
+}
+
+/// Lag snapshot returned by the `/lag` endpoint. One entry per partition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PartitionLag {
+    pub partition: i32,
+    /// Committed offset for this group on this partition (`-1` if none).
+    pub committed: i64,
+    /// Current broker high-water mark for this partition.
+    pub high_water_mark: i64,
+    /// `high_water_mark - committed` (0 if uncommitted).
+    pub lag: i64,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum SubscriptionValidationError {
+    #[error("subscription id must not be empty")]
+    EmptyId,
+    #[error("subscription id exceeds 120 characters")]
+    IdTooLong,
+    #[error("subscription id '{0}' contains characters outside [a-zA-Z0-9_-]")]
+    InvalidIdChar(String),
+    #[error("ack_timeout_ms must be > 0")]
+    ZeroAckTimeout,
+    #[error("topic must not be empty")]
+    EmptyTopic,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_sane() {
+        let s = Subscription::new("sub-1", "ns.t.orders", "ns", "t");
+        assert!(s.validate().is_ok());
+        assert_eq!(s.starting_offset, StartOffset::Latest);
+        assert_eq!(s.ack_mode, AckMode::Manual);
+        assert_eq!(s.ack_timeout_ms, 30_000);
+    }
+
+    #[test]
+    fn validate_rejects_bad_id() {
+        let mut s = Subscription::new("has.dots", "t", "ns", "tn");
+        assert!(matches!(
+            s.validate(),
+            Err(SubscriptionValidationError::InvalidIdChar(_))
+        ));
+        s.id = String::new();
+        assert_eq!(s.validate(), Err(SubscriptionValidationError::EmptyId));
+    }
+
+    #[test]
+    fn validate_rejects_zero_timeout() {
+        let mut s = Subscription::new("sub-1", "t", "ns", "tn");
+        s.ack_timeout_ms = 0;
+        assert_eq!(
+            s.validate(),
+            Err(SubscriptionValidationError::ZeroAckTimeout)
+        );
+    }
+
+    #[test]
+    fn roundtrip_serde() {
+        let mut s = Subscription::new("sub-1", "ns.t.orders", "ns", "t");
+        s.dead_letter_topic = Some("ns.t.orders-dlq".into());
+        let json = serde_json::to_string(&s).unwrap();
+        let back: Subscription = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.dead_letter_topic.as_deref(), Some("ns.t.orders-dlq"));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod action;
 pub mod analytics;
 pub mod attachment;
+pub mod bus_subscription;
 pub mod bus_topic;
 pub mod caller;
 pub mod chain;
@@ -32,6 +33,10 @@ pub use analytics::{
     AnalyticsTopEntry,
 };
 pub use attachment::{Attachment, ResolvedAttachment};
+pub use bus_subscription::{
+    AckMode, PartitionLag, StartOffset as SubscriptionStartOffset, Subscription,
+    SubscriptionStatus, SubscriptionValidationError,
+};
 pub use bus_topic::{Topic, TopicValidationError};
 pub use caller::Caller;
 pub use chain::{

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -586,3 +586,647 @@ fn sse_stream(
         Ok::<_, Infallible>(ev)
     })
 }
+
+// =============================================================================
+// Phase 2 — Subscriptions + ack + lag + DLQ
+// =============================================================================
+
+/// Request body for `POST /v1/bus/subscriptions`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateSubscriptionRequest {
+    /// Stable identifier. Doubles as the Kafka `group.id`. Must be
+    /// `[a-zA-Z0-9_-]{1..=120}`.
+    pub id: String,
+    /// Target Kafka topic (full `namespace.tenant.name` form).
+    pub topic: String,
+    /// Namespace / tenant for ACL + state scoping.
+    pub namespace: String,
+    pub tenant: String,
+    /// `earliest` or `latest`. Defaults to `latest`.
+    #[serde(default)]
+    pub starting_offset: Option<String>,
+    /// `manual` (default) or `auto_on_delivery`.
+    #[serde(default)]
+    pub ack_mode: Option<String>,
+    /// Optional DLQ topic name (`namespace.tenant.name`).
+    #[serde(default)]
+    pub dead_letter_topic: Option<String>,
+    /// Ack timeout in milliseconds.
+    #[serde(default)]
+    pub ack_timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SubscriptionResponse {
+    pub id: String,
+    pub topic: String,
+    pub namespace: String,
+    pub tenant: String,
+    pub starting_offset: String,
+    pub ack_mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dead_letter_topic: Option<String>,
+    pub ack_timeout_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub labels: HashMap<String, String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListSubscriptionsResponse {
+    pub subscriptions: Vec<SubscriptionResponse>,
+    pub count: usize,
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListSubscriptionsParams {
+    #[serde(default)]
+    pub namespace: Option<String>,
+    #[serde(default)]
+    pub tenant: Option<String>,
+    #[serde(default)]
+    pub topic: Option<String>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AckRequest {
+    pub partition: i32,
+    /// Last consumed offset. The bus commits this + 1 to Kafka so a
+    /// reconnecting consumer resumes after this record.
+    pub offset: i64,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AckResponse {
+    pub committed: bool,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct LagEntry {
+    pub partition: i32,
+    pub committed: i64,
+    pub high_water_mark: i64,
+    pub lag: i64,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct LagResponse {
+    pub subscription_id: String,
+    pub topic: String,
+    pub partitions: Vec<LagEntry>,
+    pub total_lag: i64,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct DeadLetterRequest {
+    pub partition: i32,
+    pub offset: i64,
+    pub reason: String,
+    /// Original message key/payload to preserve in the DLQ record.
+    #[serde(default)]
+    pub key: Option<String>,
+    #[serde(default)]
+    #[schema(value_type = Option<Object>)]
+    pub payload: Option<serde_json::Value>,
+    /// Original headers. `acteon.dlq.*` additions are appended by the
+    /// server before producing.
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DeadLetterResponse {
+    pub dlq_topic: String,
+    pub partition: i32,
+    pub offset: i64,
+}
+
+// =============================================================================
+// Handlers (all feature-gated like Phase 1)
+// =============================================================================
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/subscriptions",
+    tag = "bus",
+    request_body = CreateSubscriptionRequest,
+    responses(
+        (status = 201, description = "Subscription created", body = SubscriptionResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 409, description = "Subscription id already exists", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+#[allow(clippy::too_many_lines)]
+pub async fn create_subscription(
+    State(state): State<AppState>,
+    Json(req): Json<CreateSubscriptionRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        let mut sub =
+            acteon_core::Subscription::new(&req.id, &req.topic, &req.namespace, &req.tenant);
+        if let Some(so) = req.starting_offset.as_deref() {
+            sub.starting_offset = match so {
+                "earliest" => acteon_core::SubscriptionStartOffset::Earliest,
+                "latest" => acteon_core::SubscriptionStartOffset::Latest,
+                other => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!("unknown starting_offset '{other}'"),
+                        }),
+                    )
+                        .into_response();
+                }
+            };
+        }
+        if let Some(am) = req.ack_mode.as_deref() {
+            sub.ack_mode = match am {
+                "manual" => acteon_core::AckMode::Manual,
+                "auto_on_delivery" => acteon_core::AckMode::AutoOnDelivery,
+                other => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!("unknown ack_mode '{other}'"),
+                        }),
+                    )
+                        .into_response();
+                }
+            };
+        }
+        sub.dead_letter_topic = req.dead_letter_topic.clone();
+        if let Some(t) = req.ack_timeout_ms {
+            sub.ack_timeout_ms = t;
+        }
+        sub.description = req.description.clone();
+        sub.labels = req.labels.clone();
+        if let Err(e) = sub.validate() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+
+        let gw = state.gateway.read().await;
+        let store = gw.state_store();
+        let key = StateKey::new(
+            sub.namespace.clone(),
+            sub.tenant.clone(),
+            KeyKind::BusSubscription,
+            sub.id.clone(),
+        );
+        match store.get(&key).await {
+            Ok(Some(_)) => {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(ErrorResponse {
+                        error: format!("subscription {} already exists", sub.id),
+                    }),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+            Ok(None) => {}
+        }
+        let Ok(body) = serde_json::to_string(&sub) else {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "failed to serialize subscription".into(),
+                }),
+            )
+                .into_response();
+        };
+        if let Err(e) = store.set(&key, &body, None).await {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+
+        (StatusCode::CREATED, Json(subscription_to_response(&sub))).into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/bus/subscriptions",
+    tag = "bus",
+    params(ListSubscriptionsParams),
+    responses(
+        (status = 200, description = "Subscription list", body = ListSubscriptionsResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn list_subscriptions(
+    State(state): State<AppState>,
+    Query(params): Query<ListSubscriptionsParams>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        let gw = state.gateway.read().await;
+        let store = gw.state_store();
+        let entries = match store.scan_keys_by_kind(KeyKind::BusSubscription).await {
+            Ok(e) => e,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let subs: Vec<SubscriptionResponse> = entries
+            .into_iter()
+            .filter_map(|(_, v)| serde_json::from_str::<acteon_core::Subscription>(&v).ok())
+            .filter(|s| {
+                params.namespace.as_deref().is_none_or(|n| n == s.namespace)
+                    && params.tenant.as_deref().is_none_or(|t| t == s.tenant)
+                    && params.topic.as_deref().is_none_or(|t| t == s.topic)
+            })
+            .map(|s| subscription_to_response(&s))
+            .collect();
+        let body = ListSubscriptionsResponse {
+            count: subs.len(),
+            subscriptions: subs,
+        };
+        (StatusCode::OK, Json(body)).into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, params);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    delete,
+    path = "/v1/bus/subscriptions/{id}",
+    tag = "bus",
+    responses(
+        (status = 204, description = "Subscription deleted"),
+        (status = 404, description = "Subscription not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn delete_subscription(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        let gw = state.gateway.read().await;
+        let store = gw.state_store();
+        let sub = match lookup_subscription(store.as_ref(), &id).await {
+            Ok(Some(s)) => s,
+            Ok(None) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse {
+                        error: format!("subscription {id} not found"),
+                    }),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse { error: e }),
+                )
+                    .into_response();
+            }
+        };
+        let key = StateKey::new(
+            sub.namespace.clone(),
+            sub.tenant.clone(),
+            KeyKind::BusSubscription,
+            sub.id.clone(),
+        );
+        if let Err(e) = store.delete(&key).await {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        StatusCode::NO_CONTENT.into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, id);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/subscriptions/{id}/ack",
+    tag = "bus",
+    request_body = AckRequest,
+    responses(
+        (status = 200, description = "Offset committed", body = AckResponse),
+        (status = 404, description = "Subscription not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn ack_subscription(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(req): Json<AckRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        let Some(backend) = state.bus_backend.clone() else {
+            return service_unavailable("bus feature not enabled");
+        };
+        let sub = match resolve_subscription(&state, &id).await {
+            Ok(s) => s,
+            Err(resp) => return resp,
+        };
+        match backend
+            .commit_offset(
+                &sub.topic,
+                &sub.id,
+                acteon_bus::OffsetPosition {
+                    partition: req.partition,
+                    offset: req.offset,
+                },
+            )
+            .await
+        {
+            Ok(()) => (StatusCode::OK, Json(AckResponse { committed: true })).into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response(),
+        }
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, id, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/bus/subscriptions/{id}/lag",
+    tag = "bus",
+    responses(
+        (status = 200, description = "Lag snapshot", body = LagResponse),
+        (status = 404, description = "Subscription not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn subscription_lag(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        let Some(backend) = state.bus_backend.clone() else {
+            return service_unavailable("bus feature not enabled");
+        };
+        let sub = match resolve_subscription(&state, &id).await {
+            Ok(s) => s,
+            Err(resp) => return resp,
+        };
+        match backend.consumer_lag(&sub.topic, &sub.id).await {
+            Ok(entries) => {
+                let total_lag: i64 = entries.iter().map(|e| e.lag).sum();
+                let body = LagResponse {
+                    subscription_id: sub.id.clone(),
+                    topic: sub.topic.clone(),
+                    partitions: entries
+                        .into_iter()
+                        .map(|e| LagEntry {
+                            partition: e.partition,
+                            committed: e.committed,
+                            high_water_mark: e.high_water_mark,
+                            lag: e.lag,
+                        })
+                        .collect(),
+                    total_lag,
+                };
+                (StatusCode::OK, Json(body)).into_response()
+            }
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response(),
+        }
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, id);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/subscriptions/{id}/deadletter",
+    tag = "bus",
+    request_body = DeadLetterRequest,
+    responses(
+        (status = 200, description = "Message routed to DLQ", body = DeadLetterResponse),
+        (status = 400, description = "Subscription has no DLQ configured", body = ErrorResponse),
+        (status = 404, description = "Subscription not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn deadletter_subscription(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(req): Json<DeadLetterRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        let Some(backend) = state.bus_backend.clone() else {
+            return service_unavailable("bus feature not enabled");
+        };
+        let sub = match resolve_subscription(&state, &id).await {
+            Ok(s) => s,
+            Err(resp) => return resp,
+        };
+        let Some(dlq) = sub.dead_letter_topic.clone() else {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("subscription {id} has no dead_letter_topic"),
+                }),
+            )
+                .into_response();
+        };
+        // Build the DLQ record preserving the original envelope +
+        // adding `acteon.dlq.*` diagnostic headers.
+        let mut msg = acteon_bus::BusMessage::new(
+            dlq.clone(),
+            req.payload.clone().unwrap_or(serde_json::Value::Null),
+        );
+        if let Some(k) = req.key.clone() {
+            msg = msg.with_key(k);
+        }
+        for (k, v) in &req.headers {
+            msg = msg.with_header(k.clone(), v.clone());
+        }
+        // acteon.* headers bypass the user-header filter via direct
+        // insertion.
+        msg.headers
+            .insert("acteon.dlq.origin_topic".into(), sub.topic.clone());
+        msg.headers.insert(
+            "acteon.dlq.origin_partition".into(),
+            req.partition.to_string(),
+        );
+        msg.headers
+            .insert("acteon.dlq.origin_offset".into(), req.offset.to_string());
+        msg.headers
+            .insert("acteon.dlq.subscription".into(), sub.id.clone());
+        msg.headers
+            .insert("acteon.dlq.reason".into(), req.reason.clone());
+
+        match backend.produce(msg).await {
+            Ok(receipt) => (
+                StatusCode::OK,
+                Json(DeadLetterResponse {
+                    dlq_topic: receipt.topic,
+                    partition: receipt.partition,
+                    offset: receipt.offset,
+                }),
+            )
+                .into_response(),
+            Err(acteon_bus::BusError::TopicNotFound(_)) => (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("dead-letter topic {dlq} not found"),
+                }),
+            )
+                .into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response(),
+        }
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, id, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+#[cfg(feature = "bus")]
+fn subscription_to_response(s: &acteon_core::Subscription) -> SubscriptionResponse {
+    SubscriptionResponse {
+        id: s.id.clone(),
+        topic: s.topic.clone(),
+        namespace: s.namespace.clone(),
+        tenant: s.tenant.clone(),
+        starting_offset: match s.starting_offset {
+            acteon_core::SubscriptionStartOffset::Earliest => "earliest".into(),
+            acteon_core::SubscriptionStartOffset::Latest => "latest".into(),
+        },
+        ack_mode: match s.ack_mode {
+            acteon_core::AckMode::Manual => "manual".into(),
+            acteon_core::AckMode::AutoOnDelivery => "auto_on_delivery".into(),
+        },
+        dead_letter_topic: s.dead_letter_topic.clone(),
+        ack_timeout_ms: s.ack_timeout_ms,
+        description: s.description.clone(),
+        labels: s.labels.clone(),
+        created_at: s.created_at,
+        updated_at: s.updated_at,
+    }
+}
+
+#[cfg(feature = "bus")]
+async fn lookup_subscription(
+    store: &dyn acteon_state::StateStore,
+    id: &str,
+) -> Result<Option<acteon_core::Subscription>, String> {
+    let entries = store
+        .scan_keys_by_kind(KeyKind::BusSubscription)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(entries
+        .into_iter()
+        .filter_map(|(_, v)| serde_json::from_str::<acteon_core::Subscription>(&v).ok())
+        .find(|s| s.id == id))
+}
+
+#[cfg(feature = "bus")]
+async fn resolve_subscription(
+    state: &AppState,
+    id: &str,
+) -> Result<acteon_core::Subscription, axum::response::Response> {
+    let gw = state.gateway.read().await;
+    match lookup_subscription(gw.state_store().as_ref(), id).await {
+        Ok(Some(s)) => Ok(s),
+        Ok(None) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("subscription {id} not found"),
+            }),
+        )
+            .into_response()),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse { error: e }),
+        )
+            .into_response()),
+    }
+}

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -295,7 +295,7 @@ pub fn router(state: AppState) -> Router {
             "/v1/providers/health",
             get(provider_health::list_provider_health),
         )
-        // Bus (Phase 1)
+        // Bus (Phase 1 + 2)
         .route(
             "/v1/bus/topics",
             get(bus::list_topics).post(bus::create_topic),
@@ -303,6 +303,24 @@ pub fn router(state: AppState) -> Router {
         .route("/v1/bus/topics/{kafka_name}", delete(bus::delete_topic))
         .route("/v1/bus/publish", post(bus::publish))
         .route("/v1/bus/subscribe/{subscription_id}", get(bus::subscribe))
+        // Phase 2: durable subscriptions + ack + lag + DLQ
+        .route(
+            "/v1/bus/subscriptions",
+            get(bus::list_subscriptions).post(bus::create_subscription),
+        )
+        .route(
+            "/v1/bus/subscriptions/{id}",
+            delete(bus::delete_subscription),
+        )
+        .route(
+            "/v1/bus/subscriptions/{id}/ack",
+            post(bus::ack_subscription),
+        )
+        .route("/v1/bus/subscriptions/{id}/lag", get(bus::subscription_lag))
+        .route(
+            "/v1/bus/subscriptions/{id}/deadletter",
+            post(bus::deadletter_subscription),
+        )
         // Swarm runs
         .route("/v1/swarm/runs", get(swarm::list_swarm_runs))
         .route("/v1/swarm/runs/{run_id}", get(swarm::get_swarm_run))

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -163,6 +163,12 @@ use acteon_core::{
         super::bus::delete_topic,
         super::bus::publish,
         super::bus::subscribe,
+        super::bus::create_subscription,
+        super::bus::list_subscriptions,
+        super::bus::delete_subscription,
+        super::bus::ack_subscription,
+        super::bus::subscription_lag,
+        super::bus::deadletter_subscription,
     ),
     components(schemas(
         Action, ActionOutcome, ProviderResponse, ResponseStatus, ActionError,
@@ -222,6 +228,10 @@ use acteon_core::{
         super::bus::CreateTopicRequest, super::bus::TopicResponse,
         super::bus::ListTopicsResponse, super::bus::PublishRequest,
         super::bus::PublishResponse,
+        super::bus::CreateSubscriptionRequest, super::bus::SubscriptionResponse,
+        super::bus::ListSubscriptionsResponse, super::bus::AckRequest,
+        super::bus::AckResponse, super::bus::LagEntry, super::bus::LagResponse,
+        super::bus::DeadLetterRequest, super::bus::DeadLetterResponse,
     ))
 )]
 pub struct ApiDoc;

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -208,5 +208,9 @@ required-features = ["swarm"]
 name = "bus_simulation"
 required-features = ["bus"]
 
+[[example]]
+name = "bus_subscription_simulation"
+required-features = ["bus"]
+
 [lints]
 workspace = true

--- a/crates/simulation/examples/bus_subscription_simulation.rs
+++ b/crates/simulation/examples/bus_subscription_simulation.rs
@@ -1,0 +1,201 @@
+//! End-to-end exercise of the Phase 2 subscription surface.
+//!
+//! What this simulation demonstrates:
+//!
+//! 1. Create a primary topic + a dead-letter topic.
+//! 2. Produce a batch of records, some of which the consumer will mark
+//!    as failures (destined for the DLQ).
+//! 3. A consumer attaches, processes each record, commits successes,
+//!    and routes failures to the DLQ.
+//! 4. Reconnect a fresh consumer in the same group — it resumes from
+//!    the committed offset.
+//! 5. Query `consumer_lag` to prove the commit took effect.
+//! 6. Tail the DLQ and print the failure records.
+//!
+//! Prerequisite: `docker compose --profile kafka up -d`.
+//!
+//! Run with:
+//! ```text
+//! ACTEON_KAFKA_BOOTSTRAP=localhost:9092 \
+//!   cargo run -p acteon-simulation --features bus \
+//!   --example bus_subscription_simulation
+//! ```
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use tracing::{Level, info};
+
+use acteon_bus::{
+    BusBackend, BusMessage, KafkaBackend, KafkaBusConfig, OffsetPosition, StartOffset,
+};
+use acteon_core::Topic;
+
+#[tokio::main]
+#[allow(clippy::too_many_lines)]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::INFO)
+        .with_env_filter("info,acteon_bus=info")
+        .try_init()
+        .ok();
+
+    let bootstrap =
+        std::env::var("ACTEON_KAFKA_BOOTSTRAP").unwrap_or_else(|_| "localhost:9092".to_string());
+    let cfg = KafkaBusConfig {
+        bootstrap_servers: bootstrap,
+        client_id: "bus-sub-sim".into(),
+        produce_timeout_ms: 8_000,
+        extra: Vec::new(),
+    };
+    let backend: Arc<dyn BusBackend> = KafkaBackend::new(&cfg)?;
+
+    let run_id = uuid::Uuid::new_v4().simple().to_string();
+    let mut orders = Topic::new(format!("orders-{run_id}"), "agents", "demo");
+    orders.partitions = 1;
+    orders.replication_factor = 1;
+    backend.create_topic(&orders).await?;
+
+    let mut dlq = Topic::new(format!("orders-dlq-{run_id}"), "agents", "demo");
+    dlq.partitions = 1;
+    dlq.replication_factor = 1;
+    backend.create_topic(&dlq).await?;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let orders_name = orders.kafka_topic_name();
+    let dlq_name = dlq.kafka_topic_name();
+    let group = format!("order-processor-{run_id}");
+
+    info!(topic = %orders_name, dlq = %dlq_name, %group, "topics ready");
+
+    // Produce 6 records. Seq 2 and 4 are destined for the DLQ.
+    for i in 0..6 {
+        backend
+            .produce(
+                BusMessage::new(
+                    orders_name.clone(),
+                    serde_json::json!({ "seq": i, "amount": 10 + i }),
+                )
+                .with_header("x-trace-id", format!("tr-{i}")),
+            )
+            .await?;
+    }
+
+    // Phase A: consumer #1 processes 3 records (DLQing seq 2),
+    // collects the final offset, drops the consumer, *then* commits.
+    // Kafka only allows a commit from a consumer that currently owns
+    // the partition — since Phase 2's `commit_offset` API uses its own
+    // short-lived consumer, the primary must be dropped first.
+    let mut last_committed: Option<(i32, i64)> = None;
+    {
+        let mut stream = backend
+            .subscribe(&orders_name, &group, StartOffset::Earliest)
+            .await?;
+        let mut processed = 0usize;
+        while processed < 3 {
+            let Ok(Some(Ok(msg))) =
+                tokio::time::timeout(Duration::from_secs(10), stream.next()).await
+            else {
+                break;
+            };
+            let seq = msg.payload["seq"].as_i64().unwrap_or(-1);
+            if seq == 2 {
+                let dlq_record = BusMessage::new(dlq_name.clone(), msg.payload.clone())
+                    .with_key(msg.key.clone().unwrap_or_default());
+                backend.produce(dlq_record).await?;
+                info!(seq, offset = ?msg.offset, "routed to DLQ");
+            } else {
+                info!(seq, offset = ?msg.offset, "processed");
+            }
+            if let (Some(p), Some(o)) = (msg.partition, msg.offset) {
+                last_committed = Some((p, o));
+            }
+            processed += 1;
+        }
+        // `stream` (and its consumer) drops here, unregistering from the group.
+    }
+    // Give the broker a moment for the LeaveGroup to settle.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    if let Some((p, o)) = last_committed {
+        backend
+            .commit_offset(
+                &orders_name,
+                &group,
+                OffsetPosition {
+                    partition: p,
+                    offset: o,
+                },
+            )
+            .await?;
+        info!(partition = p, offset = o, "committed after phase A");
+    }
+
+    let lag_after_phase_a = backend.consumer_lag(&orders_name, &group).await?;
+    info!(?lag_after_phase_a, "lag after phase A");
+
+    // Phase B: fresh consumer in the same group — should resume after
+    // the committed offset (records 3, 4, 5). We deliberately do *not*
+    // commit inline here: the Phase 2 `commit_offset` API spins up its
+    // own consumer and can't join a group that already has an active
+    // member. Batch-committing after the stream drops (as in phase A)
+    // is the supported pattern until a future phase introduces a
+    // stateful subscription registry that shares one consumer for both
+    // reads and commits.
+    let mut seen = Vec::new();
+    {
+        let mut stream = backend
+            .subscribe(&orders_name, &group, StartOffset::Latest)
+            .await?;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(8);
+        while seen.len() < 3 {
+            match tokio::time::timeout_at(deadline, stream.next()).await {
+                Ok(Some(Ok(m))) => {
+                    let seq = m.payload["seq"].as_i64().unwrap_or(-1);
+                    info!(seq, offset = ?m.offset, "resumed consumer");
+                    seen.push((m.partition, m.offset, seq));
+                }
+                _ => break,
+            }
+        }
+    }
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    if let Some((Some(p), Some(o), _)) = seen.last() {
+        backend
+            .commit_offset(
+                &orders_name,
+                &group,
+                OffsetPosition {
+                    partition: *p,
+                    offset: *o,
+                },
+            )
+            .await?;
+    }
+    info!(resumed_seqs = ?seen.iter().map(|(_, _, s)| *s).collect::<Vec<_>>(), "phase B saw these seqs (should start at 3)");
+
+    let lag_final = backend.consumer_lag(&orders_name, &group).await?;
+    info!(?lag_final, "lag after phase B");
+
+    // Phase C: tail the DLQ so operators see the failure record.
+    {
+        let tail_group = format!("dlq-tail-{run_id}");
+        let mut stream = backend
+            .subscribe(&dlq_name, &tail_group, StartOffset::Earliest)
+            .await?;
+        let mut dlq_seen = Vec::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while let Ok(Some(Ok(m))) = tokio::time::timeout_at(deadline, stream.next()).await {
+            dlq_seen.push(m.payload.clone());
+            info!(payload = %m.payload, "DLQ record");
+        }
+        info!(count = dlq_seen.len(), "DLQ tail done");
+    }
+
+    // Cleanup.
+    backend.delete_topic(&orders_name).await.ok();
+    backend.delete_topic(&dlq_name).await.ok();
+    info!("bus subscription simulation complete");
+    Ok(())
+}

--- a/crates/state/state/src/key.rs
+++ b/crates/state/state/src/key.rs
@@ -58,6 +58,8 @@ pub enum KeyKind {
     TimeInterval,
     /// Bus topic metadata (Phase 1 of the agentic bus).
     BusTopic,
+    /// Bus subscription metadata (Phase 2 of the agentic bus).
+    BusSubscription,
     Custom(String),
 }
 
@@ -95,6 +97,7 @@ impl KeyKind {
             Self::ActiveSilences => "active_silences",
             Self::TimeInterval => "time_interval",
             Self::BusTopic => "bus_topic",
+            Self::BusSubscription => "bus_subscription",
             Self::Custom(s) => s.as_str(),
         }
     }
@@ -192,6 +195,7 @@ mod tests {
         assert_eq!(KeyKind::ChainDefinition.as_str(), "chain_def");
         assert_eq!(KeyKind::TimeInterval.as_str(), "time_interval");
         assert_eq!(KeyKind::BusTopic.as_str(), "bus_topic");
+        assert_eq!(KeyKind::BusSubscription.as_str(), "bus_subscription");
         assert_eq!(KeyKind::Custom("foo".into()).as_str(), "foo");
     }
 

--- a/docs/book/features/bus-phase-2.md
+++ b/docs/book/features/bus-phase-2.md
@@ -1,0 +1,140 @@
+# Agentic Bus — Phase 2
+
+> **Scope:** durable subscriptions, manual offset commits, per-partition
+> lag reporting, and dead-letter-queue routing. Schemas, agents,
+> conversations, and tool-call envelopes come later. See the
+> [master plan](../concepts/bus-master-plan.md).
+
+Phase 1 gave us topics + publish + SSE subscribe. Phase 2 adds the
+surfaces operators actually run the bus with: durable consumer groups
+with committed offsets that survive reconnects, lag monitoring for
+alerting, and DLQ routing so poison-pill messages don't wedge a
+partition.
+
+## What ships in Phase 2
+
+| Surface | Shape |
+|---|---|
+| Core type | `acteon_core::Subscription` — `{id, topic, namespace, tenant, starting_offset, ack_mode, dead_letter_topic, ack_timeout_ms, labels}` |
+| State | `KeyKind::BusSubscription` |
+| Backend trait | `BusBackend::commit_offset` and `BusBackend::consumer_lag` added; both backends (Kafka + in-memory) implement them with consistent `committed = last consumed offset` semantics |
+| HTTP | `POST/GET /v1/bus/subscriptions`, `DELETE /v1/bus/subscriptions/{id}`, `POST /v1/bus/subscriptions/{id}/ack`, `GET /v1/bus/subscriptions/{id}/lag`, `POST /v1/bus/subscriptions/{id}/deadletter` |
+| Rust client | `create_bus_subscription`, `list_bus_subscriptions`, `delete_bus_subscription`, `ack_bus_subscription`, `get_bus_lag`, `deadletter_bus_message` |
+| Tests | 2 new bus unit tests (commit + lag roundtrip, commit-to-missing-topic), 1 new Kafka integration test (commits survive reconnect) |
+| Simulation | `bus_subscription_simulation.rs` — end-to-end: produce, consume + DLQ one record, reconnect, observe resumption and lag |
+
+## API shape
+
+### Create subscription
+
+```http
+POST /v1/bus/subscriptions
+{
+  "id": "order-processor",
+  "topic": "agents.demo.orders",
+  "namespace": "agents",
+  "tenant": "demo",
+  "starting_offset": "earliest",
+  "ack_mode": "manual",
+  "dead_letter_topic": "agents.demo.orders-dlq",
+  "ack_timeout_ms": 30000
+}
+→ 201 SubscriptionResponse
+```
+
+### Ack
+
+```http
+POST /v1/bus/subscriptions/order-processor/ack
+{
+  "partition": 0,
+  "offset": 42
+}
+→ 200 { "committed": true }
+```
+
+`offset` is the **last consumed** offset. The bus commits `offset + 1`
+to Kafka so a fresh consumer in the same group starts at `offset + 2`.
+
+### Lag
+
+```http
+GET /v1/bus/subscriptions/order-processor/lag
+→ 200 {
+  "subscription_id": "order-processor",
+  "topic": "agents.demo.orders",
+  "partitions": [
+    { "partition": 0, "committed": 42, "high_water_mark": 50, "lag": 7 }
+  ],
+  "total_lag": 7
+}
+```
+
+`committed: -1` indicates the consumer group has never committed on that
+partition. `lag` is clamped at 0.
+
+### Dead-letter
+
+```http
+POST /v1/bus/subscriptions/order-processor/deadletter
+{
+  "partition": 0,
+  "offset": 42,
+  "reason": "schema validation failed",
+  "key": "order-42",
+  "payload": { ... original payload ... },
+  "headers": { "x-trace-id": "..." }
+}
+→ 200 { "dlq_topic": "...", "partition": 0, "offset": 0 }
+```
+
+The bus appends diagnostic headers (`acteon.dlq.origin_topic`,
+`acteon.dlq.origin_partition`, `acteon.dlq.origin_offset`,
+`acteon.dlq.subscription`, `acteon.dlq.reason`) before producing the
+DLQ record. User-supplied `acteon.*` headers are filtered out at the
+`BusMessage` layer.
+
+## Known limitation — `commit_offset` semantics
+
+Kafka only lets a consumer commit offsets for a group if that consumer
+is *currently* a member of the group. The Phase 2 `commit_offset` API
+spins up its own short-lived consumer, which means it can't join while
+another consumer is still attached. Practical pattern:
+
+1. Consume records through `BusBackend::subscribe`.
+2. **Drop the subscribe stream** (so the consumer leaves the group).
+3. Call `commit_offset` — Phase 2 will transparently spin up a new
+   consumer, JoinGroup, commit, and leave.
+
+This is fine for ack-at-end-of-batch workflows and for the
+"drain-and-checkpoint" pattern. It's **not** suitable for
+fine-grained per-record commits while the consumer is still attached
+— a future phase introduces a stateful subscription registry that
+holds one long-lived consumer and routes commits through it.
+
+See `crates/simulation/examples/bus_subscription_simulation.rs` for
+the canonical usage.
+
+## Semantics: `committed` is "last consumed"
+
+Both backends agree: `committed = N` means records 0..=N have been
+processed; next to consume is `N + 1`. When the caller supplies
+`offset = N` to `ack`, the bus commits `N + 1` to Kafka (Kafka's
+convention is "next offset to read"). The `/lag` endpoint normalizes
+back so callers see the same `committed` number they sent in.
+
+## How to try it
+
+```bash
+docker compose --profile kafka up -d
+ACTEON_KAFKA_BOOTSTRAP=localhost:9092 \
+  cargo run -p acteon-simulation --features bus \
+  --example bus_subscription_simulation
+```
+
+## What comes next (Phase 3)
+
+- JSON Schema registry (`acteon_core::Schema`, CRUD endpoints).
+- Publish-edge validation: bind a topic to a schema subject+version;
+  reject payloads that don't match.
+- Typed decoding helpers in the SDK.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -184,6 +184,7 @@ nav:
   - Agentic Bus:
     - Master Plan: concepts/bus-master-plan.md
     - Phase 1 (Topics + Publish + Subscribe): features/bus-phase-1.md
+    - Phase 2 (Subscriptions + Ack + Lag + DLQ): features/bus-phase-2.md
   - Guides:
     - guides/index.md
     - AI Agent Swarm Coordination: guides/agent-swarm-coordination.md


### PR DESCRIPTION
> **Stacked on [#125 (feat/bus-phase-1)](https://github.com/penserai/acteon/pull/125).** Base should be flipped to \`main\` after #125 merges.

## Summary
Phase 2 of the agentic-bus plan. Phase 1 shipped the transport skeleton (topics + publish + SSE subscribe); Phase 2 adds the operational surfaces that make the bus actually usable in production: durable consumer-group bindings, committed offsets that survive reconnects, per-partition lag reporting, and DLQ routing for poison-pill messages.

## What's inside
- **`acteon_core::Subscription`** — `{id, topic, namespace, tenant, starting_offset, ack_mode, dead_letter_topic, ack_timeout_ms}`. Persisted via new \`KeyKind::BusSubscription\`.
- **Extended `BusBackend` trait** — \`commit_offset\` + \`consumer_lag\`. Kafka impl uses \`alter/committed_offsets\` via short-lived consumers; memory impl uses a \`(topic, group) → committed\` map. **Unified contract**: \`committed = N\` means records 0..=N processed; \`lag\` = high_water − committed − 1 (clamped at 0).
- **HTTP surface**:
  - \`POST /v1/bus/subscriptions\` — create
  - \`GET /v1/bus/subscriptions\` — list (with namespace/tenant/topic filters)
  - \`DELETE /v1/bus/subscriptions/{id}\`
  - \`POST /v1/bus/subscriptions/{id}/ack\` — commit \`{partition, offset}\`
  - \`GET /v1/bus/subscriptions/{id}/lag\` — per-partition + \`total_lag\`
  - \`POST /v1/bus/subscriptions/{id}/deadletter\` — routes a failed record to the configured DLQ with \`acteon.dlq.*\` diagnostic headers (origin topic/partition/offset/subscription/reason)
- **Rust client SDK**: \`create_bus_subscription\`, \`list_bus_subscriptions\`, \`delete_bus_subscription\`, \`ack_bus_subscription\`, \`get_bus_lag\`, \`deadletter_bus_message\`.
- **Tests**: 2 new memory unit tests, 1 new Kafka integration test (\`commit_and_lag_survive_reconnect\`) verifying a committed group resumes at the right offset and reports correct lag.
- **Simulation**: \`bus_subscription_simulation.rs\` — produce 6 records, Phase A consumes 3 (DLQing seq=2) and commits offset 2, Phase B reconnects and resumes at seq=3, DLQ tail shows the failed record. Runs against real Kafka via docker compose.

## Known limitation (documented in the feature doc)
\`commit_offset\` needs to JoinGroup to commit, so callers must **drop their subscribe stream before committing** (the primary consumer otherwise holds the partition). This is fine for ack-at-end-of-batch and drain-and-checkpoint patterns; fine-grained per-record commits require a stateful subscription registry introduced in a later phase.

## Test plan
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --no-deps -- -D warnings\`
- [x] \`cargo clippy -p acteon-server --features bus --all-targets --no-deps -- -D warnings\`
- [x] \`cargo clippy -p acteon-simulation --features bus --example bus_subscription_simulation --no-deps -- -D warnings\`
- [x] \`cargo test --workspace --lib --bins --tests\`
- [x] \`cargo check --all-targets\` — server with/without \`bus\`, simulation with/without \`bus\`
- [x] \`cd ui && npm run lint && npm run build\`
- [x] Kafka integration: \`ACTEON_KAFKA_BOOTSTRAP=localhost:9092 cargo test -p acteon-bus --test kafka_integration\` — all 3 tests green
- [x] Simulation end-to-end — verified committed=2 after A, resumed at seq=3 in B, final lag=0, DLQ record present

🤖 Generated with [Claude Code](https://claude.com/claude-code)