### PR TITLE
feat(bus): Phase 3 — JSON-Schema registry + publish-edge validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
+ "jsonschema",
  "parking_lot",
  "rdkafka",
  "serde",
@@ -944,7 +945,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -2100,6 +2103,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +2151,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,6 +2173,12 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 dependencies = [
  "allocator-api2",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -2961,6 +2991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3192,6 +3228,9 @@ name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "embedded-io"
@@ -3267,6 +3306,17 @@ name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -3392,6 +3442,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,6 +3476,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,6 +3503,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -3979,7 +4056,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
  "serde",
 ]
 
@@ -3988,6 +4065,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -4611,6 +4693,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50180452e7808015fe083eae3efcf1ec98b89b45dd8cc204f7b4a6b7b81ea675"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4861,6 +4970,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5009,6 +5124,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5035,6 +5164,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5056,6 +5200,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -5981,6 +6136,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb0c66c7b78c1da928bee668b5cc638c678642ff587faff6e6222f797be9d4c"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -7875,6 +8047,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8039,6 +8217,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ef224d01f8c31f8c11c90290766fd622fb0a7d7025b9589d4a34a36ccf35b28"
 dependencies = [
  "getrandom 0.4.1",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
 ]
 
 [[package]]

--- a/crates/bus/Cargo.toml
+++ b/crates/bus/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
+jsonschema = { version = "0.46", default-features = false }
 parking_lot = "0.12"
 rdkafka = { version = "0.37", features = ["cmake-build", "tokio"] }
 serde = { workspace = true }

--- a/crates/bus/src/lib.rs
+++ b/crates/bus/src/lib.rs
@@ -21,6 +21,7 @@ pub mod error;
 pub mod kafka;
 pub mod memory;
 pub mod message;
+pub mod schema;
 
 pub use backend::{BusBackend, SharedBackend, SubscribeStream};
 pub use config::{BusConfig, KafkaBusConfig};
@@ -28,5 +29,6 @@ pub use error::BusError;
 pub use kafka::KafkaBackend;
 pub use memory::MemoryBackend;
 pub use message::{BusMessage, DeliveryReceipt, OffsetPosition, StartOffset};
+pub use schema::{SchemaValidator, SchemaValidatorError, ValidationIssue};
 
 pub use acteon_core::PartitionLag;

--- a/crates/bus/src/schema.rs
+++ b/crates/bus/src/schema.rs
@@ -1,0 +1,254 @@
+//! Payload schema validation (Phase 3).
+//!
+//! The bus publish edge validates payloads against a JSON Schema that a
+//! topic is bound to. Schemas are compiled once into a
+//! [`jsonschema::Validator`] and cached keyed by `(namespace, tenant,
+//! subject, version)`. Cache entries are invalidated when a schema is
+//! deleted or a topic's binding changes.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+/// Compiled-schema registry. Cheap to clone; the underlying map is
+/// shared and mutated under a write lock only on register / invalidate.
+#[derive(Clone, Default)]
+pub struct SchemaValidator {
+    inner: Arc<RwLock<HashMap<CacheKey, Arc<jsonschema::Validator>>>>,
+}
+
+/// Composite key for the compiled-validator cache.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct CacheKey {
+    namespace: String,
+    tenant: String,
+    subject: String,
+    version: i32,
+}
+
+impl SchemaValidator {
+    /// Fresh, empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Compile `body` and insert the resulting validator under
+    /// `(namespace, tenant, subject, version)`. Returns an error if the
+    /// schema body isn't a valid JSON Schema.
+    ///
+    /// Replacing an existing entry is permitted (same tuple → recompile
+    /// after edit). Callers should invalidate when a subject's version
+    /// is deleted via [`Self::remove`].
+    pub fn register(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        subject: &str,
+        version: i32,
+        body: &serde_json::Value,
+    ) -> Result<(), SchemaValidatorError> {
+        let validator = jsonschema::validator_for(body)
+            .map_err(|e| SchemaValidatorError::CompileFailed(e.to_string()))?;
+        let key = CacheKey {
+            namespace: namespace.to_string(),
+            tenant: tenant.to_string(),
+            subject: subject.to_string(),
+            version,
+        };
+        self.inner.write().insert(key, Arc::new(validator));
+        Ok(())
+    }
+
+    /// Validate `payload` against the cached validator for `(namespace,
+    /// tenant, subject, version)`. Returns
+    /// [`SchemaValidatorError::NotFound`] if no such validator exists —
+    /// callers are expected to have registered before dispatch.
+    pub fn validate(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        subject: &str,
+        version: i32,
+        payload: &serde_json::Value,
+    ) -> Result<(), SchemaValidatorError> {
+        let key = CacheKey {
+            namespace: namespace.to_string(),
+            tenant: tenant.to_string(),
+            subject: subject.to_string(),
+            version,
+        };
+        let validator = {
+            let guard = self.inner.read();
+            guard.get(&key).cloned()
+        };
+        let Some(v) = validator else {
+            return Err(SchemaValidatorError::NotFound {
+                subject: subject.to_string(),
+                version,
+            });
+        };
+        let errors: Vec<_> = v
+            .iter_errors(payload)
+            .take(10)
+            .map(|e| ValidationIssue {
+                path: e.instance_path().to_string(),
+                message: e.to_string(),
+            })
+            .collect();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(SchemaValidatorError::InvalidPayload(errors))
+        }
+    }
+
+    /// Drop any cached validator for the given tuple. No-op if absent.
+    pub fn remove(&self, namespace: &str, tenant: &str, subject: &str, version: i32) {
+        let key = CacheKey {
+            namespace: namespace.to_string(),
+            tenant: tenant.to_string(),
+            subject: subject.to_string(),
+            version,
+        };
+        self.inner.write().remove(&key);
+    }
+
+    /// Test helper: number of cached validators.
+    #[cfg(test)]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.read().len()
+    }
+}
+
+/// Detail of a single JSON-Schema violation, surfaced to the caller.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationIssue {
+    /// JSON Pointer into the payload where the error occurred
+    /// (e.g. `"/order/items/0/qty"`).
+    pub path: String,
+    /// Human-readable message from the `jsonschema` crate.
+    pub message: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SchemaValidatorError {
+    #[error("schema body failed to compile: {0}")]
+    CompileFailed(String),
+    #[error("no validator cached for subject '{subject}' version {version}")]
+    NotFound { subject: String, version: i32 },
+    #[error("payload failed schema validation: {} issue(s)", .0.len())]
+    InvalidPayload(Vec<ValidationIssue>),
+}
+
+impl SchemaValidatorError {
+    /// The list of validation issues if this is an
+    /// [`Self::InvalidPayload`] error — useful for surfacing details
+    /// over HTTP without matching manually.
+    #[must_use]
+    pub fn issues(&self) -> Option<&[ValidationIssue]> {
+        match self {
+            Self::InvalidPayload(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn order_schema() -> serde_json::Value {
+        json!({
+            "type": "object",
+            "required": ["id", "qty"],
+            "properties": {
+                "id": {"type": "string"},
+                "qty": {"type": "integer", "minimum": 1}
+            }
+        })
+    }
+
+    #[test]
+    fn register_and_validate_accepts_good_payload() {
+        let v = SchemaValidator::new();
+        v.register("ns", "t", "orders", 1, &order_schema()).unwrap();
+        v.validate("ns", "t", "orders", 1, &json!({"id": "a", "qty": 2}))
+            .unwrap();
+    }
+
+    #[test]
+    fn validate_rejects_missing_required_field() {
+        let v = SchemaValidator::new();
+        v.register("ns", "t", "orders", 1, &order_schema()).unwrap();
+        let err = v
+            .validate("ns", "t", "orders", 1, &json!({"id": "a"}))
+            .unwrap_err();
+        let issues = err.issues().expect("issues");
+        assert!(!issues.is_empty());
+    }
+
+    #[test]
+    fn validate_rejects_wrong_type() {
+        let v = SchemaValidator::new();
+        v.register("ns", "t", "orders", 1, &order_schema()).unwrap();
+        let err = v
+            .validate("ns", "t", "orders", 1, &json!({"id": "a", "qty": "nope"}))
+            .unwrap_err();
+        let issues = err.issues().expect("issues");
+        assert!(issues.iter().any(|i| i.path.contains("qty")));
+    }
+
+    #[test]
+    fn validate_not_found_for_unknown_subject() {
+        let v = SchemaValidator::new();
+        let err = v.validate("ns", "t", "missing", 1, &json!({})).unwrap_err();
+        assert!(matches!(err, SchemaValidatorError::NotFound { .. }));
+    }
+
+    #[test]
+    fn register_rejects_bad_schema_body() {
+        let v = SchemaValidator::new();
+        // "type" must be a string or array — integer is invalid.
+        let bad = json!({"type": 42});
+        let err = v.register("ns", "t", "x", 1, &bad).unwrap_err();
+        assert!(matches!(err, SchemaValidatorError::CompileFailed(_)));
+    }
+
+    #[test]
+    fn remove_drops_cached_validator() {
+        let v = SchemaValidator::new();
+        v.register("ns", "t", "orders", 1, &order_schema()).unwrap();
+        assert_eq!(v.len(), 1);
+        v.remove("ns", "t", "orders", 1);
+        assert_eq!(v.len(), 0);
+    }
+
+    #[test]
+    fn versions_are_independent() {
+        let v = SchemaValidator::new();
+        v.register("ns", "t", "orders", 1, &order_schema()).unwrap();
+        // v2 requires an extra field.
+        let stricter = json!({
+            "type": "object",
+            "required": ["id", "qty", "sku"],
+            "properties": {
+                "id": {"type": "string"},
+                "qty": {"type": "integer"},
+                "sku": {"type": "string"}
+            }
+        });
+        v.register("ns", "t", "orders", 2, &stricter).unwrap();
+        // v1 accepts the old shape…
+        v.validate("ns", "t", "orders", 1, &json!({"id": "a", "qty": 1}))
+            .unwrap();
+        // …v2 rejects it.
+        assert!(
+            v.validate("ns", "t", "orders", 2, &json!({"id": "a", "qty": 1}))
+                .is_err()
+        );
+    }
+}

--- a/crates/client/src/bus.rs
+++ b/crates/client/src/bus.rs
@@ -59,6 +59,10 @@ pub struct BusTopic {
     pub description: Option<String>,
     #[serde(default)]
     pub labels: HashMap<String, String>,
+    #[serde(default)]
+    pub schema_subject: Option<String>,
+    #[serde(default)]
+    pub schema_version: Option<i32>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -438,6 +442,295 @@ impl ActeonClient {
             None => format!("{}/v1/bus/subscriptions/{ns}/{t}/{i}", self.base_url),
         }
     }
+
+    // ----- Phase 3: schemas + topic-schema binding -----
+
+    /// Register a new version of a schema subject. The server allocates
+    /// the next monotonic version and returns the registered schema.
+    pub async fn register_bus_schema(&self, req: &RegisterBusSchema) -> Result<BusSchema, Error> {
+        let url = format!("{}/v1/bus/schemas", self.base_url);
+        let resp = self
+            .add_auth(self.client.post(&url))
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusSchema>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// List schemas, optionally filtered by namespace/tenant/subject.
+    /// When `latest_only` is true, returns only the latest version per
+    /// subject.
+    pub async fn list_bus_schemas(
+        &self,
+        filter: &BusSchemaFilter,
+    ) -> Result<ListBusSchemasResponse, Error> {
+        let url = format!("{}/v1/bus/schemas", self.base_url);
+        let resp = self
+            .add_auth(self.client.get(&url))
+            .query(filter)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<ListBusSchemasResponse>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Fetch every version of a subject, ordered oldest-to-newest.
+    pub async fn get_bus_schema_versions(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        subject: &str,
+    ) -> Result<ListBusSchemasResponse, Error> {
+        let url = self.schema_subject_url(namespace, tenant, subject);
+        let resp = self
+            .add_auth(self.client.get(&url))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<ListBusSchemasResponse>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Fetch a specific schema version. Pass `"latest"` for the most
+    /// recent; any numeric string is parsed as a version number.
+    pub async fn get_bus_schema(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        subject: &str,
+        version: &str,
+    ) -> Result<BusSchema, Error> {
+        let url = self.schema_version_url(namespace, tenant, subject, version);
+        let resp = self
+            .add_auth(self.client.get(&url))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusSchema>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Delete a schema version. Fails with 409 if any topic currently
+    /// pins this version.
+    pub async fn delete_bus_schema(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        subject: &str,
+        version: i32,
+    ) -> Result<(), Error> {
+        let url = self.schema_version_url(namespace, tenant, subject, &version.to_string());
+        let resp = self
+            .add_auth(self.client.delete(&url))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Bind a topic to a schema subject + version. The server
+    /// validates every subsequent publish against this binding.
+    pub async fn bind_topic_schema(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        topic_name: &str,
+        subject: &str,
+        version: i32,
+    ) -> Result<BindTopicSchemaResponse, Error> {
+        let url = self.topic_schema_url(namespace, tenant, topic_name);
+        let req = BindTopicSchemaRequest {
+            subject: subject.to_string(),
+            version,
+        };
+        let resp = self
+            .add_auth(self.client.put(&url))
+            .json(&req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BindTopicSchemaResponse>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Drop a topic's schema binding. Publishes after this skip
+    /// validation.
+    pub async fn unbind_topic_schema(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        topic_name: &str,
+    ) -> Result<(), Error> {
+        let url = self.topic_schema_url(namespace, tenant, topic_name);
+        let resp = self
+            .add_auth(self.client.delete(&url))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Convenience: serialize a typed value and publish it. Pair with
+    /// a schema-bound topic for end-to-end type safety.
+    pub async fn publish_typed<T: serde::Serialize>(
+        &self,
+        req: &PublishTyped<'_, T>,
+    ) -> Result<PublishReceipt, Error> {
+        let payload =
+            serde_json::to_value(req.value).map_err(|e| Error::Deserialization(e.to_string()))?;
+        let msg = PublishBusMessage {
+            topic: req.topic.map(str::to_string),
+            namespace: req.namespace.map(str::to_string),
+            tenant: req.tenant.map(str::to_string),
+            name: req.name.map(str::to_string),
+            key: req.key.map(str::to_string),
+            payload,
+            headers: req.headers.clone(),
+        };
+        self.publish_message(&msg).await
+    }
+
+    fn schema_subject_url(&self, namespace: &str, tenant: &str, subject: &str) -> String {
+        format!(
+            "{}/v1/bus/schemas/{}/{}/{}",
+            self.base_url,
+            encode_segment(namespace),
+            encode_segment(tenant),
+            encode_segment(subject)
+        )
+    }
+
+    fn schema_version_url(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        subject: &str,
+        version: &str,
+    ) -> String {
+        format!(
+            "{}/v1/bus/schemas/{}/{}/{}/{}",
+            self.base_url,
+            encode_segment(namespace),
+            encode_segment(tenant),
+            encode_segment(subject),
+            encode_segment(version)
+        )
+    }
+
+    fn topic_schema_url(&self, namespace: &str, tenant: &str, topic_name: &str) -> String {
+        format!(
+            "{}/v1/bus/topics/{}/{}/{}/schema",
+            self.base_url,
+            encode_segment(namespace),
+            encode_segment(tenant),
+            encode_segment(topic_name)
+        )
+    }
+}
+
+// ----- Phase 3: DTOs -----
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct RegisterBusSchema {
+    pub subject: String,
+    pub namespace: String,
+    pub tenant: String,
+    pub body: serde_json::Value,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub labels: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BusSchema {
+    pub subject: String,
+    pub version: i32,
+    pub namespace: String,
+    pub tenant: String,
+    pub body: serde_json::Value,
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListBusSchemasResponse {
+    pub schemas: Vec<BusSchema>,
+    pub count: usize,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct BusSchemaFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub latest_only: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct BindTopicSchemaRequest {
+    subject: String,
+    version: i32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BindTopicSchemaResponse {
+    pub topic: String,
+    pub subject: String,
+    pub version: i32,
+}
+
+/// Typed publish envelope consumed by
+/// [`ActeonClient::publish_typed`]. Borrow-based to avoid clones when
+/// the caller already has a typed value.
+#[derive(Debug)]
+pub struct PublishTyped<'a, T: serde::Serialize> {
+    pub value: &'a T,
+    pub topic: Option<&'a str>,
+    pub namespace: Option<&'a str>,
+    pub tenant: Option<&'a str>,
+    pub name: Option<&'a str>,
+    pub key: Option<&'a str>,
+    pub headers: BTreeMap<String, String>,
 }
 
 async fn map_error(resp: reqwest::Response) -> Error {

--- a/crates/core/src/bus_schema.rs
+++ b/crates/core/src/bus_schema.rs
@@ -1,0 +1,213 @@
+//! Bus payload schema — JSON Schema registry entry for a bus topic.
+//!
+//! Phase 3 of the agentic bus adds publish-edge validation. Schemas are
+//! registered as immutable `(subject, version)` pairs — posting to an
+//! existing subject allocates a new version, never replaces the old
+//! one. Topics opt into validation by binding to a subject + version
+//! via `Topic::schema_subject` / `Topic::schema_version`.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Wire format a schema document is written in.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum SchemaFormat {
+    /// JSON Schema (draft 2020-12 in practice — `jsonschema` crate
+    /// default). The only format in V1; Avro/Protobuf come later.
+    #[default]
+    JsonSchema,
+}
+
+/// A schema definition tied to a `(namespace, tenant, subject, version)`
+/// tuple.
+///
+/// `subject` is the logical name operators use ("order-v1"); `version`
+/// is a monotonic integer assigned by the server starting at 1.
+/// Schemas are immutable once registered; updating "the schema" means
+/// publishing a new version.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct Schema {
+    /// Logical schema name (e.g. `"orders"`). Namespaced per tenant.
+    pub subject: String,
+    /// Monotonic version, starting at 1. Assigned by the server on
+    /// registration.
+    pub version: i32,
+    /// Namespace the schema lives in.
+    pub namespace: String,
+    /// Tenant that owns the schema.
+    pub tenant: String,
+    /// Wire format the `body` is written in.
+    #[serde(default)]
+    pub format: SchemaFormat,
+    /// The schema document itself (JSON Schema in V1). Held as `Value`
+    /// so callers don't have to re-parse; the bus-side validator
+    /// compiles it once into a `jsonschema::Validator`.
+    pub body: serde_json::Value,
+    /// Arbitrary operator labels.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub labels: HashMap<String, String>,
+    /// When this version was registered.
+    pub created_at: DateTime<Utc>,
+}
+
+impl Schema {
+    /// Construct a schema with an explicit version. Callers generally
+    /// use the server endpoint; this constructor is primarily for tests
+    /// and for loading from state.
+    #[must_use]
+    pub fn new(
+        subject: impl Into<String>,
+        version: i32,
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+        body: serde_json::Value,
+    ) -> Self {
+        Self {
+            subject: subject.into(),
+            version,
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            format: SchemaFormat::default(),
+            body,
+            labels: HashMap::new(),
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Stable ID used as the state-store key — `"{subject}:{version}"`.
+    /// Combined with `(namespace, tenant)` in `KeyKind::BusSchema` this
+    /// gives O(1) lookup without a scan. (`KeyKind` lives in
+    /// `acteon-state`, so we use a plain code span here to avoid a
+    /// cross-crate rustdoc intra-doc link.)
+    #[must_use]
+    pub fn id(&self) -> String {
+        format!("{}:{}", self.subject, self.version)
+    }
+
+    /// Validate the schema's identity fields (subject + version +
+    /// namespace + tenant). The body itself is validated at the bus
+    /// layer when it's compiled into a validator.
+    pub fn validate(&self) -> Result<(), SchemaValidationError> {
+        Self::validate_fragment(&self.namespace)?;
+        Self::validate_fragment(&self.tenant)?;
+        Self::validate_subject(&self.subject)?;
+        if self.version < 1 {
+            return Err(SchemaValidationError::InvalidVersion(self.version));
+        }
+        Ok(())
+    }
+
+    /// Subject validation — same character set as topic fragments but a
+    /// larger length budget since subjects can be more descriptive
+    /// (`"order-created-v2"`).
+    pub fn validate_subject(s: &str) -> Result<(), SchemaValidationError> {
+        if s.is_empty() {
+            return Err(SchemaValidationError::EmptySubject);
+        }
+        if s.len() > 120 {
+            return Err(SchemaValidationError::SubjectTooLong);
+        }
+        if !s
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+        {
+            return Err(SchemaValidationError::InvalidSubjectChar(s.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Namespace / tenant validation — reuses the topic fragment rules
+    /// so a schema subject is addressable under the same key shape as
+    /// its bound topic.
+    pub fn validate_fragment(s: &str) -> Result<(), SchemaValidationError> {
+        if s.is_empty() {
+            return Err(SchemaValidationError::EmptyFragment);
+        }
+        if s.len() > 80 {
+            return Err(SchemaValidationError::FragmentTooLong);
+        }
+        if !s
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(SchemaValidationError::InvalidFragmentChar(s.to_string()));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum SchemaValidationError {
+    #[error("schema subject must not be empty")]
+    EmptySubject,
+    #[error("schema subject exceeds 120 characters")]
+    SubjectTooLong,
+    #[error("schema subject '{0}' contains characters outside [a-zA-Z0-9._-]")]
+    InvalidSubjectChar(String),
+    #[error("schema namespace/tenant must not be empty")]
+    EmptyFragment,
+    #[error("schema namespace/tenant fragment exceeds 80 characters")]
+    FragmentTooLong,
+    #[error("schema fragment '{0}' contains characters outside [a-zA-Z0-9_-]")]
+    InvalidFragmentChar(String),
+    #[error("schema version must be >= 1 (got {0})")]
+    InvalidVersion(i32),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn id_is_subject_colon_version() {
+        let s = Schema::new("orders", 3, "agents", "demo", json!({"type": "object"}));
+        assert_eq!(s.id(), "orders:3");
+    }
+
+    #[test]
+    fn validate_rejects_zero_version() {
+        let s = Schema::new("orders", 0, "agents", "demo", json!({}));
+        assert_eq!(s.validate(), Err(SchemaValidationError::InvalidVersion(0)));
+    }
+
+    #[test]
+    fn validate_rejects_empty_subject() {
+        let s = Schema::new("", 1, "agents", "demo", json!({}));
+        assert_eq!(s.validate(), Err(SchemaValidationError::EmptySubject));
+    }
+
+    #[test]
+    fn validate_rejects_subject_with_slash() {
+        let s = Schema::new("orders/v1", 1, "agents", "demo", json!({}));
+        assert!(matches!(
+            s.validate(),
+            Err(SchemaValidationError::InvalidSubjectChar(_))
+        ));
+    }
+
+    #[test]
+    fn validate_accepts_dotted_subject() {
+        // Dots are allowed in subjects (unlike topic fragments) because
+        // subjects are opaque strings and versioned naming like
+        // "orders.v1" is conventional.
+        let s = Schema::new("orders.v1", 1, "agents", "demo", json!({}));
+        s.validate().unwrap();
+    }
+
+    #[test]
+    fn roundtrip_serde() {
+        let mut s = Schema::new("orders", 2, "agents", "demo", json!({"type": "object"}));
+        s.labels.insert("owner".to_string(), "payments".to_string());
+        let j = serde_json::to_string(&s).unwrap();
+        let back: Schema = serde_json::from_str(&j).unwrap();
+        assert_eq!(back.subject, s.subject);
+        assert_eq!(back.version, s.version);
+        assert_eq!(back.labels.get("owner"), Some(&"payments".to_string()));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod action;
 pub mod analytics;
 pub mod attachment;
+pub mod bus_schema;
 pub mod bus_subscription;
 pub mod bus_topic;
 pub mod caller;
@@ -33,6 +34,7 @@ pub use analytics::{
     AnalyticsTopEntry,
 };
 pub use attachment::{Attachment, ResolvedAttachment};
+pub use bus_schema::{Schema, SchemaFormat, SchemaValidationError};
 pub use bus_subscription::{
     AckMode, PartitionLag, StartOffset as SubscriptionStartOffset, Subscription,
     SubscriptionStatus, SubscriptionValidationError,

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -68,6 +68,7 @@ fn authorize_bus_op(
         BusOp::Manage => (Permission::Dispatch, "manage"),
         BusOp::Publish => (Permission::Dispatch, "publish"),
         BusOp::Subscribe => (Permission::StreamSubscribe, "subscribe"),
+        BusOp::ManageSchema => (Permission::Dispatch, "schema"),
     };
     if !identity.role.has_permission(permission) {
         return Err((
@@ -103,6 +104,8 @@ enum BusOp {
     Publish,
     /// Subscribe (SSE) to a topic.
     Subscribe,
+    /// Schema CRUD + topic-binding CRUD (Phase 3).
+    ManageSchema,
 }
 
 /// Parse a `namespace.tenant.name` Kafka topic string.
@@ -156,6 +159,10 @@ pub struct TopicResponse {
     pub description: Option<String>,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub labels: HashMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_subject: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<i32>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -522,7 +529,7 @@ pub async fn delete_topic(
     request_body = PublishRequest,
     responses(
         (status = 200, description = "Published", body = PublishResponse),
-        (status = 400, description = "Invalid topic or reserved header prefix", body = ErrorResponse),
+        (status = 400, description = "Invalid topic, reserved header, or schema-validation failure", body = SchemaValidationErrorResponse),
         (status = 404, description = "Topic not found", body = ErrorResponse),
         (status = 503, description = "Bus feature disabled", body = ErrorResponse),
     ),
@@ -595,12 +602,23 @@ pub async fn publish(
         // that the topic is registered in state *before* we hand the
         // message to Kafka. Without this check a client could bypass
         // Acteon entirely when the broker has `auto.create.topics.enable`
-        // — future schema validation (Phase 3) would have no hook.
+        // — Phase 3 schema validation would have no hook either.
         let topic_key = StateKey::new(ns, tenant, KeyKind::BusTopic, &topic_name);
-        {
+        let topic: Topic = {
             let gw = state.gateway.read().await;
             match gw.state_store().get(&topic_key).await {
-                Ok(Some(_)) => {}
+                Ok(Some(raw)) => match serde_json::from_str::<Topic>(&raw) {
+                    Ok(t) => t,
+                    Err(e) => {
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(ErrorResponse {
+                                error: format!("corrupt topic record for {topic_name}: {e}"),
+                            }),
+                        )
+                            .into_response();
+                    }
+                },
                 Ok(None) => {
                     return (
                         StatusCode::NOT_FOUND,
@@ -608,6 +626,61 @@ pub async fn publish(
                             error: format!(
                                 "topic {topic_name} is not registered in Acteon; create it with POST /v1/bus/topics first"
                             ),
+                        }),
+                    )
+                        .into_response();
+                }
+                Err(e) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse {
+                            error: e.to_string(),
+                        }),
+                    )
+                        .into_response();
+                }
+            }
+        };
+        // Phase 3: if the topic is bound to a schema, validate the
+        // payload before we hand it to Kafka. A bound topic with a
+        // missing compiled validator is a server bug — log it and fall
+        // through rather than blocking publish on a cold cache, since
+        // the state row is the source of truth and we re-hydrate on
+        // startup via `ensure_schema_in_validator` below.
+        if let (Some(subject), Some(version)) = (&topic.schema_subject, topic.schema_version) {
+            if let Err(resp) = ensure_schema_in_validator(
+                &state,
+                &topic.namespace,
+                &topic.tenant,
+                subject,
+                version,
+            )
+            .await
+            {
+                return resp;
+            }
+            match state.bus_schema_validator.validate(
+                &topic.namespace,
+                &topic.tenant,
+                subject,
+                version,
+                &req.payload,
+            ) {
+                Ok(()) => {}
+                Err(acteon_bus::SchemaValidatorError::InvalidPayload(issues)) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(SchemaValidationErrorResponse {
+                            error: format!("payload does not match schema '{subject}' v{version}"),
+                            subject: subject.clone(),
+                            version,
+                            issues: issues
+                                .into_iter()
+                                .map(|i| SchemaValidationIssueDto {
+                                    path: i.path,
+                                    message: i.message,
+                                })
+                                .collect(),
                         }),
                     )
                         .into_response();
@@ -763,6 +836,8 @@ fn topic_to_response(t: &Topic) -> TopicResponse {
         retention_ms: t.retention_ms,
         description: t.description.clone(),
         labels: t.labels.clone(),
+        schema_subject: t.schema_subject.clone(),
+        schema_version: t.schema_version,
         created_at: t.created_at,
         updated_at: t.updated_at,
     }
@@ -1617,5 +1692,1004 @@ async fn load_subscription(
             }),
         )
             .into_response()),
+    }
+}
+
+// =============================================================================
+// Phase 3: JSON-Schema registry + topic binding
+// =============================================================================
+
+/// Body of a request to register a new schema version.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateSchemaRequest {
+    pub subject: String,
+    pub namespace: String,
+    pub tenant: String,
+    /// JSON Schema document (draft 2020-12). Validated by the
+    /// `jsonschema` crate when compiled.
+    #[schema(value_type = Object)]
+    pub body: serde_json::Value,
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+}
+
+/// Wire representation of a registered schema version.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SchemaResponse {
+    pub subject: String,
+    pub version: i32,
+    pub namespace: String,
+    pub tenant: String,
+    #[schema(value_type = Object)]
+    pub body: serde_json::Value,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub labels: HashMap<String, String>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListSchemasResponse {
+    pub schemas: Vec<SchemaResponse>,
+    pub count: usize,
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListSchemasParams {
+    #[serde(default)]
+    pub namespace: Option<String>,
+    #[serde(default)]
+    pub tenant: Option<String>,
+    #[serde(default)]
+    pub subject: Option<String>,
+    /// When true, return only the latest version per subject (default
+    /// false — returns all versions).
+    #[serde(default)]
+    pub latest_only: bool,
+}
+
+/// Body of a `PUT /v1/bus/topics/{ns}/{t}/{name}/schema` request.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct BindTopicSchemaRequest {
+    pub subject: String,
+    /// Specific version to pin. Must be >= 1.
+    pub version: i32,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct BindTopicSchemaResponse {
+    pub topic: String,
+    pub subject: String,
+    pub version: i32,
+}
+
+/// Response body for payload-validation failures. Uses a distinct type
+/// so `OpenAPI` consumers can see the per-issue detail without matching
+/// on `ErrorResponse`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SchemaValidationErrorResponse {
+    pub error: String,
+    pub subject: String,
+    pub version: i32,
+    pub issues: Vec<SchemaValidationIssueDto>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SchemaValidationIssueDto {
+    pub path: String,
+    pub message: String,
+}
+
+#[cfg(feature = "bus")]
+fn schema_to_response(s: &acteon_core::Schema) -> SchemaResponse {
+    SchemaResponse {
+        subject: s.subject.clone(),
+        version: s.version,
+        namespace: s.namespace.clone(),
+        tenant: s.tenant.clone(),
+        body: s.body.clone(),
+        labels: s.labels.clone(),
+        created_at: s.created_at,
+    }
+}
+
+/// Rehydrate a schema body into the in-memory validator cache if it
+/// isn't there already. The validator cache is process-local and
+/// survives only while the server is up, so on cold-start or after the
+/// cache was evicted we need to read from state and recompile.
+///
+/// Returns `Err(Response)` for surfacing to callers when the schema row
+/// is missing (bound topic with deleted schema — a governance hole)
+/// or when recompilation fails.
+#[cfg(feature = "bus")]
+async fn ensure_schema_in_validator(
+    state: &AppState,
+    namespace: &str,
+    tenant: &str,
+    subject: &str,
+    version: i32,
+) -> Result<(), axum::response::Response> {
+    // Optimistic path: validate() below will succeed if the entry is
+    // present. We re-register unconditionally here which is a cheap
+    // hash-map write; the extra cost is negligible vs. the cross-
+    // process cache-miss path.
+    let key = StateKey::new(
+        namespace.to_string(),
+        tenant.to_string(),
+        KeyKind::BusSchema,
+        format!("{subject}:{version}"),
+    );
+    let gw = state.gateway.read().await;
+    match gw.state_store().get(&key).await {
+        Ok(Some(raw)) => match serde_json::from_str::<acteon_core::Schema>(&raw) {
+            Ok(s) => state
+                .bus_schema_validator
+                .register(&s.namespace, &s.tenant, &s.subject, s.version, &s.body)
+                .map_err(|e| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse {
+                            error: format!("failed to compile schema {subject}:{version}: {e}"),
+                        }),
+                    )
+                        .into_response()
+                }),
+            Err(e) => Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("corrupt schema record for {subject}:{version}: {e}"),
+                }),
+            )
+                .into_response()),
+        },
+        Ok(None) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: format!(
+                    "topic binding points at missing schema '{subject}' v{version} — unbind or re-register the schema"
+                ),
+            }),
+        )
+            .into_response()),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response()),
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/schemas",
+    tag = "bus",
+    request_body = CreateSchemaRequest,
+    responses(
+        (status = 201, description = "Schema version registered", body = SchemaResponse),
+        (status = 400, description = "Invalid subject or schema body", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+#[allow(clippy::too_many_lines)]
+pub async fn create_schema(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Json(req): Json<CreateSchemaRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) =
+            authorize_bus_op(&identity, &req.tenant, &req.namespace, BusOp::ManageSchema)
+        {
+            return resp;
+        }
+        if let Err(e) = acteon_core::Schema::validate_subject(&req.subject) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        if let Err(e) = acteon_core::Schema::validate_fragment(&req.namespace) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("invalid namespace: {e}"),
+                }),
+            )
+                .into_response();
+        }
+        if let Err(e) = acteon_core::Schema::validate_fragment(&req.tenant) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("invalid tenant: {e}"),
+                }),
+            )
+                .into_response();
+        }
+        // Compile the body first — a bad body should fail fast with a
+        // 400 rather than land in state and cause 500s on publish later.
+        if let Err(e) = acteon_bus::SchemaValidator::new().register(
+            &req.namespace,
+            &req.tenant,
+            &req.subject,
+            1,
+            &req.body,
+        ) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("schema body invalid: {e}"),
+                }),
+            )
+                .into_response();
+        }
+        // Scan existing versions for this subject to pick the next one.
+        let gw = state.gateway.read().await;
+        let prefix = format!("{}:", req.subject);
+        let next_version: i32 = match gw
+            .state_store()
+            .scan_keys(
+                &req.namespace,
+                &req.tenant,
+                KeyKind::BusSchema,
+                Some(&prefix),
+            )
+            .await
+        {
+            Ok(rows) => rows
+                .iter()
+                .filter_map(|(_, v)| serde_json::from_str::<acteon_core::Schema>(v).ok())
+                .filter(|s| s.subject == req.subject)
+                .map(|s| s.version)
+                .max()
+                .map_or(1, |m| m + 1),
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let now = Utc::now();
+        let schema = acteon_core::Schema {
+            subject: req.subject.clone(),
+            version: next_version,
+            namespace: req.namespace.clone(),
+            tenant: req.tenant.clone(),
+            format: acteon_core::SchemaFormat::default(),
+            body: req.body.clone(),
+            labels: req.labels.clone(),
+            created_at: now,
+        };
+        if let Err(e) = schema.validate() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        let key = StateKey::new(
+            schema.namespace.clone(),
+            schema.tenant.clone(),
+            KeyKind::BusSchema,
+            schema.id(),
+        );
+        let payload = match serde_json::to_string(&schema) {
+            Ok(s) => s,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        if let Err(e) = gw.state_store().set(&key, &payload, None).await {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        drop(gw);
+        // Eagerly register with the compiled-validator cache so the
+        // next publish is a warm hit.
+        let _ = state.bus_schema_validator.register(
+            &schema.namespace,
+            &schema.tenant,
+            &schema.subject,
+            schema.version,
+            &schema.body,
+        );
+        (StatusCode::CREATED, Json(schema_to_response(&schema))).into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/bus/schemas",
+    tag = "bus",
+    params(ListSchemasParams),
+    responses(
+        (status = 200, description = "Schema list", body = ListSchemasResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn list_schemas(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Query(params): Query<ListSchemasParams>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        // Authorize with whatever scope the caller filtered on; when
+        // neither namespace nor tenant is given, fall through to caller
+        // iteration below — list is a read surface without mutations,
+        // but we still gate on ManageSchema so downstream tools don't
+        // accidentally expose schema bodies to low-privilege clients.
+        let (ns_filter, t_filter) = (params.namespace.as_deref(), params.tenant.as_deref());
+        if let (Some(ns), Some(t)) = (ns_filter, t_filter) {
+            if let Err(resp) = authorize_bus_op(&identity, t, ns, BusOp::ManageSchema) {
+                return resp;
+            }
+        } else if !identity.role.has_permission(Permission::Dispatch) {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse {
+                    error: "insufficient role for bus.schema listing".to_string(),
+                }),
+            )
+                .into_response();
+        }
+        let gw = state.gateway.read().await;
+        let rows = match gw.state_store().scan_keys_by_kind(KeyKind::BusSchema).await {
+            Ok(r) => r,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let mut schemas: Vec<acteon_core::Schema> = rows
+            .into_iter()
+            .filter_map(|(_, v)| serde_json::from_str::<acteon_core::Schema>(&v).ok())
+            .filter(|s| ns_filter.is_none_or(|n| s.namespace == n))
+            .filter(|s| t_filter.is_none_or(|t| s.tenant == t))
+            .filter(|s| params.subject.as_deref().is_none_or(|sub| s.subject == sub))
+            .collect();
+        if params.latest_only {
+            let mut by_subject: std::collections::HashMap<
+                (String, String, String),
+                acteon_core::Schema,
+            > = std::collections::HashMap::new();
+            for s in schemas.drain(..) {
+                let key = (s.namespace.clone(), s.tenant.clone(), s.subject.clone());
+                match by_subject.get(&key) {
+                    Some(existing) if existing.version >= s.version => {}
+                    _ => {
+                        by_subject.insert(key, s);
+                    }
+                }
+            }
+            schemas = by_subject.into_values().collect();
+        }
+        schemas.sort_by(|a, b| {
+            a.namespace
+                .cmp(&b.namespace)
+                .then(a.tenant.cmp(&b.tenant))
+                .then(a.subject.cmp(&b.subject))
+                .then(a.version.cmp(&b.version))
+        });
+        let responses: Vec<SchemaResponse> = schemas.iter().map(schema_to_response).collect();
+        let count = responses.len();
+        (
+            StatusCode::OK,
+            Json(ListSchemasResponse {
+                schemas: responses,
+                count,
+            }),
+        )
+            .into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, params);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/bus/schemas/{namespace}/{tenant}/{subject}",
+    tag = "bus",
+    params(
+        ("namespace" = String, Path, description = "Topic namespace"),
+        ("tenant" = String, Path, description = "Tenant ID"),
+        ("subject" = String, Path, description = "Schema subject"),
+    ),
+    responses(
+        (status = 200, description = "All versions of the subject", body = ListSchemasResponse),
+        (status = 404, description = "No versions registered", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn get_subject_versions(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, subject)): Path<(String, String, String)>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageSchema) {
+            return resp;
+        }
+        let gw = state.gateway.read().await;
+        let rows = match gw
+            .state_store()
+            .scan_keys(
+                &namespace,
+                &tenant,
+                KeyKind::BusSchema,
+                Some(&format!("{subject}:")),
+            )
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let mut schemas: Vec<acteon_core::Schema> = rows
+            .into_iter()
+            .filter_map(|(_, v)| serde_json::from_str::<acteon_core::Schema>(&v).ok())
+            .filter(|s| s.subject == subject)
+            .collect();
+        if schemas.is_empty() {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("no versions of subject '{subject}' registered"),
+                }),
+            )
+                .into_response();
+        }
+        schemas.sort_by_key(|s| s.version);
+        let responses: Vec<SchemaResponse> = schemas.iter().map(schema_to_response).collect();
+        let count = responses.len();
+        (
+            StatusCode::OK,
+            Json(ListSchemasResponse {
+                schemas: responses,
+                count,
+            }),
+        )
+            .into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, subject);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/bus/schemas/{namespace}/{tenant}/{subject}/{version}",
+    tag = "bus",
+    params(
+        ("namespace" = String, Path, description = "Topic namespace"),
+        ("tenant" = String, Path, description = "Tenant ID"),
+        ("subject" = String, Path, description = "Schema subject"),
+        ("version" = String, Path, description = "Version number or 'latest'"),
+    ),
+    responses(
+        (status = 200, description = "Schema version", body = SchemaResponse),
+        (status = 404, description = "Not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn get_schema_version(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, subject, version)): Path<(String, String, String, String)>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageSchema) {
+            return resp;
+        }
+        let schema =
+            match resolve_schema_version(&state, &namespace, &tenant, &subject, &version).await {
+                Ok(s) => s,
+                Err(resp) => return resp,
+            };
+        (StatusCode::OK, Json(schema_to_response(&schema))).into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, subject, version);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+/// Resolve `"latest"` or a numeric version string to a concrete
+/// `Schema`. Shared by `get_schema_version` and `bind_topic_schema`.
+#[cfg(feature = "bus")]
+async fn resolve_schema_version(
+    state: &AppState,
+    namespace: &str,
+    tenant: &str,
+    subject: &str,
+    version: &str,
+) -> Result<acteon_core::Schema, axum::response::Response> {
+    let gw = state.gateway.read().await;
+    if version.eq_ignore_ascii_case("latest") {
+        let rows = gw
+            .state_store()
+            .scan_keys(
+                namespace,
+                tenant,
+                KeyKind::BusSchema,
+                Some(&format!("{subject}:")),
+            )
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response()
+            })?;
+        let latest = rows
+            .into_iter()
+            .filter_map(|(_, v)| serde_json::from_str::<acteon_core::Schema>(&v).ok())
+            .filter(|s| s.subject == subject)
+            .max_by_key(|s| s.version);
+        latest.ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("no versions of subject '{subject}' registered"),
+                }),
+            )
+                .into_response()
+        })
+    } else {
+        let v: i32 = version.parse().map_err(|_| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("version '{version}' is not an integer or 'latest'"),
+                }),
+            )
+                .into_response()
+        })?;
+        let key = StateKey::new(
+            namespace.to_string(),
+            tenant.to_string(),
+            KeyKind::BusSchema,
+            format!("{subject}:{v}"),
+        );
+        match gw.state_store().get(&key).await {
+            Ok(Some(raw)) => serde_json::from_str::<acteon_core::Schema>(&raw).map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: format!("corrupt schema record for {subject}:{v}: {e}"),
+                    }),
+                )
+                    .into_response()
+            }),
+            Ok(None) => Err((
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("schema '{subject}' v{v} not found"),
+                }),
+            )
+                .into_response()),
+            Err(e) => Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response()),
+        }
+    }
+}
+
+#[utoipa::path(
+    delete,
+    path = "/v1/bus/schemas/{namespace}/{tenant}/{subject}/{version}",
+    tag = "bus",
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("subject" = String, Path),
+        ("version" = i32, Path),
+    ),
+    responses(
+        (status = 204, description = "Deleted"),
+        (status = 404, description = "Not found", body = ErrorResponse),
+        (status = 409, description = "Schema is pinned by a topic; unbind first", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn delete_schema_version(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, subject, version)): Path<(String, String, String, i32)>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageSchema) {
+            return resp;
+        }
+        // Block the delete if any topic currently pins this version.
+        let gw = state.gateway.read().await;
+        let topic_rows = match gw
+            .state_store()
+            .scan_keys(&namespace, &tenant, KeyKind::BusTopic, None)
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let pinned_by: Vec<String> = topic_rows
+            .into_iter()
+            .filter_map(|(_, v)| serde_json::from_str::<Topic>(&v).ok())
+            .filter(|t| {
+                t.schema_subject.as_deref() == Some(subject.as_str())
+                    && t.schema_version == Some(version)
+            })
+            .map(|t| t.kafka_topic_name())
+            .collect();
+        if !pinned_by.is_empty() {
+            return (
+                StatusCode::CONFLICT,
+                Json(ErrorResponse {
+                    error: format!(
+                        "schema '{subject}' v{version} is pinned by topics: {}; unbind them first",
+                        pinned_by.join(", ")
+                    ),
+                }),
+            )
+                .into_response();
+        }
+        let key = StateKey::new(
+            namespace.clone(),
+            tenant.clone(),
+            KeyKind::BusSchema,
+            format!("{subject}:{version}"),
+        );
+        match gw.state_store().get(&key).await {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse {
+                        error: format!("schema '{subject}' v{version} not found"),
+                    }),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        }
+        if let Err(e) = gw.state_store().delete(&key).await {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        drop(gw);
+        state
+            .bus_schema_validator
+            .remove(&namespace, &tenant, &subject, version);
+        StatusCode::NO_CONTENT.into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, subject, version);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    put,
+    path = "/v1/bus/topics/{namespace}/{tenant}/{name}/schema",
+    tag = "bus",
+    request_body = BindTopicSchemaRequest,
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("name" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Binding set", body = BindTopicSchemaResponse),
+        (status = 404, description = "Topic or schema not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+#[allow(clippy::too_many_lines)]
+pub async fn bind_topic_schema(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, name)): Path<(String, String, String)>,
+    Json(req): Json<BindTopicSchemaRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageSchema) {
+            return resp;
+        }
+        // Resolve the schema first — returns 404 if missing.
+        let schema = match resolve_schema_version(
+            &state,
+            &namespace,
+            &tenant,
+            &req.subject,
+            &req.version.to_string(),
+        )
+        .await
+        {
+            Ok(s) => s,
+            Err(resp) => return resp,
+        };
+        let kafka_name = format!("{namespace}.{tenant}.{name}");
+        let topic_key = StateKey::new(
+            namespace.clone(),
+            tenant.clone(),
+            KeyKind::BusTopic,
+            &kafka_name,
+        );
+        let gw = state.gateway.read().await;
+        let mut topic: Topic = match gw.state_store().get(&topic_key).await {
+            Ok(Some(raw)) => match serde_json::from_str::<Topic>(&raw) {
+                Ok(t) => t,
+                Err(e) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse {
+                            error: format!("corrupt topic record for {kafka_name}: {e}"),
+                        }),
+                    )
+                        .into_response();
+                }
+            },
+            Ok(None) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse {
+                        error: format!("topic {kafka_name} not found"),
+                    }),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        topic.schema_subject = Some(schema.subject.clone());
+        topic.schema_version = Some(schema.version);
+        topic.updated_at = Utc::now();
+        let payload = match serde_json::to_string(&topic) {
+            Ok(s) => s,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        if let Err(e) = gw.state_store().set(&topic_key, &payload, None).await {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        drop(gw);
+        // Warm the validator cache so the next publish is a hit.
+        let _ = state.bus_schema_validator.register(
+            &schema.namespace,
+            &schema.tenant,
+            &schema.subject,
+            schema.version,
+            &schema.body,
+        );
+        (
+            StatusCode::OK,
+            Json(BindTopicSchemaResponse {
+                topic: kafka_name,
+                subject: schema.subject,
+                version: schema.version,
+            }),
+        )
+            .into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, name, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    delete,
+    path = "/v1/bus/topics/{namespace}/{tenant}/{name}/schema",
+    tag = "bus",
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("name" = String, Path),
+    ),
+    responses(
+        (status = 204, description = "Binding removed"),
+        (status = 404, description = "Topic not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn unbind_topic_schema(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, name)): Path<(String, String, String)>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageSchema) {
+            return resp;
+        }
+        let kafka_name = format!("{namespace}.{tenant}.{name}");
+        let topic_key = StateKey::new(
+            namespace.clone(),
+            tenant.clone(),
+            KeyKind::BusTopic,
+            &kafka_name,
+        );
+        let gw = state.gateway.read().await;
+        let mut topic: Topic = match gw.state_store().get(&topic_key).await {
+            Ok(Some(raw)) => match serde_json::from_str::<Topic>(&raw) {
+                Ok(t) => t,
+                Err(e) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse {
+                            error: format!("corrupt topic record for {kafka_name}: {e}"),
+                        }),
+                    )
+                        .into_response();
+                }
+            },
+            Ok(None) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse {
+                        error: format!("topic {kafka_name} not found"),
+                    }),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        topic.schema_subject = None;
+        topic.schema_version = None;
+        topic.updated_at = Utc::now();
+        let payload = match serde_json::to_string(&topic) {
+            Ok(s) => s,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        if let Err(e) = gw.state_store().set(&topic_key, &payload, None).await {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        StatusCode::NO_CONTENT.into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, name);
+        service_unavailable("bus feature not compiled")
     }
 }

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -108,6 +108,11 @@ pub struct AppState {
     /// `[bus].enabled = false`).
     #[cfg(feature = "bus")]
     pub bus_backend: Option<acteon_bus::SharedBackend>,
+    /// Compiled-schema registry for publish-edge validation. Always
+    /// constructed with the bus feature; stays empty until schemas are
+    /// registered.
+    #[cfg(feature = "bus")]
+    pub bus_schema_validator: acteon_bus::SchemaValidator,
 }
 
 /// Build the Axum router with all API routes, middleware, and Swagger UI.
@@ -325,6 +330,25 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/v1/bus/subscriptions/{namespace}/{tenant}/{id}/deadletter",
             post(bus::deadletter_subscription),
+        )
+        // Phase 3: JSON-Schema registry + topic binding. Tenant-scoped
+        // URLs keep state lookups O(1) and make authorization surfaces
+        // explicit, matching topics and subscriptions.
+        .route(
+            "/v1/bus/schemas",
+            get(bus::list_schemas).post(bus::create_schema),
+        )
+        .route(
+            "/v1/bus/schemas/{namespace}/{tenant}/{subject}",
+            get(bus::get_subject_versions),
+        )
+        .route(
+            "/v1/bus/schemas/{namespace}/{tenant}/{subject}/{version}",
+            get(bus::get_schema_version).delete(bus::delete_schema_version),
+        )
+        .route(
+            "/v1/bus/topics/{namespace}/{tenant}/{name}/schema",
+            put(bus::bind_topic_schema).delete(bus::unbind_topic_schema),
         )
         // Swarm runs
         .route("/v1/swarm/runs", get(swarm::list_swarm_runs))

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -169,6 +169,13 @@ use acteon_core::{
         super::bus::ack_subscription,
         super::bus::subscription_lag,
         super::bus::deadletter_subscription,
+        super::bus::create_schema,
+        super::bus::list_schemas,
+        super::bus::get_subject_versions,
+        super::bus::get_schema_version,
+        super::bus::delete_schema_version,
+        super::bus::bind_topic_schema,
+        super::bus::unbind_topic_schema,
     ),
     components(schemas(
         Action, ActionOutcome, ProviderResponse, ResponseStatus, ActionError,
@@ -232,6 +239,10 @@ use acteon_core::{
         super::bus::ListSubscriptionsResponse, super::bus::AckRequest,
         super::bus::AckResponse, super::bus::LagEntry, super::bus::LagResponse,
         super::bus::DeadLetterRequest, super::bus::DeadLetterResponse,
+        super::bus::CreateSchemaRequest, super::bus::SchemaResponse,
+        super::bus::ListSchemasResponse, super::bus::BindTopicSchemaRequest,
+        super::bus::BindTopicSchemaResponse, super::bus::SchemaValidationErrorResponse,
+        super::bus::SchemaValidationIssueDto,
     ))
 )]
 pub struct ApiDoc;

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -2335,6 +2335,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         swarm_registry,
         #[cfg(feature = "bus")]
         bus_backend,
+        #[cfg(feature = "bus")]
+        bus_schema_validator: acteon_bus::SchemaValidator::new(),
     };
     let app = acteon_server::api::router(state);
 

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -212,5 +212,9 @@ required-features = ["bus"]
 name = "bus_subscription_simulation"
 required-features = ["bus"]
 
+[[example]]
+name = "bus_schema_simulation"
+required-features = ["bus"]
+
 [lints]
 workspace = true

--- a/crates/simulation/examples/bus_schema_simulation.rs
+++ b/crates/simulation/examples/bus_schema_simulation.rs
@@ -1,0 +1,113 @@
+//! Phase 3 schema-registry + publish-edge validation demo.
+//!
+//! Runs entirely against the in-memory bus backend plus a compiled
+//! [`SchemaValidator`], so no Kafka or HTTP server is required. The
+//! same validator lives behind `/v1/bus/publish` in production; this
+//! example exercises the shared code path end-to-end.
+//!
+//! Scenarios:
+//!
+//! 1. Register `orders` v1.
+//! 2. Validate a conforming payload — accepted.
+//! 3. Validate a non-conforming payload — rejected with per-field
+//!    JSON-Pointer paths.
+//! 4. Register a stricter `orders` v2 that requires a new `sku` field.
+//! 5. Re-validate the v1 payload against v2 — rejected; confirm v1
+//!    still accepts it (versions are independent).
+//! 6. Remove v1 from the validator cache (simulating a deletion after
+//!    unbinding) — further v1 validations return `NotFound`.
+//!
+//! Run with:
+//! ```text
+//! cargo run -p acteon-simulation --features bus --example bus_schema_simulation
+//! ```
+
+use acteon_bus::{SchemaValidator, SchemaValidatorError};
+use serde_json::json;
+use tracing::{Level, info, warn};
+
+fn orders_v1() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "required": ["id", "qty"],
+        "properties": {
+            "id": {"type": "string"},
+            "qty": {"type": "integer", "minimum": 1}
+        }
+    })
+}
+
+fn orders_v2() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "required": ["id", "qty", "sku"],
+        "properties": {
+            "id": {"type": "string"},
+            "qty": {"type": "integer", "minimum": 1},
+            "sku": {"type": "string", "pattern": "^[A-Z]{3}-[0-9]+$"}
+        }
+    })
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::INFO)
+        .with_env_filter("info,acteon_bus=info")
+        .init();
+
+    let validator = SchemaValidator::new();
+
+    // 1. Register orders v1.
+    info!("registering schema orders v1");
+    validator.register("agents", "demo", "orders", 1, &orders_v1())?;
+
+    // 2. Valid payload.
+    let good = json!({"id": "ord-1", "qty": 2});
+    info!(payload = %good, "validating conforming payload");
+    validator.validate("agents", "demo", "orders", 1, &good)?;
+    info!("v1 accepted the payload");
+
+    // 3. Invalid payload — missing required field.
+    let bad = json!({"id": "ord-2"});
+    info!(payload = %bad, "validating non-conforming payload");
+    match validator.validate("agents", "demo", "orders", 1, &bad) {
+        Err(SchemaValidatorError::InvalidPayload(issues)) => {
+            warn!(count = issues.len(), "payload rejected");
+            for issue in &issues {
+                warn!(path = %issue.path, message = %issue.message, "schema issue");
+            }
+        }
+        other => return Err(format!("expected InvalidPayload, got {other:?}").into()),
+    }
+
+    // 4. Register stricter v2.
+    info!("registering schema orders v2 (adds sku)");
+    validator.register("agents", "demo", "orders", 2, &orders_v2())?;
+
+    // 5. Versions are independent.
+    let without_sku = json!({"id": "ord-3", "qty": 1});
+    match validator.validate("agents", "demo", "orders", 2, &without_sku) {
+        Err(e) => warn!(error = %e, "v2 rejects payloads that v1 accepts"),
+        Ok(()) => return Err("v2 should have rejected payload missing sku".into()),
+    }
+    validator.validate("agents", "demo", "orders", 1, &without_sku)?;
+    info!("v1 still accepts the same payload — versions are independent");
+
+    let full = json!({"id": "ord-4", "qty": 3, "sku": "ABC-42"});
+    validator.validate("agents", "demo", "orders", 2, &full)?;
+    info!("v2 accepts payloads with a well-formed sku");
+
+    // 6. Remove v1 — subsequent validations return NotFound.
+    validator.remove("agents", "demo", "orders", 1);
+    match validator.validate("agents", "demo", "orders", 1, &good) {
+        Err(SchemaValidatorError::NotFound { .. }) => {
+            info!(
+                "v1 no longer cached after remove(); the server layer recompiles on next publish"
+            );
+        }
+        other => return Err(format!("expected NotFound, got {other:?}").into()),
+    }
+
+    info!("schema simulation complete");
+    Ok(())
+}

--- a/crates/state/state/src/key.rs
+++ b/crates/state/state/src/key.rs
@@ -60,6 +60,8 @@ pub enum KeyKind {
     BusTopic,
     /// Bus subscription metadata (Phase 2 of the agentic bus).
     BusSubscription,
+    /// Bus payload schema (Phase 3 of the agentic bus).
+    BusSchema,
     Custom(String),
 }
 
@@ -98,6 +100,7 @@ impl KeyKind {
             Self::TimeInterval => "time_interval",
             Self::BusTopic => "bus_topic",
             Self::BusSubscription => "bus_subscription",
+            Self::BusSchema => "bus_schema",
             Self::Custom(s) => s.as_str(),
         }
     }
@@ -196,6 +199,7 @@ mod tests {
         assert_eq!(KeyKind::TimeInterval.as_str(), "time_interval");
         assert_eq!(KeyKind::BusTopic.as_str(), "bus_topic");
         assert_eq!(KeyKind::BusSubscription.as_str(), "bus_subscription");
+        assert_eq!(KeyKind::BusSchema.as_str(), "bus_schema");
         assert_eq!(KeyKind::Custom("foo".into()).as_str(), "foo");
     }
 

--- a/docs/book/features/bus-phase-3.md
+++ b/docs/book/features/bus-phase-3.md
@@ -1,0 +1,182 @@
+# Agentic Bus — Phase 3
+
+> **Scope:** JSON-Schema registry, publish-edge validation, typed SDK
+> helpers. Agents, conversations, and tool-call envelopes come later.
+> See the [master plan](../concepts/bus-master-plan.md).
+
+Phase 1 gave us topics + publish + SSE subscribe. Phase 2 added durable
+subscriptions with ack, lag, and DLQ. Phase 3 moves Acteon up from
+"arbitrary JSON on the wire" to a schema-aware control plane: register
+a schema, bind a topic to it, and let the publish edge enforce the
+contract for you.
+
+## What ships in Phase 3
+
+| Surface | Shape |
+|---|---|
+| Core type | `acteon_core::Schema` — `{subject, version, namespace, tenant, format, body, labels, created_at}` |
+| State | `KeyKind::BusSchema`; key id = `"{subject}:{version}"` |
+| Validator | `acteon_bus::SchemaValidator` — compiled-schema cache keyed by `(namespace, tenant, subject, version)`. Uses the `jsonschema` crate (draft 2020-12). |
+| HTTP | `POST/GET /v1/bus/schemas`, `GET /v1/bus/schemas/{ns}/{t}/{subject}`, `GET|DELETE /v1/bus/schemas/{ns}/{t}/{subject}/{version}`, `PUT|DELETE /v1/bus/topics/{ns}/{t}/{name}/schema` |
+| Rust client | `register_bus_schema`, `list_bus_schemas`, `get_bus_schema_versions`, `get_bus_schema`, `delete_bus_schema`, `bind_topic_schema`, `unbind_topic_schema`, `publish_typed` |
+| Tests | 7 validator unit tests (register/validate/versioning/remove/compile-fail) |
+| Simulation | `bus_schema_simulation.rs` — registers v1 and v2, demonstrates acceptance, rejection-with-paths, and version independence |
+
+## Model
+
+- **Subjects are logical names.** `"orders"`, `"tool-calls"`,
+  `"agent-events"`. Scoped per `(namespace, tenant)`.
+- **Versions are monotonic integers, assigned by the server.**
+  `POST /v1/bus/schemas` with `subject = "orders"` picks `max(version) + 1`
+  (or 1 if none exist). Schemas are immutable once registered.
+- **Topics opt into validation.** A `Topic` has
+  `schema_subject: Option<String>` and `schema_version: Option<i32>`.
+  Bound → validate on every publish; unbound → no validation.
+- **No compatibility checker in V1.** `POST` accepts any body that
+  compiles as a JSON Schema. Backward/forward compat enforcement is a
+  future concern; ship what we need now.
+
+## API shape
+
+### Register a schema version
+
+```http
+POST /v1/bus/schemas
+{
+  "subject": "orders",
+  "namespace": "agents",
+  "tenant": "demo",
+  "body": {
+    "type": "object",
+    "required": ["id", "qty"],
+    "properties": {
+      "id": {"type": "string"},
+      "qty": {"type": "integer", "minimum": 1}
+    }
+  }
+}
+→ 201 SchemaResponse { subject: "orders", version: 1, ... }
+```
+
+Post the same subject again and you get version 2. The server compiles
+the body first — a malformed JSON-Schema document returns `400` before
+touching state.
+
+### Bind a topic
+
+```http
+PUT /v1/bus/topics/agents/demo/orders/schema
+{ "subject": "orders", "version": 1 }
+→ 200 { "topic": "agents.demo.orders", "subject": "orders", "version": 1 }
+```
+
+A topic can bind to any registered version. Pin to a specific version
+for strict control; pass `"latest"` on the SDK's `get_bus_schema` if
+you want to read the latest but still pin the binding explicitly.
+
+### Publish validation
+
+Once bound, every publish against that topic runs through the compiled
+validator. Conforming payloads produce as before. Non-conforming
+payloads return `400`:
+
+```http
+POST /v1/bus/publish
+{
+  "topic": "agents.demo.orders",
+  "payload": { "id": "ord-1" }
+}
+→ 400 {
+  "error": "payload does not match schema 'orders' v1",
+  "subject": "orders",
+  "version": 1,
+  "issues": [
+    { "path": "", "message": "\"qty\" is a required property" }
+  ]
+}
+```
+
+Up to 10 issues are returned per response. `path` is a JSON Pointer
+into the payload (e.g. `/items/3/qty`), so clients can pinpoint the
+offending field without re-running a local validator.
+
+### Unbind
+
+```http
+DELETE /v1/bus/topics/agents/demo/orders/schema
+→ 204
+```
+
+Subsequent publishes bypass validation. The schema object itself is
+not deleted — call `DELETE /v1/bus/schemas/...` if you want that too.
+
+### Delete a schema version
+
+```http
+DELETE /v1/bus/schemas/agents/demo/orders/1
+→ 204
+```
+
+Fails with `409 Conflict` if any topic currently pins this version.
+Unbind first, then delete.
+
+## SDK example
+
+```rust
+use acteon_client::{ActeonClient, RegisterBusSchema};
+
+let client = ActeonClient::new("http://localhost:3000")?;
+
+// Register.
+let schema = client.register_bus_schema(&RegisterBusSchema {
+    subject: "orders".to_string(),
+    namespace: "agents".to_string(),
+    tenant: "demo".to_string(),
+    body: serde_json::json!({ "type": "object", "required": ["id"] }),
+    ..Default::default()
+}).await?;
+
+// Bind.
+client.bind_topic_schema("agents", "demo", "orders", "orders", schema.version).await?;
+
+// Typed publish — serializes your value, validates, produces.
+#[derive(serde::Serialize)]
+struct Order { id: String, qty: i32 }
+
+client.publish_typed(&acteon_client::PublishTyped {
+    value: &Order { id: "ord-1".into(), qty: 2 },
+    topic: Some("agents.demo.orders"),
+    ..Default::default()
+}).await?;
+```
+
+## Validator cache semantics
+
+Compiled validators live in an in-memory cache on the server
+(`AppState::bus_schema_validator`). On cold-start or after an explicit
+`remove`, the publish path reads the schema row from state and
+recompiles on demand. This means:
+
+- **State is the source of truth.** Restart the server and validation
+  keeps working.
+- **Cache writes are lazy.** The first publish after restart pays one
+  recompile per subject; subsequent publishes hit the warm cache.
+- **Unbinding doesn't invalidate the cache.** Binding a topic to a new
+  subject simply stops consulting the old one.
+
+## How to try it
+
+```bash
+# No broker required — the simulation runs entirely against the
+# in-memory validator.
+cargo run -p acteon-simulation --features bus --example bus_schema_simulation
+```
+
+For an end-to-end HTTP flow, start the server with the bus feature
+enabled and use the SDK methods above.
+
+## What comes next (Phase 4)
+
+- `Agent` type — identity, capabilities, heartbeat, and the shared
+  inbox topic keyed by `agent_id`.
+- Per-agent schema selection for inbound tool-call envelopes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -185,6 +185,7 @@ nav:
     - Master Plan: concepts/bus-master-plan.md
     - Phase 1 (Topics + Publish + Subscribe): features/bus-phase-1.md
     - Phase 2 (Subscriptions + Ack + Lag + DLQ): features/bus-phase-2.md
+    - Phase 3 (Schemas + Publish Validation): features/bus-phase-3.md
   - Guides:
     - guides/index.md
     - AI Agent Swarm Coordination: guides/agent-swarm-coordination.md


### PR DESCRIPTION
## Summary

Phase 3 of the agentic bus. Adds the schema-aware layer on top of the transport (Phase 1) and durable-subscription (Phase 2) surfaces.

- **Schema registry** — `acteon_core::Schema`, stored under `KeyKind::BusSchema` keyed by `\"{subject}:{version}\"`. Versions are monotonic and assigned server-side. Immutable once registered.
- **Compiled-schema validator** — `acteon_bus::SchemaValidator` wraps the `jsonschema` crate (draft 2020-12) with an `(namespace, tenant, subject, version)`-keyed cache. Returns up to 10 structured `ValidationIssue`s with JSON Pointer paths on failure.
- **Publish-edge enforcement** — when a topic is bound to a subject+version, every `POST /v1/bus/publish` loads the topic, ensures the validator is compiled (rehydrating from state on cold cache), and validates the payload. Rejections surface a dedicated `SchemaValidationErrorResponse` with per-issue paths.
- **Tenant-scoped URLs** — `POST/GET /v1/bus/schemas`, `GET /v1/bus/schemas/{ns}/{t}/{subject}`, `GET|DELETE /v1/bus/schemas/{ns}/{t}/{subject}/{version}` (also accepts `\"latest\"`), `PUT|DELETE /v1/bus/topics/{ns}/{t}/{name}/schema`. All authorized via `BusOp::ManageSchema`.
- **Governance** — malformed schema bodies fail fast with 400; deleting a version that a topic currently pins returns 409 (unbind first).
- **Rust SDK** — `register_bus_schema`, `list_bus_schemas`, `get_bus_schema_versions`, `get_bus_schema`, `delete_bus_schema`, `bind_topic_schema`, `unbind_topic_schema`, plus a typed `publish_typed<T: Serialize>` convenience.
- **Simulation + docs** — `bus_schema_simulation.rs` (runs without Kafka; exercises the validator directly) and `docs/book/features/bus-phase-3.md`.

## Design notes

- **No compatibility checker in V1.** We ship what's needed: monotonic versioning and per-version immutability. Backward/forward compat enforcement is a future concern — easy to layer on.
- **State is the source of truth.** The compiled-validator cache is process-local; restarts or explicit `remove()` calls cause lazy recompilation from state on the next publish.
- **Bindings live on the `Topic`.** A separate `SchemaBinding` object would buy nothing — the common case is one binding per topic, looked up at publish time, and we already have the topic row loaded.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --no-deps -- -D warnings`
- [x] `cargo clippy -p acteon-server --features bus --no-deps -- -D warnings`
- [x] `cargo test --workspace --lib --bins --tests` (all green; only flake is a pre-existing parallel-tmpdir race in `acteon-wasm-runtime::registry::tests::load_empty_plugin_dir`, unrelated — passes in isolation)
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps`
- [x] `cargo check --all-targets`
- [x] `cd ui && npm run lint && npm run build`
- [x] `cargo run -p acteon-simulation --features bus --example bus_schema_simulation` — passes end-to-end

## Polyglot SDKs

Phase 3 client parity across Python/Node/Go/Java is deferred to Phase 8 per the [master plan](../blob/main/docs/book/concepts/bus-master-plan.md) (5-SDK parity for the entire bus surface lands together). Rust client ships here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)