### PR TITLE
feat(bus): Phase 4 — Agent identity, shared inbox, heartbeat

### DIFF
--- a/crates/client/src/bus.rs
+++ b/crates/client/src/bus.rs
@@ -662,6 +662,180 @@ impl ActeonClient {
             encode_segment(topic_name)
         )
     }
+
+    // ----- Phase 4: agents -----
+
+    /// Register an agent. First agent in a `(namespace, tenant)`
+    /// causes the shared inbox topic `{ns}.{tenant}.agents-inbox` to
+    /// be auto-created.
+    pub async fn register_bus_agent(&self, req: &RegisterBusAgent) -> Result<BusAgent, Error> {
+        let url = format!("{}/v1/bus/agents", self.base_url);
+        let resp = self
+            .add_auth(self.client.post(&url))
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusAgent>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// List agents, optionally filtered by namespace/tenant/capability/status.
+    pub async fn list_bus_agents(
+        &self,
+        filter: &BusAgentFilter,
+    ) -> Result<ListBusAgentsResponse, Error> {
+        let url = format!("{}/v1/bus/agents", self.base_url);
+        let resp = self
+            .add_auth(self.client.get(&url))
+            .query(filter)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<ListBusAgentsResponse>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Fetch a single agent record.
+    pub async fn get_bus_agent(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        agent_id: &str,
+    ) -> Result<BusAgent, Error> {
+        let url = self.agent_url(namespace, tenant, agent_id, None);
+        let resp = self
+            .add_auth(self.client.get(&url))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusAgent>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Patch-style update of the mutable fields on an agent record.
+    pub async fn update_bus_agent(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        agent_id: &str,
+        req: &UpdateBusAgent,
+    ) -> Result<BusAgent, Error> {
+        let url = self.agent_url(namespace, tenant, agent_id, None);
+        let resp = self
+            .add_auth(self.client.put(&url))
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusAgent>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Delete an agent record. The shared inbox topic is left in
+    /// place — other agents in the tenant may still need it.
+    pub async fn delete_bus_agent(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        agent_id: &str,
+    ) -> Result<(), Error> {
+        let url = self.agent_url(namespace, tenant, agent_id, None);
+        let resp = self
+            .add_auth(self.client.delete(&url))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Record a heartbeat. Agents typically call this once per
+    /// `heartbeat_ttl_ms / 3` to stay `Online`.
+    pub async fn heartbeat_bus_agent(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        agent_id: &str,
+    ) -> Result<BusAgentHeartbeat, Error> {
+        let url = self.agent_url(namespace, tenant, agent_id, Some("heartbeat"));
+        let resp = self
+            .add_auth(self.client.post(&url))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusAgentHeartbeat>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Deliver a message to the agent's inbox. Keyed by `agent_id` so
+    /// Kafka routes to a stable partition per agent.
+    pub async fn send_to_bus_agent(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        agent_id: &str,
+        req: &SendToBusAgent,
+    ) -> Result<BusAgentSendReceipt, Error> {
+        let url = self.agent_url(namespace, tenant, agent_id, Some("send"));
+        let resp = self
+            .add_auth(self.client.post(&url))
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusAgentSendReceipt>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    fn agent_url(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        agent_id: &str,
+        suffix: Option<&str>,
+    ) -> String {
+        let ns = encode_segment(namespace);
+        let t = encode_segment(tenant);
+        let a = encode_segment(agent_id);
+        match suffix {
+            Some(s) => format!("{}/v1/bus/agents/{ns}/{t}/{a}/{s}", self.base_url),
+            None => format!("{}/v1/bus/agents/{ns}/{t}/{a}", self.base_url),
+        }
+    }
 }
 
 // ----- Phase 3: DTOs -----
@@ -731,6 +905,100 @@ pub struct PublishTyped<'a, T: serde::Serialize> {
     pub name: Option<&'a str>,
     pub key: Option<&'a str>,
     pub headers: BTreeMap<String, String>,
+}
+
+// ----- Phase 4: agent DTOs -----
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct RegisterBusAgent {
+    pub agent_id: String,
+    pub namespace: String,
+    pub tenant: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inbox_topic: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heartbeat_ttl_ms: Option<i64>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub labels: HashMap<String, String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct UpdateBusAgent {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inbox_topic: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heartbeat_ttl_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BusAgent {
+    pub agent_id: String,
+    pub namespace: String,
+    pub tenant: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    pub inbox_topic: String,
+    pub heartbeat_ttl_ms: i64,
+    #[serde(default)]
+    pub last_heartbeat_at: Option<String>,
+    pub status: String,
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListBusAgentsResponse {
+    pub agents: Vec<BusAgent>,
+    pub count: usize,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct BusAgentFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capability: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BusAgentHeartbeat {
+    pub agent_id: String,
+    pub last_heartbeat_at: String,
+    pub status: String,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct SendToBusAgent {
+    pub payload: serde_json::Value,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BusAgentSendReceipt {
+    pub inbox_topic: String,
+    pub agent_id: String,
+    pub partition: i32,
+    pub offset: i64,
+    pub produced_at: String,
 }
 
 async fn map_error(resp: reqwest::Response) -> Error {

--- a/crates/core/src/bus_agent.rs
+++ b/crates/core/src/bus_agent.rs
@@ -1,0 +1,359 @@
+//! Bus agent — identity + capabilities + heartbeat for an AI-agent
+//! participant on the bus (Phase 4).
+//!
+//! Agents share one inbox topic per `(namespace, tenant)` — named
+//! `{namespace}.{tenant}.agents-inbox` by default — rather than owning
+//! a topic each. Messages to a specific agent are produced with
+//! `key = agent_id`, so Kafka's key-based partitioning gives each
+//! agent a stable partition and per-agent FIFO ordering without any
+//! subscription gymnastics.
+//!
+//! Status is **derived** from `last_heartbeat_at + heartbeat_ttl_ms`
+//! on every read rather than via a background reaper. That keeps
+//! Phase 4 free of new timers; the trade-off is that "dead" agent
+//! records stay in state until an operator explicitly deletes them.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Default inbox topic suffix. Combined with `{namespace}.{tenant}.` to
+/// form the Kafka topic name all agents in that tenant share.
+pub const DEFAULT_AGENT_INBOX_SUFFIX: &str = "agents-inbox";
+
+/// Default heartbeat TTL: an agent that hasn't pinged in 60s is
+/// reported as `Idle`; twice that and it's `Dead`. Chosen to be large
+/// enough that a long GC pause or brief network blip doesn't flip an
+/// otherwise healthy agent.
+pub const DEFAULT_HEARTBEAT_TTL_MS: i64 = 60_000;
+
+/// Liveness status, computed on read from the last heartbeat.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum AgentStatus {
+    /// Heartbeat within the TTL window — agent is live.
+    Online,
+    /// Heartbeat is stale but not long enough to declare dead (within
+    /// `2 * heartbeat_ttl_ms` of now). Operators often want to route
+    /// around idle agents without erasing them.
+    Idle,
+    /// Heartbeat older than `2 * heartbeat_ttl_ms`. Treat as unreachable.
+    Dead,
+    /// Never received a heartbeat since registration. Distinguishes
+    /// fresh registrations from actually-failed agents.
+    Unknown,
+}
+
+/// A bus-resident agent identity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct Agent {
+    /// Stable identifier (e.g. `"planner-01"`). Used as the Kafka
+    /// partition key when messages are sent to the inbox topic.
+    pub agent_id: String,
+    /// Namespace the agent belongs to.
+    pub namespace: String,
+    /// Tenant that owns the agent.
+    pub tenant: String,
+    /// Human-readable display name.
+    #[serde(default)]
+    pub display_name: Option<String>,
+    /// Capabilities the agent advertises (e.g. `["tool.calendar",
+    /// "ocr", "web-search"]`). Discoverable via the `capability=`
+    /// list filter.
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    /// Kafka topic the agent reads its inbox from. Defaults to
+    /// `{namespace}.{tenant}.agents-inbox` when unset.
+    #[serde(default)]
+    pub inbox_topic: Option<String>,
+    /// Heartbeat TTL in milliseconds. Within `ttl` = `Online`; within
+    /// `2*ttl` = `Idle`; beyond = `Dead`.
+    #[serde(default = "default_heartbeat_ttl_ms")]
+    pub heartbeat_ttl_ms: i64,
+    /// Last heartbeat the server has seen. `None` until the first
+    /// heartbeat arrives.
+    #[serde(default)]
+    pub last_heartbeat_at: Option<DateTime<Utc>>,
+    /// Free-form operator labels.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub labels: HashMap<String, String>,
+    /// Registration time.
+    pub created_at: DateTime<Utc>,
+    /// Last time the agent record was mutated (register / update /
+    /// heartbeat).
+    pub updated_at: DateTime<Utc>,
+}
+
+fn default_heartbeat_ttl_ms() -> i64 {
+    DEFAULT_HEARTBEAT_TTL_MS
+}
+
+impl Agent {
+    /// Construct an agent with sensible defaults.
+    #[must_use]
+    pub fn new(
+        agent_id: impl Into<String>,
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            agent_id: agent_id.into(),
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            display_name: None,
+            capabilities: Vec::new(),
+            inbox_topic: None,
+            heartbeat_ttl_ms: default_heartbeat_ttl_ms(),
+            last_heartbeat_at: None,
+            labels: HashMap::new(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Canonical Kafka topic name the agent reads from. Falls back to
+    /// the default `{namespace}.{tenant}.agents-inbox` when
+    /// `inbox_topic` is unset.
+    #[must_use]
+    pub fn effective_inbox_topic(&self) -> String {
+        self.inbox_topic.clone().unwrap_or_else(|| {
+            format!(
+                "{}.{}.{}",
+                self.namespace, self.tenant, DEFAULT_AGENT_INBOX_SUFFIX
+            )
+        })
+    }
+
+    /// Stable state-store id. The `agent_id` alone is unique within a
+    /// `(namespace, tenant)` and is already included in the `StateKey`'s
+    /// higher-level scope.
+    #[must_use]
+    pub fn id(&self) -> String {
+        self.agent_id.clone()
+    }
+
+    /// Derive the liveness status from `last_heartbeat_at` + TTL as of
+    /// `now`.
+    #[must_use]
+    pub fn status_at(&self, now: DateTime<Utc>) -> AgentStatus {
+        let Some(last) = self.last_heartbeat_at else {
+            return AgentStatus::Unknown;
+        };
+        let age_ms = (now - last).num_milliseconds();
+        if age_ms < 0 {
+            // Clock skew — treat as fresh.
+            return AgentStatus::Online;
+        }
+        if age_ms <= self.heartbeat_ttl_ms {
+            AgentStatus::Online
+        } else if age_ms <= self.heartbeat_ttl_ms.saturating_mul(2) {
+            AgentStatus::Idle
+        } else {
+            AgentStatus::Dead
+        }
+    }
+
+    /// Convenience — [`Self::status_at`] with `Utc::now()`.
+    #[must_use]
+    pub fn status(&self) -> AgentStatus {
+        self.status_at(Utc::now())
+    }
+
+    /// Validate the agent's identity fields.
+    pub fn validate(&self) -> Result<(), AgentValidationError> {
+        Self::validate_id(&self.agent_id)?;
+        Self::validate_fragment(&self.namespace)?;
+        Self::validate_fragment(&self.tenant)?;
+        if self.heartbeat_ttl_ms < 1_000 {
+            return Err(AgentValidationError::HeartbeatTtlTooShort(
+                self.heartbeat_ttl_ms,
+            ));
+        }
+        for cap in &self.capabilities {
+            Self::validate_capability(cap)?;
+        }
+        Ok(())
+    }
+
+    /// Agent IDs allow a slightly richer alphabet than topic fragments
+    /// (dots are allowed so hierarchical names like `"planner.main"`
+    /// work), but still no slashes or whitespace — the id goes into
+    /// both state keys and URL paths.
+    pub fn validate_id(s: &str) -> Result<(), AgentValidationError> {
+        if s.is_empty() {
+            return Err(AgentValidationError::EmptyId);
+        }
+        if s.len() > 120 {
+            return Err(AgentValidationError::IdTooLong);
+        }
+        if !s
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+        {
+            return Err(AgentValidationError::InvalidIdChar(s.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Namespace/tenant rules — reuses the topic fragment alphabet so
+    /// the generated inbox topic name is always valid.
+    pub fn validate_fragment(s: &str) -> Result<(), AgentValidationError> {
+        if s.is_empty() {
+            return Err(AgentValidationError::EmptyFragment);
+        }
+        if s.len() > 80 {
+            return Err(AgentValidationError::FragmentTooLong);
+        }
+        if !s
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(AgentValidationError::InvalidFragmentChar(s.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Capability tokens are dotted names like `"tool.calendar"` —
+    /// same alphabet as agent IDs.
+    pub fn validate_capability(s: &str) -> Result<(), AgentValidationError> {
+        if s.is_empty() {
+            return Err(AgentValidationError::EmptyCapability);
+        }
+        if s.len() > 120 {
+            return Err(AgentValidationError::CapabilityTooLong);
+        }
+        if !s
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+        {
+            return Err(AgentValidationError::InvalidCapabilityChar(s.to_string()));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum AgentValidationError {
+    #[error("agent_id must not be empty")]
+    EmptyId,
+    #[error("agent_id exceeds 120 characters")]
+    IdTooLong,
+    #[error("agent_id '{0}' contains characters outside [a-zA-Z0-9._-]")]
+    InvalidIdChar(String),
+    #[error("namespace/tenant fragment must not be empty")]
+    EmptyFragment,
+    #[error("namespace/tenant fragment exceeds 80 characters")]
+    FragmentTooLong,
+    #[error("namespace/tenant fragment '{0}' contains characters outside [a-zA-Z0-9_-]")]
+    InvalidFragmentChar(String),
+    #[error("capability token must not be empty")]
+    EmptyCapability,
+    #[error("capability token exceeds 120 characters")]
+    CapabilityTooLong,
+    #[error("capability token '{0}' contains characters outside [a-zA-Z0-9._-]")]
+    InvalidCapabilityChar(String),
+    #[error("heartbeat_ttl_ms must be >= 1000 (got {0})")]
+    HeartbeatTtlTooShort(i64),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    #[test]
+    fn effective_inbox_topic_defaults_when_unset() {
+        let a = Agent::new("planner-1", "agents", "demo");
+        assert_eq!(a.effective_inbox_topic(), "agents.demo.agents-inbox");
+    }
+
+    #[test]
+    fn effective_inbox_topic_honors_override() {
+        let mut a = Agent::new("planner-1", "agents", "demo");
+        a.inbox_topic = Some("agents.demo.planners".to_string());
+        assert_eq!(a.effective_inbox_topic(), "agents.demo.planners");
+    }
+
+    #[test]
+    fn status_unknown_before_first_heartbeat() {
+        let a = Agent::new("p", "ns", "t");
+        assert_eq!(a.status(), AgentStatus::Unknown);
+    }
+
+    #[test]
+    fn status_online_within_ttl() {
+        let mut a = Agent::new("p", "ns", "t");
+        let now = Utc::now();
+        a.last_heartbeat_at = Some(now - Duration::milliseconds(5_000));
+        // default ttl 60s → 5s < 60s → Online
+        assert_eq!(a.status_at(now), AgentStatus::Online);
+    }
+
+    #[test]
+    fn status_idle_after_single_ttl() {
+        let mut a = Agent::new("p", "ns", "t");
+        let now = Utc::now();
+        a.last_heartbeat_at = Some(now - Duration::milliseconds(70_000));
+        // 70s > 60s (online) but < 120s (dead) → Idle
+        assert_eq!(a.status_at(now), AgentStatus::Idle);
+    }
+
+    #[test]
+    fn status_dead_after_double_ttl() {
+        let mut a = Agent::new("p", "ns", "t");
+        let now = Utc::now();
+        a.last_heartbeat_at = Some(now - Duration::milliseconds(300_000));
+        assert_eq!(a.status_at(now), AgentStatus::Dead);
+    }
+
+    #[test]
+    fn validate_rejects_short_ttl() {
+        let mut a = Agent::new("p", "ns", "t");
+        a.heartbeat_ttl_ms = 500;
+        assert_eq!(
+            a.validate(),
+            Err(AgentValidationError::HeartbeatTtlTooShort(500))
+        );
+    }
+
+    #[test]
+    fn validate_rejects_slash_in_id() {
+        let a = Agent::new("a/b", "ns", "t");
+        assert!(matches!(
+            a.validate(),
+            Err(AgentValidationError::InvalidIdChar(_))
+        ));
+    }
+
+    #[test]
+    fn validate_accepts_dotted_id() {
+        let a = Agent::new("planner.main", "ns", "t");
+        a.validate().unwrap();
+    }
+
+    #[test]
+    fn validate_rejects_invalid_capability() {
+        let mut a = Agent::new("p", "ns", "t");
+        a.capabilities.push("bad cap".to_string());
+        assert!(matches!(
+            a.validate(),
+            Err(AgentValidationError::InvalidCapabilityChar(_))
+        ));
+    }
+
+    #[test]
+    fn roundtrip_serde() {
+        let mut a = Agent::new("p", "ns", "t");
+        a.capabilities.push("ocr".to_string());
+        a.labels.insert("owner".into(), "ml-team".into());
+        let j = serde_json::to_string(&a).unwrap();
+        let back: Agent = serde_json::from_str(&j).unwrap();
+        assert_eq!(back.agent_id, a.agent_id);
+        assert_eq!(back.capabilities, a.capabilities);
+        assert_eq!(back.labels, a.labels);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod action;
 pub mod analytics;
 pub mod attachment;
+pub mod bus_agent;
 pub mod bus_schema;
 pub mod bus_subscription;
 pub mod bus_topic;
@@ -34,6 +35,9 @@ pub use analytics::{
     AnalyticsTopEntry,
 };
 pub use attachment::{Attachment, ResolvedAttachment};
+pub use bus_agent::{
+    Agent, AgentStatus, AgentValidationError, DEFAULT_AGENT_INBOX_SUFFIX, DEFAULT_HEARTBEAT_TTL_MS,
+};
 pub use bus_schema::{Schema, SchemaFormat, SchemaValidationError};
 pub use bus_subscription::{
     AckMode, PartitionLag, StartOffset as SubscriptionStartOffset, Subscription,

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -69,6 +69,7 @@ fn authorize_bus_op(
         BusOp::Publish => (Permission::Dispatch, "publish"),
         BusOp::Subscribe => (Permission::StreamSubscribe, "subscribe"),
         BusOp::ManageSchema => (Permission::Dispatch, "schema"),
+        BusOp::ManageAgent => (Permission::Dispatch, "agent"),
     };
     if !identity.role.has_permission(permission) {
         return Err((
@@ -106,6 +107,11 @@ enum BusOp {
     Subscribe,
     /// Schema CRUD + topic-binding CRUD (Phase 3).
     ManageSchema,
+    /// Agent CRUD + heartbeat + send-to-agent (Phase 4). Send also
+    /// flows through [`BusOp::Publish`] on the underlying topic so
+    /// operators can restrict *inbox writes* independently of *agent
+    /// registry ops*.
+    ManageAgent,
 }
 
 /// Parse a `namespace.tenant.name` Kafka topic string.
@@ -2691,5 +2697,881 @@ pub async fn unbind_topic_schema(
     {
         let _ = (state, namespace, tenant, name);
         service_unavailable("bus feature not compiled")
+    }
+}
+
+// =============================================================================
+// Phase 4: Agent identity + shared inbox + heartbeat
+// =============================================================================
+
+/// Body of `POST /v1/bus/agents`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct RegisterAgentRequest {
+    pub agent_id: String,
+    pub namespace: String,
+    pub tenant: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    /// Override inbox topic (defaults to
+    /// `{namespace}.{tenant}.agents-inbox`).
+    #[serde(default)]
+    pub inbox_topic: Option<String>,
+    #[serde(default)]
+    pub heartbeat_ttl_ms: Option<i64>,
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+}
+
+/// Body of `PUT /v1/bus/agents/{ns}/{t}/{id}`. Only the mutable fields
+/// appear here — `agent_id`, `namespace`, `tenant`, and `created_at`
+/// are immutable after registration.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateAgentRequest {
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub capabilities: Option<Vec<String>>,
+    #[serde(default)]
+    pub inbox_topic: Option<String>,
+    #[serde(default)]
+    pub heartbeat_ttl_ms: Option<i64>,
+    #[serde(default)]
+    pub labels: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AgentResponse {
+    pub agent_id: String,
+    pub namespace: String,
+    pub tenant: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    pub capabilities: Vec<String>,
+    pub inbox_topic: String,
+    pub heartbeat_ttl_ms: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_heartbeat_at: Option<DateTime<Utc>>,
+    pub status: String,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub labels: HashMap<String, String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListAgentsResponse {
+    pub agents: Vec<AgentResponse>,
+    pub count: usize,
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListAgentsParams {
+    #[serde(default)]
+    pub namespace: Option<String>,
+    #[serde(default)]
+    pub tenant: Option<String>,
+    /// Filter to agents advertising this capability token.
+    #[serde(default)]
+    pub capability: Option<String>,
+    /// Filter by derived status (`online`, `idle`, `dead`, `unknown`).
+    #[serde(default)]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct HeartbeatResponse {
+    pub agent_id: String,
+    pub last_heartbeat_at: DateTime<Utc>,
+    pub status: String,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SendToAgentRequest {
+    /// Free-form payload.
+    #[schema(value_type = Object)]
+    pub payload: serde_json::Value,
+    /// Optional operator-set headers. `acteon.*` keys are reserved.
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SendToAgentResponse {
+    pub inbox_topic: String,
+    pub agent_id: String,
+    pub partition: i32,
+    pub offset: i64,
+    pub produced_at: DateTime<Utc>,
+}
+
+#[cfg(feature = "bus")]
+fn agent_to_response(a: &acteon_core::Agent) -> AgentResponse {
+    AgentResponse {
+        agent_id: a.agent_id.clone(),
+        namespace: a.namespace.clone(),
+        tenant: a.tenant.clone(),
+        display_name: a.display_name.clone(),
+        capabilities: a.capabilities.clone(),
+        inbox_topic: a.effective_inbox_topic(),
+        heartbeat_ttl_ms: a.heartbeat_ttl_ms,
+        last_heartbeat_at: a.last_heartbeat_at,
+        status: agent_status_str(a.status()),
+        labels: a.labels.clone(),
+        created_at: a.created_at,
+        updated_at: a.updated_at,
+    }
+}
+
+#[cfg(feature = "bus")]
+fn agent_status_str(s: acteon_core::AgentStatus) -> String {
+    match s {
+        acteon_core::AgentStatus::Online => "online",
+        acteon_core::AgentStatus::Idle => "idle",
+        acteon_core::AgentStatus::Dead => "dead",
+        acteon_core::AgentStatus::Unknown => "unknown",
+    }
+    .to_string()
+}
+
+/// Ensure the shared inbox topic exists in state + Kafka. Called from
+/// `register_agent` and `send_to_agent` — first agent to register a
+/// `(namespace, tenant)` causes the topic to be auto-created; every
+/// subsequent call is a no-op (state lookup short-circuits).
+///
+/// Returns `Ok(topic_name)` on success. We deliberately `set(&key)`
+/// the row unconditionally after creation: a crash between Kafka
+/// create and state insert would otherwise leave the inbox topic in
+/// Kafka but unregistered in Acteon, which would fail the publish-
+/// edge governance check.
+#[cfg(feature = "bus")]
+async fn ensure_agent_inbox_topic(
+    state: &AppState,
+    namespace: &str,
+    tenant: &str,
+    inbox_topic_name: &str,
+) -> Result<(), axum::response::Response> {
+    let key = StateKey::new(
+        namespace.to_string(),
+        tenant.to_string(),
+        KeyKind::BusTopic,
+        inbox_topic_name,
+    );
+    let Some(backend) = state.bus_backend.as_ref() else {
+        return Err(service_unavailable("bus feature not enabled"));
+    };
+    let gw = state.gateway.read().await;
+    let store = gw.state_store();
+    if matches!(store.get(&key).await, Ok(Some(_))) {
+        return Ok(());
+    }
+    // Derive the leaf name from the Kafka-form topic. Our naming
+    // convention is `{ns}.{tenant}.{leaf}`; the leaf is everything
+    // after the second dot.
+    let leaf_name = inbox_topic_name
+        .splitn(3, '.')
+        .nth(2)
+        .unwrap_or(inbox_topic_name);
+    let topic = Topic::new(leaf_name, namespace, tenant);
+    if let Err(e) = topic.validate() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("invalid inbox topic name '{inbox_topic_name}': {e}"),
+            }),
+        )
+            .into_response());
+    }
+    let body = match serde_json::to_string(&topic) {
+        Ok(b) => b,
+        Err(e) => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response());
+        }
+    };
+    if let Err(e) = store.set(&key, &body, None).await {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response());
+    }
+    drop(gw);
+    if let Err(e) = backend.create_topic(&topic).await {
+        // Already exists (AlreadyExists from admin) is fine — another
+        // agent may have raced the create. Log everything else.
+        if !e.to_string().to_lowercase().contains("alreadyexists") {
+            tracing::warn!(error = %e, topic = %inbox_topic_name, "auto-create of agent inbox topic failed");
+        }
+    }
+    Ok(())
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/agents",
+    tag = "bus",
+    request_body = RegisterAgentRequest,
+    responses(
+        (status = 201, description = "Agent registered", body = AgentResponse),
+        (status = 400, description = "Invalid agent definition", body = ErrorResponse),
+        (status = 409, description = "Agent already exists", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+#[allow(clippy::too_many_lines)]
+pub async fn register_agent(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Json(req): Json<RegisterAgentRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) =
+            authorize_bus_op(&identity, &req.tenant, &req.namespace, BusOp::ManageAgent)
+        {
+            return resp;
+        }
+        let mut agent = acteon_core::Agent::new(&req.agent_id, &req.namespace, &req.tenant);
+        agent.display_name = req.display_name.clone();
+        agent.capabilities = req.capabilities.clone();
+        agent.inbox_topic = req.inbox_topic.clone();
+        if let Some(ttl) = req.heartbeat_ttl_ms {
+            agent.heartbeat_ttl_ms = ttl;
+        }
+        agent.labels = req.labels.clone();
+        if let Err(e) = agent.validate() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        let inbox = agent.effective_inbox_topic();
+        // Require that a custom inbox belongs to the same tenant. Same
+        // check we enforce on subscriptions so an agent can't hijack
+        // another tenant's topic.
+        if let Ok((topic_ns, topic_t, _)) = parse_kafka_name(&inbox)
+            && (topic_ns != agent.namespace || topic_t != agent.tenant)
+        {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "inbox topic {inbox} crosses tenants: must be under {}.{}",
+                        agent.namespace, agent.tenant
+                    ),
+                }),
+            )
+                .into_response();
+        }
+        let key = StateKey::new(
+            agent.namespace.clone(),
+            agent.tenant.clone(),
+            KeyKind::BusAgent,
+            agent.id(),
+        );
+        let gw = state.gateway.read().await;
+        match gw.state_store().get(&key).await {
+            Ok(Some(_)) => {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(ErrorResponse {
+                        error: format!(
+                            "agent {}.{}.{} already registered",
+                            agent.namespace, agent.tenant, agent.agent_id
+                        ),
+                    }),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+            Ok(None) => {}
+        }
+        drop(gw);
+        // Provision the shared inbox topic on first registration.
+        if let Err(resp) =
+            ensure_agent_inbox_topic(&state, &agent.namespace, &agent.tenant, &inbox).await
+        {
+            return resp;
+        }
+        let payload = match serde_json::to_string(&agent) {
+            Ok(s) => s,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let gw = state.gateway.read().await;
+        if let Err(e) = gw.state_store().set(&key, &payload, None).await {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        (StatusCode::CREATED, Json(agent_to_response(&agent))).into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/bus/agents",
+    tag = "bus",
+    params(ListAgentsParams),
+    responses(
+        (status = 200, description = "Agent list", body = ListAgentsResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn list_agents(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Query(params): Query<ListAgentsParams>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        let gw = state.gateway.read().await;
+        let rows = match gw.state_store().scan_keys_by_kind(KeyKind::BusAgent).await {
+            Ok(r) => r,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let agents: Vec<acteon_core::Agent> = rows
+            .into_iter()
+            .filter_map(|(_, v)| serde_json::from_str::<acteon_core::Agent>(&v).ok())
+            .filter(|a| params.namespace.as_deref().is_none_or(|n| a.namespace == n))
+            .filter(|a| params.tenant.as_deref().is_none_or(|t| a.tenant == t))
+            .filter(|a| {
+                params
+                    .capability
+                    .as_deref()
+                    .is_none_or(|c| a.capabilities.iter().any(|cap| cap == c))
+            })
+            .filter(|a| identity.is_authorized(&a.tenant, &a.namespace, "bus", "agent"))
+            .filter(|a| {
+                params
+                    .status
+                    .as_deref()
+                    .is_none_or(|s| agent_status_str(a.status()).eq_ignore_ascii_case(s))
+            })
+            .collect();
+        let responses: Vec<AgentResponse> = agents.iter().map(agent_to_response).collect();
+        let count = responses.len();
+        (
+            StatusCode::OK,
+            Json(ListAgentsResponse {
+                agents: responses,
+                count,
+            }),
+        )
+            .into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, params);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/bus/agents/{namespace}/{tenant}/{agent_id}",
+    tag = "bus",
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("agent_id" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Agent detail", body = AgentResponse),
+        (status = 404, description = "Agent not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn get_agent(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, agent_id)): Path<(String, String, String)>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageAgent) {
+            return resp;
+        }
+        match load_agent(&state, &namespace, &tenant, &agent_id).await {
+            Ok(a) => (StatusCode::OK, Json(agent_to_response(&a))).into_response(),
+            Err(resp) => resp,
+        }
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, agent_id);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    put,
+    path = "/v1/bus/agents/{namespace}/{tenant}/{agent_id}",
+    tag = "bus",
+    request_body = UpdateAgentRequest,
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("agent_id" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Agent updated", body = AgentResponse),
+        (status = 400, description = "Invalid update", body = ErrorResponse),
+        (status = 404, description = "Agent not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn update_agent(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, agent_id)): Path<(String, String, String)>,
+    Json(req): Json<UpdateAgentRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageAgent) {
+            return resp;
+        }
+        let mut agent = match load_agent(&state, &namespace, &tenant, &agent_id).await {
+            Ok(a) => a,
+            Err(resp) => return resp,
+        };
+        if let Some(d) = req.display_name.clone() {
+            agent.display_name = Some(d);
+        }
+        if let Some(c) = req.capabilities.clone() {
+            agent.capabilities = c;
+        }
+        if let Some(i) = req.inbox_topic.clone() {
+            agent.inbox_topic = Some(i);
+        }
+        if let Some(ttl) = req.heartbeat_ttl_ms {
+            agent.heartbeat_ttl_ms = ttl;
+        }
+        if let Some(l) = req.labels.clone() {
+            agent.labels = l;
+        }
+        agent.updated_at = Utc::now();
+        if let Err(e) = agent.validate() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        let key = StateKey::new(
+            namespace.clone(),
+            tenant.clone(),
+            KeyKind::BusAgent,
+            agent.id(),
+        );
+        let payload = match serde_json::to_string(&agent) {
+            Ok(s) => s,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let gw = state.gateway.read().await;
+        if let Err(e) = gw.state_store().set(&key, &payload, None).await {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        (StatusCode::OK, Json(agent_to_response(&agent))).into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, agent_id, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    delete,
+    path = "/v1/bus/agents/{namespace}/{tenant}/{agent_id}",
+    tag = "bus",
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("agent_id" = String, Path),
+    ),
+    responses(
+        (status = 204, description = "Agent deleted"),
+        (status = 404, description = "Agent not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn delete_agent(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, agent_id)): Path<(String, String, String)>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageAgent) {
+            return resp;
+        }
+        let key = StateKey::new(
+            namespace.clone(),
+            tenant.clone(),
+            KeyKind::BusAgent,
+            &agent_id,
+        );
+        let gw = state.gateway.read().await;
+        match gw.state_store().get(&key).await {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse {
+                        error: format!("agent {namespace}.{tenant}.{agent_id} not found"),
+                    }),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        }
+        if let Err(e) = gw.state_store().delete(&key).await {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        StatusCode::NO_CONTENT.into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, agent_id);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/agents/{namespace}/{tenant}/{agent_id}/heartbeat",
+    tag = "bus",
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("agent_id" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Heartbeat recorded", body = HeartbeatResponse),
+        (status = 404, description = "Agent not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn heartbeat_agent(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, agent_id)): Path<(String, String, String)>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageAgent) {
+            return resp;
+        }
+        let mut agent = match load_agent(&state, &namespace, &tenant, &agent_id).await {
+            Ok(a) => a,
+            Err(resp) => return resp,
+        };
+        let now = Utc::now();
+        agent.last_heartbeat_at = Some(now);
+        agent.updated_at = now;
+        let key = StateKey::new(
+            namespace.clone(),
+            tenant.clone(),
+            KeyKind::BusAgent,
+            agent.id(),
+        );
+        let payload = match serde_json::to_string(&agent) {
+            Ok(s) => s,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let gw = state.gateway.read().await;
+        if let Err(e) = gw.state_store().set(&key, &payload, None).await {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        (
+            StatusCode::OK,
+            Json(HeartbeatResponse {
+                agent_id: agent.agent_id.clone(),
+                last_heartbeat_at: now,
+                status: agent_status_str(agent.status_at(now)),
+            }),
+        )
+            .into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, agent_id);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/agents/{namespace}/{tenant}/{agent_id}/send",
+    tag = "bus",
+    request_body = SendToAgentRequest,
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("agent_id" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Message delivered to inbox", body = SendToAgentResponse),
+        (status = 400, description = "Reserved header or invalid payload", body = ErrorResponse),
+        (status = 404, description = "Agent not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn send_to_agent(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, agent_id)): Path<(String, String, String)>,
+    Json(req): Json<SendToAgentRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        let Some(backend) = state.bus_backend.as_ref() else {
+            return service_unavailable("bus feature not enabled");
+        };
+        // Two-level auth: caller must hold ManageAgent (so random
+        // publishers can't target arbitrary agents) and Publish on the
+        // inbox topic's tenant (reusing the same gate as direct
+        // `/v1/bus/publish`).
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageAgent) {
+            return resp;
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::Publish) {
+            return resp;
+        }
+        if let Some(reserved) = req.headers.keys().find(|k| k.starts_with("acteon.")) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "header '{reserved}' uses the reserved 'acteon.' prefix; those are set by the server"
+                    ),
+                }),
+            )
+                .into_response();
+        }
+        let agent = match load_agent(&state, &namespace, &tenant, &agent_id).await {
+            Ok(a) => a,
+            Err(resp) => return resp,
+        };
+        let inbox = agent.effective_inbox_topic();
+        // Defensive: confirm the inbox topic is still registered. In
+        // normal flow `register_agent` guarantees this, but operators
+        // can delete the topic out from under the agent and we want a
+        // clean 404 rather than a downstream Kafka error.
+        let inbox_key = StateKey::new(namespace.clone(), tenant.clone(), KeyKind::BusTopic, &inbox);
+        {
+            let gw = state.gateway.read().await;
+            match gw.state_store().get(&inbox_key).await {
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    return (
+                        StatusCode::NOT_FOUND,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "agent inbox topic {inbox} is not registered; re-register the agent or create the topic"
+                            ),
+                        }),
+                    )
+                        .into_response();
+                }
+                Err(e) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse {
+                            error: e.to_string(),
+                        }),
+                    )
+                        .into_response();
+                }
+            }
+        }
+        // Key by agent_id so Kafka's partitioner routes all messages
+        // for a given agent to a stable partition — gives us per-agent
+        // FIFO without any extra subscription machinery.
+        let mut msg = acteon_bus::BusMessage::new(inbox.clone(), req.payload.clone())
+            .with_key(&agent.agent_id);
+        for (k, v) in &req.headers {
+            msg = msg.with_header(k.clone(), v.clone());
+        }
+        // Stamp the recipient so subscribers can route locally without
+        // parsing the payload. `with_header` silently drops reserved
+        // `acteon.*` keys — the server inserts them directly.
+        msg.headers
+            .insert("acteon.agent.id".into(), agent.agent_id.clone());
+        match backend.produce(msg).await {
+            Ok(receipt) => (
+                StatusCode::OK,
+                Json(SendToAgentResponse {
+                    inbox_topic: receipt.topic,
+                    agent_id: agent.agent_id,
+                    partition: receipt.partition,
+                    offset: receipt.offset,
+                    produced_at: receipt.timestamp,
+                }),
+            )
+                .into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response(),
+        }
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, agent_id, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+/// Direct `StateKey` lookup of an agent record.
+#[cfg(feature = "bus")]
+async fn load_agent(
+    state: &AppState,
+    namespace: &str,
+    tenant: &str,
+    agent_id: &str,
+) -> Result<acteon_core::Agent, axum::response::Response> {
+    let key = StateKey::new(
+        namespace.to_string(),
+        tenant.to_string(),
+        KeyKind::BusAgent,
+        agent_id.to_string(),
+    );
+    let gw = state.gateway.read().await;
+    match gw.state_store().get(&key).await {
+        Ok(Some(raw)) => serde_json::from_str::<acteon_core::Agent>(&raw).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("corrupt agent record for {namespace}.{tenant}.{agent_id}: {e}"),
+                }),
+            )
+                .into_response()
+        }),
+        Ok(None) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("agent {namespace}.{tenant}.{agent_id} not found"),
+            }),
+        )
+            .into_response()),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response()),
     }
 }

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -350,6 +350,27 @@ pub fn router(state: AppState) -> Router {
             "/v1/bus/topics/{namespace}/{tenant}/{name}/schema",
             put(bus::bind_topic_schema).delete(bus::unbind_topic_schema),
         )
+        // Phase 4: Agent identity + heartbeat + send-to-agent. Shared
+        // inbox topic `{ns}.{tenant}.agents-inbox` is auto-created on
+        // first registration.
+        .route(
+            "/v1/bus/agents",
+            get(bus::list_agents).post(bus::register_agent),
+        )
+        .route(
+            "/v1/bus/agents/{namespace}/{tenant}/{agent_id}",
+            get(bus::get_agent)
+                .put(bus::update_agent)
+                .delete(bus::delete_agent),
+        )
+        .route(
+            "/v1/bus/agents/{namespace}/{tenant}/{agent_id}/heartbeat",
+            post(bus::heartbeat_agent),
+        )
+        .route(
+            "/v1/bus/agents/{namespace}/{tenant}/{agent_id}/send",
+            post(bus::send_to_agent),
+        )
         // Swarm runs
         .route("/v1/swarm/runs", get(swarm::list_swarm_runs))
         .route("/v1/swarm/runs/{run_id}", get(swarm::get_swarm_run))

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -176,6 +176,13 @@ use acteon_core::{
         super::bus::delete_schema_version,
         super::bus::bind_topic_schema,
         super::bus::unbind_topic_schema,
+        super::bus::register_agent,
+        super::bus::list_agents,
+        super::bus::get_agent,
+        super::bus::update_agent,
+        super::bus::delete_agent,
+        super::bus::heartbeat_agent,
+        super::bus::send_to_agent,
     ),
     components(schemas(
         Action, ActionOutcome, ProviderResponse, ResponseStatus, ActionError,
@@ -243,6 +250,10 @@ use acteon_core::{
         super::bus::ListSchemasResponse, super::bus::BindTopicSchemaRequest,
         super::bus::BindTopicSchemaResponse, super::bus::SchemaValidationErrorResponse,
         super::bus::SchemaValidationIssueDto,
+        super::bus::RegisterAgentRequest, super::bus::UpdateAgentRequest,
+        super::bus::AgentResponse, super::bus::ListAgentsResponse,
+        super::bus::HeartbeatResponse, super::bus::SendToAgentRequest,
+        super::bus::SendToAgentResponse,
     ))
 )]
 pub struct ApiDoc;

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -216,5 +216,9 @@ required-features = ["bus"]
 name = "bus_schema_simulation"
 required-features = ["bus"]
 
+[[example]]
+name = "bus_agent_simulation"
+required-features = ["bus"]
+
 [lints]
 workspace = true

--- a/crates/simulation/examples/bus_agent_simulation.rs
+++ b/crates/simulation/examples/bus_agent_simulation.rs
@@ -1,0 +1,179 @@
+//! Phase 4 agent-registry + shared-inbox demo.
+//!
+//! This sim drives the core `Agent` type and the in-memory bus
+//! backend directly — no Kafka, no HTTP — so you can see the shape
+//! of Phase 4 in isolation. The actual HTTP endpoints
+//! (`POST /v1/bus/agents`, `/heartbeat`, `/send`) delegate to the
+//! same types on the server side.
+//!
+//! Scenarios:
+//!
+//! 1. Register two agents in the same `(namespace, tenant)` — both
+//!    share one inbox topic.
+//! 2. Discover agents by capability.
+//! 3. Show status transitions: Unknown → Online → Idle → Dead as the
+//!    last-heartbeat timestamp ages past the TTL thresholds.
+//! 4. Produce messages keyed by `agent_id` and observe them arriving
+//!    on the shared inbox topic. Since Kafka's partitioner is
+//!    deterministic on key, each agent's traffic stays on one
+//!    partition (we verify the key makes it through the backend
+//!    round-trip).
+//!
+//! Run with:
+//! ```text
+//! cargo run -p acteon-simulation --features bus --example bus_agent_simulation
+//! ```
+
+use std::time::Duration;
+
+use chrono::Utc;
+use futures::StreamExt;
+use tracing::{Level, info};
+
+use acteon_bus::{BusMessage, MemoryBackend, StartOffset};
+use acteon_core::{Agent, AgentStatus, Topic};
+
+#[tokio::main]
+#[allow(clippy::too_many_lines)]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::INFO)
+        .with_env_filter("info,acteon_bus=info")
+        .init();
+
+    let backend: acteon_bus::SharedBackend = MemoryBackend::new();
+
+    // -----------------------------------------------------------------
+    // 1. Register two agents, both pointing at the default shared inbox
+    // -----------------------------------------------------------------
+
+    let mut planner = Agent::new("planner-1", "agents", "demo");
+    planner.display_name = Some("Planner One".into());
+    planner.capabilities = vec!["planning".into(), "reasoning".into()];
+    planner.validate()?;
+
+    let mut ocr = Agent::new("ocr-svc", "agents", "demo");
+    ocr.display_name = Some("OCR Worker".into());
+    ocr.capabilities = vec!["ocr".into(), "vision".into()];
+    ocr.validate()?;
+
+    assert_eq!(planner.effective_inbox_topic(), "agents.demo.agents-inbox");
+    assert_eq!(planner.effective_inbox_topic(), ocr.effective_inbox_topic());
+    info!(
+        inbox = %planner.effective_inbox_topic(),
+        "registered two agents on the shared inbox"
+    );
+
+    // Provision the inbox topic once (the server does this on first
+    // register_agent; here we do it directly).
+    let inbox = Topic::new("agents-inbox", "agents", "demo");
+    backend.create_topic(&inbox).await?;
+
+    // -----------------------------------------------------------------
+    // 2. Capability discovery
+    // -----------------------------------------------------------------
+
+    let agents = [&planner, &ocr];
+    let ocr_candidates: Vec<&Agent> = agents
+        .iter()
+        .copied()
+        .filter(|a| a.capabilities.iter().any(|c| c == "ocr"))
+        .collect();
+    info!(
+        count = ocr_candidates.len(),
+        picked = %ocr_candidates[0].agent_id,
+        "discovered agents advertising the 'ocr' capability"
+    );
+
+    // -----------------------------------------------------------------
+    // 3. Heartbeat-derived status transitions
+    // -----------------------------------------------------------------
+
+    let now = Utc::now();
+    // No heartbeat → Unknown.
+    assert_eq!(planner.status_at(now), AgentStatus::Unknown);
+    info!("fresh agent reports status=Unknown");
+
+    planner.last_heartbeat_at = Some(now);
+    assert_eq!(planner.status_at(now), AgentStatus::Online);
+    info!("after heartbeat, status=Online");
+
+    // Move "now" forward past single TTL (60s default).
+    let t_idle = now + chrono::Duration::milliseconds(planner.heartbeat_ttl_ms + 5_000);
+    assert_eq!(planner.status_at(t_idle), AgentStatus::Idle);
+    info!(
+        age_ms = planner.heartbeat_ttl_ms + 5_000,
+        "after ttl but within 2*ttl, status=Idle"
+    );
+
+    // Past 2x TTL → Dead.
+    let t_dead = now + chrono::Duration::milliseconds((planner.heartbeat_ttl_ms * 2) + 5_000);
+    assert_eq!(planner.status_at(t_dead), AgentStatus::Dead);
+    info!(
+        age_ms = (planner.heartbeat_ttl_ms * 2) + 5_000,
+        "past 2*ttl, status=Dead"
+    );
+
+    // -----------------------------------------------------------------
+    // 4. Send-to-agent: produce keyed by agent_id and observe delivery
+    // -----------------------------------------------------------------
+
+    // Attach a subscriber before producing.
+    let mut stream = backend
+        .subscribe(
+            &planner.effective_inbox_topic(),
+            "sim-consumer",
+            StartOffset::Earliest,
+        )
+        .await?;
+
+    // Send one message to each agent. `with_header` filters reserved
+    // `acteon.*` keys (an anti-spoofing guard on user input), so the
+    // server — and this simulation — populate them via direct
+    // `headers.insert`.
+    let mut planner_msg = BusMessage::new(
+        planner.effective_inbox_topic(),
+        serde_json::json!({"task": "break down user request"}),
+    )
+    .with_key(&planner.agent_id);
+    planner_msg
+        .headers
+        .insert("acteon.agent.id".into(), planner.agent_id.clone());
+    let mut ocr_msg = BusMessage::new(
+        ocr.effective_inbox_topic(),
+        serde_json::json!({"task": "extract text", "image": "s3://.../receipt.png"}),
+    )
+    .with_key(&ocr.agent_id);
+    ocr_msg
+        .headers
+        .insert("acteon.agent.id".into(), ocr.agent_id.clone());
+    backend.produce(planner_msg).await?;
+    backend.produce(ocr_msg).await?;
+
+    let mut seen: Vec<(String, String)> = Vec::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    while seen.len() < 2 && tokio::time::Instant::now() < deadline {
+        tokio::select! {
+            maybe = stream.next() => {
+                if let Some(Ok(msg)) = maybe {
+                    let key = msg.key.clone().unwrap_or_default();
+                    let recipient = msg
+                        .headers
+                        .get("acteon.agent.id")
+                        .cloned()
+                        .unwrap_or_default();
+                    seen.push((key, recipient));
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+        }
+    }
+    assert_eq!(seen.len(), 2, "expected both inbox messages");
+    for (key, recipient) in &seen {
+        assert_eq!(key, recipient, "inbox key must equal agent_id header");
+        info!(agent = %key, "inbox message received");
+    }
+
+    info!("agent simulation complete");
+    Ok(())
+}

--- a/crates/state/state/src/key.rs
+++ b/crates/state/state/src/key.rs
@@ -62,6 +62,8 @@ pub enum KeyKind {
     BusSubscription,
     /// Bus payload schema (Phase 3 of the agentic bus).
     BusSchema,
+    /// Bus agent identity + heartbeat (Phase 4 of the agentic bus).
+    BusAgent,
     Custom(String),
 }
 
@@ -101,6 +103,7 @@ impl KeyKind {
             Self::BusTopic => "bus_topic",
             Self::BusSubscription => "bus_subscription",
             Self::BusSchema => "bus_schema",
+            Self::BusAgent => "bus_agent",
             Self::Custom(s) => s.as_str(),
         }
     }
@@ -200,6 +203,7 @@ mod tests {
         assert_eq!(KeyKind::BusTopic.as_str(), "bus_topic");
         assert_eq!(KeyKind::BusSubscription.as_str(), "bus_subscription");
         assert_eq!(KeyKind::BusSchema.as_str(), "bus_schema");
+        assert_eq!(KeyKind::BusAgent.as_str(), "bus_agent");
         assert_eq!(KeyKind::Custom("foo".into()).as_str(), "foo");
     }
 

--- a/docs/book/features/bus-phase-4.md
+++ b/docs/book/features/bus-phase-4.md
@@ -1,0 +1,183 @@
+# Agentic Bus — Phase 4
+
+> **Scope:** `Agent` identity + capabilities + heartbeat + shared inbox
+> topic. Conversations and tool-call envelopes land in Phase 5/6. See
+> the [master plan](../concepts/bus-master-plan.md).
+
+Phase 1–3 gave us topics, durable subscriptions, and schemas. Phase 4
+makes the bus *agent-aware*: the operator registers an agent once, gets
+a stable identity with capabilities and heartbeat, and can address
+messages to that agent by id without managing a topic per agent.
+
+## What ships in Phase 4
+
+| Surface | Shape |
+|---|---|
+| Core type | `acteon_core::Agent` — `{agent_id, namespace, tenant, display_name, capabilities, inbox_topic, heartbeat_ttl_ms, last_heartbeat_at, labels, created_at, updated_at}`; derived `AgentStatus` |
+| State | `KeyKind::BusAgent`; key id = `agent_id` |
+| Shared inbox | Default `{namespace}.{tenant}.agents-inbox`, auto-created on first agent registration. All agents in the same `(namespace, tenant)` share it; messages are keyed by `agent_id` so Kafka gives per-agent FIFO for free. |
+| HTTP | `POST/GET /v1/bus/agents`, `GET|PUT|DELETE /v1/bus/agents/{ns}/{t}/{id}`, `POST /v1/bus/agents/{ns}/{t}/{id}/heartbeat`, `POST /v1/bus/agents/{ns}/{t}/{id}/send` |
+| Rust client | `register_bus_agent`, `list_bus_agents`, `get_bus_agent`, `update_bus_agent`, `delete_bus_agent`, `heartbeat_bus_agent`, `send_to_bus_agent` |
+| Tests | 11 core unit tests (status derivation, validation, serde roundtrip, inbox defaults + overrides) |
+| Simulation | `bus_agent_simulation.rs` — register → discover by capability → status transitions → send → consume from shared inbox |
+
+## Model
+
+### Shared inbox, keyed delivery
+
+Rather than giving each agent its own topic (which would explode Kafka
+metadata and ACLs), all agents in a tenant share one inbox topic and
+Acteon keys every message by `agent_id`. Kafka's default partitioner is
+deterministic on key, so each agent's traffic lands on one partition —
+per-agent FIFO ordering with zero subscription bookkeeping.
+
+```
+agents.demo.agents-inbox      (partitions = 3)
+├── partition 0 ── agent_id=planner-1   msg msg msg
+├── partition 1 ── agent_id=ocr-svc      msg msg
+└── partition 2 ── agent_id=planner-2   msg msg msg
+```
+
+Subscribers filter locally by the `acteon.agent.id` header
+(server-stamped) or the Kafka key. A fleet-wide consumer reads the
+entire inbox and dispatches; a single-agent consumer reads from its
+assigned partition.
+
+Operators can override `inbox_topic` per agent if they want isolation
+(for example, a sensitive-data agent that shouldn't share a topic with
+the general pool). Cross-tenant inboxes are rejected at registration.
+
+### Heartbeat-derived status
+
+Agents POST to `/heartbeat` periodically. Status is computed on every
+read:
+
+| Age since last heartbeat | Status |
+|---|---|
+| no heartbeat yet | `Unknown` |
+| within `heartbeat_ttl_ms` | `Online` |
+| within `2 * heartbeat_ttl_ms` | `Idle` |
+| older | `Dead` |
+
+No background reaper, no TTL index, no timers. Dead records stay in
+state until explicitly deleted.
+
+## API shape
+
+### Register
+
+```http
+POST /v1/bus/agents
+{
+  "agent_id": "planner-1",
+  "namespace": "agents",
+  "tenant": "demo",
+  "display_name": "Planner One",
+  "capabilities": ["planning", "reasoning"],
+  "heartbeat_ttl_ms": 60000
+}
+→ 201 AgentResponse { inbox_topic: "agents.demo.agents-inbox", status: "unknown", ... }
+```
+
+First registration in `(namespace, tenant)` auto-creates the shared
+inbox topic in both state and Kafka.
+
+### Heartbeat
+
+```http
+POST /v1/bus/agents/agents/demo/planner-1/heartbeat
+→ 200 { "agent_id": "planner-1", "last_heartbeat_at": "...", "status": "online" }
+```
+
+Cheap and idempotent. A common cadence is every `ttl / 3`.
+
+### List + filter
+
+```http
+GET /v1/bus/agents?namespace=agents&tenant=demo&capability=ocr&status=online
+→ 200 { "agents": [...], "count": 1 }
+```
+
+Capability matching is exact; a future phase can add semantic
+matching. Status filter uses the derived status, so results reflect
+the current heartbeat window.
+
+### Send
+
+```http
+POST /v1/bus/agents/agents/demo/planner-1/send
+{ "payload": { "task": "break down user request" } }
+→ 200 { "inbox_topic": "agents.demo.agents-inbox", "agent_id": "planner-1", "partition": 0, "offset": 17, ... }
+```
+
+The server keys the Kafka record by `agent_id` and stamps
+`acteon.agent.id` as a header. Callers can supply additional
+non-reserved headers via `headers`.
+
+## SDK example
+
+```rust
+use acteon_client::{ActeonClient, RegisterBusAgent, SendToBusAgent};
+
+let client = ActeonClient::new("http://localhost:3000")?;
+
+// Register.
+let agent = client.register_bus_agent(&RegisterBusAgent {
+    agent_id: "planner-1".into(),
+    namespace: "agents".into(),
+    tenant: "demo".into(),
+    capabilities: vec!["planning".into()],
+    ..Default::default()
+}).await?;
+
+// Heartbeat loop (run on a timer in your process).
+client.heartbeat_bus_agent("agents", "demo", "planner-1").await?;
+
+// Send.
+client.send_to_bus_agent("agents", "demo", "planner-1", &SendToBusAgent {
+    payload: serde_json::json!({"task": "summarize doc"}),
+    ..Default::default()
+}).await?;
+```
+
+## Authorization
+
+All agent endpoints flow through `BusOp::ManageAgent` (requires the
+`Dispatch` permission and a grant for verb `agent` on the target
+`(tenant, namespace)`).
+
+`send_to_agent` additionally checks `BusOp::Publish`, so operators
+can hand out registry-read access without letting the same caller
+blast messages into inboxes.
+
+## Design decisions
+
+- **Shared inbox, not per-agent topic.** Locked in the master plan —
+  fewer topics to govern, partition utilization stays high, and
+  Kafka's key-based partitioning gives us per-agent ordering without
+  any subscription gymnastics.
+- **Status on read, no reaper.** Simplicity wins in V1. If operators
+  want proactive cleanup of dead records, a future phase can add a
+  reaper; the current model keeps the core small.
+- **Heartbeat endpoint, not "liveness inferred from send".** Sending
+  a message doesn't mean the agent is reading its inbox. Keep the
+  signals separate.
+- **Inbox overrides stay tenant-scoped.** An agent can point at a
+  dedicated topic, but only within its own `(namespace, tenant)`.
+
+## How to try it
+
+```bash
+# Standalone — no Kafka required.
+cargo run -p acteon-simulation --features bus --example bus_agent_simulation
+```
+
+For end-to-end HTTP, start the server with the bus feature and use the
+SDK methods above.
+
+## What comes next (Phase 5)
+
+- `Conversation` type: per-conversation partitioning on a shared
+  events topic, thread UI, conversation state machines.
+- HITL gate for agent-initiated actions (pre-publish approval of
+  messages the agent wants to send to other agents).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -186,6 +186,7 @@ nav:
     - Phase 1 (Topics + Publish + Subscribe): features/bus-phase-1.md
     - Phase 2 (Subscriptions + Ack + Lag + DLQ): features/bus-phase-2.md
     - Phase 3 (Schemas + Publish Validation): features/bus-phase-3.md
+    - Phase 4 (Agents + Shared Inbox + Heartbeat): features/bus-phase-4.md
   - Guides:
     - guides/index.md
     - AI Agent Swarm Coordination: guides/agent-swarm-coordination.md


### PR DESCRIPTION
## Summary

Phase 4 of the agentic bus. Makes the bus agent-aware: one registration call gives you a stable identity, capability advertisement, liveness signal, and a place to receive messages — no topic-per-agent overhead.

- **Core type** — \`acteon_core::Agent\` with \`{agent_id, namespace, tenant, display_name, capabilities, inbox_topic, heartbeat_ttl_ms, last_heartbeat_at, labels, created_at, updated_at}\`. \`KeyKind::BusAgent\`.
- **Heartbeat-derived liveness** — \`AgentStatus\` is computed on read: \`Unknown\` → \`Online\` (within TTL) → \`Idle\` (within 2×TTL) → \`Dead\`. Zero timers, zero background reapers.
- **Shared inbox model** — default topic \`{ns}.{tenant}.agents-inbox\` auto-provisioned (state + Kafka) on first \`register_agent\`. Messages keyed by \`agent_id\` so Kafka's default partitioner gives per-agent FIFO for free. Custom inbox overrides are allowed but must stay tenant-scoped.
- **HTTP** — \`POST/GET /v1/bus/agents\`, \`GET|PUT|DELETE /v1/bus/agents/{ns}/{t}/{agent_id}\`, \`POST /v1/bus/agents/{ns}/{t}/{agent_id}/heartbeat\`, \`POST /v1/bus/agents/{ns}/{t}/{agent_id}/send\`. \`send\` server-stamps \`acteon.agent.id\` as a header.
- **Authorization** — \`BusOp::ManageAgent\` (Dispatch, verb \`agent\`); \`send\` additionally requires \`BusOp::Publish\`.
- **Rust SDK** — \`register_bus_agent\`, \`list_bus_agents\`, \`get_bus_agent\`, \`update_bus_agent\`, \`delete_bus_agent\`, \`heartbeat_bus_agent\`, \`send_to_bus_agent\`.
- **11 new core unit tests** covering status derivation at each TTL threshold, id/fragment/capability validation, inbox defaults + overrides, and serde roundtrip.
- **Simulation** — \`bus_agent_simulation.rs\` exercises register → discover-by-capability → status transitions → send → consume from the shared inbox. Runs against \`MemoryBackend\` (no Kafka).
- **Docs** — \`docs/book/features/bus-phase-4.md\`.

## Design notes

- **Shared inbox, not per-agent topic** — locked by the master plan. Fewer topics to govern, partition utilization stays high, and Kafka's key-based partitioning gives us per-agent ordering with zero subscription gymnastics.
- **Status on read, no reaper** — keeps the core small. Dead records stick around until explicitly deleted; a future phase can add proactive cleanup if operators want it.
- **Heartbeat ≠ send** — a successful send doesn't prove the agent is reading its inbox. Separate signals.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --no-deps -- -D warnings\`
- [x] \`cargo clippy -p acteon-server --features bus --no-deps -- -D warnings\`
- [x] \`cargo test --workspace --lib --bins --tests\` — 2505 passed, 0 failed
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps\`
- [x] \`cargo check --all-targets\`
- [x] \`cd ui && npm run lint && npm run build\`
- [x] \`ACTEON_KAFKA_BOOTSTRAP=localhost:9092 cargo test -p acteon-bus --test kafka_integration\` — 3/3 pass
- [x] \`cargo run -p acteon-simulation --features bus --example bus_agent_simulation\` — end-to-end green

## Polyglot SDKs

Python/Node/Go/Java parity for the agent surface is deferred to Phase 8 per the [master plan](../blob/main/docs/book/concepts/bus-master-plan.md), which lands 5-SDK parity for the entire bus surface together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)