### PR TITLE
fix(bus): close TOCTOU on the four create paths via check_and_set

### DIFF
--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -1953,7 +1953,6 @@ pub async fn create_schema(
         // fine — V1 throughput on a single subject is operator-driven.
         let gw = state.gateway.read().await;
         let prefix = format!("{}:", req.subject);
-        let now = Utc::now();
         let mut allocated: Option<acteon_core::Schema> = None;
         for _ in 0..MAX_VERSION_ALLOC_ATTEMPTS {
             let next_version: i32 = match gw
@@ -1983,6 +1982,10 @@ pub async fn create_schema(
                         .into_response();
                 }
             };
+            // Stamp `created_at` per attempt so the persisted timestamp
+            // reflects when the version was actually claimed, not when
+            // the handler started. Version is the canonical ordering
+            // signal; this just keeps timestamps honest under retry.
             let candidate = acteon_core::Schema {
                 subject: req.subject.clone(),
                 version: next_version,
@@ -1991,7 +1994,7 @@ pub async fn create_schema(
                 format: acteon_core::SchemaFormat::default(),
                 body: req.body.clone(),
                 labels: req.labels.clone(),
-                created_at: now,
+                created_at: Utc::now(),
             };
             if let Err(e) = candidate.validate() {
                 return (

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -304,8 +304,21 @@ pub async fn create_topic(
             KeyKind::BusTopic,
             topic.id(),
         );
-        match store.get(&key).await {
-            Ok(Some(_)) => {
+        let Ok(body) = serde_json::to_string(&topic) else {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "failed to serialize topic".into(),
+                }),
+            )
+                .into_response();
+        };
+        // Atomic conflict check + insert. Two concurrent creates with
+        // the same key are guaranteed to see exactly one `true` here;
+        // the loser gets `Ok(false)` and a clean 409.
+        match store.check_and_set(&key, &body, None).await {
+            Ok(true) => {}
+            Ok(false) => {
                 return (
                     StatusCode::CONFLICT,
                     Json(ErrorResponse {
@@ -323,26 +336,6 @@ pub async fn create_topic(
                 )
                     .into_response();
             }
-            Ok(None) => {}
-        }
-
-        let Ok(body) = serde_json::to_string(&topic) else {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "failed to serialize topic".into(),
-                }),
-            )
-                .into_response();
-        };
-        if let Err(e) = store.set(&key, &body, None).await {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
-            )
-                .into_response();
         }
         drop(gw);
 
@@ -1203,8 +1196,20 @@ pub async fn create_subscription(
             KeyKind::BusSubscription,
             sub.id.clone(),
         );
-        match store.get(&sub_key).await {
-            Ok(Some(_)) => {
+        let Ok(body) = serde_json::to_string(&sub) else {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "failed to serialize subscription".into(),
+                }),
+            )
+                .into_response();
+        };
+        // Atomic conflict check + insert; see `create_topic` for the
+        // rationale.
+        match store.check_and_set(&sub_key, &body, None).await {
+            Ok(true) => {}
+            Ok(false) => {
                 return (
                     StatusCode::CONFLICT,
                     Json(ErrorResponse {
@@ -1222,25 +1227,6 @@ pub async fn create_subscription(
                 )
                     .into_response();
             }
-            Ok(None) => {}
-        }
-        let Ok(body) = serde_json::to_string(&sub) else {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "failed to serialize subscription".into(),
-                }),
-            )
-                .into_response();
-        };
-        if let Err(e) = store.set(&sub_key, &body, None).await {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
-            )
-                .into_response();
         }
 
         (StatusCode::CREATED, Json(subscription_to_response(&sub))).into_response()
@@ -1720,6 +1706,13 @@ async fn load_subscription(
 // Phase 3: JSON-Schema registry + topic binding
 // =============================================================================
 
+/// Bound on how many times `create_schema` retries scan-then-claim for
+/// the next monotonic version. With N concurrent registrations on the
+/// same subject, the worst case is N attempts; 8 is comfortably above
+/// any realistic operator-driven concurrency on schema CRUD.
+#[cfg(feature = "bus")]
+const MAX_VERSION_ALLOC_ATTEMPTS: u32 = 8;
+
 /// Body of a request to register a new schema version.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateSchemaRequest {
@@ -1952,83 +1945,113 @@ pub async fn create_schema(
             )
                 .into_response();
         }
-        // Scan existing versions for this subject to pick the next one.
+        // Reserving the next monotonic version requires a scan-then-
+        // claim pattern. Two concurrent posts can compute the same
+        // `next_version`; the atomic `check_and_set` below detects
+        // this and we retry up to MAX_VERSION_ALLOC_ATTEMPTS. With N
+        // concurrent posts the loop is N attempts at worst, which is
+        // fine — V1 throughput on a single subject is operator-driven.
         let gw = state.gateway.read().await;
         let prefix = format!("{}:", req.subject);
-        let next_version: i32 = match gw
-            .state_store()
-            .scan_keys(
-                &req.namespace,
-                &req.tenant,
-                KeyKind::BusSchema,
-                Some(&prefix),
-            )
-            .await
-        {
-            Ok(rows) => rows
-                .iter()
-                .filter_map(|(_, v)| serde_json::from_str::<acteon_core::Schema>(v).ok())
-                .filter(|s| s.subject == req.subject)
-                .map(|s| s.version)
-                .max()
-                .map_or(1, |m| m + 1),
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse {
-                        error: e.to_string(),
-                    }),
-                )
-                    .into_response();
-            }
-        };
         let now = Utc::now();
-        let schema = acteon_core::Schema {
-            subject: req.subject.clone(),
-            version: next_version,
-            namespace: req.namespace.clone(),
-            tenant: req.tenant.clone(),
-            format: acteon_core::SchemaFormat::default(),
-            body: req.body.clone(),
-            labels: req.labels.clone(),
-            created_at: now,
-        };
-        if let Err(e) = schema.validate() {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
-            )
-                .into_response();
-        }
-        let key = StateKey::new(
-            schema.namespace.clone(),
-            schema.tenant.clone(),
-            KeyKind::BusSchema,
-            schema.id(),
-        );
-        let payload = match serde_json::to_string(&schema) {
-            Ok(s) => s,
-            Err(e) => {
+        let mut allocated: Option<acteon_core::Schema> = None;
+        for _ in 0..MAX_VERSION_ALLOC_ATTEMPTS {
+            let next_version: i32 = match gw
+                .state_store()
+                .scan_keys(
+                    &req.namespace,
+                    &req.tenant,
+                    KeyKind::BusSchema,
+                    Some(&prefix),
+                )
+                .await
+            {
+                Ok(rows) => rows
+                    .iter()
+                    .filter_map(|(_, v)| serde_json::from_str::<acteon_core::Schema>(v).ok())
+                    .filter(|s| s.subject == req.subject)
+                    .map(|s| s.version)
+                    .max()
+                    .map_or(1, |m| m + 1),
+                Err(e) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse {
+                            error: e.to_string(),
+                        }),
+                    )
+                        .into_response();
+                }
+            };
+            let candidate = acteon_core::Schema {
+                subject: req.subject.clone(),
+                version: next_version,
+                namespace: req.namespace.clone(),
+                tenant: req.tenant.clone(),
+                format: acteon_core::SchemaFormat::default(),
+                body: req.body.clone(),
+                labels: req.labels.clone(),
+                created_at: now,
+            };
+            if let Err(e) = candidate.validate() {
                 return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
+                    StatusCode::BAD_REQUEST,
                     Json(ErrorResponse {
                         error: e.to_string(),
                     }),
                 )
                     .into_response();
             }
-        };
-        if let Err(e) = gw.state_store().set(&key, &payload, None).await {
+            let key = StateKey::new(
+                candidate.namespace.clone(),
+                candidate.tenant.clone(),
+                KeyKind::BusSchema,
+                candidate.id(),
+            );
+            let payload = match serde_json::to_string(&candidate) {
+                Ok(s) => s,
+                Err(e) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse {
+                            error: e.to_string(),
+                        }),
+                    )
+                        .into_response();
+                }
+            };
+            match gw.state_store().check_and_set(&key, &payload, None).await {
+                Ok(true) => {
+                    allocated = Some(candidate);
+                    break;
+                }
+                // Lost the race against another concurrent registration
+                // for this subject — rescan and retry on next loop
+                // iteration.
+                Ok(false) => {}
+                Err(e) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse {
+                            error: e.to_string(),
+                        }),
+                    )
+                        .into_response();
+                }
+            }
+        }
+        let Some(schema) = allocated else {
             return (
-                StatusCode::INTERNAL_SERVER_ERROR,
+                StatusCode::CONFLICT,
                 Json(ErrorResponse {
-                    error: e.to_string(),
+                    error: format!(
+                        "schema '{}' could not allocate a unique version after {MAX_VERSION_ALLOC_ATTEMPTS} attempts; retry or coordinate writers",
+                        req.subject
+                    ),
                 }),
             )
                 .into_response();
-        }
+        };
         drop(gw);
         // Eagerly register with the compiled-validator cache so the
         // next publish is a warm hit.
@@ -3010,9 +3033,33 @@ pub async fn register_agent(
             KeyKind::BusAgent,
             agent.id(),
         );
+        // Provision the shared inbox topic before reserving the agent
+        // id. Inbox provisioning is idempotent across concurrent
+        // registrations (any `TopicAlreadyExists` is benign — see
+        // `ensure_agent_inbox_topic`); the atomic agent reservation
+        // below is what guarantees only one caller wins for a given
+        // `agent_id`.
+        if let Err(resp) =
+            ensure_agent_inbox_topic(&state, &agent.namespace, &agent.tenant, &inbox).await
+        {
+            return resp;
+        }
+        let payload = match serde_json::to_string(&agent) {
+            Ok(s) => s,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
         let gw = state.gateway.read().await;
-        match gw.state_store().get(&key).await {
-            Ok(Some(_)) => {
+        match gw.state_store().check_and_set(&key, &payload, None).await {
+            Ok(true) => {}
+            Ok(false) => {
                 return (
                     StatusCode::CONFLICT,
                     Json(ErrorResponse {
@@ -3033,36 +3080,6 @@ pub async fn register_agent(
                 )
                     .into_response();
             }
-            Ok(None) => {}
-        }
-        drop(gw);
-        // Provision the shared inbox topic on first registration.
-        if let Err(resp) =
-            ensure_agent_inbox_topic(&state, &agent.namespace, &agent.tenant, &inbox).await
-        {
-            return resp;
-        }
-        let payload = match serde_json::to_string(&agent) {
-            Ok(s) => s,
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse {
-                        error: e.to_string(),
-                    }),
-                )
-                    .into_response();
-            }
-        };
-        let gw = state.gateway.read().await;
-        if let Err(e) = gw.state_store().set(&key, &payload, None).await {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
-            )
-                .into_response();
         }
         (StatusCode::CREATED, Json(agent_to_response(&agent))).into_response()
     }

--- a/crates/state/memory/src/store.rs
+++ b/crates/state/memory/src/store.rs
@@ -464,4 +464,38 @@ mod tests {
         let existed = store.delete(&key).await.unwrap();
         assert!(!existed);
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn check_and_set_is_atomic_under_contention() {
+        // 100 concurrent writers race to insert the same key. Exactly
+        // one must observe `Ok(true)`; everyone else gets `Ok(false)`.
+        // This is the contract the bus handlers (`create_topic`,
+        // `create_subscription`, `register_agent`, `create_schema`)
+        // depend on for their conflict-detection guarantees.
+        let store = std::sync::Arc::new(MemoryStateStore::new());
+        let key = test_key(KeyKind::State, "race");
+        let n = 100;
+        let mut handles = Vec::with_capacity(n);
+        for i in 0..n {
+            let store = store.clone();
+            let key = key.clone();
+            handles.push(tokio::spawn(async move {
+                store
+                    .check_and_set(&key, &format!("v{i}"), None)
+                    .await
+                    .unwrap()
+            }));
+        }
+        let mut winners = 0;
+        for h in handles {
+            if h.await.unwrap() {
+                winners += 1;
+            }
+        }
+        assert_eq!(winners, 1, "exactly one writer must win the race");
+        // The stored value must come from one of the writers (we don't
+        // care which); we only assert the key exists.
+        let stored = store.get(&key).await.unwrap();
+        assert!(stored.is_some(), "key must be present after race");
+    }
 }


### PR DESCRIPTION
## Summary

Resolves the third reviewer finding from #131 (out of scope at the time): the get-then-set conflict-check pattern in the bus create handlers had a race window where two concurrent POSTs could both observe \`Ok(None)\` from \`state_store.get(&key)\`, both proceed to \`state_store.set(&key, ...)\`, and the second silently overwrites the first.

The fix is small because \`StateStore::check_and_set\` already exists and is atomic on every in-tree backend (memory: dashmap \`entry\`; redis: Lua script; postgres: \`INSERT ON CONFLICT DO NOTHING\`; dynamodb: \`PutItem\` with \`attribute_not_exists\`). The bus handlers were just doing the unsafe pattern by hand. Now they don't.

## Changes

- **\`create_topic\`**: collapses \`get\` + \`set\` into one \`check_and_set\` returning a clean 409 to the loser of any concurrent attempt.
- **\`create_subscription\`**: same shape.
- **\`register_agent\`**: reorders the inbox-topic provision (already idempotent for concurrent registers per #131) before the atomic agent_id reservation. Two callers can both provision the inbox; only one wins the agent_id row.
- **\`create_schema\`**: scan-then-claim is unavoidable since version is monotonic, but now wrapped in a bounded retry loop (\`MAX_VERSION_ALLOC_ATTEMPTS = 8\`). The loser of \`check_and_set\` re-scans and retries; if attempts exhaust, returns 409 with a retry hint.
- **Test**: \`check_and_set_is_atomic_under_contention\` on \`MemoryStateStore\` — 100 concurrent writers race for one key, asserts exactly one observes \`Ok(true)\`.

## Why \`check_and_set\` and not a new \`set_if_absent\` method

Looked at adding one and discovered the trait already has \`check_and_set\` with exactly the right contract. The bug was purely callsite — handlers reaching for \`get\`/\`set\` instead of the existing atomic primitive. No new trait surface needed.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --no-deps -- -D warnings\`
- [x] \`cargo clippy -p acteon-server --features bus --no-deps -- -D warnings\`
- [x] \`cargo test --workspace --lib --bins --tests\` — 2507 passed, 0 failed
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps\`
- [x] \`cargo check --all-targets\`
- [x] \`ACTEON_KAFKA_BOOTSTRAP=localhost:9092 cargo test -p acteon-bus --test kafka_integration\` — 3/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)