### PR TITLE
feat(bus): Phase 5 — Conversations, threads, and lifecycle state

### DIFF
--- a/crates/bus/Cargo.toml
+++ b/crates/bus/Cargo.toml
@@ -24,10 +24,10 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt", "macros"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util", "time"] }
-uuid = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/bus/src/backend.rs
+++ b/crates/bus/src/backend.rs
@@ -59,6 +59,27 @@ pub trait BusBackend: Send + Sync + 'static {
         kafka_topic: &str,
         group_id: &str,
     ) -> Result<Vec<PartitionLag>, BusError>;
+
+    /// One-shot replay of a topic without joining a consumer group.
+    ///
+    /// Conceptually like [`Self::subscribe`] but uses partition
+    /// assignment (Kafka's `assign()` API) instead of dynamic group
+    /// membership. Two consequences matter for the bus's replay
+    /// endpoints:
+    ///
+    /// 1. **No group metadata is created.** Repeated replays do not
+    ///    accumulate dead consumer groups in `__consumer_offsets`.
+    /// 2. **No offset commits.** This is purely a read; offsets are
+    ///    not persisted to Kafka.
+    ///
+    /// Use this for ephemeral, one-off scans (e.g. conversation thread
+    /// replay). For durable consumer-group semantics call
+    /// [`Self::subscribe`] instead.
+    async fn scan_topic(
+        &self,
+        kafka_topic: &str,
+        from: StartOffset,
+    ) -> Result<SubscribeStream, BusError>;
 }
 
 /// Shared-ownership handle for consumers that want to stash a backend

--- a/crates/bus/src/backend.rs
+++ b/crates/bus/src/backend.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -8,6 +9,31 @@ use acteon_core::{PartitionLag, Topic};
 
 use crate::error::BusError;
 use crate::message::{BusMessage, DeliveryReceipt, OffsetPosition, StartOffset};
+
+/// Where a [`BusBackend::scan_topic`] should start reading. A simple
+/// `Earliest` / `Latest` covers the open-ended replay case; the
+/// `FromOffsets` variant resumes from explicit per-partition offsets,
+/// which is how the conversation-replay endpoint paginates without
+/// holding state on the server.
+#[derive(Debug, Clone)]
+pub enum ScanFrom {
+    /// Read from the earliest retained record on every partition.
+    Earliest,
+    /// Read from the broker's high-water mark on every partition.
+    Latest,
+    /// Read each partition starting at the explicit offset given;
+    /// partitions absent from the map are skipped (the caller has
+    /// already drained them).
+    FromOffsets(BTreeMap<i32, i64>),
+}
+
+/// Snapshot of a scan's position, captured by `scan_topic_watermarks`
+/// or after a partial replay so a client can resume where it left off.
+#[derive(Debug, Clone, Default)]
+pub struct ScanWatermarks {
+    /// Per-partition high-water marks at the time of capture.
+    pub high_water_marks: BTreeMap<i32, i64>,
+}
 
 /// Stream yielded by [`BusBackend::subscribe`]. Items are individual
 /// `BusMessage`s; a transport error ends the stream.
@@ -78,8 +104,16 @@ pub trait BusBackend: Send + Sync + 'static {
     async fn scan_topic(
         &self,
         kafka_topic: &str,
-        from: StartOffset,
+        from: ScanFrom,
     ) -> Result<SubscribeStream, BusError>;
+
+    /// Snapshot the high-water mark of every partition. Replay
+    /// endpoints call this once at the start of a scan so they can
+    /// determine end-of-stream by comparing tracked offsets against
+    /// the captured marks. Without this snapshot, an `assign`-based
+    /// scan never naturally terminates — Kafka keeps the stream open
+    /// waiting for new records.
+    async fn scan_topic_watermarks(&self, kafka_topic: &str) -> Result<ScanWatermarks, BusError>;
 }
 
 /// Shared-ownership handle for consumers that want to stash a backend

--- a/crates/bus/src/kafka.rs
+++ b/crates/bus/src/kafka.rs
@@ -25,7 +25,7 @@ use rdkafka::TopicPartitionList;
 
 use acteon_core::{PartitionLag, Topic};
 
-use crate::backend::{BusBackend, SubscribeStream};
+use crate::backend::{BusBackend, ScanFrom, ScanWatermarks, SubscribeStream};
 use crate::config::KafkaBusConfig;
 use crate::error::BusError;
 use crate::message::{BusMessage, DeliveryReceipt, OffsetPosition, StartOffset};
@@ -406,7 +406,7 @@ impl BusBackend for KafkaBackend {
     async fn scan_topic(
         &self,
         kafka_topic: &str,
-        from: StartOffset,
+        from: ScanFrom,
     ) -> Result<SubscribeStream, BusError> {
         // `assign()` (manual partition placement) bypasses the consumer
         // group coordinator entirely — no JoinGroup, no
@@ -415,13 +415,21 @@ impl BusBackend for KafkaBackend {
         // because rdkafka still requires the field; without an explicit
         // commit it never reaches the broker.
         let group_id = format!("acteon-scan-{}", uuid::Uuid::new_v4());
-        let cfg = self.consumer_config(&group_id, from);
+        let consumer_start = match from {
+            ScanFrom::Earliest => StartOffset::Earliest,
+            // Latest and FromOffsets both ignore `auto.offset.reset`
+            // because we always set explicit offsets via `assign`.
+            ScanFrom::Latest | ScanFrom::FromOffsets(_) => StartOffset::Latest,
+        };
+        let cfg = self.consumer_config(&group_id, consumer_start);
         let consumer: StreamConsumer = cfg
             .create()
             .map_err(|e| BusError::Transport(format!("scan consumer: {e}")))?;
         // Discover partitions, then `assign` each at the requested
         // start offset. `Beginning` / `End` map cleanly to our
-        // `StartOffset` variants and don't require a separate seek.
+        // `ScanFrom::Earliest`/`Latest` variants. `FromOffsets` uses
+        // `Offset::Offset(n)` per partition so clients can paginate
+        // a long scan across multiple requests.
         let metadata = consumer
             .fetch_metadata(Some(kafka_topic), Duration::from_secs(10))
             .map_err(map_kafka_error)?;
@@ -431,13 +439,36 @@ impl BusBackend for KafkaBackend {
             .find(|t| t.name() == kafka_topic)
             .ok_or_else(|| BusError::TopicNotFound(kafka_topic.into()))?;
         let mut tpl = TopicPartitionList::new();
-        let offset = match from {
-            StartOffset::Earliest => rdkafka::Offset::Beginning,
-            StartOffset::Latest => rdkafka::Offset::End,
-        };
-        for p in topic_meta.partitions() {
-            tpl.add_partition_offset(kafka_topic, p.id(), offset)
-                .map_err(|e| BusError::Transport(format!("tpl: {e}")))?;
+        match &from {
+            ScanFrom::Earliest => {
+                for p in topic_meta.partitions() {
+                    tpl.add_partition_offset(kafka_topic, p.id(), rdkafka::Offset::Beginning)
+                        .map_err(|e| BusError::Transport(format!("tpl: {e}")))?;
+                }
+            }
+            ScanFrom::Latest => {
+                for p in topic_meta.partitions() {
+                    tpl.add_partition_offset(kafka_topic, p.id(), rdkafka::Offset::End)
+                        .map_err(|e| BusError::Transport(format!("tpl: {e}")))?;
+                }
+            }
+            ScanFrom::FromOffsets(offsets) => {
+                // Resume each partition from the next-after-last
+                // offset the caller saw. Partitions absent from the
+                // map are skipped — the contract is "the caller has
+                // already drained them" (e.g. a single-partition
+                // conversation that lives entirely on partition 0).
+                for p in topic_meta.partitions() {
+                    if let Some(&last_seen) = offsets.get(&p.id()) {
+                        tpl.add_partition_offset(
+                            kafka_topic,
+                            p.id(),
+                            rdkafka::Offset::Offset(last_seen + 1),
+                        )
+                        .map_err(|e| BusError::Transport(format!("tpl: {e}")))?;
+                    }
+                }
+            }
         }
         consumer
             .assign(&tpl)
@@ -491,5 +522,31 @@ impl BusBackend for KafkaBackend {
             }
         };
         Ok(Box::pin(stream))
+    }
+
+    async fn scan_topic_watermarks(&self, kafka_topic: &str) -> Result<ScanWatermarks, BusError> {
+        // We need a consumer to call `fetch_watermarks`; throwaway
+        // group.id matching `scan_topic`'s pattern.
+        let group_id = format!("acteon-watermark-{}", uuid::Uuid::new_v4());
+        let cfg = self.consumer_config(&group_id, StartOffset::Latest);
+        let consumer: StreamConsumer = cfg
+            .create()
+            .map_err(|e| BusError::Transport(format!("watermark consumer: {e}")))?;
+        let metadata = consumer
+            .fetch_metadata(Some(kafka_topic), Duration::from_secs(10))
+            .map_err(map_kafka_error)?;
+        let topic_meta = metadata
+            .topics()
+            .iter()
+            .find(|t| t.name() == kafka_topic)
+            .ok_or_else(|| BusError::TopicNotFound(kafka_topic.into()))?;
+        let mut high_water_marks = std::collections::BTreeMap::new();
+        for p in topic_meta.partitions() {
+            let (_low, high) = consumer
+                .fetch_watermarks(kafka_topic, p.id(), Duration::from_secs(10))
+                .map_err(map_kafka_error)?;
+            high_water_marks.insert(p.id(), high);
+        }
+        Ok(ScanWatermarks { high_water_marks })
     }
 }

--- a/crates/bus/src/kafka.rs
+++ b/crates/bus/src/kafka.rs
@@ -402,4 +402,94 @@ impl BusBackend for KafkaBackend {
         }
         Ok(out)
     }
+
+    async fn scan_topic(
+        &self,
+        kafka_topic: &str,
+        from: StartOffset,
+    ) -> Result<SubscribeStream, BusError> {
+        // `assign()` (manual partition placement) bypasses the consumer
+        // group coordinator entirely — no JoinGroup, no
+        // `__consumer_offsets` row, no metadata leak when the consumer
+        // is dropped. We use a unique throwaway `group.id` defensively
+        // because rdkafka still requires the field; without an explicit
+        // commit it never reaches the broker.
+        let group_id = format!("acteon-scan-{}", uuid::Uuid::new_v4());
+        let cfg = self.consumer_config(&group_id, from);
+        let consumer: StreamConsumer = cfg
+            .create()
+            .map_err(|e| BusError::Transport(format!("scan consumer: {e}")))?;
+        // Discover partitions, then `assign` each at the requested
+        // start offset. `Beginning` / `End` map cleanly to our
+        // `StartOffset` variants and don't require a separate seek.
+        let metadata = consumer
+            .fetch_metadata(Some(kafka_topic), Duration::from_secs(10))
+            .map_err(map_kafka_error)?;
+        let topic_meta = metadata
+            .topics()
+            .iter()
+            .find(|t| t.name() == kafka_topic)
+            .ok_or_else(|| BusError::TopicNotFound(kafka_topic.into()))?;
+        let mut tpl = TopicPartitionList::new();
+        let offset = match from {
+            StartOffset::Earliest => rdkafka::Offset::Beginning,
+            StartOffset::Latest => rdkafka::Offset::End,
+        };
+        for p in topic_meta.partitions() {
+            tpl.add_partition_offset(kafka_topic, p.id(), offset)
+                .map_err(|e| BusError::Transport(format!("tpl: {e}")))?;
+        }
+        consumer
+            .assign(&tpl)
+            .map_err(|e| BusError::Transport(format!("assign: {e}")))?;
+
+        let topic_owned = kafka_topic.to_string();
+        let stream = async_stream::stream! {
+            let mut stream = consumer.stream();
+            while let Some(res) = stream.next().await {
+                match res {
+                    Ok(msg) => {
+                        let payload = msg.payload().map_or(serde_json::Value::Null, |b| {
+                            serde_json::from_slice::<serde_json::Value>(b)
+                                .unwrap_or(serde_json::Value::Null)
+                        });
+                        let key = msg
+                            .key()
+                            .and_then(|b| std::str::from_utf8(b).ok())
+                            .map(str::to_string);
+                        let mut headers = std::collections::BTreeMap::new();
+                        if let Some(h) = msg.headers() {
+                            for i in 0..h.count() {
+                                let rec = h.get(i);
+                                let name = rec.key.to_string();
+                                if let Some(v) = rec.value
+                                    && let Ok(s) = std::str::from_utf8(v)
+                                {
+                                    headers.insert(name, s.to_string());
+                                }
+                            }
+                        }
+                        let timestamp = msg
+                            .timestamp()
+                            .to_millis()
+                            .and_then(|ms| Utc.timestamp_millis_opt(ms).single());
+                        yield Ok(BusMessage {
+                            topic: topic_owned.clone(),
+                            key,
+                            payload,
+                            headers,
+                            partition: Some(msg.partition()),
+                            offset: Some(msg.offset()),
+                            timestamp,
+                        });
+                    }
+                    Err(e) => {
+                        yield Err(BusError::Transport(e.to_string()));
+                        break;
+                    }
+                }
+            }
+        };
+        Ok(Box::pin(stream))
+    }
 }

--- a/crates/bus/src/lib.rs
+++ b/crates/bus/src/lib.rs
@@ -23,7 +23,7 @@ pub mod memory;
 pub mod message;
 pub mod schema;
 
-pub use backend::{BusBackend, SharedBackend, SubscribeStream};
+pub use backend::{BusBackend, ScanFrom, ScanWatermarks, SharedBackend, SubscribeStream};
 pub use config::{BusConfig, KafkaBusConfig};
 pub use error::BusError;
 pub use kafka::KafkaBackend;

--- a/crates/bus/src/memory.rs
+++ b/crates/bus/src/memory.rs
@@ -16,7 +16,7 @@ use tokio::sync::broadcast;
 
 use acteon_core::Topic;
 
-use crate::backend::{BusBackend, SubscribeStream};
+use crate::backend::{BusBackend, ScanFrom, ScanWatermarks, SubscribeStream};
 use acteon_core::PartitionLag;
 
 use crate::error::BusError;
@@ -183,13 +183,58 @@ impl BusBackend for MemoryBackend {
     async fn scan_topic(
         &self,
         kafka_topic: &str,
-        from: StartOffset,
+        from: ScanFrom,
     ) -> Result<SubscribeStream, BusError> {
         // Memory backend has no consumer-group concept — `scan_topic`
         // and `subscribe` are equivalent here. The distinction
         // matters in the Kafka backend where `scan_topic` uses
         // `assign()` to avoid leaking consumer-group metadata.
-        self.subscribe(kafka_topic, "memory-scan", from).await
+        let (start_offset, skip_until_offset) = match from {
+            ScanFrom::Earliest => (StartOffset::Earliest, None),
+            ScanFrom::Latest => (StartOffset::Latest, None),
+            // Memory backend has only one partition (id 0); honor the
+            // partition-0 entry if present, otherwise replay from
+            // earliest. We materialize the skip-until offset and let
+            // the caller filter inline.
+            ScanFrom::FromOffsets(map) => {
+                let skip = map.get(&0).copied();
+                (StartOffset::Earliest, skip)
+            }
+        };
+        let stream = self
+            .subscribe(kafka_topic, "memory-scan", start_offset)
+            .await?;
+        match skip_until_offset {
+            None => Ok(stream),
+            Some(skip) => {
+                use futures::StreamExt;
+                // Caller provided per-partition resume offsets; drop
+                // anything at-or-before `skip` so callers see only
+                // strictly-newer messages. Memory backend doesn't
+                // populate `BusMessage.offset`, so we count by index
+                // — the contract `subscribe(Earliest)` gives is
+                // monotonic-from-zero, matching memory's offset model.
+                let mut idx: i64 = -1;
+                let s = stream.filter(move |m| {
+                    if m.is_ok() {
+                        idx += 1;
+                    }
+                    futures::future::ready(idx > skip)
+                });
+                Ok(Box::pin(s))
+            }
+        }
+    }
+
+    async fn scan_topic_watermarks(&self, kafka_topic: &str) -> Result<ScanWatermarks, BusError> {
+        let topics = self.topics.lock();
+        let state = topics
+            .get(kafka_topic)
+            .ok_or_else(|| BusError::TopicNotFound(kafka_topic.into()))?;
+        let mut high_water_marks = std::collections::BTreeMap::new();
+        // Single-partition contract for the in-memory backend.
+        high_water_marks.insert(0, state.next_offset);
+        Ok(ScanWatermarks { high_water_marks })
     }
 }
 

--- a/crates/bus/src/memory.rs
+++ b/crates/bus/src/memory.rs
@@ -179,6 +179,18 @@ impl BusBackend for MemoryBackend {
             lag,
         }])
     }
+
+    async fn scan_topic(
+        &self,
+        kafka_topic: &str,
+        from: StartOffset,
+    ) -> Result<SubscribeStream, BusError> {
+        // Memory backend has no consumer-group concept — `scan_topic`
+        // and `subscribe` are equivalent here. The distinction
+        // matters in the Kafka backend where `scan_topic` uses
+        // `assign()` to avoid leaking consumer-group metadata.
+        self.subscribe(kafka_topic, "memory-scan", from).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/client/src/bus.rs
+++ b/crates/client/src/bus.rs
@@ -1319,6 +1319,10 @@ pub struct ReplayBusConversationParams {
     pub limit: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout_ms: Option<u64>,
+    /// Resume token from a previous response's `cursor`. When set,
+    /// `from` is ignored.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1333,12 +1337,27 @@ pub struct BusConversationReplayMessage {
     pub timestamp: String,
 }
 
+/// Why the server-side replay loop terminated. `Complete` = thread
+/// fully drained at scan time; `Limit` and `Timeout` = partial,
+/// follow-up needed via `cursor`.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BusReplayExitReason {
+    Complete,
+    Limit,
+    Timeout,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct BusConversationReplay {
     pub conversation_id: String,
     pub events_topic: String,
     pub messages: Vec<BusConversationReplayMessage>,
-    pub limit_reached: bool,
+    pub exit_reason: BusReplayExitReason,
+    /// `Some` when the scan is incomplete. Pass back as
+    /// `ReplayBusConversationParams.cursor` to continue.
+    #[serde(default)]
+    pub cursor: Option<String>,
 }
 
 async fn map_error(resp: reqwest::Response) -> Error {

--- a/crates/client/src/bus.rs
+++ b/crates/client/src/bus.rs
@@ -836,6 +836,214 @@ impl ActeonClient {
             None => format!("{}/v1/bus/agents/{ns}/{t}/{a}", self.base_url),
         }
     }
+
+    // ----- Phase 5: conversations -----
+
+    /// Register a conversation. First conversation in a `(namespace,
+    /// tenant)` causes the shared events topic
+    /// `{ns}.{tenant}.conversations-events` to be auto-created.
+    pub async fn register_bus_conversation(
+        &self,
+        req: &RegisterBusConversation,
+    ) -> Result<BusConversation, Error> {
+        let url = format!("{}/v1/bus/conversations", self.base_url);
+        let resp = self
+            .add_auth(self.client.post(&url))
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusConversation>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// List conversations, optionally filtered by namespace/tenant/state/participant.
+    pub async fn list_bus_conversations(
+        &self,
+        filter: &BusConversationFilter,
+    ) -> Result<ListBusConversationsResponse, Error> {
+        let url = format!("{}/v1/bus/conversations", self.base_url);
+        let resp = self
+            .add_auth(self.client.get(&url))
+            .query(filter)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<ListBusConversationsResponse>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Fetch a single conversation record.
+    pub async fn get_bus_conversation(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        conversation_id: &str,
+    ) -> Result<BusConversation, Error> {
+        let url = self.conversation_url(namespace, tenant, conversation_id, None);
+        let resp = self
+            .add_auth(self.client.get(&url))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusConversation>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Patch-style update of mutable fields. State transitions go
+    /// through [`Self::transition_bus_conversation`] instead.
+    pub async fn update_bus_conversation(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        conversation_id: &str,
+        req: &UpdateBusConversation,
+    ) -> Result<BusConversation, Error> {
+        let url = self.conversation_url(namespace, tenant, conversation_id, None);
+        let resp = self
+            .add_auth(self.client.put(&url))
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusConversation>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Delete a conversation record. The shared events topic is
+    /// preserved — other conversations in the tenant share it.
+    pub async fn delete_bus_conversation(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        conversation_id: &str,
+    ) -> Result<(), Error> {
+        let url = self.conversation_url(namespace, tenant, conversation_id, None);
+        let resp = self
+            .add_auth(self.client.delete(&url))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Drive the conversation through its state machine. Server
+    /// returns 409 if the requested transition is illegal for the
+    /// current state.
+    pub async fn transition_bus_conversation(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        conversation_id: &str,
+        transition: BusConversationTransition,
+    ) -> Result<BusConversation, Error> {
+        let url = self.conversation_url(namespace, tenant, conversation_id, Some("transition"));
+        let resp = self
+            .add_auth(self.client.post(&url))
+            .json(&serde_json::json!({ "transition": transition }))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusConversation>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Append a message to the conversation thread. Keyed by
+    /// `conversation_id` so Kafka routes all messages for this thread
+    /// to a stable partition (per-thread FIFO).
+    pub async fn append_bus_conversation_message(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        conversation_id: &str,
+        req: &AppendBusConversationMessage,
+    ) -> Result<BusConversationAppendReceipt, Error> {
+        let url = self.conversation_url(namespace, tenant, conversation_id, Some("messages"));
+        let resp = self
+            .add_auth(self.client.post(&url))
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusConversationAppendReceipt>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Replay the message history for a conversation. The server
+    /// reads from the shared events topic and filters on the
+    /// server-stamped `acteon.conversation.id` header.
+    pub async fn replay_bus_conversation_messages(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        conversation_id: &str,
+        params: &ReplayBusConversationParams,
+    ) -> Result<BusConversationReplay, Error> {
+        let url = self.conversation_url(namespace, tenant, conversation_id, Some("messages"));
+        let resp = self
+            .add_auth(self.client.get(&url))
+            .query(params)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusConversationReplay>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    fn conversation_url(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        conversation_id: &str,
+        suffix: Option<&str>,
+    ) -> String {
+        let ns = encode_segment(namespace);
+        let t = encode_segment(tenant);
+        let c = encode_segment(conversation_id);
+        match suffix {
+            Some(s) => format!("{}/v1/bus/conversations/{ns}/{t}/{c}/{s}", self.base_url),
+            None => format!("{}/v1/bus/conversations/{ns}/{t}/{c}", self.base_url),
+        }
+    }
 }
 
 // ----- Phase 3: DTOs -----
@@ -999,6 +1207,134 @@ pub struct BusAgentSendReceipt {
     pub partition: i32,
     pub offset: i64,
     pub produced_at: String,
+}
+
+// ----- Phase 5: conversation DTOs -----
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct RegisterBusConversation {
+    pub conversation_id: String,
+    pub namespace: String,
+    pub tenant: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub participants: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub events_topic: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub labels: HashMap<String, String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct UpdateBusConversation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub participants: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub events_topic: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BusConversationState {
+    Active,
+    Resolved,
+    Archived,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BusConversationTransition {
+    Resolve,
+    Reopen,
+    Archive,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BusConversation {
+    pub conversation_id: String,
+    pub namespace: String,
+    pub tenant: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    pub state: BusConversationState,
+    #[serde(default)]
+    pub participants: Vec<String>,
+    pub events_topic: String,
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListBusConversationsResponse {
+    pub conversations: Vec<BusConversation>,
+    pub count: usize,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct BusConversationFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub participant: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct AppendBusConversationMessage {
+    pub payload: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sender: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BusConversationAppendReceipt {
+    pub events_topic: String,
+    pub conversation_id: String,
+    pub partition: i32,
+    pub offset: i64,
+    pub produced_at: String,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct ReplayBusConversationParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BusConversationReplayMessage {
+    pub partition: i32,
+    pub offset: i64,
+    #[serde(default)]
+    pub key: Option<String>,
+    pub payload: serde_json::Value,
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+    pub timestamp: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BusConversationReplay {
+    pub conversation_id: String,
+    pub events_topic: String,
+    pub messages: Vec<BusConversationReplayMessage>,
+    pub limit_reached: bool,
 }
 
 async fn map_error(resp: reqwest::Response) -> Error {

--- a/crates/client/src/bus.rs
+++ b/crates/client/src/bus.rs
@@ -1134,14 +1134,16 @@ pub struct RegisterBusAgent {
     pub labels: HashMap<String, String>,
 }
 
+/// `inbox_topic` is intentionally absent — once an agent is
+/// registered, its inbox is fixed. Migrating to a different topic
+/// would orphan in-flight messages; delete and re-register if you
+/// need a different inbox.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct UpdateBusAgent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capabilities: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub inbox_topic: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub heartbeat_ttl_ms: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1226,14 +1228,16 @@ pub struct RegisterBusConversation {
     pub labels: HashMap<String, String>,
 }
 
+/// `events_topic` is intentionally absent — once a conversation is
+/// registered, the topic it produces to is fixed. Migrating mid-thread
+/// would split the message log across two topics; delete and
+/// re-register if you need a different topic.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct UpdateBusConversation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub participants: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub events_topic: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<HashMap<String, String>>,
 }

--- a/crates/core/src/bus_conversation.rs
+++ b/crates/core/src/bus_conversation.rs
@@ -1,0 +1,353 @@
+//! Bus conversation — multi-agent thread with state and ordered
+//! message log (Phase 5).
+//!
+//! Conversations are an Acteon-side state object that pairs with a
+//! shared Kafka events topic. Messages addressed to a conversation
+//! are produced with `key = conversation_id`, so Kafka's key-based
+//! partitioner gives per-conversation FIFO ordering without any
+//! per-conversation topic explosion. Participants are recorded
+//! on the conversation itself rather than inferred from message
+//! senders so an operator can ACL the thread before the first
+//! message lands.
+//!
+//! State machine:
+//!
+//! ```text
+//!   ┌─────────┐  resolve   ┌──────────┐  archive   ┌──────────┐
+//!   │ Active  │───────────▶│ Resolved │───────────▶│ Archived │
+//!   └─────────┘            └──────────┘            └──────────┘
+//!         ▲                      │
+//!         └─────── reopen ───────┘
+//! ```
+//!
+//! Linear by design; `Active → Archived` requires going through
+//! `Resolved` first. `Reopen` is allowed back to `Active` from
+//! `Resolved` only — once `Archived`, the conversation is final.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Default events-topic suffix. Combined with `{namespace}.{tenant}.`
+/// to form the shared Kafka topic that all conversations in that
+/// tenant produce to.
+pub const DEFAULT_CONVERSATIONS_EVENTS_SUFFIX: &str = "conversations-events";
+
+/// Lifecycle state of a conversation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum ConversationState {
+    /// Conversation is open; participants may post messages.
+    #[default]
+    Active,
+    /// Conversation has been resolved. Posts are still allowed (a
+    /// participant may need to add a follow-up note) but the operator
+    /// has marked the work as complete.
+    Resolved,
+    /// Conversation is closed and read-only. Posts are rejected.
+    Archived,
+}
+
+/// Allowed transitions between states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum ConversationTransition {
+    /// `Active → Resolved`.
+    Resolve,
+    /// `Resolved → Active`. Mistakes happen.
+    Reopen,
+    /// `Resolved → Archived`. Final.
+    Archive,
+}
+
+/// A multi-agent thread tracked by Acteon.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct Conversation {
+    /// Stable identifier. Used as the Kafka partition key for
+    /// every message in this thread.
+    pub conversation_id: String,
+    /// Namespace the conversation belongs to.
+    pub namespace: String,
+    /// Tenant that owns the conversation.
+    pub tenant: String,
+    /// Operator-supplied title.
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Current lifecycle state.
+    #[serde(default)]
+    pub state: ConversationState,
+    /// Agent IDs allowed to post in this conversation. Empty means
+    /// "any agent in the tenant" — operators tighten the ACL by
+    /// listing specific participants.
+    #[serde(default)]
+    pub participants: Vec<String>,
+    /// Override events topic (defaults to
+    /// `{namespace}.{tenant}.conversations-events`).
+    #[serde(default)]
+    pub events_topic: Option<String>,
+    /// Free-form operator labels.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub labels: HashMap<String, String>,
+    /// Creation timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Last mutation timestamp (CRUD or transition).
+    pub updated_at: DateTime<Utc>,
+}
+
+impl Conversation {
+    /// Construct a fresh conversation with sensible defaults.
+    #[must_use]
+    pub fn new(
+        conversation_id: impl Into<String>,
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            conversation_id: conversation_id.into(),
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            title: None,
+            state: ConversationState::default(),
+            participants: Vec::new(),
+            events_topic: None,
+            labels: HashMap::new(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Canonical Kafka events-topic name for this conversation. Falls
+    /// back to the tenant-shared default when `events_topic` is unset.
+    #[must_use]
+    pub fn effective_events_topic(&self) -> String {
+        self.events_topic.clone().unwrap_or_else(|| {
+            format!(
+                "{}.{}.{}",
+                self.namespace, self.tenant, DEFAULT_CONVERSATIONS_EVENTS_SUFFIX
+            )
+        })
+    }
+
+    /// State-store id. The `conversation_id` is unique within a
+    /// `(namespace, tenant)` so the parent scope already disambiguates.
+    #[must_use]
+    pub fn id(&self) -> String {
+        self.conversation_id.clone()
+    }
+
+    /// Apply a transition, returning the resulting state. Rejects
+    /// illegal transitions explicitly so the API can surface a 409
+    /// instead of silently writing nothing.
+    pub fn apply_transition(
+        &mut self,
+        transition: ConversationTransition,
+    ) -> Result<ConversationState, ConversationValidationError> {
+        let next = match (self.state, transition) {
+            (ConversationState::Active, ConversationTransition::Resolve) => {
+                ConversationState::Resolved
+            }
+            (ConversationState::Resolved, ConversationTransition::Reopen) => {
+                ConversationState::Active
+            }
+            (ConversationState::Resolved, ConversationTransition::Archive) => {
+                ConversationState::Archived
+            }
+            // Everything else (e.g. Resolve from Archived, Archive
+            // from Active without going through Resolved) is illegal.
+            (from, t) => {
+                return Err(ConversationValidationError::IllegalTransition {
+                    from,
+                    transition: t,
+                });
+            }
+        };
+        self.state = next;
+        self.updated_at = Utc::now();
+        Ok(next)
+    }
+
+    /// Whether the conversation accepts new messages. `Archived` is
+    /// read-only by design; `Active` and `Resolved` both allow posts
+    /// (a follow-up after resolution is a common pattern).
+    #[must_use]
+    pub fn accepts_messages(&self) -> bool {
+        !matches!(self.state, ConversationState::Archived)
+    }
+
+    /// Validate identity + ACL fields end-to-end.
+    pub fn validate(&self) -> Result<(), ConversationValidationError> {
+        Self::validate_id(&self.conversation_id)?;
+        Self::validate_fragment(&self.namespace)?;
+        Self::validate_fragment(&self.tenant)?;
+        for p in &self.participants {
+            Self::validate_id(p)
+                .map_err(|_| ConversationValidationError::InvalidParticipant(p.clone()))?;
+        }
+        Ok(())
+    }
+
+    /// Conversation IDs follow the agent-ID alphabet —
+    /// `[a-zA-Z0-9._-]`, max 120 chars — so they're safe in URLs,
+    /// state keys, and Kafka headers.
+    pub fn validate_id(s: &str) -> Result<(), ConversationValidationError> {
+        if s.is_empty() {
+            return Err(ConversationValidationError::EmptyId);
+        }
+        if s.len() > 120 {
+            return Err(ConversationValidationError::IdTooLong);
+        }
+        if !s
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+        {
+            return Err(ConversationValidationError::InvalidIdChar(s.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Namespace/tenant rules — same as topics so the generated
+    /// events-topic name is always valid.
+    pub fn validate_fragment(s: &str) -> Result<(), ConversationValidationError> {
+        if s.is_empty() {
+            return Err(ConversationValidationError::EmptyFragment);
+        }
+        if s.len() > 80 {
+            return Err(ConversationValidationError::FragmentTooLong);
+        }
+        if !s
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(ConversationValidationError::InvalidFragmentChar(
+                s.to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ConversationValidationError {
+    #[error("conversation_id must not be empty")]
+    EmptyId,
+    #[error("conversation_id exceeds 120 characters")]
+    IdTooLong,
+    #[error("conversation_id '{0}' contains characters outside [a-zA-Z0-9._-]")]
+    InvalidIdChar(String),
+    #[error("namespace/tenant fragment must not be empty")]
+    EmptyFragment,
+    #[error("namespace/tenant fragment exceeds 80 characters")]
+    FragmentTooLong,
+    #[error("namespace/tenant fragment '{0}' contains characters outside [a-zA-Z0-9_-]")]
+    InvalidFragmentChar(String),
+    #[error("participant '{0}' is not a valid agent_id")]
+    InvalidParticipant(String),
+    #[error("illegal transition {transition:?} from state {from:?}")]
+    IllegalTransition {
+        from: ConversationState,
+        transition: ConversationTransition,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effective_events_topic_defaults_when_unset() {
+        let c = Conversation::new("c1", "agents", "demo");
+        assert_eq!(
+            c.effective_events_topic(),
+            "agents.demo.conversations-events"
+        );
+    }
+
+    #[test]
+    fn effective_events_topic_honors_override() {
+        let mut c = Conversation::new("c1", "agents", "demo");
+        c.events_topic = Some("agents.demo.priority-thread".into());
+        assert_eq!(c.effective_events_topic(), "agents.demo.priority-thread");
+    }
+
+    #[test]
+    fn default_state_is_active() {
+        let c = Conversation::new("c1", "ns", "t");
+        assert_eq!(c.state, ConversationState::Active);
+        assert!(c.accepts_messages());
+    }
+
+    #[test]
+    fn transitions_resolve_then_archive() {
+        let mut c = Conversation::new("c1", "ns", "t");
+        c.apply_transition(ConversationTransition::Resolve).unwrap();
+        assert_eq!(c.state, ConversationState::Resolved);
+        assert!(c.accepts_messages());
+
+        c.apply_transition(ConversationTransition::Archive).unwrap();
+        assert_eq!(c.state, ConversationState::Archived);
+        assert!(!c.accepts_messages());
+    }
+
+    #[test]
+    fn transition_reopen_from_resolved() {
+        let mut c = Conversation::new("c1", "ns", "t");
+        c.apply_transition(ConversationTransition::Resolve).unwrap();
+        c.apply_transition(ConversationTransition::Reopen).unwrap();
+        assert_eq!(c.state, ConversationState::Active);
+    }
+
+    #[test]
+    fn cannot_archive_directly_from_active() {
+        let mut c = Conversation::new("c1", "ns", "t");
+        let err = c
+            .apply_transition(ConversationTransition::Archive)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ConversationValidationError::IllegalTransition { .. }
+        ));
+    }
+
+    #[test]
+    fn cannot_reopen_from_archived() {
+        let mut c = Conversation::new("c1", "ns", "t");
+        c.apply_transition(ConversationTransition::Resolve).unwrap();
+        c.apply_transition(ConversationTransition::Archive).unwrap();
+        assert!(c.apply_transition(ConversationTransition::Reopen).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_invalid_participant() {
+        let mut c = Conversation::new("c1", "ns", "t");
+        c.participants.push("bad/agent".into());
+        let err = c.validate().unwrap_err();
+        assert!(matches!(
+            err,
+            ConversationValidationError::InvalidParticipant(_)
+        ));
+    }
+
+    #[test]
+    fn validate_accepts_dotted_id() {
+        let c = Conversation::new("thread.42", "ns", "t");
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn roundtrip_serde() {
+        let mut c = Conversation::new("c1", "ns", "t");
+        c.title = Some("planning meeting".into());
+        c.participants = vec!["planner-1".into(), "ocr-svc".into()];
+        c.labels.insert("project".into(), "alpha".into());
+        let j = serde_json::to_string(&c).unwrap();
+        let back: Conversation = serde_json::from_str(&j).unwrap();
+        assert_eq!(back.title, c.title);
+        assert_eq!(back.participants, c.participants);
+        assert_eq!(back.labels, c.labels);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod action;
 pub mod analytics;
 pub mod attachment;
 pub mod bus_agent;
+pub mod bus_conversation;
 pub mod bus_schema;
 pub mod bus_subscription;
 pub mod bus_topic;
@@ -37,6 +38,10 @@ pub use analytics::{
 pub use attachment::{Attachment, ResolvedAttachment};
 pub use bus_agent::{
     Agent, AgentStatus, AgentValidationError, DEFAULT_AGENT_INBOX_SUFFIX, DEFAULT_HEARTBEAT_TTL_MS,
+};
+pub use bus_conversation::{
+    Conversation, ConversationState, ConversationTransition, ConversationValidationError,
+    DEFAULT_CONVERSATIONS_EVENTS_SUFFIX,
 };
 pub use bus_schema::{Schema, SchemaFormat, SchemaValidationError};
 pub use bus_subscription::{

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -5796,6 +5796,22 @@ impl acteon_state::StateStore for PlaygroundStateStore<'_> {
         self.inner.get(key).await
     }
 
+    async fn get_versioned(
+        &self,
+        key: &acteon_state::StateKey,
+    ) -> Result<Option<(String, u64)>, acteon_state::StateError> {
+        // Overrides expose the value but no version metadata; callers
+        // that go through the playground are expected to read-only,
+        // so version 0 ("never seen a version") is the safe answer.
+        if let Some(val) = self.overrides.get(&key.canonical()) {
+            return Ok(Some((val.clone(), 0)));
+        }
+        if let Some(val) = self.overrides.get(&key.id) {
+            return Ok(Some((val.clone(), 0)));
+        }
+        self.inner.get_versioned(key).await
+    }
+
     // All other methods are no-ops or errors since the playground is read-only.
     async fn set(
         &self,
@@ -5913,6 +5929,12 @@ impl acteon_state::StateStore for BorrowedStateStore<'_> {
         k: &acteon_state::StateKey,
     ) -> Result<Option<String>, acteon_state::StateError> {
         self.0.get(k).await
+    }
+    async fn get_versioned(
+        &self,
+        k: &acteon_state::StateKey,
+    ) -> Result<Option<(String, u64)>, acteon_state::StateError> {
+        self.0.get_versioned(k).await
     }
     async fn set(
         &self,

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -3020,20 +3020,36 @@ pub async fn register_agent(
         let inbox = agent.effective_inbox_topic();
         // Require that a custom inbox belongs to the same tenant. Same
         // check we enforce on subscriptions so an agent can't hijack
-        // another tenant's topic.
-        if let Ok((topic_ns, topic_t, _)) = parse_kafka_name(&inbox)
-            && (topic_ns != agent.namespace || topic_t != agent.tenant)
-        {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: format!(
-                        "inbox topic {inbox} crosses tenants: must be under {}.{}",
-                        agent.namespace, agent.tenant
-                    ),
-                }),
-            )
-                .into_response();
+        // another tenant's topic. Fail-closed: an unparseable
+        // override is rejected — the previous `if let Ok && ...` form
+        // silently accepted malformed names that bypassed the tenant
+        // check entirely (Phase 5 review found the same shape there).
+        if let Some(override_topic) = req.inbox_topic.as_deref() {
+            match parse_kafka_name(override_topic) {
+                Ok((topic_ns, topic_t, _)) => {
+                    if topic_ns != agent.namespace || topic_t != agent.tenant {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Json(ErrorResponse {
+                                error: format!(
+                                    "inbox topic {override_topic} crosses tenants: must be under {}.{}",
+                                    agent.namespace, agent.tenant
+                                ),
+                            }),
+                        )
+                            .into_response();
+                    }
+                }
+                Err(msg) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!("inbox topic '{override_topic}' is invalid: {msg}"),
+                        }),
+                    )
+                        .into_response();
+                }
+            }
         }
         let key = StateKey::new(
             agent.namespace.clone(),
@@ -3703,6 +3719,13 @@ pub struct ListConversationsParams {
     /// Filter conversations whose participant list contains this `agent_id`.
     #[serde(default)]
     pub participant: Option<String>,
+    /// Hard cap on returned rows. Default 100, max 500. The current
+    /// implementation scans every row of `KeyKind::BusConversation`
+    /// and filters in memory, so this bounds the response payload
+    /// while a future state-store cursor primitive is added for true
+    /// pagination at scale.
+    #[serde(default)]
+    pub limit: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -3911,21 +3934,40 @@ pub async fn register_conversation(
             )
                 .into_response();
         }
-        let events_topic = conv.effective_events_topic();
-        if let Ok((topic_ns, topic_t, _)) = parse_kafka_name(&events_topic)
-            && (topic_ns != conv.namespace || topic_t != conv.tenant)
-        {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: format!(
-                        "events topic {events_topic} crosses tenants: must be under {}.{}",
-                        conv.namespace, conv.tenant
-                    ),
-                }),
-            )
-                .into_response();
+        // Validate any caller-supplied `events_topic` override before
+        // we touch state or Kafka. Fail-closed: an unparseable name
+        // (zero or too many dots, no namespace.tenant prefix) MUST
+        // be rejected. The earlier `if let Ok(...) && ...` form
+        // silently *accepted* unparseable names, which let a tenant
+        // produce to arbitrary topics — fixed here.
+        if let Some(override_topic) = req.events_topic.as_deref() {
+            match parse_kafka_name(override_topic) {
+                Ok((topic_ns, topic_t, _)) => {
+                    if topic_ns != conv.namespace || topic_t != conv.tenant {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Json(ErrorResponse {
+                                error: format!(
+                                    "events topic {override_topic} crosses tenants: must be under {}.{}",
+                                    conv.namespace, conv.tenant
+                                ),
+                            }),
+                        )
+                            .into_response();
+                    }
+                }
+                Err(msg) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!("events topic '{override_topic}' is invalid: {msg}"),
+                        }),
+                    )
+                        .into_response();
+                }
+            }
         }
+        let events_topic = conv.effective_events_topic();
         if let Err(resp) =
             ensure_conversation_events_topic(&state, &conv.namespace, &conv.tenant, &events_topic)
                 .await
@@ -4021,6 +4063,13 @@ pub async fn list_conversations(
                     .into_response();
             }
         };
+        // Bound the response. `scan_keys_by_kind` still pulls every
+        // row from the state store for filtering; a future
+        // state-store cursor primitive will let us push the bound
+        // down to the backend. Until then, the `take(limit)` here
+        // protects the response payload and serialization cost from
+        // OOM at scale.
+        let limit = params.limit.unwrap_or(100).min(500);
         let convs: Vec<acteon_core::Conversation> = rows
             .into_iter()
             .filter_map(|(_, v)| serde_json::from_str::<acteon_core::Conversation>(&v).ok())
@@ -4039,6 +4088,7 @@ pub async fn list_conversations(
                     .is_none_or(|p| c.participants.iter().any(|x| x == p))
             })
             .filter(|c| identity.is_authorized(&c.tenant, &c.namespace, "bus", "conversation"))
+            .take(limit)
             .collect();
         let responses: Vec<ConversationResponse> =
             convs.iter().map(conversation_to_response).collect();
@@ -4424,20 +4474,38 @@ pub async fn append_conversation_message(
             )
                 .into_response();
         }
-        if let Some(sender) = req.sender.as_deref()
-            && !conv.participants.is_empty()
-            && !conv.participants.iter().any(|p| p == sender)
-        {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: format!(
-                        "sender '{sender}' is not a participant of conversation {}",
-                        conv.conversation_id
-                    ),
-                }),
-            )
-                .into_response();
+        // Participant ACL: when participants is non-empty, the sender
+        // must be present and listed. The earlier `if let Some(sender)`
+        // form silently allowed anonymous posts (sender = None) on
+        // restricted threads, defeating the gate entirely.
+        if !conv.participants.is_empty() {
+            match req.sender.as_deref() {
+                Some(s) if conv.participants.iter().any(|p| p == s) => {}
+                Some(s) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "sender '{s}' is not a participant of conversation {}",
+                                conv.conversation_id
+                            ),
+                        }),
+                    )
+                        .into_response();
+                }
+                None => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "conversation {} has a participant ACL; `sender` is required",
+                                conv.conversation_id
+                            ),
+                        }),
+                    )
+                        .into_response();
+                }
+            }
         }
         let events_topic = conv.effective_events_topic();
         let topic_key = StateKey::new(
@@ -4566,14 +4634,11 @@ pub async fn replay_conversation_messages(
         let limit = params.limit.unwrap_or(200).min(1000);
         let timeout_ms = params.timeout_ms.unwrap_or(1500);
         let events_topic = conv.effective_events_topic();
-        // Use a one-shot consumer group so this read doesn't interfere
-        // with any durable subscription state.
-        let group_id = format!(
-            "acteon-replay-{}-{}",
-            conv.conversation_id,
-            uuid::Uuid::new_v4()
-        );
-        let mut stream = match backend.subscribe(&events_topic, &group_id, from).await {
+        // `scan_topic` uses Kafka's `assign()` rather than dynamic
+        // consumer-group subscribe — no `__consumer_offsets` rows are
+        // created so repeated replays don't accumulate dead groups in
+        // the cluster.
+        let mut stream = match backend.scan_topic(&events_topic, from).await {
             Ok(s) => s,
             Err(acteon_bus::BusError::TopicNotFound(_)) => {
                 return (
@@ -4597,8 +4662,14 @@ pub async fn replay_conversation_messages(
         let deadline = tokio::time::Instant::now() + Duration::from_millis(timeout_ms);
         let mut messages: Vec<ReplayMessageEntry> = Vec::new();
         let mut limit_reached = false;
+        // Fetch `limit + 1` so we can distinguish "exactly `limit`
+        // messages exist" (limit_reached = false) from "more messages
+        // exist past `limit`" (limit_reached = true). Avoids the
+        // off-by-one that would have clients paginate into an empty
+        // tail when the thread length happens to equal the request.
         loop {
-            if messages.len() >= limit {
+            if messages.len() > limit {
+                messages.truncate(limit);
                 limit_reached = true;
                 break;
             }

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -331,15 +331,44 @@ fn encode_replay_cursor(offsets: &std::collections::BTreeMap<i32, i64>) -> Strin
     base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json.as_bytes())
 }
 
+/// Hard cap on a decoded replay cursor's length, in bytes. A cursor
+/// is a JSON object of `{partition: offset}` — at JSON cost of ~20
+/// bytes per entry, 8 KB comfortably fits ~400 partitions, well past
+/// any realistic Kafka topic. Capping here keeps a malicious client
+/// from forcing the server to allocate megabytes for `serde_json` to
+/// chew through before any business logic runs.
+#[cfg(feature = "bus")]
+const MAX_REPLAY_CURSOR_BYTES: usize = 8 * 1024;
+
 /// Decode a cursor produced by [`encode_replay_cursor`]. Tolerates a
 /// missing or malformed token with a structured error so the handler
-/// can surface a 400.
+/// can surface a 400. Caps the decoded payload at
+/// [`MAX_REPLAY_CURSOR_BYTES`] *before* the JSON parse so a hostile
+/// client can't trigger a CPU/memory denial-of-service by sending a megabyte of
+/// nested JSON in the query string.
 #[cfg(feature = "bus")]
 fn decode_replay_cursor(s: &str) -> Result<std::collections::BTreeMap<i32, i64>, String> {
     use base64::Engine;
+    // Reject the encoded form first to skip the base64 work entirely
+    // when the input is already too big. Base64 expands ~33%, so
+    // anything past `MAX * 4 / 3 + a few` bytes can't possibly decode
+    // to ≤ MAX bytes.
+    if s.len() > MAX_REPLAY_CURSOR_BYTES * 4 / 3 + 4 {
+        return Err(format!(
+            "cursor too large: {} encoded bytes (max ~{} encoded)",
+            s.len(),
+            MAX_REPLAY_CURSOR_BYTES * 4 / 3
+        ));
+    }
     let raw = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .decode(s.as_bytes())
         .map_err(|e| format!("base64: {e}"))?;
+    if raw.len() > MAX_REPLAY_CURSOR_BYTES {
+        return Err(format!(
+            "cursor too large: {} decoded bytes (max {MAX_REPLAY_CURSOR_BYTES})",
+            raw.len()
+        ));
+    }
     let json = std::str::from_utf8(&raw).map_err(|e| format!("utf8: {e}"))?;
     serde_json::from_str::<std::collections::BTreeMap<i32, i64>>(json)
         .map_err(|e| format!("json: {e}"))
@@ -4085,8 +4114,18 @@ pub struct ReplayMessageEntry {
 #[serde(rename_all = "snake_case")]
 pub enum ReplayExitReason {
     /// The scan reached or surpassed every partition's high-water
-    /// mark — there are no more messages on the topic at the time
-    /// the scan started. The caller is done.
+    /// mark **as snapshotted at the moment the request started**.
+    /// The caller has every message that existed when they asked.
+    ///
+    /// **Snapshot semantics**: new messages produced *after* the
+    /// scan began are *not* part of this response. For chat-style
+    /// usage where the client wants to keep tailing, treat
+    /// `Complete` as "I've drained the snapshot — call me again
+    /// (with the returned `cursor`, which still encodes the per-
+    /// partition tail) for any new messages." Without this caveat,
+    /// a high-volume conversation can race ahead of the scan and
+    /// produce messages that the next replay starting fresh would
+    /// have to re-discover.
     Complete,
     /// Hit the per-request `limit` before scanning the whole topic.
     /// More messages may exist; resume with `cursor`.
@@ -4102,9 +4141,13 @@ pub struct ReplayConversationResponse {
     pub events_topic: String,
     pub messages: Vec<ReplayMessageEntry>,
     pub exit_reason: ReplayExitReason,
-    /// Opaque resume token. `None` only when `exit_reason ==
-    /// Complete`; otherwise present and meant to be passed back as
-    /// `cursor` on the next request to continue the scan.
+    /// Opaque resume token, always present. On `Limit` and
+    /// `Timeout`, pass it back as `cursor` to keep paginating the
+    /// remainder of the snapshot. On `Complete`, the cursor encodes
+    /// the per-partition tail position at scan end — tailing clients
+    /// pass it back to a follow-up request to pick up messages
+    /// produced after this snapshot. Clients doing a one-shot
+    /// drain ignore the cursor when `exit_reason == Complete`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
 }
@@ -5048,6 +5091,45 @@ pub async fn replay_conversation_messages(
                     .into_response();
             }
         };
+        // Pre-seed the per-partition offset tracker so that *if* the
+        // scan exits without consuming any record on a given
+        // partition (timeout, or no matches), the cursor still
+        // points at a sensible resume position. Without this, an
+        // empty `Latest` scan returned `cursor = "{}"`, which
+        // decoded back to `ScanFrom::FromOffsets({})` — an empty TPL
+        // — and the caller's polling loop would never see a new
+        // message. We use `start - 1` because the kafka backend
+        // resumes at `last_seen + 1`.
+        //
+        // For `Earliest`, seed all known partitions with `-1` →
+        // resume at offset 0.
+        // For `Latest`, seed each partition with `hwm - 1` → resume
+        // at `hwm` (next-to-be-produced).
+        // For `FromOffsets(map)`, copy the caller's positions and
+        // fill any partitions absent from the map with `hwm - 1`
+        // (the contract is "caller has already drained them").
+        let mut last_offsets: std::collections::BTreeMap<i32, i64> =
+            std::collections::BTreeMap::new();
+        match &scan_from {
+            acteon_bus::ScanFrom::Earliest => {
+                for &p in watermarks.high_water_marks.keys() {
+                    last_offsets.insert(p, -1);
+                }
+            }
+            acteon_bus::ScanFrom::Latest => {
+                for (&p, &hwm) in &watermarks.high_water_marks {
+                    last_offsets.insert(p, hwm - 1);
+                }
+            }
+            acteon_bus::ScanFrom::FromOffsets(map) => {
+                for (&p, &off) in map {
+                    last_offsets.insert(p, off);
+                }
+                for (&p, &hwm) in &watermarks.high_water_marks {
+                    last_offsets.entry(p).or_insert(hwm - 1);
+                }
+            }
+        }
         // `scan_topic` uses Kafka's `assign()` rather than dynamic
         // consumer-group subscribe — no `__consumer_offsets` rows are
         // created so repeated replays don't accumulate dead groups in
@@ -5075,12 +5157,10 @@ pub async fn replay_conversation_messages(
         };
         let deadline = tokio::time::Instant::now() + Duration::from_millis(timeout_ms);
         let mut messages: Vec<ReplayMessageEntry> = Vec::new();
-        // Track the highest offset *consumed* per partition (matched
-        // or skipped — both advance the scan position). The cursor
-        // is built from these offsets at the end so a follow-up
-        // request resumes at offset+1 per partition.
-        let mut last_offsets: std::collections::BTreeMap<i32, i64> =
-            std::collections::BTreeMap::new();
+        // `last_offsets` was pre-seeded above. The loop bumps each
+        // partition's entry on every record physically read so the
+        // cursor reflects scan position rather than per-conversation
+        // position.
         // Each branch terminates the loop with an explicit reason;
         // `loop { break <value>; }` lets the compiler prove
         // exhaustiveness without an unread initial value.
@@ -5165,12 +5245,13 @@ pub async fn replay_conversation_messages(
                 }
             }
         };
-        let cursor = match exit_reason {
-            ReplayExitReason::Complete => None,
-            ReplayExitReason::Limit | ReplayExitReason::Timeout => {
-                Some(encode_replay_cursor(&last_offsets))
-            }
-        };
+        // Always emit a cursor — even on `Complete`. The
+        // `Complete` cursor encodes the per-partition tail at scan
+        // end, so a tailing client can immediately re-poll to pick
+        // up messages produced after this snapshot. Clients that
+        // genuinely just want a one-shot drain ignore the cursor
+        // when `exit_reason == Complete`.
+        let cursor = Some(encode_replay_cursor(&last_offsets));
         (
             StatusCode::OK,
             Json(ReplayConversationResponse {

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -183,9 +183,18 @@ where
     T: serde::Serialize + serde::de::DeserializeOwned,
     F: FnMut(&mut T) -> Result<(), axum::response::Response>,
 {
-    for _ in 0..MAX_CAS_RETRY_ATTEMPTS {
+    // Clone the `Arc<dyn StateStore>` once outside the loop and drop
+    // the gateway read guard before any `.await` on the state store.
+    // Holding `gw` across DB roundtrips — and worse, across all 8
+    // retry iterations — would block any pending gateway writer
+    // (config reloader, etc.) and cascade into queue-head-blocking
+    // for every other incoming request, since tokio's `RwLock` is
+    // fair. This was the third-pass review's HIGH finding.
+    let store: std::sync::Arc<dyn acteon_state::StateStore> = {
         let gw = state.gateway.read().await;
-        let store = gw.state_store();
+        gw.state_store().clone()
+    };
+    for _ in 0..MAX_CAS_RETRY_ATTEMPTS {
         let (raw, version) = match store.get_versioned(key).await {
             Ok(Some(p)) => p,
             Ok(None) => {
@@ -4385,6 +4394,25 @@ pub async fn update_conversation(
         let req_participants = req.participants.clone();
         let req_labels = req.labels.clone();
         let result = cas_update::<acteon_core::Conversation, _>(&state, &key, &missing, |conv| {
+            // Archived threads are immutable. Allowing edits to title /
+            // participants / labels after archive would undermine the
+            // audit trail (the participant list is the ACL gate at
+            // append time; rewriting it post-archive would let an
+            // operator silently change who *appeared* to have access
+            // to a closed thread). Operators who need a different
+            // shape should reopen via /transition first.
+            if !conv.accepts_messages() {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse {
+                        error: format!(
+                            "conversation {} is archived; reopen via /transition before updating",
+                            conv.conversation_id
+                        ),
+                    }),
+                )
+                    .into_response());
+            }
             if let Some(t) = req_title.clone() {
                 conv.title = Some(t);
             }
@@ -4733,9 +4761,17 @@ pub async fn append_conversation_message(
                 )
                 .await;
                 if let Err(_resp) = bump {
-                    tracing::debug!(
+                    // Fail-open: the message is already on Kafka so we
+                    // don't fail the response, but the state row is now
+                    // stale relative to thread activity (UI sort by
+                    // `updated_at` will misrank). `warn!` so operators
+                    // notice if this becomes chronic — it usually
+                    // means either the state store is unreachable or
+                    // a single conversation is taking sustained CAS
+                    // contention beyond `MAX_CAS_RETRY_ATTEMPTS`.
+                    tracing::warn!(
                         conversation_id = %conv_id,
-                        "conversation updated_at bump failed (race or backend outage); message was produced successfully"
+                        "conversation updated_at bump failed (CAS contention exhausted or backend error); message was produced successfully but list/sort will see a stale timestamp",
                     );
                 }
                 (

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -7,6 +7,14 @@
 //! reference is a plain code span rather than a rustdoc link because
 //! `acteon_bus` is only in scope when built with `--features bus`, and
 //! CI's `cargo doc` runs with default features.
+//
+// The handlers all use `Result<_, axum::response::Response>` for early-
+// return error paths so each error path can shape its own status +
+// body without a custom error enum and `IntoResponse` impl. The Err
+// variant is large because `Response` carries a body buffer, but it's
+// constructed only on errors and consumed immediately, so the size is
+// not a real cost — silence the lint module-wide.
+#![allow(clippy::result_large_err)]
 
 use std::collections::{BTreeMap, HashMap};
 
@@ -132,6 +140,165 @@ fn parse_kafka_name(topic: &str) -> Result<(&str, &str, &str), String> {
         ));
     }
     Ok((parts[0], parts[1], parts[2]))
+}
+
+/// Caps on user-supplied headers across every publish-style handler.
+/// Sized to fit comfortably within typical Kafka `message.max.bytes`
+/// budgets while leaving room for the payload, so a misbehaving
+/// caller can't blow up the producer's memory or wedge the broker
+/// connection with oversized records.
+#[cfg(feature = "bus")]
+const MAX_USER_HEADER_COUNT: usize = 20;
+#[cfg(feature = "bus")]
+const MAX_USER_HEADER_KEY_BYTES: usize = 256;
+#[cfg(feature = "bus")]
+const MAX_USER_HEADER_VALUE_BYTES: usize = 4096;
+
+/// Bound on how many times a CAS-update loop retries on conflict.
+/// The expected per-record contention is low (operator + agent
+/// concurrent edit on the same conversation), so 8 attempts is well
+/// past the realistic worst case before declaring a 409.
+#[cfg(feature = "bus")]
+const MAX_CAS_RETRY_ATTEMPTS: u32 = 8;
+
+/// Read-modify-write a JSON-serialized state row atomically via
+/// `compare_and_swap`. The mutator closure runs on a freshly-loaded
+/// copy each iteration; if the underlying row changed mid-loop, the
+/// CAS fails and we re-read and re-apply. Returns the mutated value
+/// after a successful commit, or a typed `Response` for missing key,
+/// mutator rejection, contention exhaustion, or a backend error.
+///
+/// Used by `update_*` and `transition_*` handlers to close the
+/// load-then-set TOCTOU window the second adversarial review
+/// flagged.
+#[cfg(feature = "bus")]
+#[allow(clippy::result_large_err)]
+async fn cas_update<T, F>(
+    state: &AppState,
+    key: &StateKey,
+    missing_msg: &str,
+    mut mutate: F,
+) -> Result<T, axum::response::Response>
+where
+    T: serde::Serialize + serde::de::DeserializeOwned,
+    F: FnMut(&mut T) -> Result<(), axum::response::Response>,
+{
+    for _ in 0..MAX_CAS_RETRY_ATTEMPTS {
+        let gw = state.gateway.read().await;
+        let store = gw.state_store();
+        let (raw, version) = match store.get_versioned(key).await {
+            Ok(Some(p)) => p,
+            Ok(None) => {
+                return Err((
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse {
+                        error: missing_msg.to_string(),
+                    }),
+                )
+                    .into_response());
+            }
+            Err(e) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response());
+            }
+        };
+        let mut current: T = serde_json::from_str(&raw).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("corrupt state record at {}: {e}", key.canonical()),
+                }),
+            )
+                .into_response()
+        })?;
+        mutate(&mut current)?;
+        let payload = serde_json::to_string(&current).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response()
+        })?;
+        match store.compare_and_swap(key, version, &payload, None).await {
+            Ok(acteon_state::CasResult::Ok) => return Ok(current),
+            // Lost the race; reload and reapply on the next loop iteration.
+            Ok(acteon_state::CasResult::Conflict { .. }) => {}
+            Err(e) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response());
+            }
+        }
+    }
+    Err((
+        StatusCode::CONFLICT,
+        Json(ErrorResponse {
+            error: format!("state at {} is changing too fast; retry", key.canonical()),
+        }),
+    )
+        .into_response())
+}
+
+/// Validate a caller-supplied header map. Rejects anything that looks
+/// like an attempt to oversize the publish path. The reserved
+/// `acteon.*` prefix is checked separately by each handler so the
+/// error message can describe which path the prefix conflict came
+/// from.
+#[cfg(feature = "bus")]
+#[allow(clippy::result_large_err)]
+fn validate_user_headers(
+    headers: &std::collections::BTreeMap<String, String>,
+) -> Result<(), axum::response::Response> {
+    if headers.len() > MAX_USER_HEADER_COUNT {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!(
+                    "too many headers: {}; max is {MAX_USER_HEADER_COUNT}",
+                    headers.len()
+                ),
+            }),
+        )
+            .into_response());
+    }
+    for (k, v) in headers {
+        if k.len() > MAX_USER_HEADER_KEY_BYTES {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "header key length {} exceeds {MAX_USER_HEADER_KEY_BYTES} bytes",
+                        k.len()
+                    ),
+                }),
+            )
+                .into_response());
+        }
+        if v.len() > MAX_USER_HEADER_VALUE_BYTES {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "header '{k}' value length {} exceeds {MAX_USER_HEADER_VALUE_BYTES} bytes",
+                        v.len()
+                    ),
+                }),
+            )
+                .into_response());
+        }
+    }
+    Ok(())
 }
 
 // =============================================================================
@@ -571,6 +738,12 @@ pub async fn publish(
                     .into_response();
             }
         };
+        // Reject oversized header sets before doing anything else; a
+        // misbehaving caller could otherwise saturate the producer's
+        // memory or trip Kafka's `message.max.bytes` ceiling.
+        if let Err(resp) = validate_user_headers(&req.headers) {
+            return resp;
+        }
         // Reject reserved `acteon.*` headers explicitly so callers see a
         // 400 instead of having the header silently dropped by
         // `BusMessage::with_header`. Silent stripping caused a
@@ -1541,6 +1714,9 @@ pub async fn deadletter_subscription(
             )
                 .into_response();
         };
+        if let Err(resp) = validate_user_headers(&req.headers) {
+            return resp;
+        }
         // Governance: confirm the DLQ topic is still registered in
         // state. Normally guaranteed by create_subscription but the
         // topic could have been deleted since then — we don't want to
@@ -2771,16 +2947,17 @@ pub struct RegisterAgentRequest {
 }
 
 /// Body of `PUT /v1/bus/agents/{ns}/{t}/{id}`. Only the mutable fields
-/// appear here — `agent_id`, `namespace`, `tenant`, and `created_at`
-/// are immutable after registration.
+/// appear here — `agent_id`, `namespace`, `tenant`, `created_at`, and
+/// `inbox_topic` are immutable after registration. (Migrating an
+/// agent to a new inbox topic mid-flight would orphan in-flight
+/// messages on the old topic; delete and re-register if you need a
+/// different inbox.)
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateAgentRequest {
     #[serde(default)]
     pub display_name: Option<String>,
     #[serde(default)]
     pub capabilities: Option<Vec<String>>,
-    #[serde(default)]
-    pub inbox_topic: Option<String>,
     #[serde(default)]
     pub heartbeat_ttl_ms: Option<i64>,
     #[serde(default)]
@@ -2898,6 +3075,34 @@ async fn ensure_agent_inbox_topic(
     tenant: &str,
     inbox_topic_name: &str,
 ) -> Result<(), axum::response::Response> {
+    // Defense in depth: every caller-facing handler validates
+    // `parse_kafka_name` upstream, but if a future caller forgot,
+    // the previous `splitn(3,'.').nth(2).unwrap_or(_)` fallback would
+    // silently provision a topic under `{ns}.{tenant}.{full-bad-name}`
+    // while the producer side used the bad name unchanged — split
+    // brain. Reject unparseable names here too so the contract is
+    // enforced at the boundary.
+    let (parsed_ns, parsed_tenant, leaf_name) =
+        parse_kafka_name(inbox_topic_name).map_err(|msg| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("invalid inbox topic name '{inbox_topic_name}': {msg}"),
+                }),
+            )
+                .into_response()
+        })?;
+    if parsed_ns != namespace || parsed_tenant != tenant {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!(
+                    "inbox topic '{inbox_topic_name}' crosses tenants: must be under {namespace}.{tenant}"
+                ),
+            }),
+        )
+            .into_response());
+    }
     let key = StateKey::new(
         namespace.to_string(),
         tenant.to_string(),
@@ -2912,13 +3117,6 @@ async fn ensure_agent_inbox_topic(
     if matches!(store.get(&key).await, Ok(Some(_))) {
         return Ok(());
     }
-    // Derive the leaf name from the Kafka-form topic. Our naming
-    // convention is `{ns}.{tenant}.{leaf}`; the leaf is everything
-    // after the second dot.
-    let leaf_name = inbox_topic_name
-        .splitn(3, '.')
-        .nth(2)
-        .unwrap_or(inbox_topic_name);
     let topic = Topic::new(leaf_name, namespace, tenant);
     if let Err(e) = topic.validate() {
         return Err((
@@ -3255,64 +3453,46 @@ pub async fn update_agent(
         if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageAgent) {
             return resp;
         }
-        let mut agent = match load_agent(&state, &namespace, &tenant, &agent_id).await {
-            Ok(a) => a,
-            Err(resp) => return resp,
-        };
-        if let Some(d) = req.display_name.clone() {
-            agent.display_name = Some(d);
-        }
-        if let Some(c) = req.capabilities.clone() {
-            agent.capabilities = c;
-        }
-        if let Some(i) = req.inbox_topic.clone() {
-            agent.inbox_topic = Some(i);
-        }
-        if let Some(ttl) = req.heartbeat_ttl_ms {
-            agent.heartbeat_ttl_ms = ttl;
-        }
-        if let Some(l) = req.labels.clone() {
-            agent.labels = l;
-        }
-        agent.updated_at = Utc::now();
-        if let Err(e) = agent.validate() {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
-            )
-                .into_response();
-        }
         let key = StateKey::new(
             namespace.clone(),
             tenant.clone(),
             KeyKind::BusAgent,
-            agent.id(),
+            &agent_id,
         );
-        let payload = match serde_json::to_string(&agent) {
-            Ok(s) => s,
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
+        let missing = format!("agent {namespace}.{tenant}.{agent_id} not found");
+        let req_display = req.display_name.clone();
+        let req_caps = req.capabilities.clone();
+        let req_ttl = req.heartbeat_ttl_ms;
+        let req_labels = req.labels.clone();
+        let result = cas_update::<acteon_core::Agent, _>(&state, &key, &missing, |agent| {
+            if let Some(d) = req_display.clone() {
+                agent.display_name = Some(d);
+            }
+            if let Some(c) = req_caps.clone() {
+                agent.capabilities = c;
+            }
+            if let Some(ttl) = req_ttl {
+                agent.heartbeat_ttl_ms = ttl;
+            }
+            if let Some(l) = req_labels.clone() {
+                agent.labels = l;
+            }
+            agent.updated_at = Utc::now();
+            agent.validate().map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
                     Json(ErrorResponse {
                         error: e.to_string(),
                     }),
                 )
-                    .into_response();
-            }
-        };
-        let gw = state.gateway.read().await;
-        if let Err(e) = gw.state_store().set(&key, &payload, None).await {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
-            )
-                .into_response();
+                    .into_response()
+            })
+        })
+        .await;
+        match result {
+            Ok(agent) => (StatusCode::OK, Json(agent_to_response(&agent))).into_response(),
+            Err(resp) => resp,
         }
-        (StatusCode::OK, Json(agent_to_response(&agent))).into_response()
     }
     #[cfg(not(feature = "bus"))]
     {
@@ -3423,50 +3603,35 @@ pub async fn heartbeat_agent(
         if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageAgent) {
             return resp;
         }
-        let mut agent = match load_agent(&state, &namespace, &tenant, &agent_id).await {
-            Ok(a) => a,
-            Err(resp) => return resp,
-        };
-        let now = Utc::now();
-        agent.last_heartbeat_at = Some(now);
-        agent.updated_at = now;
         let key = StateKey::new(
             namespace.clone(),
             tenant.clone(),
             KeyKind::BusAgent,
-            agent.id(),
+            &agent_id,
         );
-        let payload = match serde_json::to_string(&agent) {
-            Ok(s) => s,
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse {
-                        error: e.to_string(),
+        let missing = format!("agent {namespace}.{tenant}.{agent_id} not found");
+        let result = cas_update::<acteon_core::Agent, _>(&state, &key, &missing, |agent| {
+            let now = Utc::now();
+            agent.last_heartbeat_at = Some(now);
+            agent.updated_at = now;
+            Ok(())
+        })
+        .await;
+        match result {
+            Ok(agent) => {
+                let now = agent.last_heartbeat_at.unwrap_or_else(Utc::now);
+                (
+                    StatusCode::OK,
+                    Json(HeartbeatResponse {
+                        agent_id: agent.agent_id.clone(),
+                        last_heartbeat_at: now,
+                        status: agent_status_str(agent.status_at(now)),
                     }),
                 )
-                    .into_response();
+                    .into_response()
             }
-        };
-        let gw = state.gateway.read().await;
-        if let Err(e) = gw.state_store().set(&key, &payload, None).await {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
-            )
-                .into_response();
+            Err(resp) => resp,
         }
-        (
-            StatusCode::OK,
-            Json(HeartbeatResponse {
-                agent_id: agent.agent_id.clone(),
-                last_heartbeat_at: now,
-                status: agent_status_str(agent.status_at(now)),
-            }),
-        )
-            .into_response()
     }
     #[cfg(not(feature = "bus"))]
     {
@@ -3511,6 +3676,9 @@ pub async fn send_to_agent(
             return resp;
         }
         if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::Publish) {
+            return resp;
+        }
+        if let Err(resp) = validate_user_headers(&req.headers) {
             return resp;
         }
         if let Some(reserved) = req.headers.keys().find(|k| k.starts_with("acteon.")) {
@@ -3666,16 +3834,19 @@ pub struct CreateConversationRequest {
 }
 
 /// Body of `PUT /v1/bus/conversations/{ns}/{t}/{id}`. Mutable fields
-/// only — id, namespace, tenant, `created_at`, and state are immutable
-/// from this endpoint (state changes via `/transition`).
+/// only. `id`, `namespace`, `tenant`, `created_at`, `events_topic`,
+/// and `state` are immutable from this endpoint — state changes go
+/// through `/transition`, and the events topic is set once at
+/// registration time. Mid-flight events-topic swaps would orphan
+/// in-flight messages on the old topic and have been a topic-
+/// injection vector when the validation was incomplete; closed by
+/// removing the field.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateConversationRequest {
     #[serde(default)]
     pub title: Option<String>,
     #[serde(default)]
     pub participants: Option<Vec<String>>,
-    #[serde(default)]
-    pub events_topic: Option<String>,
     #[serde(default)]
     pub labels: Option<HashMap<String, String>>,
 }
@@ -3828,6 +3999,29 @@ async fn ensure_conversation_events_topic(
     tenant: &str,
     events_topic_name: &str,
 ) -> Result<(), axum::response::Response> {
+    // Defense in depth: parse_kafka_name first so an unparseable name
+    // can never reach Kafka. Mirrors the agent-inbox check.
+    let (parsed_ns, parsed_tenant, leaf_name) =
+        parse_kafka_name(events_topic_name).map_err(|msg| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("invalid events topic name '{events_topic_name}': {msg}"),
+                }),
+            )
+                .into_response()
+        })?;
+    if parsed_ns != namespace || parsed_tenant != tenant {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!(
+                    "events topic '{events_topic_name}' crosses tenants: must be under {namespace}.{tenant}"
+                ),
+            }),
+        )
+            .into_response());
+    }
     let key = StateKey::new(
         namespace.to_string(),
         tenant.to_string(),
@@ -3842,10 +4036,6 @@ async fn ensure_conversation_events_topic(
     if matches!(store.get(&key).await, Ok(Some(_))) {
         return Ok(());
     }
-    let leaf_name = events_topic_name
-        .splitn(3, '.')
-        .nth(2)
-        .unwrap_or(events_topic_name);
     let topic = Topic::new(leaf_name, namespace, tenant);
     if let Err(e) = topic.validate() {
         return Err((
@@ -4184,62 +4374,42 @@ pub async fn update_conversation(
         {
             return resp;
         }
-        let mut conv = match load_conversation(&state, &namespace, &tenant, &conversation_id).await
-        {
-            Ok(c) => c,
-            Err(resp) => return resp,
-        };
-        if let Some(t) = req.title.clone() {
-            conv.title = Some(t);
-        }
-        if let Some(p) = req.participants.clone() {
-            conv.participants = p;
-        }
-        if let Some(et) = req.events_topic.clone() {
-            conv.events_topic = Some(et);
-        }
-        if let Some(l) = req.labels.clone() {
-            conv.labels = l;
-        }
-        conv.updated_at = Utc::now();
-        if let Err(e) = conv.validate() {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
-            )
-                .into_response();
-        }
         let key = StateKey::new(
             namespace.clone(),
             tenant.clone(),
             KeyKind::BusConversation,
-            conv.id(),
+            &conversation_id,
         );
-        let payload = match serde_json::to_string(&conv) {
-            Ok(s) => s,
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
+        let missing = format!("conversation {namespace}.{tenant}.{conversation_id} not found");
+        let req_title = req.title.clone();
+        let req_participants = req.participants.clone();
+        let req_labels = req.labels.clone();
+        let result = cas_update::<acteon_core::Conversation, _>(&state, &key, &missing, |conv| {
+            if let Some(t) = req_title.clone() {
+                conv.title = Some(t);
+            }
+            if let Some(p) = req_participants.clone() {
+                conv.participants = p;
+            }
+            if let Some(l) = req_labels.clone() {
+                conv.labels = l;
+            }
+            conv.updated_at = Utc::now();
+            conv.validate().map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
                     Json(ErrorResponse {
                         error: e.to_string(),
                     }),
                 )
-                    .into_response();
-            }
-        };
-        let gw = state.gateway.read().await;
-        if let Err(e) = gw.state_store().set(&key, &payload, None).await {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
-            )
-                .into_response();
+                    .into_response()
+            })
+        })
+        .await;
+        match result {
+            Ok(conv) => (StatusCode::OK, Json(conversation_to_response(&conv))).into_response(),
+            Err(resp) => resp,
         }
-        (StatusCode::OK, Json(conversation_to_response(&conv))).into_response()
     }
     #[cfg(not(feature = "bus"))]
     {
@@ -4359,49 +4529,30 @@ pub async fn transition_conversation(
         {
             return resp;
         }
-        let mut conv = match load_conversation(&state, &namespace, &tenant, &conversation_id).await
-        {
-            Ok(c) => c,
-            Err(resp) => return resp,
-        };
-        if let Err(e) = conv.apply_transition(req.transition) {
-            return (
-                StatusCode::CONFLICT,
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
-            )
-                .into_response();
-        }
         let key = StateKey::new(
             namespace.clone(),
             tenant.clone(),
             KeyKind::BusConversation,
-            conv.id(),
+            &conversation_id,
         );
-        let payload = match serde_json::to_string(&conv) {
-            Ok(s) => s,
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
+        let missing = format!("conversation {namespace}.{tenant}.{conversation_id} not found");
+        let transition = req.transition;
+        let result = cas_update::<acteon_core::Conversation, _>(&state, &key, &missing, |conv| {
+            conv.apply_transition(transition).map(|_| ()).map_err(|e| {
+                (
+                    StatusCode::CONFLICT,
                     Json(ErrorResponse {
                         error: e.to_string(),
                     }),
                 )
-                    .into_response();
-            }
-        };
-        let gw = state.gateway.read().await;
-        if let Err(e) = gw.state_store().set(&key, &payload, None).await {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
-            )
-                .into_response();
+                    .into_response()
+            })
+        })
+        .await;
+        match result {
+            Ok(conv) => (StatusCode::OK, Json(conversation_to_response(&conv))).into_response(),
+            Err(resp) => resp,
         }
-        (StatusCode::OK, Json(conversation_to_response(&conv))).into_response()
     }
     #[cfg(not(feature = "bus"))]
     {
@@ -4445,6 +4596,9 @@ pub async fn append_conversation_message(
             return resp;
         }
         if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::Publish) {
+            return resp;
+        }
+        if let Err(resp) = validate_user_headers(&req.headers) {
             return resp;
         }
         if let Some(reserved) = req.headers.keys().find(|k| k.starts_with("acteon.")) {
@@ -4554,17 +4708,48 @@ pub async fn append_conversation_message(
                 .insert("acteon.conversation.sender".into(), sender.clone());
         }
         match backend.produce(msg).await {
-            Ok(receipt) => (
-                StatusCode::OK,
-                Json(AppendConversationMessageResponse {
-                    events_topic: receipt.topic,
-                    conversation_id: conv.conversation_id,
-                    partition: receipt.partition,
-                    offset: receipt.offset,
-                    produced_at: receipt.timestamp,
-                }),
-            )
-                .into_response(),
+            Ok(receipt) => {
+                // Bump `updated_at` so list APIs and UI sorts by
+                // activity reflect that the thread is alive. Uses CAS
+                // so a concurrent transition can't be silently dropped
+                // here. Best-effort: a CAS contention failure leaves
+                // the timestamp stale but the message itself is
+                // already on Kafka, so we don't fail the append.
+                let conv_id = conv.conversation_id.clone();
+                let conv_key = StateKey::new(
+                    namespace.clone(),
+                    tenant.clone(),
+                    KeyKind::BusConversation,
+                    &conv_id,
+                );
+                let bump = cas_update::<acteon_core::Conversation, _>(
+                    &state,
+                    &conv_key,
+                    "conversation gone",
+                    |c| {
+                        c.updated_at = Utc::now();
+                        Ok(())
+                    },
+                )
+                .await;
+                if let Err(_resp) = bump {
+                    tracing::debug!(
+                        conversation_id = %conv_id,
+                        "conversation updated_at bump failed (race or backend outage); message was produced successfully"
+                    );
+                }
+                (
+                    StatusCode::OK,
+                    Json(AppendConversationMessageResponse {
+                        events_topic: receipt.topic,
+                        conversation_id: conv_id,
+                        partition: receipt.partition,
+                        offset: receipt.offset,
+                        produced_at: receipt.timestamp,
+                    }),
+                )
+                    .into_response()
+            }
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -259,6 +259,92 @@ where
         .into_response())
 }
 
+/// Caps on operator-supplied `labels` maps across all create/update
+/// DTOs. Labels are persisted in the state store and replayed via
+/// `list_*` handlers — without bounds, a single registration could
+/// bloat the row and OOM the gateway during a list scan.
+#[cfg(feature = "bus")]
+const MAX_LABELS_COUNT: usize = 32;
+#[cfg(feature = "bus")]
+const MAX_LABEL_KEY_BYTES: usize = 256;
+#[cfg(feature = "bus")]
+const MAX_LABEL_VALUE_BYTES: usize = 4096;
+
+/// Validate a caller-supplied labels map. Same rationale as
+/// [`validate_user_headers`] but applied to the persisted-state path
+/// rather than the publish path.
+#[cfg(feature = "bus")]
+fn validate_user_labels(
+    labels: &std::collections::HashMap<String, String>,
+) -> Result<(), axum::response::Response> {
+    if labels.len() > MAX_LABELS_COUNT {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!(
+                    "too many labels: {}; max is {MAX_LABELS_COUNT}",
+                    labels.len()
+                ),
+            }),
+        )
+            .into_response());
+    }
+    for (k, v) in labels {
+        if k.len() > MAX_LABEL_KEY_BYTES {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "label key length {} exceeds {MAX_LABEL_KEY_BYTES} bytes",
+                        k.len()
+                    ),
+                }),
+            )
+                .into_response());
+        }
+        if v.len() > MAX_LABEL_VALUE_BYTES {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "label '{k}' value length {} exceeds {MAX_LABEL_VALUE_BYTES} bytes",
+                        v.len()
+                    ),
+                }),
+            )
+                .into_response());
+        }
+    }
+    Ok(())
+}
+
+/// Encode a per-partition offset map as an opaque resume token.
+/// URL-safe base64 of a JSON object so clients can pass it back
+/// through query strings without manual escaping. Cheap to decode and
+/// debug-readable when base64-decoded.
+#[cfg(feature = "bus")]
+fn encode_replay_cursor(offsets: &std::collections::BTreeMap<i32, i64>) -> String {
+    use base64::Engine;
+    // Render as `{"P": O, "P": O}`; serde_json keeps key order via
+    // the BTreeMap, so the cursor is stable for a given offset map.
+    let json = serde_json::to_string(offsets).unwrap_or_else(|_| "{}".to_string());
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json.as_bytes())
+}
+
+/// Decode a cursor produced by [`encode_replay_cursor`]. Tolerates a
+/// missing or malformed token with a structured error so the handler
+/// can surface a 400.
+#[cfg(feature = "bus")]
+fn decode_replay_cursor(s: &str) -> Result<std::collections::BTreeMap<i32, i64>, String> {
+    use base64::Engine;
+    let raw = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(s.as_bytes())
+        .map_err(|e| format!("base64: {e}"))?;
+    let json = std::str::from_utf8(&raw).map_err(|e| format!("utf8: {e}"))?;
+    serde_json::from_str::<std::collections::BTreeMap<i32, i64>>(json)
+        .map_err(|e| format!("json: {e}"))
+}
+
 /// Validate a caller-supplied header map. Rejects anything that looks
 /// like an attempt to oversize the publish path. The reserved
 /// `acteon.*` prefix is checked separately by each handler so the
@@ -464,6 +550,9 @@ pub async fn create_topic(
         }
         topic.retention_ms = req.retention_ms;
         topic.description = req.description.clone();
+        if let Err(resp) = validate_user_labels(&req.labels) {
+            return resp;
+        }
         topic.labels = req.labels.clone();
         if let Err(e) = topic.validate() {
             return (
@@ -1309,6 +1398,9 @@ pub async fn create_subscription(
             sub.ack_timeout_ms = t;
         }
         sub.description = req.description.clone();
+        if let Err(resp) = validate_user_labels(&req.labels) {
+            return resp;
+        }
         sub.labels = req.labels.clone();
         if let Err(e) = sub.validate() {
             return (
@@ -2089,6 +2181,9 @@ pub async fn create_schema(
         if let Err(resp) =
             authorize_bus_op(&identity, &req.tenant, &req.namespace, BusOp::ManageSchema)
         {
+            return resp;
+        }
+        if let Err(resp) = validate_user_labels(&req.labels) {
             return resp;
         }
         if let Err(e) = acteon_core::Schema::validate_subject(&req.subject) {
@@ -3121,8 +3216,14 @@ async fn ensure_agent_inbox_topic(
     let Some(backend) = state.bus_backend.as_ref() else {
         return Err(service_unavailable("bus feature not enabled"));
     };
-    let gw = state.gateway.read().await;
-    let store = gw.state_store();
+    // Same lock-amplification fix as `cas_update`: clone the
+    // `Arc<dyn StateStore>` once and drop the gateway read guard
+    // before any `.await`, so DB roundtrips don't queue-head-block
+    // pending gateway writers.
+    let store: std::sync::Arc<dyn acteon_state::StateStore> = {
+        let gw = state.gateway.read().await;
+        gw.state_store().clone()
+    };
     if matches!(store.get(&key).await, Ok(Some(_))) {
         return Ok(());
     }
@@ -3157,7 +3258,6 @@ async fn ensure_agent_inbox_topic(
         )
             .into_response());
     }
-    drop(gw);
     if let Err(e) = backend.create_topic(&topic).await {
         // The shared inbox is a tenant-scoped, agent-shared resource.
         // `TopicAlreadyExists` here means another concurrent
@@ -3213,6 +3313,9 @@ pub async fn register_agent(
         agent.inbox_topic = req.inbox_topic.clone();
         if let Some(ttl) = req.heartbeat_ttl_ms {
             agent.heartbeat_ttl_ms = ttl;
+        }
+        if let Err(resp) = validate_user_labels(&req.labels) {
+            return resp;
         }
         agent.labels = req.labels.clone();
         if let Err(e) = agent.validate() {
@@ -3469,6 +3572,11 @@ pub async fn update_agent(
             &agent_id,
         );
         let missing = format!("agent {namespace}.{tenant}.{agent_id} not found");
+        if let Some(labels) = &req.labels
+            && let Err(resp) = validate_user_labels(labels)
+        {
+            return resp;
+        }
         let req_display = req.display_name.clone();
         let req_caps = req.capabilities.clone();
         let req_ttl = req.heartbeat_ttl_ms;
@@ -3936,7 +4044,7 @@ pub struct AppendConversationMessageResponse {
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ReplayConversationParams {
     /// `earliest` (default — full thread) or `latest` (only new
-    /// messages, useful as a probe).
+    /// messages, useful as a probe). Ignored when `cursor` is set.
     #[serde(default)]
     pub from: Option<String>,
     /// Hard cap on returned messages. Default 200, max 1000.
@@ -3946,6 +4054,11 @@ pub struct ReplayConversationParams {
     /// Default 1500ms; bounds replay latency on quiet topics.
     #[serde(default)]
     pub timeout_ms: Option<u64>,
+    /// Resume token from a previous response's `cursor`. When set,
+    /// `from` is ignored and the scan picks up at the per-partition
+    /// offsets the previous call left off at.
+    #[serde(default)]
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -3961,15 +4074,39 @@ pub struct ReplayMessageEntry {
     pub timestamp: DateTime<Utc>,
 }
 
+/// Why the replay loop terminated. Distinguishes end-of-stream
+/// (operator caller is done) from a partial result (operator must
+/// paginate via `cursor`). The previous `limit_reached: bool` shape
+/// silently lied on timeout: a timeout-bounded scan that didn't hit
+/// the count limit reported `false`, suggesting the thread was
+/// drained when in fact the server just gave up early. Now every
+/// non-`Complete` reason carries an explicit cursor.
+#[derive(Debug, Clone, Copy, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplayExitReason {
+    /// The scan reached or surpassed every partition's high-water
+    /// mark — there are no more messages on the topic at the time
+    /// the scan started. The caller is done.
+    Complete,
+    /// Hit the per-request `limit` before scanning the whole topic.
+    /// More messages may exist; resume with `cursor`.
+    Limit,
+    /// Hit the `timeout_ms` budget before exhausting partitions or
+    /// the limit. More messages may exist; resume with `cursor`.
+    Timeout,
+}
+
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ReplayConversationResponse {
     pub conversation_id: String,
     pub events_topic: String,
     pub messages: Vec<ReplayMessageEntry>,
-    /// True if the response is bounded by `limit` rather than end of
-    /// the timeout window. Caller can paginate by reading from the
-    /// last returned offset+1 in a subsequent call.
-    pub limit_reached: bool,
+    pub exit_reason: ReplayExitReason,
+    /// Opaque resume token. `None` only when `exit_reason ==
+    /// Complete`; otherwise present and meant to be passed back as
+    /// `cursor` on the next request to continue the scan.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
 }
 
 #[cfg(feature = "bus")]
@@ -4040,8 +4177,14 @@ async fn ensure_conversation_events_topic(
     let Some(backend) = state.bus_backend.as_ref() else {
         return Err(service_unavailable("bus feature not enabled"));
     };
-    let gw = state.gateway.read().await;
-    let store = gw.state_store();
+    // Same lock-amplification fix as `cas_update`: clone the
+    // `Arc<dyn StateStore>` once and drop the gateway read guard
+    // before any `.await`, so DB roundtrips don't queue-head-block
+    // pending gateway writers.
+    let store: std::sync::Arc<dyn acteon_state::StateStore> = {
+        let gw = state.gateway.read().await;
+        gw.state_store().clone()
+    };
     if matches!(store.get(&key).await, Ok(Some(_))) {
         return Ok(());
     }
@@ -4078,7 +4221,6 @@ async fn ensure_conversation_events_topic(
         )
             .into_response());
     }
-    drop(gw);
     if let Err(e) = backend.create_topic(&topic).await
         && !matches!(&e, acteon_bus::BusError::TopicAlreadyExists(_))
     {
@@ -4116,6 +4258,9 @@ pub async fn register_conversation(
             &req.namespace,
             BusOp::ManageConversation,
         ) {
+            return resp;
+        }
+        if let Err(resp) = validate_user_labels(&req.labels) {
             return resp;
         }
         let mut conv =
@@ -4390,6 +4535,11 @@ pub async fn update_conversation(
             &conversation_id,
         );
         let missing = format!("conversation {namespace}.{tenant}.{conversation_id} not found");
+        if let Some(labels) = &req.labels
+            && let Err(resp) = validate_user_labels(labels)
+        {
+            return resp;
+        }
         let req_title = req.title.clone();
         let req_participants = req.participants.clone();
         let req_labels = req.labels.clone();
@@ -4839,10 +4989,56 @@ pub async fn replay_conversation_messages(
             Ok(c) => c,
             Err(resp) => return resp,
         };
-        let from = match params.from.as_deref() {
-            Some("latest") => acteon_bus::StartOffset::Latest,
-            Some("earliest") | None => acteon_bus::StartOffset::Earliest,
-            Some(other) => {
+        let limit = params.limit.unwrap_or(200).min(1000);
+        let timeout_ms = params.timeout_ms.unwrap_or(1500);
+        let events_topic = conv.effective_events_topic();
+        // Capture per-partition high-water marks at scan start so we
+        // can report `Complete` when the tracked offsets reach them.
+        // Without this, an `assign()`-based scan never naturally
+        // ends — Kafka holds the stream open waiting for new records,
+        // and we'd have no way to distinguish "drained" from "took a
+        // 1.5s nap on a quiet topic."
+        let watermarks = match backend.scan_topic_watermarks(&events_topic).await {
+            Ok(w) => w,
+            Err(acteon_bus::BusError::TopicNotFound(_)) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse {
+                        error: format!("events topic {events_topic} not found"),
+                    }),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        // Resume from the cursor if one was provided; otherwise start
+        // at earliest/latest per `from`. `from` is ignored when
+        // `cursor` is set so a paginating client doesn't accidentally
+        // restart the scan.
+        let scan_from = match (&params.cursor, params.from.as_deref()) {
+            (Some(cursor_str), _) => match decode_replay_cursor(cursor_str) {
+                Ok(offsets) => acteon_bus::ScanFrom::FromOffsets(offsets),
+                Err(msg) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!("invalid replay cursor: {msg}"),
+                        }),
+                    )
+                        .into_response();
+                }
+            },
+            (None, Some("latest")) => acteon_bus::ScanFrom::Latest,
+            (None, Some("earliest") | None) => acteon_bus::ScanFrom::Earliest,
+            (None, Some(other)) => {
                 return (
                     StatusCode::BAD_REQUEST,
                     Json(ErrorResponse {
@@ -4852,14 +5048,11 @@ pub async fn replay_conversation_messages(
                     .into_response();
             }
         };
-        let limit = params.limit.unwrap_or(200).min(1000);
-        let timeout_ms = params.timeout_ms.unwrap_or(1500);
-        let events_topic = conv.effective_events_topic();
         // `scan_topic` uses Kafka's `assign()` rather than dynamic
         // consumer-group subscribe — no `__consumer_offsets` rows are
         // created so repeated replays don't accumulate dead groups in
         // the cluster.
-        let mut stream = match backend.scan_topic(&events_topic, from).await {
+        let mut stream = match backend.scan_topic(&events_topic, scan_from).await {
             Ok(s) => s,
             Err(acteon_bus::BusError::TopicNotFound(_)) => {
                 return (
@@ -4882,31 +5075,65 @@ pub async fn replay_conversation_messages(
         };
         let deadline = tokio::time::Instant::now() + Duration::from_millis(timeout_ms);
         let mut messages: Vec<ReplayMessageEntry> = Vec::new();
-        let mut limit_reached = false;
+        // Track the highest offset *consumed* per partition (matched
+        // or skipped — both advance the scan position). The cursor
+        // is built from these offsets at the end so a follow-up
+        // request resumes at offset+1 per partition.
+        let mut last_offsets: std::collections::BTreeMap<i32, i64> =
+            std::collections::BTreeMap::new();
+        // Each branch terminates the loop with an explicit reason;
+        // `loop { break <value>; }` lets the compiler prove
+        // exhaustiveness without an unread initial value.
         // Fetch `limit + 1` so we can distinguish "exactly `limit`
-        // messages exist" (limit_reached = false) from "more messages
-        // exist past `limit`" (limit_reached = true). Avoids the
-        // off-by-one that would have clients paginate into an empty
-        // tail when the thread length happens to equal the request.
-        loop {
+        // messages exist" from "more exist" (the latter yields
+        // `Limit`).
+        let exit_reason: ReplayExitReason = loop {
             if messages.len() > limit {
                 messages.truncate(limit);
-                limit_reached = true;
-                break;
+                break ReplayExitReason::Limit;
             }
             let now = tokio::time::Instant::now();
             if now >= deadline {
-                break;
+                break ReplayExitReason::Timeout;
+            }
+            // Detect end-of-stream by comparing every partition's
+            // tracked offset against its captured high-water mark.
+            // `hwm - 1` is "last produced offset" (Kafka's `hwm` is
+            // "next-to-be-produced"), so the partition is drained
+            // when `last_offset >= hwm - 1`. Empty partitions
+            // (hwm == 0) are trivially drained.
+            let drained =
+                watermarks
+                    .high_water_marks
+                    .iter()
+                    .all(|(p, hwm)| match last_offsets.get(p) {
+                        _ if *hwm == 0 => true,
+                        Some(seen) => *seen >= *hwm - 1,
+                        None => false,
+                    });
+            if drained {
+                break ReplayExitReason::Complete;
             }
             let remaining = deadline - now;
             tokio::select! {
                 next = stream.next() => {
                     match next {
                         Some(Ok(msg)) => {
-                            // Filter to this conversation. The shared
-                            // events topic carries every conversation
-                            // in the tenant; match on the
-                            // server-stamped header.
+                            let p = msg.partition.unwrap_or(0);
+                            let off = msg.offset.unwrap_or(0);
+                            // Always advance the per-partition cursor,
+                            // even when the message belongs to a
+                            // different conversation; a future
+                            // pagination must skip past every record
+                            // we've physically read.
+                            last_offsets
+                                .entry(p)
+                                .and_modify(|e| {
+                                    if off > *e {
+                                        *e = off;
+                                    }
+                                })
+                                .or_insert(off);
                             let belongs = msg
                                 .headers
                                 .get("acteon.conversation.id")
@@ -4915,29 +5142,43 @@ pub async fn replay_conversation_messages(
                                 continue;
                             }
                             messages.push(ReplayMessageEntry {
-                                partition: msg.partition.unwrap_or(0),
-                                offset: msg.offset.unwrap_or(0),
+                                partition: p,
+                                offset: off,
                                 key: msg.key.clone(),
                                 payload: msg.payload.clone(),
                                 headers: msg.headers.clone(),
                                 timestamp: msg.timestamp.unwrap_or_else(Utc::now),
                             });
                         }
-                        Some(Err(_)) | None => break,
+                        Some(Err(_)) | None => {
+                            // Stream ended unexpectedly — not at the
+                            // high-water mark, but no more messages
+                            // from the backend. Treat as a partial
+                            // result so the client paginates; safer
+                            // than silently lying about completeness.
+                            break ReplayExitReason::Timeout;
+                        }
                     }
                 }
                 () = tokio::time::sleep(remaining) => {
-                    break;
+                    break ReplayExitReason::Timeout;
                 }
             }
-        }
+        };
+        let cursor = match exit_reason {
+            ReplayExitReason::Complete => None,
+            ReplayExitReason::Limit | ReplayExitReason::Timeout => {
+                Some(encode_replay_cursor(&last_offsets))
+            }
+        };
         (
             StatusCode::OK,
             Json(ReplayConversationResponse {
                 conversation_id: conv.conversation_id,
                 events_topic,
                 messages,
-                limit_reached,
+                exit_reason,
+                cursor,
             }),
         )
             .into_response()

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -70,6 +70,7 @@ fn authorize_bus_op(
         BusOp::Subscribe => (Permission::StreamSubscribe, "subscribe"),
         BusOp::ManageSchema => (Permission::Dispatch, "schema"),
         BusOp::ManageAgent => (Permission::Dispatch, "agent"),
+        BusOp::ManageConversation => (Permission::Dispatch, "conversation"),
     };
     if !identity.role.has_permission(permission) {
         return Err((
@@ -112,6 +113,10 @@ enum BusOp {
     /// operators can restrict *inbox writes* independently of *agent
     /// registry ops*.
     ManageAgent,
+    /// Conversation CRUD + transitions + thread reads (Phase 5).
+    /// Appending a message also flows through [`BusOp::Publish`] so
+    /// operators can split read/write ACLs.
+    ManageConversation,
 }
 
 /// Parse a `namespace.tenant.name` Kafka topic string.
@@ -3609,6 +3614,1080 @@ async fn load_agent(
             StatusCode::NOT_FOUND,
             Json(ErrorResponse {
                 error: format!("agent {namespace}.{tenant}.{agent_id} not found"),
+            }),
+        )
+            .into_response()),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response()),
+    }
+}
+
+// =============================================================================
+// Phase 5: Conversations — multi-agent threads on a shared events topic
+// =============================================================================
+
+/// Body of `POST /v1/bus/conversations`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateConversationRequest {
+    pub conversation_id: String,
+    pub namespace: String,
+    pub tenant: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub participants: Vec<String>,
+    /// Override the events topic this conversation produces to.
+    /// Defaults to `{ns}.{tenant}.conversations-events`.
+    #[serde(default)]
+    pub events_topic: Option<String>,
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+}
+
+/// Body of `PUT /v1/bus/conversations/{ns}/{t}/{id}`. Mutable fields
+/// only — id, namespace, tenant, `created_at`, and state are immutable
+/// from this endpoint (state changes via `/transition`).
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateConversationRequest {
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub participants: Option<Vec<String>>,
+    #[serde(default)]
+    pub events_topic: Option<String>,
+    #[serde(default)]
+    pub labels: Option<HashMap<String, String>>,
+}
+
+/// Body of `POST /v1/bus/conversations/{ns}/{t}/{id}/transition`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ConversationTransitionRequest {
+    pub transition: acteon_core::ConversationTransition,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ConversationResponse {
+    pub conversation_id: String,
+    pub namespace: String,
+    pub tenant: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    pub state: acteon_core::ConversationState,
+    pub participants: Vec<String>,
+    pub events_topic: String,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub labels: HashMap<String, String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListConversationsResponse {
+    pub conversations: Vec<ConversationResponse>,
+    pub count: usize,
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListConversationsParams {
+    #[serde(default)]
+    pub namespace: Option<String>,
+    #[serde(default)]
+    pub tenant: Option<String>,
+    #[serde(default)]
+    pub state: Option<String>,
+    /// Filter conversations whose participant list contains this `agent_id`.
+    #[serde(default)]
+    pub participant: Option<String>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AppendConversationMessageRequest {
+    /// Free-form payload — the same shape as `/v1/bus/publish`.
+    #[schema(value_type = Object)]
+    pub payload: serde_json::Value,
+    /// Optional sender (an `agent_id`). Stamped as
+    /// `acteon.conversation.sender` header so subscribers can route
+    /// locally without parsing the payload. Server-validated against
+    /// the conversation's participant list when one is configured.
+    #[serde(default)]
+    pub sender: Option<String>,
+    /// Operator-supplied headers; `acteon.*` prefix is reserved.
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AppendConversationMessageResponse {
+    pub events_topic: String,
+    pub conversation_id: String,
+    pub partition: i32,
+    pub offset: i64,
+    pub produced_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ReplayConversationParams {
+    /// `earliest` (default — full thread) or `latest` (only new
+    /// messages, useful as a probe).
+    #[serde(default)]
+    pub from: Option<String>,
+    /// Hard cap on returned messages. Default 200, max 1000.
+    #[serde(default)]
+    pub limit: Option<usize>,
+    /// How long to wait for messages before returning a partial result.
+    /// Default 1500ms; bounds replay latency on quiet topics.
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ReplayMessageEntry {
+    pub partition: i32,
+    pub offset: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    #[schema(value_type = Object)]
+    pub payload: serde_json::Value,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, String>,
+    pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ReplayConversationResponse {
+    pub conversation_id: String,
+    pub events_topic: String,
+    pub messages: Vec<ReplayMessageEntry>,
+    /// True if the response is bounded by `limit` rather than end of
+    /// the timeout window. Caller can paginate by reading from the
+    /// last returned offset+1 in a subsequent call.
+    pub limit_reached: bool,
+}
+
+#[cfg(feature = "bus")]
+fn conversation_to_response(c: &acteon_core::Conversation) -> ConversationResponse {
+    ConversationResponse {
+        conversation_id: c.conversation_id.clone(),
+        namespace: c.namespace.clone(),
+        tenant: c.tenant.clone(),
+        title: c.title.clone(),
+        state: c.state,
+        participants: c.participants.clone(),
+        events_topic: c.effective_events_topic(),
+        labels: c.labels.clone(),
+        created_at: c.created_at,
+        updated_at: c.updated_at,
+    }
+}
+
+#[cfg(feature = "bus")]
+fn conversation_state_str(s: acteon_core::ConversationState) -> String {
+    match s {
+        acteon_core::ConversationState::Active => "active",
+        acteon_core::ConversationState::Resolved => "resolved",
+        acteon_core::ConversationState::Archived => "archived",
+    }
+    .to_string()
+}
+
+/// Ensure the shared events topic exists in state + Kafka. Same idea
+/// as `ensure_agent_inbox_topic` — first conversation in a tenant
+/// provisions the topic, subsequent registrations are no-ops.
+#[cfg(feature = "bus")]
+async fn ensure_conversation_events_topic(
+    state: &AppState,
+    namespace: &str,
+    tenant: &str,
+    events_topic_name: &str,
+) -> Result<(), axum::response::Response> {
+    let key = StateKey::new(
+        namespace.to_string(),
+        tenant.to_string(),
+        KeyKind::BusTopic,
+        events_topic_name,
+    );
+    let Some(backend) = state.bus_backend.as_ref() else {
+        return Err(service_unavailable("bus feature not enabled"));
+    };
+    let gw = state.gateway.read().await;
+    let store = gw.state_store();
+    if matches!(store.get(&key).await, Ok(Some(_))) {
+        return Ok(());
+    }
+    let leaf_name = events_topic_name
+        .splitn(3, '.')
+        .nth(2)
+        .unwrap_or(events_topic_name);
+    let topic = Topic::new(leaf_name, namespace, tenant);
+    if let Err(e) = topic.validate() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("invalid events topic name '{events_topic_name}': {e}"),
+            }),
+        )
+            .into_response());
+    }
+    let body = match serde_json::to_string(&topic) {
+        Ok(b) => b,
+        Err(e) => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response());
+        }
+    };
+    // Use check_and_set so two concurrent provision attempts can't
+    // both write the topic row. The loser silently no-ops.
+    if let Err(e) = store.check_and_set(&key, &body, None).await {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response());
+    }
+    drop(gw);
+    if let Err(e) = backend.create_topic(&topic).await
+        && !matches!(&e, acteon_bus::BusError::TopicAlreadyExists(_))
+    {
+        tracing::warn!(error = %e, topic = %events_topic_name, "auto-create of conversation events topic returned a non-AlreadyExists error; continuing with state row as canonical");
+    }
+    Ok(())
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/conversations",
+    tag = "bus",
+    request_body = CreateConversationRequest,
+    responses(
+        (status = 201, description = "Conversation registered", body = ConversationResponse),
+        (status = 400, description = "Invalid conversation definition", body = ErrorResponse),
+        (status = 409, description = "Conversation already exists", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+#[allow(clippy::too_many_lines)]
+pub async fn register_conversation(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Json(req): Json<CreateConversationRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) = authorize_bus_op(
+            &identity,
+            &req.tenant,
+            &req.namespace,
+            BusOp::ManageConversation,
+        ) {
+            return resp;
+        }
+        let mut conv =
+            acteon_core::Conversation::new(&req.conversation_id, &req.namespace, &req.tenant);
+        conv.title = req.title.clone();
+        conv.participants = req.participants.clone();
+        conv.events_topic = req.events_topic.clone();
+        conv.labels = req.labels.clone();
+        if let Err(e) = conv.validate() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        let events_topic = conv.effective_events_topic();
+        if let Ok((topic_ns, topic_t, _)) = parse_kafka_name(&events_topic)
+            && (topic_ns != conv.namespace || topic_t != conv.tenant)
+        {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "events topic {events_topic} crosses tenants: must be under {}.{}",
+                        conv.namespace, conv.tenant
+                    ),
+                }),
+            )
+                .into_response();
+        }
+        if let Err(resp) =
+            ensure_conversation_events_topic(&state, &conv.namespace, &conv.tenant, &events_topic)
+                .await
+        {
+            return resp;
+        }
+        let key = StateKey::new(
+            conv.namespace.clone(),
+            conv.tenant.clone(),
+            KeyKind::BusConversation,
+            conv.id(),
+        );
+        let payload = match serde_json::to_string(&conv) {
+            Ok(s) => s,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let gw = state.gateway.read().await;
+        match gw.state_store().check_and_set(&key, &payload, None).await {
+            Ok(true) => {}
+            Ok(false) => {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(ErrorResponse {
+                        error: format!(
+                            "conversation {}.{}.{} already registered",
+                            conv.namespace, conv.tenant, conv.conversation_id
+                        ),
+                    }),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        }
+        (StatusCode::CREATED, Json(conversation_to_response(&conv))).into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/bus/conversations",
+    tag = "bus",
+    params(ListConversationsParams),
+    responses(
+        (status = 200, description = "Conversation list", body = ListConversationsResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn list_conversations(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Query(params): Query<ListConversationsParams>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        let gw = state.gateway.read().await;
+        let rows = match gw
+            .state_store()
+            .scan_keys_by_kind(KeyKind::BusConversation)
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let convs: Vec<acteon_core::Conversation> = rows
+            .into_iter()
+            .filter_map(|(_, v)| serde_json::from_str::<acteon_core::Conversation>(&v).ok())
+            .filter(|c| params.namespace.as_deref().is_none_or(|n| c.namespace == n))
+            .filter(|c| params.tenant.as_deref().is_none_or(|t| c.tenant == t))
+            .filter(|c| {
+                params
+                    .state
+                    .as_deref()
+                    .is_none_or(|s| conversation_state_str(c.state).eq_ignore_ascii_case(s))
+            })
+            .filter(|c| {
+                params
+                    .participant
+                    .as_deref()
+                    .is_none_or(|p| c.participants.iter().any(|x| x == p))
+            })
+            .filter(|c| identity.is_authorized(&c.tenant, &c.namespace, "bus", "conversation"))
+            .collect();
+        let responses: Vec<ConversationResponse> =
+            convs.iter().map(conversation_to_response).collect();
+        let count = responses.len();
+        (
+            StatusCode::OK,
+            Json(ListConversationsResponse {
+                conversations: responses,
+                count,
+            }),
+        )
+            .into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, params);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}",
+    tag = "bus",
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("conversation_id" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Conversation detail", body = ConversationResponse),
+        (status = 404, description = "Conversation not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn get_conversation(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, conversation_id)): Path<(String, String, String)>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        match load_conversation(&state, &namespace, &tenant, &conversation_id).await {
+            Ok(c) => (StatusCode::OK, Json(conversation_to_response(&c))).into_response(),
+            Err(resp) => resp,
+        }
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, conversation_id);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    put,
+    path = "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}",
+    tag = "bus",
+    request_body = UpdateConversationRequest,
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("conversation_id" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Conversation updated", body = ConversationResponse),
+        (status = 400, description = "Invalid update", body = ErrorResponse),
+        (status = 404, description = "Conversation not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn update_conversation(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, conversation_id)): Path<(String, String, String)>,
+    Json(req): Json<UpdateConversationRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        let mut conv = match load_conversation(&state, &namespace, &tenant, &conversation_id).await
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
+        if let Some(t) = req.title.clone() {
+            conv.title = Some(t);
+        }
+        if let Some(p) = req.participants.clone() {
+            conv.participants = p;
+        }
+        if let Some(et) = req.events_topic.clone() {
+            conv.events_topic = Some(et);
+        }
+        if let Some(l) = req.labels.clone() {
+            conv.labels = l;
+        }
+        conv.updated_at = Utc::now();
+        if let Err(e) = conv.validate() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        let key = StateKey::new(
+            namespace.clone(),
+            tenant.clone(),
+            KeyKind::BusConversation,
+            conv.id(),
+        );
+        let payload = match serde_json::to_string(&conv) {
+            Ok(s) => s,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let gw = state.gateway.read().await;
+        if let Err(e) = gw.state_store().set(&key, &payload, None).await {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        (StatusCode::OK, Json(conversation_to_response(&conv))).into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, conversation_id, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    delete,
+    path = "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}",
+    tag = "bus",
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("conversation_id" = String, Path),
+    ),
+    responses(
+        (status = 204, description = "Conversation deleted"),
+        (status = 404, description = "Conversation not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn delete_conversation(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, conversation_id)): Path<(String, String, String)>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        let key = StateKey::new(
+            namespace.clone(),
+            tenant.clone(),
+            KeyKind::BusConversation,
+            &conversation_id,
+        );
+        let gw = state.gateway.read().await;
+        match gw.state_store().get(&key).await {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse {
+                        error: format!(
+                            "conversation {namespace}.{tenant}.{conversation_id} not found"
+                        ),
+                    }),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        }
+        if let Err(e) = gw.state_store().delete(&key).await {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        StatusCode::NO_CONTENT.into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, conversation_id);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}/transition",
+    tag = "bus",
+    request_body = ConversationTransitionRequest,
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("conversation_id" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Transition applied", body = ConversationResponse),
+        (status = 404, description = "Conversation not found", body = ErrorResponse),
+        (status = 409, description = "Illegal transition for current state", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn transition_conversation(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, conversation_id)): Path<(String, String, String)>,
+    Json(req): Json<ConversationTransitionRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        let mut conv = match load_conversation(&state, &namespace, &tenant, &conversation_id).await
+        {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
+        if let Err(e) = conv.apply_transition(req.transition) {
+            return (
+                StatusCode::CONFLICT,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        let key = StateKey::new(
+            namespace.clone(),
+            tenant.clone(),
+            KeyKind::BusConversation,
+            conv.id(),
+        );
+        let payload = match serde_json::to_string(&conv) {
+            Ok(s) => s,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let gw = state.gateway.read().await;
+        if let Err(e) = gw.state_store().set(&key, &payload, None).await {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        (StatusCode::OK, Json(conversation_to_response(&conv))).into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, conversation_id, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}/messages",
+    tag = "bus",
+    request_body = AppendConversationMessageRequest,
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("conversation_id" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Message appended", body = AppendConversationMessageResponse),
+        (status = 400, description = "Reserved header, invalid sender, or archived conversation", body = ErrorResponse),
+        (status = 404, description = "Conversation not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+#[allow(clippy::too_many_lines)]
+pub async fn append_conversation_message(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, conversation_id)): Path<(String, String, String)>,
+    Json(req): Json<AppendConversationMessageRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        let Some(backend) = state.bus_backend.as_ref() else {
+            return service_unavailable("bus feature not enabled");
+        };
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::Publish) {
+            return resp;
+        }
+        if let Some(reserved) = req.headers.keys().find(|k| k.starts_with("acteon.")) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "header '{reserved}' uses the reserved 'acteon.' prefix; those are set by the server"
+                    ),
+                }),
+            )
+                .into_response();
+        }
+        let conv = match load_conversation(&state, &namespace, &tenant, &conversation_id).await {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
+        if !conv.accepts_messages() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "conversation {}.{}.{} is archived; reopen via /transition to post",
+                        conv.namespace, conv.tenant, conv.conversation_id
+                    ),
+                }),
+            )
+                .into_response();
+        }
+        if let Some(sender) = req.sender.as_deref()
+            && !conv.participants.is_empty()
+            && !conv.participants.iter().any(|p| p == sender)
+        {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "sender '{sender}' is not a participant of conversation {}",
+                        conv.conversation_id
+                    ),
+                }),
+            )
+                .into_response();
+        }
+        let events_topic = conv.effective_events_topic();
+        let topic_key = StateKey::new(
+            namespace.clone(),
+            tenant.clone(),
+            KeyKind::BusTopic,
+            &events_topic,
+        );
+        {
+            let gw = state.gateway.read().await;
+            match gw.state_store().get(&topic_key).await {
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    return (
+                        StatusCode::NOT_FOUND,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "events topic {events_topic} is not registered; re-register the conversation or create the topic"
+                            ),
+                        }),
+                    )
+                        .into_response();
+                }
+                Err(e) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse {
+                            error: e.to_string(),
+                        }),
+                    )
+                        .into_response();
+                }
+            }
+        }
+        let mut msg = acteon_bus::BusMessage::new(events_topic.clone(), req.payload.clone())
+            .with_key(&conv.conversation_id);
+        for (k, v) in &req.headers {
+            msg = msg.with_header(k.clone(), v.clone());
+        }
+        msg.headers.insert(
+            "acteon.conversation.id".into(),
+            conv.conversation_id.clone(),
+        );
+        if let Some(sender) = &req.sender {
+            msg.headers
+                .insert("acteon.conversation.sender".into(), sender.clone());
+        }
+        match backend.produce(msg).await {
+            Ok(receipt) => (
+                StatusCode::OK,
+                Json(AppendConversationMessageResponse {
+                    events_topic: receipt.topic,
+                    conversation_id: conv.conversation_id,
+                    partition: receipt.partition,
+                    offset: receipt.offset,
+                    produced_at: receipt.timestamp,
+                }),
+            )
+                .into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response(),
+        }
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, conversation_id, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}/messages",
+    tag = "bus",
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("conversation_id" = String, Path),
+        ReplayConversationParams,
+    ),
+    responses(
+        (status = 200, description = "Thread replay", body = ReplayConversationResponse),
+        (status = 404, description = "Conversation not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+#[allow(clippy::too_many_lines)]
+pub async fn replay_conversation_messages(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, conversation_id)): Path<(String, String, String)>,
+    Query(params): Query<ReplayConversationParams>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        let Some(backend) = state.bus_backend.clone() else {
+            return service_unavailable("bus feature not enabled");
+        };
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        let conv = match load_conversation(&state, &namespace, &tenant, &conversation_id).await {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
+        let from = match params.from.as_deref() {
+            Some("latest") => acteon_bus::StartOffset::Latest,
+            Some("earliest") | None => acteon_bus::StartOffset::Earliest,
+            Some(other) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse {
+                        error: format!("unknown 'from' value '{other}' (expected earliest|latest)"),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let limit = params.limit.unwrap_or(200).min(1000);
+        let timeout_ms = params.timeout_ms.unwrap_or(1500);
+        let events_topic = conv.effective_events_topic();
+        // Use a one-shot consumer group so this read doesn't interfere
+        // with any durable subscription state.
+        let group_id = format!(
+            "acteon-replay-{}-{}",
+            conv.conversation_id,
+            uuid::Uuid::new_v4()
+        );
+        let mut stream = match backend.subscribe(&events_topic, &group_id, from).await {
+            Ok(s) => s,
+            Err(acteon_bus::BusError::TopicNotFound(_)) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse {
+                        error: format!("events topic {events_topic} not found"),
+                    }),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(timeout_ms);
+        let mut messages: Vec<ReplayMessageEntry> = Vec::new();
+        let mut limit_reached = false;
+        loop {
+            if messages.len() >= limit {
+                limit_reached = true;
+                break;
+            }
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                break;
+            }
+            let remaining = deadline - now;
+            tokio::select! {
+                next = stream.next() => {
+                    match next {
+                        Some(Ok(msg)) => {
+                            // Filter to this conversation. The shared
+                            // events topic carries every conversation
+                            // in the tenant; match on the
+                            // server-stamped header.
+                            let belongs = msg
+                                .headers
+                                .get("acteon.conversation.id")
+                                .is_some_and(|v| v == &conv.conversation_id);
+                            if !belongs {
+                                continue;
+                            }
+                            messages.push(ReplayMessageEntry {
+                                partition: msg.partition.unwrap_or(0),
+                                offset: msg.offset.unwrap_or(0),
+                                key: msg.key.clone(),
+                                payload: msg.payload.clone(),
+                                headers: msg.headers.clone(),
+                                timestamp: msg.timestamp.unwrap_or_else(Utc::now),
+                            });
+                        }
+                        Some(Err(_)) | None => break,
+                    }
+                }
+                () = tokio::time::sleep(remaining) => {
+                    break;
+                }
+            }
+        }
+        (
+            StatusCode::OK,
+            Json(ReplayConversationResponse {
+                conversation_id: conv.conversation_id,
+                events_topic,
+                messages,
+                limit_reached,
+            }),
+        )
+            .into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, conversation_id, params);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+/// Direct `StateKey` lookup of a conversation record.
+#[cfg(feature = "bus")]
+async fn load_conversation(
+    state: &AppState,
+    namespace: &str,
+    tenant: &str,
+    conversation_id: &str,
+) -> Result<acteon_core::Conversation, axum::response::Response> {
+    let key = StateKey::new(
+        namespace.to_string(),
+        tenant.to_string(),
+        KeyKind::BusConversation,
+        conversation_id.to_string(),
+    );
+    let gw = state.gateway.read().await;
+    match gw.state_store().get(&key).await {
+        Ok(Some(raw)) => serde_json::from_str::<acteon_core::Conversation>(&raw).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!(
+                        "corrupt conversation record for {namespace}.{tenant}.{conversation_id}: {e}"
+                    ),
+                }),
+            )
+                .into_response()
+        }),
+        Ok(None) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("conversation {namespace}.{tenant}.{conversation_id} not found"),
             }),
         )
             .into_response()),

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -371,6 +371,28 @@ pub fn router(state: AppState) -> Router {
             "/v1/bus/agents/{namespace}/{tenant}/{agent_id}/send",
             post(bus::send_to_agent),
         )
+        // Phase 5: Conversations — multi-agent threads on a shared
+        // events topic. Messages are keyed by conversation_id for
+        // per-thread Kafka FIFO; replay filters on the
+        // `acteon.conversation.id` header.
+        .route(
+            "/v1/bus/conversations",
+            get(bus::list_conversations).post(bus::register_conversation),
+        )
+        .route(
+            "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}",
+            get(bus::get_conversation)
+                .put(bus::update_conversation)
+                .delete(bus::delete_conversation),
+        )
+        .route(
+            "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}/transition",
+            post(bus::transition_conversation),
+        )
+        .route(
+            "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}/messages",
+            get(bus::replay_conversation_messages).post(bus::append_conversation_message),
+        )
         // Swarm runs
         .route("/v1/swarm/runs", get(swarm::list_swarm_runs))
         .route("/v1/swarm/runs/{run_id}", get(swarm::get_swarm_run))

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -183,6 +183,14 @@ use acteon_core::{
         super::bus::delete_agent,
         super::bus::heartbeat_agent,
         super::bus::send_to_agent,
+        super::bus::register_conversation,
+        super::bus::list_conversations,
+        super::bus::get_conversation,
+        super::bus::update_conversation,
+        super::bus::delete_conversation,
+        super::bus::transition_conversation,
+        super::bus::append_conversation_message,
+        super::bus::replay_conversation_messages,
     ),
     components(schemas(
         Action, ActionOutcome, ProviderResponse, ResponseStatus, ActionError,
@@ -254,6 +262,13 @@ use acteon_core::{
         super::bus::AgentResponse, super::bus::ListAgentsResponse,
         super::bus::HeartbeatResponse, super::bus::SendToAgentRequest,
         super::bus::SendToAgentResponse,
+        super::bus::CreateConversationRequest, super::bus::UpdateConversationRequest,
+        super::bus::ConversationResponse, super::bus::ListConversationsResponse,
+        super::bus::ConversationTransitionRequest,
+        super::bus::AppendConversationMessageRequest,
+        super::bus::AppendConversationMessageResponse,
+        super::bus::ReplayMessageEntry, super::bus::ReplayConversationResponse,
+        acteon_core::ConversationState, acteon_core::ConversationTransition,
     ))
 )]
 pub struct ApiDoc;

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -268,6 +268,7 @@ use acteon_core::{
         super::bus::AppendConversationMessageRequest,
         super::bus::AppendConversationMessageResponse,
         super::bus::ReplayMessageEntry, super::bus::ReplayConversationResponse,
+        super::bus::ReplayExitReason,
         acteon_core::ConversationState, acteon_core::ConversationTransition,
     ))
 )]

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -220,5 +220,9 @@ required-features = ["bus"]
 name = "bus_agent_simulation"
 required-features = ["bus"]
 
+[[example]]
+name = "bus_conversation_simulation"
+required-features = ["bus"]
+
 [lints]
 workspace = true

--- a/crates/simulation/examples/bus_conversation_simulation.rs
+++ b/crates/simulation/examples/bus_conversation_simulation.rs
@@ -1,0 +1,189 @@
+//! Phase 5 multi-agent conversation demo.
+//!
+//! Drives the in-memory bus backend directly (no Kafka, no HTTP) so
+//! the test fits into the wider simulation suite. The HTTP handlers
+//! `POST /v1/bus/conversations/.../messages` and
+//! `GET /v1/bus/conversations/.../messages` delegate to the same
+//! types and the same shared events topic.
+//!
+//! Scenarios:
+//!
+//! 1. Two conversations share one events topic; messages are keyed
+//!    by `conversation_id` so each thread's records land on a stable
+//!    partition. We verify replay only returns the requested
+//!    conversation's messages.
+//! 2. Linear state machine: Active → Resolved → Archived. Posts to an
+//!    archived conversation are rejected; reopening from Resolved
+//!    works.
+//! 3. Participant ACL: a sender outside the participant list is
+//!    rejected when participants are configured; an empty
+//!    participant list means "open thread".
+//!
+//! Run with:
+//! ```text
+//! cargo run -p acteon-simulation --features bus --example bus_conversation_simulation
+//! ```
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use tracing::{Level, info};
+
+use acteon_bus::{BusMessage, MemoryBackend, StartOffset};
+use acteon_core::{Conversation, ConversationState, ConversationTransition, Topic};
+
+#[tokio::main]
+#[allow(clippy::too_many_lines)]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::INFO)
+        .with_env_filter("info,acteon_bus=info")
+        .init();
+
+    let backend: acteon_bus::SharedBackend = MemoryBackend::new();
+    let events = Topic::new("conversations-events", "agents", "demo");
+    backend.create_topic(&events).await?;
+
+    // -----------------------------------------------------------------
+    // 1. Two conversations on the shared events topic
+    // -----------------------------------------------------------------
+
+    let mut planning = Conversation::new("plan-001", "agents", "demo");
+    planning.title = Some("Planning Q3".into());
+    planning.participants = vec!["planner-1".into(), "ocr-svc".into()];
+    planning.validate()?;
+
+    let mut review = Conversation::new("rev-002", "agents", "demo");
+    review.title = Some("Code review #1234".into());
+    review.participants = vec!["reviewer-1".into()];
+    review.validate()?;
+
+    assert_eq!(
+        planning.effective_events_topic(),
+        review.effective_events_topic()
+    );
+    let topic = planning.effective_events_topic();
+    info!(
+        topic = %topic,
+        "two conversations sharing one events topic"
+    );
+
+    // Post 3 messages each, interleaved.
+    for i in 0..3 {
+        let mut p_msg = BusMessage::new(
+            topic.clone(),
+            serde_json::json!({"step": i, "from": "planning"}),
+        )
+        .with_key(&planning.conversation_id);
+        p_msg.headers.insert(
+            "acteon.conversation.id".into(),
+            planning.conversation_id.clone(),
+        );
+        p_msg
+            .headers
+            .insert("acteon.conversation.sender".into(), "planner-1".into());
+        backend.produce(p_msg).await?;
+
+        let mut r_msg = BusMessage::new(
+            topic.clone(),
+            serde_json::json!({"step": i, "from": "review"}),
+        )
+        .with_key(&review.conversation_id);
+        r_msg.headers.insert(
+            "acteon.conversation.id".into(),
+            review.conversation_id.clone(),
+        );
+        r_msg
+            .headers
+            .insert("acteon.conversation.sender".into(), "reviewer-1".into());
+        backend.produce(r_msg).await?;
+    }
+
+    // Replay just the planning thread by reading from earliest and
+    // filtering on the server-stamped header — same logic the
+    // `GET /messages` handler runs.
+    let mut stream = backend
+        .subscribe(&topic, "sim-replay-planning", StartOffset::Earliest)
+        .await?;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let mut planning_msgs = Vec::new();
+    while planning_msgs.len() < 3 && tokio::time::Instant::now() < deadline {
+        tokio::select! {
+            next = stream.next() => {
+                match next {
+                    Some(Ok(msg)) => {
+                        if msg
+                            .headers
+                            .get("acteon.conversation.id")
+                            .is_some_and(|v| v == &planning.conversation_id)
+                        {
+                            planning_msgs.push(msg);
+                        }
+                    }
+                    Some(Err(_)) | None => break,
+                }
+            }
+            () = tokio::time::sleep(Duration::from_millis(100)) => {}
+        }
+    }
+    assert_eq!(
+        planning_msgs.len(),
+        3,
+        "expected exactly 3 planning messages"
+    );
+    for msg in &planning_msgs {
+        assert_eq!(msg.key.as_deref(), Some(planning.conversation_id.as_str()));
+    }
+    info!(
+        count = planning_msgs.len(),
+        "replay returned only the planning thread's messages from the shared topic"
+    );
+
+    // -----------------------------------------------------------------
+    // 2. State machine
+    // -----------------------------------------------------------------
+
+    let mut conv = Conversation::new("flow-1", "agents", "demo");
+    assert_eq!(conv.state, ConversationState::Active);
+    assert!(conv.accepts_messages());
+
+    conv.apply_transition(ConversationTransition::Resolve)?;
+    assert_eq!(conv.state, ConversationState::Resolved);
+    assert!(conv.accepts_messages());
+    info!("after resolve: state=Resolved, accepts_messages=true (follow-ups OK)");
+
+    conv.apply_transition(ConversationTransition::Reopen)?;
+    assert_eq!(conv.state, ConversationState::Active);
+    info!("reopened back to Active");
+
+    conv.apply_transition(ConversationTransition::Resolve)?;
+    conv.apply_transition(ConversationTransition::Archive)?;
+    assert_eq!(conv.state, ConversationState::Archived);
+    assert!(!conv.accepts_messages());
+    info!("after archive: state=Archived, accepts_messages=false");
+
+    let illegal = conv.apply_transition(ConversationTransition::Reopen);
+    assert!(illegal.is_err(), "reopen from Archived must be rejected");
+    info!("reopen-from-Archived correctly rejected");
+
+    // -----------------------------------------------------------------
+    // 3. Participant ACL
+    // -----------------------------------------------------------------
+
+    let mut closed = Conversation::new("closed-1", "agents", "demo");
+    closed.participants = vec!["alpha".into(), "beta".into()];
+    let allowed = closed.participants.iter().any(|p| p == "alpha");
+    let rejected = closed.participants.iter().any(|p| p == "gamma");
+    assert!(allowed && !rejected);
+    info!(
+        participants = ?closed.participants,
+        "participant 'alpha' allowed; 'gamma' would be rejected with 400"
+    );
+
+    let mut open = Conversation::new("open-1", "agents", "demo");
+    open.participants.clear();
+    info!("empty participant list = open thread; any sender accepted");
+
+    info!("conversation simulation complete");
+    Ok(())
+}

--- a/crates/state/dynamodb/src/store.rs
+++ b/crates/state/dynamodb/src/store.rs
@@ -179,6 +179,39 @@ impl StateStore for DynamoStateStore {
         }
     }
 
+    async fn get_versioned(&self, key: &StateKey) -> Result<Option<(String, u64)>, StateError> {
+        let pk = build_pk(&self.prefix, key);
+        let sk = build_sk(key);
+        let result = self
+            .client
+            .get_item()
+            .table_name(&self.table_name)
+            .key("pk", AttributeValue::S(pk))
+            .key("sk", AttributeValue::S(sk))
+            .send()
+            .await
+            .map_err(|e| StateError::Backend(e.to_string()))?;
+        let Some(item) = result.item() else {
+            return Ok(None);
+        };
+        if Self::is_expired(item) {
+            return Ok(None);
+        }
+        let value = match item.get("value") {
+            Some(AttributeValue::S(v)) => v.clone(),
+            _ => return Ok(None),
+        };
+        // `version` is stored as a numeric attribute. Items written by
+        // `check_and_set` carry version=1 already; items without a
+        // version field (legacy inserts) report version 0 so the
+        // first CAS migrates them safely.
+        let version = match item.get("version") {
+            Some(AttributeValue::N(s)) => s.parse::<u64>().unwrap_or(0),
+            _ => 0,
+        };
+        Ok(Some((value, version)))
+    }
+
     async fn set(
         &self,
         key: &StateKey,

--- a/crates/state/memory/src/store.rs
+++ b/crates/state/memory/src/store.rs
@@ -130,6 +130,19 @@ impl StateStore for MemoryStateStore {
         Ok(None)
     }
 
+    async fn get_versioned(&self, key: &StateKey) -> Result<Option<(String, u64)>, StateError> {
+        let rendered = Self::render_key(key);
+        if let Some(entry) = self.data.get(&rendered) {
+            if entry.is_expired() {
+                drop(entry);
+                self.data.remove(&rendered);
+                return Ok(None);
+            }
+            return Ok(Some((entry.value.clone(), entry.version)));
+        }
+        Ok(None)
+    }
+
     async fn set(
         &self,
         key: &StateKey,

--- a/crates/state/postgres/src/store.rs
+++ b/crates/state/postgres/src/store.rs
@@ -171,6 +171,21 @@ impl StateStore for PostgresStateStore {
         Ok(row.map(|(v,)| v))
     }
 
+    async fn get_versioned(&self, key: &StateKey) -> Result<Option<(String, u64)>, StateError> {
+        let canonical = key.canonical();
+        let table = self.config.state_table();
+        let query = format!(
+            "SELECT value, version FROM {table} \
+             WHERE key = $1 AND (expires_at IS NULL OR expires_at > NOW())"
+        );
+        let row: Option<(String, i64)> = sqlx::query_as(&query)
+            .bind(&canonical)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StateError::Backend(e.to_string()))?;
+        Ok(row.map(|(v, ver)| (v, u64::try_from(ver).unwrap_or(0))))
+    }
+
     async fn set(
         &self,
         key: &StateKey,

--- a/crates/state/redis/src/store.rs
+++ b/crates/state/redis/src/store.rs
@@ -118,6 +118,32 @@ impl StateStore for RedisStateStore {
         Ok(val)
     }
 
+    async fn get_versioned(&self, key: &StateKey) -> Result<Option<(String, u64)>, StateError> {
+        let hash_key = self.hash_key(key);
+        let mut conn = self.conn().await?;
+        // Hash storage carries the version; CAS-only callers update
+        // through this path.
+        let (val, ver): (Option<String>, Option<u64>) = redis::pipe()
+            .hget(&hash_key, "v")
+            .hget(&hash_key, "ver")
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| StateError::Backend(e.to_string()))?;
+        if let (Some(v), Some(ver)) = (val, ver) {
+            return Ok(Some((v, ver)));
+        }
+        // Plain-string fallback for entries written by `check_and_set`
+        // (no version tracked). Report version 0 — the first
+        // `compare_and_swap(_, 0, ...)` call will atomically promote
+        // the entry into hash form with version 1.
+        let string_key = self.string_key(key);
+        let val: Option<String> = conn
+            .get(&string_key)
+            .await
+            .map_err(|e| StateError::Backend(e.to_string()))?;
+        Ok(val.map(|v| (v, 0)))
+    }
+
     async fn set(
         &self,
         key: &StateKey,

--- a/crates/state/state/src/key.rs
+++ b/crates/state/state/src/key.rs
@@ -64,6 +64,8 @@ pub enum KeyKind {
     BusSchema,
     /// Bus agent identity + heartbeat (Phase 4 of the agentic bus).
     BusAgent,
+    /// Bus conversation thread (Phase 5 of the agentic bus).
+    BusConversation,
     Custom(String),
 }
 
@@ -104,6 +106,7 @@ impl KeyKind {
             Self::BusSubscription => "bus_subscription",
             Self::BusSchema => "bus_schema",
             Self::BusAgent => "bus_agent",
+            Self::BusConversation => "bus_conversation",
             Self::Custom(s) => s.as_str(),
         }
     }
@@ -204,6 +207,7 @@ mod tests {
         assert_eq!(KeyKind::BusSubscription.as_str(), "bus_subscription");
         assert_eq!(KeyKind::BusSchema.as_str(), "bus_schema");
         assert_eq!(KeyKind::BusAgent.as_str(), "bus_agent");
+        assert_eq!(KeyKind::BusConversation.as_str(), "bus_conversation");
         assert_eq!(KeyKind::Custom("foo".into()).as_str(), "foo");
     }
 

--- a/crates/state/state/src/store.rs
+++ b/crates/state/state/src/store.rs
@@ -34,6 +34,13 @@ pub trait StateStore: Send + Sync {
     /// Get the value for a key. Returns `None` if not found or expired.
     async fn get(&self, key: &StateKey) -> Result<Option<String>, StateError>;
 
+    /// Get the value and its current version for a key. Used by
+    /// optimistic-concurrency callers that follow up with
+    /// [`Self::compare_and_swap`]. Returns `None` if not found or
+    /// expired. Versions begin at 1 for newly-inserted entries and
+    /// increment on each successful `set` / `compare_and_swap`.
+    async fn get_versioned(&self, key: &StateKey) -> Result<Option<(String, u64)>, StateError>;
+
     /// Set a value with an optional TTL, overwriting any previous value.
     async fn set(
         &self,

--- a/docs/book/features/bus-phase-5.md
+++ b/docs/book/features/bus-phase-5.md
@@ -1,0 +1,244 @@
+# Agentic Bus — Phase 5
+
+> **Scope**: `Conversation` type, multi-agent threads on a shared
+> events topic with Kafka-keyed FIFO ordering, lifecycle state machine,
+> participant ACL, message append + replay. Tool-call envelopes and
+> streaming chunks land in Phase 6. See the
+> [master plan](../concepts/bus-master-plan.md).
+
+Phases 1–4 gave us topics, durable subscriptions, schemas, and agents.
+Phase 5 makes the bus *thread-aware*: operators register a
+conversation once, agents post messages to it, and any reader can
+replay the full history filtered to one thread — without provisioning
+a Kafka topic per conversation.
+
+## What ships in Phase 5
+
+| Surface | Shape |
+|---|---|
+| Core type | `acteon_core::Conversation` — `{conversation_id, namespace, tenant, title, state, participants, events_topic, labels, created_at, updated_at}` |
+| State | `KeyKind::BusConversation`; key id = `conversation_id` |
+| Shared events topic | Default `{namespace}.{tenant}.conversations-events`, auto-created on first conversation registration. All conversations in the tenant share it; messages keyed by `conversation_id` so Kafka's partitioner gives per-thread FIFO ordering for free. |
+| HTTP | `POST/GET /v1/bus/conversations`, `GET\|PUT\|DELETE /v1/bus/conversations/{ns}/{t}/{id}`, `POST /v1/bus/conversations/{ns}/{t}/{id}/transition`, `POST\|GET /v1/bus/conversations/{ns}/{t}/{id}/messages` |
+| Rust client | `register_bus_conversation`, `list_bus_conversations`, `get_bus_conversation`, `update_bus_conversation`, `delete_bus_conversation`, `transition_bus_conversation`, `append_bus_conversation_message`, `replay_bus_conversation_messages` |
+| Tests | 10 core unit tests covering the state machine, validation, inbox defaults + overrides, and serde roundtrip |
+| Simulation | `bus_conversation_simulation.rs` — two conversations on one shared topic, replay with header filter, full state-machine walkthrough, participant ACL |
+
+## Model
+
+### Shared events topic, keyed messages
+
+Same trick as the agent inbox: every conversation in a tenant shares
+one Kafka topic. Acteon keys each message by `conversation_id`, so
+Kafka's default partitioner deterministically routes one thread's
+traffic to one partition — per-conversation FIFO ordering with no
+subscription bookkeeping.
+
+```
+agents.demo.conversations-events       (partitions = 3)
+├── partition 0 ── conversation_id=plan-001  msg msg msg
+├── partition 1 ── conversation_id=rev-002    msg msg
+└── partition 2 ── conversation_id=plan-007  msg msg msg
+```
+
+Replay reads the topic from the requested offset, filters on the
+server-stamped `acteon.conversation.id` header, and bounds latency
+with a small budget (default 1500ms / 200 messages, both tunable).
+
+Operators can override `events_topic` per conversation if they want
+isolation — for example, a high-volume thread that should not share a
+topic with the general pool. Cross-tenant overrides are rejected at
+registration.
+
+### Lifecycle state machine
+
+```text
+   ┌─────────┐  resolve   ┌──────────┐  archive   ┌──────────┐
+   │ Active  │───────────▶│ Resolved │───────────▶│ Archived │
+   └─────────┘            └──────────┘            └──────────┘
+         ▲                      │
+         └─────── reopen ───────┘
+```
+
+- `Active` and `Resolved` accept message posts. A follow-up after
+  resolution is a common pattern; the bus doesn't punish it.
+- `Archived` is read-only by design. Reopen is rejected; the only
+  way back is to register a new conversation.
+- `Active → Archived` requires going through `Resolved` first. No
+  shortcut.
+
+### Participant ACL
+
+Each conversation carries a `participants: Vec<String>` of agent IDs
+who are allowed to post. Empty list means "open thread, any sender
+accepted." When the list is non-empty, append-message rejects any
+sender outside it with `400 Bad Request`. This is checked
+**after** the standard publish authorization, so participant ACL is
+strictly a *narrower* gate than the tenant's bus-write grant.
+
+## API shape
+
+### Register
+
+```http
+POST /v1/bus/conversations
+{
+  "conversation_id": "plan-001",
+  "namespace": "agents",
+  "tenant": "demo",
+  "title": "Planning Q3",
+  "participants": ["planner-1", "ocr-svc"]
+}
+→ 201 ConversationResponse {
+  "events_topic": "agents.demo.conversations-events",
+  "state": "active", ...
+}
+```
+
+First registration in `(namespace, tenant)` auto-provisions the shared
+events topic in both state and Kafka.
+
+### Append message
+
+```http
+POST /v1/bus/conversations/agents/demo/plan-001/messages
+{
+  "payload": { "kind": "draft", "body": "Step 1..." },
+  "sender": "planner-1"
+}
+→ 200 { "events_topic": "...", "conversation_id": "plan-001",
+         "partition": 0, "offset": 17, "produced_at": "..." }
+```
+
+The server keys the Kafka record by `conversation_id` and stamps two
+reserved headers: `acteon.conversation.id` and (if `sender` is set)
+`acteon.conversation.sender`.
+
+### Replay thread
+
+```http
+GET /v1/bus/conversations/agents/demo/plan-001/messages?from=earliest&limit=200&timeout_ms=1500
+→ 200 {
+  "conversation_id": "plan-001",
+  "events_topic": "agents.demo.conversations-events",
+  "messages": [
+    { "partition": 0, "offset": 12, "key": "plan-001",
+      "payload": {...}, "headers": {...}, "timestamp": "..." },
+    ...
+  ],
+  "limit_reached": false
+}
+```
+
+Each replay opens a one-shot consumer group (UUID-suffixed) so it
+doesn't interfere with any durable subscription state. `limit_reached
+= true` means more messages may exist past the returned tail; clients
+paginate by re-issuing with a higher offset (or just request more
+messages with a larger `limit`).
+
+### State transitions
+
+```http
+POST /v1/bus/conversations/agents/demo/plan-001/transition
+{ "transition": "resolve" }
+→ 200 ConversationResponse { "state": "resolved", ... }
+```
+
+Illegal transitions return `409 Conflict` with the enum-described
+disallowed move (e.g. `archive` from `active`).
+
+## SDK example
+
+```rust
+use acteon_client::{
+    ActeonClient, AppendBusConversationMessage, BusConversationTransition,
+    RegisterBusConversation, ReplayBusConversationParams,
+};
+
+let client = ActeonClient::new("http://localhost:3000")?;
+
+// Register.
+let conv = client.register_bus_conversation(&RegisterBusConversation {
+    conversation_id: "plan-001".into(),
+    namespace: "agents".into(),
+    tenant: "demo".into(),
+    title: Some("Planning Q3".into()),
+    participants: vec!["planner-1".into(), "ocr-svc".into()],
+    ..Default::default()
+}).await?;
+
+// Append.
+client.append_bus_conversation_message("agents", "demo", "plan-001",
+    &AppendBusConversationMessage {
+        payload: serde_json::json!({"kind": "draft", "step": 1}),
+        sender: Some("planner-1".into()),
+        ..Default::default()
+    }
+).await?;
+
+// Replay.
+let history = client.replay_bus_conversation_messages("agents", "demo", "plan-001",
+    &ReplayBusConversationParams { ..Default::default() }).await?;
+println!("thread has {} messages", history.messages.len());
+
+// Resolve.
+client.transition_bus_conversation(
+    "agents", "demo", "plan-001",
+    BusConversationTransition::Resolve,
+).await?;
+```
+
+## Authorization
+
+All conversation endpoints flow through `BusOp::ManageConversation`
+(requires `Dispatch` permission and a grant for verb `conversation`
+on the target `(tenant, namespace)`).
+
+`POST /messages` additionally requires `BusOp::Publish`, so operators
+can split read-only viewer roles from posting agents.
+
+Participant ACL is enforced **after** the publish gate: even with
+publish rights, a sender outside the participant list is rejected
+with `400`.
+
+## Atomic create
+
+`register_conversation` uses `StateStore::check_and_set` for the
+conversation row, mirroring the post-#132 pattern. Two concurrent
+posts for the same `conversation_id` cleanly produce one `201` and
+one `409` — no silent overwrite.
+
+## Design decisions
+
+- **Shared events topic, not per-conversation topic.** Locked by the
+  master plan. Fewer topics, simpler ACLs, Kafka's key partitioner
+  gives per-thread ordering. Override per-conversation if you need
+  isolation.
+- **Replay via topic scan + header filter.** One source of truth
+  (Kafka), no parallel store, no consistency window. The latency
+  budget bounds the cost.
+- **Linear state machine with explicit `Reopen`.** No `Active →
+  Archived` shortcut; mistakes happen, so `Resolved → Active` is
+  allowed.
+- **Participants on the conversation, not derived from message
+  senders.** Lets operators ACL the thread before any agent posts.
+
+## How to try it
+
+```bash
+# Standalone — no Kafka required.
+cargo run -p acteon-simulation --features bus --example bus_conversation_simulation
+```
+
+For end-to-end HTTP, start the server with the bus feature and use the
+SDK methods above.
+
+## What comes next (Phase 6)
+
+- `ToolCall` / `ToolResult` envelope types riding on top of
+  `Conversation`.
+- `correlation_id` / `reply_to` semantics so a tool-call request and
+  its response thread together cleanly.
+- Streaming chunks (per-chunk Kafka records with a terminal marker)
+  for LLM token streams and partial tool results.
+- HITL pre-publish approvals for sensitive tool-call envelopes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -187,6 +187,7 @@ nav:
     - Phase 2 (Subscriptions + Ack + Lag + DLQ): features/bus-phase-2.md
     - Phase 3 (Schemas + Publish Validation): features/bus-phase-3.md
     - Phase 4 (Agents + Shared Inbox + Heartbeat): features/bus-phase-4.md
+    - Phase 5 (Conversations + Threads): features/bus-phase-5.md
   - Guides:
     - guides/index.md
     - AI Agent Swarm Coordination: guides/agent-swarm-coordination.md


### PR DESCRIPTION
## Summary

Phase 5 of the agentic bus. Adds multi-agent conversation threads on a shared events topic — same architectural trick as the agent inbox in Phase 4: one Kafka topic per tenant, keyed by `conversation_id` for per-thread FIFO ordering, no topic-per-conversation.

- **Core type** \`acteon_core::Conversation\` with linear state machine (\`Active → Resolved → Archived\`, with explicit \`Reopen\` only from \`Resolved\`). \`KeyKind::BusConversation\`.
- **Shared events topic** \`{ns}.{tenant}.conversations-events\` auto-provisioned on first registration. Atomic \`check_and_set\` on both the topic row and the conversation row (post-#132 pattern).
- **HTTP** — 8 endpoints under \`/v1/bus/conversations\` covering CRUD, list with filters, state transitions, message append, and thread replay.
- **Replay** — opens a one-shot consumer group (UUID-suffixed), reads from earliest/latest, filters on the server-stamped \`acteon.conversation.id\` header, bounded by \`limit\` (default 200, max 1000) and \`timeout_ms\` (default 1500).
- **Append message** — keys by \`conversation_id\`, server-stamps \`acteon.conversation.id\` and optional \`acteon.conversation.sender\`, rejects archived threads, enforces participant ACL when one is configured.
- **Authorization** — \`BusOp::ManageConversation\` (Dispatch, verb \`conversation\`); message append additionally requires \`BusOp::Publish\`.
- **Rust SDK** — 8 helper methods + DTOs.
- **Tests** — 10 new core unit tests for the state machine, validation, and serde roundtrip.
- **Simulation** — \`bus_conversation_simulation.rs\` runs against \`MemoryBackend\` (no Kafka), demonstrates two conversations sharing a topic with header-filtered replay, full state-machine walk, and participant ACL.
- **Docs** — \`docs/book/features/bus-phase-5.md\`.

## Design notes

- **Shared events topic, not per-conversation topic.** Master-plan decision. Fewer topics, simpler ACLs, Kafka's key partitioner handles ordering.
- **Replay via topic scan + header filter.** One source of truth (Kafka), no parallel store, no consistency window. Latency budget bounds the cost.
- **Linear state machine with explicit \`Reopen\`.** No \`Active → Archived\` shortcut; \`Resolved → Active\` for mistakes.
- **Participants on the conversation, not derived.** Lets operators ACL the thread before any agent posts.

## Out of scope (Phase 7)

Thread UI bundles into the dedicated UI phase along with Topics/Subscriptions/Agents views.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --no-deps -- -D warnings\`
- [x] \`cargo clippy -p acteon-server --features bus --no-deps -- -D warnings\`
- [x] \`cargo test --workspace --lib --bins --tests\` — 2517 passed, 0 failed
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps\`
- [x] \`cargo check --all-targets\`
- [x] \`ACTEON_KAFKA_BOOTSTRAP=localhost:9092 cargo test -p acteon-bus --test kafka_integration\` — 3/3
- [x] \`cargo run -p acteon-simulation --features bus --example bus_conversation_simulation\` — end-to-end green

## Polyglot SDKs

Per the [master plan](../blob/main/docs/book/concepts/bus-master-plan.md), Python/Node/Go/Java parity for the entire bus surface lands together in Phase 8. Rust client ships here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)