### PR TITLE
feat(bus): Phase 6a — tool-call envelopes on conversations

### DIFF
--- a/crates/bus/src/backend.rs
+++ b/crates/bus/src/backend.rs
@@ -22,8 +22,21 @@ pub enum ScanFrom {
     /// Read from the broker's high-water mark on every partition.
     Latest,
     /// Read each partition starting at the explicit offset given;
-    /// partitions absent from the map are skipped (the caller has
-    /// already drained them).
+    /// partitions absent from the map default to `Latest` (the
+    /// broker's high-water mark at scan start). This shape
+    /// preserves "resume here" intent for partitions the caller has
+    /// tracked while still catching new records on partitions the
+    /// caller doesn't have an offset for — important for flows like
+    /// tool-call lookup where a single-partition cursor (the
+    /// originating call's partition) must still observe results
+    /// that land on other partitions via `reply_to`.
+    ///
+    /// Earlier the contract was "absent partitions are skipped"
+    /// (intent: the caller had drained them). That made
+    /// `FromOffsets` a footgun for any caller that didn't fully
+    /// pre-populate the map; the safer contract is to scan
+    /// everything by default and let the explicit entries narrow
+    /// the start point per partition.
     FromOffsets(BTreeMap<i32, i64>),
 }
 

--- a/crates/bus/src/kafka.rs
+++ b/crates/bus/src/kafka.rs
@@ -453,20 +453,24 @@ impl BusBackend for KafkaBackend {
                 }
             }
             ScanFrom::FromOffsets(offsets) => {
-                // Resume each partition from the next-after-last
-                // offset the caller saw. Partitions absent from the
-                // map are skipped — the contract is "the caller has
-                // already drained them" (e.g. a single-partition
-                // conversation that lives entirely on partition 0).
+                // Listed partitions resume at `last_seen + 1`;
+                // partitions absent from the map default to `End`
+                // (the broker's high-water mark at scan start). The
+                // earlier "skip absent" contract silently locked
+                // single-partition cursors (e.g. a `ToolCall`
+                // receipt) to one partition, so reply_to flows that
+                // routed the result to a different partition would
+                // never see it. The new shape preserves the
+                // caller's resume intent on listed partitions while
+                // letting unlisted ones still observe new records.
                 for p in topic_meta.partitions() {
-                    if let Some(&last_seen) = offsets.get(&p.id()) {
-                        tpl.add_partition_offset(
-                            kafka_topic,
-                            p.id(),
-                            rdkafka::Offset::Offset(last_seen + 1),
-                        )
+                    let offset = offsets
+                        .get(&p.id())
+                        .map_or(rdkafka::Offset::End, |&last_seen| {
+                            rdkafka::Offset::Offset(last_seen + 1)
+                        });
+                    tpl.add_partition_offset(kafka_topic, p.id(), offset)
                         .map_err(|e| BusError::Transport(format!("tpl: {e}")))?;
-                    }
                 }
             }
         }

--- a/crates/bus/src/memory.rs
+++ b/crates/bus/src/memory.rs
@@ -192,14 +192,18 @@ impl BusBackend for MemoryBackend {
         let (start_offset, skip_until_offset) = match from {
             ScanFrom::Earliest => (StartOffset::Earliest, None),
             ScanFrom::Latest => (StartOffset::Latest, None),
-            // Memory backend has only one partition (id 0); honor the
-            // partition-0 entry if present, otherwise replay from
-            // earliest. We materialize the skip-until offset and let
-            // the caller filter inline.
-            ScanFrom::FromOffsets(map) => {
-                let skip = map.get(&0).copied();
-                (StartOffset::Earliest, skip)
-            }
+            // Memory backend has only one partition (id 0). When
+            // the caller's map covers it, honor the explicit offset.
+            // When it doesn't (e.g. a tool-call cursor whose call
+            // landed on a Kafka partition that the in-memory
+            // backend doesn't model), default to `Latest` — same
+            // shape the kafka backend now uses for unlisted
+            // partitions, so single-backend tests can exercise
+            // both branches.
+            ScanFrom::FromOffsets(map) => match map.get(&0).copied() {
+                Some(offset) => (StartOffset::Earliest, Some(offset)),
+                None => (StartOffset::Latest, None),
+            },
         };
         let stream = self
             .subscribe(kafka_topic, "memory-scan", start_offset)
@@ -397,5 +401,36 @@ mod tests {
             }
             other => panic!("expected TopicAlreadyExists, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn scan_from_offsets_with_missing_partition_defaults_to_latest() {
+        // `ScanFrom::FromOffsets` no longer skips partitions absent
+        // from the map — they default to Latest. Verify the memory
+        // backend honors this contract by passing an offsets map
+        // that doesn't cover partition 0 and confirming the scan
+        // does *not* yield the existing backlog (Latest = no backlog).
+        let backend = MemoryBackend::new();
+        let topic = Topic::new("scan-default", "ns", "tn");
+        backend.create_topic(&topic).await.unwrap();
+        backend
+            .produce(BusMessage::new(
+                topic.kafka_topic_name(),
+                serde_json::json!({"n": 0}),
+            ))
+            .await
+            .unwrap();
+        // Empty FromOffsets map → all partitions default to Latest.
+        // Memory backend's lone partition is 0; the produced record
+        // is *backlog*, so a Latest scan must not return it.
+        let mut stream = backend
+            .scan_topic(
+                &topic.kafka_topic_name(),
+                crate::backend::ScanFrom::FromOffsets(std::collections::BTreeMap::new()),
+            )
+            .await
+            .unwrap();
+        let next = tokio::time::timeout(std::time::Duration::from_millis(50), stream.next()).await;
+        assert!(next.is_err(), "Latest-default scan must not yield backlog");
     }
 }

--- a/crates/client/src/bus.rs
+++ b/crates/client/src/bus.rs
@@ -1165,6 +1165,12 @@ impl ActeonClient {
                 conversation_id: receipt.conversation_id,
                 cursor: Some(receipt.cursor),
                 timeout_ms,
+                // Carry the call's `sender` through as `as_agent` so
+                // the read-side participant ACL accepts us when the
+                // conversation is private. Mirrors the natural
+                // request/response flow: an agent that posted the
+                // call is also the one waiting for the result.
+                as_agent: req.sender.clone(),
             },
         )
         .await
@@ -1448,6 +1454,11 @@ pub struct ReplayBusConversationParams {
     /// `from` is ignored.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
+    /// `agent_id` the caller is acting as. Required when the target
+    /// conversation has a non-empty `participants` ACL — the server
+    /// rejects with 403 if the agent isn't on the list.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub as_agent: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1560,6 +1571,13 @@ pub struct BusToolResultLookupParams {
     /// How long to wait for a matching result. Default 5000ms; max 30000ms.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout_ms: Option<u64>,
+    /// `agent_id` the caller is acting as. Required when the target
+    /// conversation has a non-empty `participants` ACL — the server
+    /// rejects with 403 if the agent isn't on the list. Open
+    /// conversations (empty participants) accept any caller with the
+    /// tenant grant; this field is then ignored.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub as_agent: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/client/src/bus.rs
+++ b/crates/client/src/bus.rs
@@ -1044,6 +1044,95 @@ impl ActeonClient {
             None => format!("{}/v1/bus/conversations/{ns}/{t}/{c}", self.base_url),
         }
     }
+
+    // ----- Phase 6a: tool-call envelopes -----
+
+    /// Append a tool-call envelope to a conversation. The bus stamps
+    /// `acteon.envelope.kind = tool_call`, `acteon.tool.call_id`,
+    /// `acteon.correlation_id`, and `acteon.reply_to` headers so
+    /// subscribers can route on the call without parsing the payload.
+    pub async fn post_bus_tool_call(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        conversation_id: &str,
+        req: &PostBusToolCall,
+    ) -> Result<BusToolEnvelopeReceipt, Error> {
+        let url = self.conversation_url(namespace, tenant, conversation_id, Some("tool-calls"));
+        let resp = self
+            .add_auth(self.client.post(&url))
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusToolEnvelopeReceipt>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Append a tool-result envelope. Carries the originating
+    /// `call_id` so consumers (and `lookup_bus_tool_result`) can match
+    /// it to the call.
+    pub async fn post_bus_tool_result(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        conversation_id: &str,
+        req: &PostBusToolResult,
+    ) -> Result<BusToolEnvelopeReceipt, Error> {
+        let url = self.conversation_url(namespace, tenant, conversation_id, Some("tool-results"));
+        let resp = self
+            .add_auth(self.client.post(&url))
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusToolEnvelopeReceipt>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Wait for a tool result matching `call_id`. The server scans
+    /// the events topic with a `timeout_ms` budget (default 5000ms,
+    /// max 30000ms). Use `params.conversation_id` if the result is
+    /// expected to land in a different conversation than the call
+    /// (`reply_to` pattern).
+    pub async fn lookup_bus_tool_result(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        call_id: &str,
+        params: &BusToolResultLookupParams,
+    ) -> Result<BusToolResultLookup, Error> {
+        let url = format!(
+            "{}/v1/bus/tool-calls/{}/{}/{}/result",
+            self.base_url,
+            encode_segment(namespace),
+            encode_segment(tenant),
+            encode_segment(call_id),
+        );
+        let resp = self
+            .add_auth(self.client.get(&url))
+            .query(params)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusToolResultLookup>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
 }
 
 // ----- Phase 3: DTOs -----
@@ -1358,6 +1447,97 @@ pub struct BusConversationReplay {
     /// `ReplayBusConversationParams.cursor` to continue.
     #[serde(default)]
     pub cursor: Option<String>,
+}
+
+// ----- Phase 6a: tool-envelope DTOs -----
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct PostBusToolCall {
+    pub call_id: String,
+    pub tool: String,
+    #[serde(default)]
+    pub arguments: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reply_to: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sender: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BusToolResultStatus {
+    Ok,
+    Error,
+    Canceled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PostBusToolResult {
+    pub call_id: String,
+    pub status: BusToolResultStatus,
+    #[serde(default)]
+    pub output: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BusToolEnvelopeReceipt {
+    pub events_topic: String,
+    pub conversation_id: String,
+    pub call_id: String,
+    pub partition: i32,
+    pub offset: i64,
+    pub produced_at: String,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct BusToolResultLookupParams {
+    /// Specific conversation to scan. Omit to scan the tenant's
+    /// default conversation events topic.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_id: Option<String>,
+    /// How long to wait for a matching result. Default 5000ms; max 30000ms.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BusToolResult {
+    pub call_id: String,
+    pub status: BusToolResultStatus,
+    #[serde(default)]
+    pub output: serde_json::Value,
+    #[serde(default)]
+    pub error_message: Option<String>,
+    #[serde(default)]
+    pub correlation_id: Option<String>,
+    #[serde(default)]
+    pub sender: Option<String>,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BusToolResultLookup {
+    pub call_id: String,
+    pub events_topic: String,
+    pub conversation_id: String,
+    pub partition: i32,
+    pub offset: i64,
+    pub produced_at: String,
+    pub result: BusToolResult,
 }
 
 async fn map_error(resp: reqwest::Response) -> Error {

--- a/crates/client/src/bus.rs
+++ b/crates/client/src/bus.rs
@@ -1133,6 +1133,42 @@ impl ActeonClient {
             Err(map_error(resp).await)
         }
     }
+
+    /// Post a tool call and wait for its matching result on the same
+    /// conversation. Wires the receipt's `cursor` directly into the
+    /// lookup so the scan starts strictly *after* the call was
+    /// produced — avoiding the race where the result lands between
+    /// the post and a separate lookup, and the busy-cluster path
+    /// where a cursor-less lookup defaults to scanning from the
+    /// topic tail.
+    ///
+    /// Use this for the common request/response pattern. For
+    /// `reply_to`-routed flows where the result lands in a different
+    /// conversation, call [`Self::post_bus_tool_call`] then
+    /// [`Self::lookup_bus_tool_result`] explicitly.
+    pub async fn post_bus_tool_call_and_wait(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        conversation_id: &str,
+        req: &PostBusToolCall,
+        timeout_ms: Option<u64>,
+    ) -> Result<BusToolResultLookup, Error> {
+        let receipt = self
+            .post_bus_tool_call(namespace, tenant, conversation_id, req)
+            .await?;
+        self.lookup_bus_tool_result(
+            namespace,
+            tenant,
+            &receipt.call_id,
+            &BusToolResultLookupParams {
+                conversation_id: receipt.conversation_id,
+                cursor: Some(receipt.cursor),
+                timeout_ms,
+            },
+        )
+        .await
+    }
 }
 
 // ----- Phase 3: DTOs -----
@@ -1499,14 +1535,28 @@ pub struct BusToolEnvelopeReceipt {
     pub partition: i32,
     pub offset: i64,
     pub produced_at: String,
+    /// Opaque cursor pointing at this envelope's `partition`+`offset`.
+    /// Pass it back as [`BusToolResultLookupParams::cursor`] so the
+    /// lookup scans only messages produced strictly after this
+    /// envelope (avoids the busy-cluster denial-of-service path of
+    /// scanning topic history).
+    pub cursor: String,
 }
 
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct BusToolResultLookupParams {
-    /// Specific conversation to scan. Omit to scan the tenant's
-    /// default conversation events topic.
+    /// Required: the conversation to scan. For `reply_to`-routed
+    /// flows, set this to the `reply_to` conversation. (Defaulting
+    /// to the tenant's shared events topic was unsafe — a
+    /// custom-events-topic conversation would have been silently
+    /// scanned at the wrong place.)
+    pub conversation_id: String,
+    /// Resume cursor from the originating call's
+    /// [`BusToolEnvelopeReceipt::cursor`]. Strongly recommended:
+    /// without one the lookup defaults to scanning from the tail of
+    /// the topic, which races with the result landing.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub conversation_id: Option<String>,
+    pub cursor: Option<String>,
     /// How long to wait for a matching result. Default 5000ms; max 30000ms.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout_ms: Option<u64>,

--- a/crates/client/src/error.rs
+++ b/crates/client/src/error.rs
@@ -42,14 +42,25 @@ impl Error {
     /// Returns `true` if this error is retryable.
     ///
     /// Connection errors and API errors marked as retryable return `true`.
-    /// HTTP 5xx errors also return `true`.
+    /// HTTP 5xx errors retry. HTTP 408 (Request Timeout) also retries —
+    /// callers waiting for an async outcome (e.g. a bus
+    /// `lookup_bus_tool_result` that hasn't seen the matching result
+    /// yet) typically just want to issue another request.
     pub fn is_retryable(&self) -> bool {
         match self {
             Self::Connection(_) => true,
-            Self::Http { status, .. } => *status >= 500,
+            Self::Http { status, .. } => *status >= 500 || *status == 408,
             Self::Api { retryable, .. } => *retryable,
             Self::Deserialization(_) | Self::Configuration(_) => false,
         }
+    }
+
+    /// Returns `true` if this is an HTTP 408 Request Timeout. Used by
+    /// callers of long-poll-style endpoints (e.g.
+    /// `lookup_bus_tool_result`) to distinguish "no result yet,
+    /// retry" from a real failure without string-matching the body.
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, Self::Http { status: 408, .. })
     }
 
     /// Returns `true` if this is a connection error.
@@ -135,5 +146,32 @@ mod tests {
     fn deserialization_error_not_retryable() {
         let err = Error::Deserialization("invalid JSON".to_string());
         assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn http_408_is_typed_timeout_and_retryable() {
+        let err = Error::Http {
+            status: 408,
+            message: "Request Timeout".to_string(),
+        };
+        assert!(err.is_timeout());
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn other_http_codes_are_not_timeout() {
+        let err = Error::Http {
+            status: 400,
+            message: "Bad Request".to_string(),
+        };
+        assert!(!err.is_timeout());
+        let err = Error::Http {
+            status: 504,
+            message: "Gateway Timeout".to_string(),
+        };
+        // 504 is *retryable* (5xx) but not specifically `is_timeout`,
+        // which is reserved for the long-poll 408 contract.
+        assert!(!err.is_timeout());
+        assert!(err.is_retryable());
     }
 }

--- a/crates/core/src/bus_tool.rs
+++ b/crates/core/src/bus_tool.rs
@@ -126,10 +126,13 @@ impl ToolCall {
         if let Some(s) = &self.sender {
             Self::validate_id_field("sender", s)?;
         }
-        if let Some(r) = &self.reply_to
-            && r.is_empty()
-        {
-            return Err(ToolEnvelopeValidationError::EmptyReplyTo);
+        // `reply_to` shares the same alphabet as the other id
+        // fields. The previous emptiness-only check let an agent
+        // sneak path-traversal characters or oversized strings into
+        // the field, which the server later stamps as a header and
+        // could derive `StateKey`s from in future code.
+        if let Some(r) = &self.reply_to {
+            Self::validate_id_field("reply_to", r)?;
         }
         Ok(())
     }
@@ -257,8 +260,6 @@ pub enum ToolEnvelopeValidationError {
     EmptyTool,
     #[error("tool name exceeds 200 characters")]
     ToolTooLong,
-    #[error("reply_to must not be empty when set")]
-    EmptyReplyTo,
     #[error("error_message exceeds 4096 characters")]
     ErrorMessageTooLong,
 }
@@ -295,6 +296,33 @@ mod tests {
         assert!(matches!(
             c.validate(),
             Err(ToolEnvelopeValidationError::InvalidIdChar { .. })
+        ));
+    }
+
+    #[test]
+    fn tool_call_validates_reply_to_alphabet() {
+        // `reply_to` runs through the same id-field validator as
+        // `call_id` / `correlation_id` — path-traversal characters
+        // and oversize strings are rejected.
+        let mut c = ToolCall::new("c", "tool", json!({}));
+        c.reply_to = Some("../escape".into());
+        assert!(matches!(
+            c.validate(),
+            Err(ToolEnvelopeValidationError::InvalidIdChar { .. })
+        ));
+
+        let mut c = ToolCall::new("c", "tool", json!({}));
+        c.reply_to = Some(String::new());
+        assert!(matches!(
+            c.validate(),
+            Err(ToolEnvelopeValidationError::EmptyId(field)) if field == "reply_to"
+        ));
+
+        let mut c = ToolCall::new("c", "tool", json!({}));
+        c.reply_to = Some("a".repeat(200));
+        assert!(matches!(
+            c.validate(),
+            Err(ToolEnvelopeValidationError::IdTooLong(field)) if field == "reply_to"
         ));
     }
 

--- a/crates/core/src/bus_tool.rs
+++ b/crates/core/src/bus_tool.rs
@@ -1,0 +1,354 @@
+//! Bus tool-call envelopes — `ToolCall` / `ToolResult` types that
+//! ride on top of conversation messages (Phase 6a).
+//!
+//! Tool-calling is the dominant agent-to-agent protocol. Rather than
+//! building a parallel Kafka pipeline, Acteon layers typed envelopes
+//! over the existing conversation events topic:
+//!
+//! - A `ToolCall` is a conversation message with envelope kind
+//!   `"tool_call"`, the structured `ToolCall` body as the payload,
+//!   and `acteon.tool.call_id`, `acteon.envelope.kind`, optionally
+//!   `acteon.correlation_id` and `acteon.reply_to` as
+//!   server-stamped headers.
+//! - A `ToolResult` is a conversation message with envelope kind
+//!   `"tool_result"` and the matching `acteon.tool.call_id`.
+//!
+//! Subscribers can route tool messages locally without parsing the
+//! payload by matching on the headers; the bus's audit and replay
+//! machinery already governs the underlying transport.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Outcome of a tool invocation. A typed status keeps callers from
+/// having to inspect free-form fields to know if the call succeeded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum ToolResultStatus {
+    /// The tool ran and produced a (possibly empty) output.
+    Ok,
+    /// The tool ran but returned a structured error. `error_message`
+    /// on the [`ToolResult`] carries the human-readable detail.
+    Error,
+    /// The tool was canceled before producing a result. Distinct from
+    /// `Error` so callers can retry or escalate selectively.
+    Canceled,
+}
+
+/// A request to invoke a tool, addressed to an agent participant in a
+/// conversation. Wrapped in a conversation message at the bus layer;
+/// the structured fields here become the payload, and the bus stamps
+/// routing headers separately so subscribers don't need to parse the
+/// JSON to filter.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ToolCall {
+    /// Stable identifier for this call. Replies cite it via
+    /// [`ToolResult::call_id`]; the bus stamps it as
+    /// `acteon.tool.call_id` so a result-fetcher can filter without
+    /// scanning payloads.
+    pub call_id: String,
+    /// Tool name (e.g. `"calendar.list_events"`). Free-form to the
+    /// bus; the receiving agent dispatches on it.
+    pub tool: String,
+    /// Tool arguments as a JSON object. Tools define their own schema
+    /// (Phase 3 schema-bound topics also apply here transparently —
+    /// the conversation events topic can carry a schema binding).
+    #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub arguments: serde_json::Value,
+    /// Operator-supplied correlation token. Same value appears on the
+    /// matching [`ToolResult`] so a request and its response thread
+    /// together regardless of intermediate hops. Stamped as
+    /// `acteon.correlation_id`.
+    #[serde(default)]
+    pub correlation_id: Option<String>,
+    /// Where the responder should send the [`ToolResult`]. Empty
+    /// means "same conversation"; set this when the request and
+    /// response should land in different threads (e.g. a dispatcher
+    /// agent that fans out tool calls but collects results in a
+    /// dedicated thread). Stamped as `acteon.reply_to`.
+    #[serde(default)]
+    pub reply_to: Option<String>,
+    /// `agent_id` of the caller. The bus also stamps this on the
+    /// underlying conversation message via `acteon.conversation.sender`,
+    /// but carrying it on the envelope makes the audit story
+    /// payload-only.
+    #[serde(default)]
+    pub sender: Option<String>,
+    /// Free-form metadata an agent can attach to the call (e.g.
+    /// trace IDs, cost budget). Bounded by the publish path's header
+    /// caps — see `validate_user_labels` on the server.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, String>,
+    /// When the envelope was constructed. Distinct from the bus's
+    /// `produced_at` (which is broker-stamped) so agent-side timing
+    /// signals survive the queue.
+    pub created_at: DateTime<Utc>,
+}
+
+impl ToolCall {
+    /// Construct a tool-call envelope with sensible defaults.
+    #[must_use]
+    pub fn new(
+        call_id: impl Into<String>,
+        tool: impl Into<String>,
+        arguments: serde_json::Value,
+    ) -> Self {
+        Self {
+            call_id: call_id.into(),
+            tool: tool.into(),
+            arguments,
+            correlation_id: None,
+            reply_to: None,
+            sender: None,
+            metadata: HashMap::new(),
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Validate identity fields. The same alphabet as conversation IDs
+    /// — `[a-zA-Z0-9._-]` — keeps these safe in URLs and Kafka headers.
+    pub fn validate(&self) -> Result<(), ToolEnvelopeValidationError> {
+        Self::validate_id_field("call_id", &self.call_id)?;
+        if self.tool.is_empty() {
+            return Err(ToolEnvelopeValidationError::EmptyTool);
+        }
+        if self.tool.len() > 200 {
+            return Err(ToolEnvelopeValidationError::ToolTooLong);
+        }
+        if let Some(c) = &self.correlation_id {
+            Self::validate_id_field("correlation_id", c)?;
+        }
+        if let Some(s) = &self.sender {
+            Self::validate_id_field("sender", s)?;
+        }
+        if let Some(r) = &self.reply_to
+            && r.is_empty()
+        {
+            return Err(ToolEnvelopeValidationError::EmptyReplyTo);
+        }
+        Ok(())
+    }
+
+    /// Shared id-character rule used by `call_id`, `correlation_id`,
+    /// and `sender`.
+    pub fn validate_id_field(field: &str, s: &str) -> Result<(), ToolEnvelopeValidationError> {
+        if s.is_empty() {
+            return Err(ToolEnvelopeValidationError::EmptyId(field.to_string()));
+        }
+        if s.len() > 120 {
+            return Err(ToolEnvelopeValidationError::IdTooLong(field.to_string()));
+        }
+        if !s
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+        {
+            return Err(ToolEnvelopeValidationError::InvalidIdChar {
+                field: field.to_string(),
+                value: s.to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Response to a [`ToolCall`]. Carries the same `call_id` so consumers
+/// can match a result against the request that triggered it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ToolResult {
+    /// The originating call's `call_id`. Stamped as
+    /// `acteon.tool.call_id` on the resulting bus message so a
+    /// result-fetcher can filter by header.
+    pub call_id: String,
+    /// Outcome of the call. See [`ToolResultStatus`].
+    pub status: ToolResultStatus,
+    /// Tool output payload. Convention: `Ok` results put the structured
+    /// return value here; `Error` and `Canceled` results put a
+    /// machine-readable error blob if applicable. Tools define the
+    /// shape.
+    #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub output: serde_json::Value,
+    /// Human-readable error message, set on `Error` and `Canceled`.
+    #[serde(default)]
+    pub error_message: Option<String>,
+    /// Mirrors [`ToolCall::correlation_id`]. Stamped as
+    /// `acteon.correlation_id`.
+    #[serde(default)]
+    pub correlation_id: Option<String>,
+    /// `agent_id` of the agent that produced the result.
+    #[serde(default)]
+    pub sender: Option<String>,
+    /// Free-form metadata.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, String>,
+    /// When the result envelope was constructed.
+    pub created_at: DateTime<Utc>,
+}
+
+impl ToolResult {
+    /// Construct a successful result.
+    #[must_use]
+    pub fn ok(call_id: impl Into<String>, output: serde_json::Value) -> Self {
+        Self {
+            call_id: call_id.into(),
+            status: ToolResultStatus::Ok,
+            output,
+            error_message: None,
+            correlation_id: None,
+            sender: None,
+            metadata: HashMap::new(),
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Construct an error result.
+    #[must_use]
+    pub fn error(call_id: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            call_id: call_id.into(),
+            status: ToolResultStatus::Error,
+            output: serde_json::Value::Null,
+            error_message: Some(message.into()),
+            correlation_id: None,
+            sender: None,
+            metadata: HashMap::new(),
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Validate identity fields.
+    pub fn validate(&self) -> Result<(), ToolEnvelopeValidationError> {
+        ToolCall::validate_id_field("call_id", &self.call_id)?;
+        if let Some(c) = &self.correlation_id {
+            ToolCall::validate_id_field("correlation_id", c)?;
+        }
+        if let Some(s) = &self.sender {
+            ToolCall::validate_id_field("sender", s)?;
+        }
+        match self.status {
+            ToolResultStatus::Error | ToolResultStatus::Canceled => {
+                // We don't *require* an error message on canceled
+                // results — sometimes a cancel is just a cancel —
+                // but if one is supplied, cap its length so a
+                // misbehaving agent can't blow up the publish-edge
+                // header budget on the conversation message.
+                if let Some(m) = &self.error_message
+                    && m.len() > 4096
+                {
+                    return Err(ToolEnvelopeValidationError::ErrorMessageTooLong);
+                }
+            }
+            ToolResultStatus::Ok => {}
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ToolEnvelopeValidationError {
+    #[error("{0} must not be empty")]
+    EmptyId(String),
+    #[error("{0} exceeds 120 characters")]
+    IdTooLong(String),
+    #[error("{field} '{value}' contains characters outside [a-zA-Z0-9._-]")]
+    InvalidIdChar { field: String, value: String },
+    #[error("tool name must not be empty")]
+    EmptyTool,
+    #[error("tool name exceeds 200 characters")]
+    ToolTooLong,
+    #[error("reply_to must not be empty when set")]
+    EmptyReplyTo,
+    #[error("error_message exceeds 4096 characters")]
+    ErrorMessageTooLong,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn tool_call_basic_validate() {
+        let mut c = ToolCall::new("call-1", "calendar.list", json!({"day": "today"}));
+        c.sender = Some("planner-1".into());
+        c.correlation_id = Some("trace-42".into());
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn tool_call_rejects_empty_call_id() {
+        let c = ToolCall::new("", "x", json!({}));
+        let err = c.validate().unwrap_err();
+        assert!(matches!(err, ToolEnvelopeValidationError::EmptyId(f) if f == "call_id"));
+    }
+
+    #[test]
+    fn tool_call_rejects_empty_tool() {
+        let c = ToolCall::new("c", "", json!({}));
+        assert_eq!(c.validate(), Err(ToolEnvelopeValidationError::EmptyTool));
+    }
+
+    #[test]
+    fn tool_call_rejects_invalid_id_char() {
+        let c = ToolCall::new("a/b", "tool", json!({}));
+        assert!(matches!(
+            c.validate(),
+            Err(ToolEnvelopeValidationError::InvalidIdChar { .. })
+        ));
+    }
+
+    #[test]
+    fn tool_result_ok_validate() {
+        let r = ToolResult::ok("call-1", json!({"events": []}));
+        r.validate().unwrap();
+        assert_eq!(r.status, ToolResultStatus::Ok);
+        assert!(r.error_message.is_none());
+    }
+
+    #[test]
+    fn tool_result_error_validate() {
+        let r = ToolResult::error("call-1", "calendar API timed out");
+        r.validate().unwrap();
+        assert_eq!(r.status, ToolResultStatus::Error);
+    }
+
+    #[test]
+    fn tool_result_rejects_oversize_error_message() {
+        let mut r = ToolResult::error("call-1", "x");
+        r.error_message = Some("y".repeat(5000));
+        assert_eq!(
+            r.validate(),
+            Err(ToolEnvelopeValidationError::ErrorMessageTooLong)
+        );
+    }
+
+    #[test]
+    fn roundtrip_serde_tool_call() {
+        let mut c = ToolCall::new("c-1", "tool.x", json!({"k": "v"}));
+        c.correlation_id = Some("trace".into());
+        c.sender = Some("a-1".into());
+        c.metadata.insert("budget".into(), "1.5s".into());
+        let j = serde_json::to_string(&c).unwrap();
+        let back: ToolCall = serde_json::from_str(&j).unwrap();
+        assert_eq!(back.call_id, c.call_id);
+        assert_eq!(back.tool, c.tool);
+        assert_eq!(back.metadata.get("budget"), Some(&"1.5s".into()));
+    }
+
+    #[test]
+    fn roundtrip_serde_tool_result_canceled() {
+        let mut r = ToolResult::ok("c", json!(null));
+        r.status = ToolResultStatus::Canceled;
+        r.error_message = Some("user aborted".into());
+        let j = serde_json::to_string(&r).unwrap();
+        let back: ToolResult = serde_json::from_str(&j).unwrap();
+        assert_eq!(back.status, ToolResultStatus::Canceled);
+        assert_eq!(back.error_message.as_deref(), Some("user aborted"));
+    }
+}

--- a/crates/core/src/bus_tool.rs
+++ b/crates/core/src/bus_tool.rs
@@ -231,20 +231,15 @@ impl ToolResult {
         if let Some(s) = &self.sender {
             ToolCall::validate_id_field("sender", s)?;
         }
-        match self.status {
-            ToolResultStatus::Error | ToolResultStatus::Canceled => {
-                // We don't *require* an error message on canceled
-                // results — sometimes a cancel is just a cancel —
-                // but if one is supplied, cap its length so a
-                // misbehaving agent can't blow up the publish-edge
-                // header budget on the conversation message.
-                if let Some(m) = &self.error_message
-                    && m.len() > 4096
-                {
-                    return Err(ToolEnvelopeValidationError::ErrorMessageTooLong);
-                }
-            }
-            ToolResultStatus::Ok => {}
+        // Cap unconditionally. The original gate only fired on Error
+        // or Canceled, but a malicious caller could ship a multi-MB
+        // `error_message` alongside `status: ok` to dodge the limit.
+        // The contract is "if you set it, it's bounded," regardless
+        // of which status bucket the result falls into.
+        if let Some(m) = &self.error_message
+            && m.len() > 4096
+        {
+            return Err(ToolEnvelopeValidationError::ErrorMessageTooLong);
         }
         Ok(())
     }
@@ -322,6 +317,19 @@ mod tests {
     fn tool_result_rejects_oversize_error_message() {
         let mut r = ToolResult::error("call-1", "x");
         r.error_message = Some("y".repeat(5000));
+        assert_eq!(
+            r.validate(),
+            Err(ToolEnvelopeValidationError::ErrorMessageTooLong)
+        );
+    }
+
+    #[test]
+    fn tool_result_caps_error_message_even_on_ok() {
+        // The cap applies regardless of status — a malicious caller
+        // could otherwise ship a multi-MB `error_message` with
+        // `status: ok` to bypass it.
+        let mut r = ToolResult::ok("call-1", serde_json::json!({}));
+        r.error_message = Some("z".repeat(5000));
         assert_eq!(
             r.validate(),
             Err(ToolEnvelopeValidationError::ErrorMessageTooLong)

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod bus_agent;
 pub mod bus_conversation;
 pub mod bus_schema;
 pub mod bus_subscription;
+pub mod bus_tool;
 pub mod bus_topic;
 pub mod caller;
 pub mod chain;
@@ -48,6 +49,7 @@ pub use bus_subscription::{
     AckMode, PartitionLag, StartOffset as SubscriptionStartOffset, Subscription,
     SubscriptionStatus, SubscriptionValidationError,
 };
+pub use bus_tool::{ToolCall, ToolEnvelopeValidationError, ToolResult, ToolResultStatus};
 pub use bus_topic::{Topic, TopicValidationError};
 pub use caller::Caller;
 pub use chain::{

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -6143,19 +6143,64 @@ pub async fn lookup_tool_result(
         // result landing. Earlier the default was `Earliest`, which
         // turned every lookup into a full-history scan and was a
         // straightforward DoS vector.
+        //
+        // **Cursor + reply_to caveat**: the cursor from a `ToolCall`
+        // receipt only covers the partition the call landed on. If
+        // the result is routed via `reply_to` to a different
+        // conversation, it lands on a partition the cursor doesn't
+        // cover, and a strict `FromOffsets(cursor)` scan would
+        // exclude that partition entirely (its contract is "skip
+        // partitions absent from the map"). To make cursor-based
+        // lookups work across the reply_to flow, we fill the
+        // partitions the cursor doesn't cover with the topic's
+        // current high-water mark — i.e. "scan the call's
+        // partition from the recorded offset onward, and every
+        // other partition from the moment the lookup began." This
+        // makes the cursor a "starting hint" for the call's
+        // partition and `Latest` for the rest.
         let scan_from = match &params.cursor {
-            Some(c) => match decode_replay_cursor(c) {
-                Ok(offsets) => acteon_bus::ScanFrom::FromOffsets(offsets),
-                Err(msg) => {
-                    return (
-                        StatusCode::BAD_REQUEST,
-                        Json(ErrorResponse {
-                            error: format!("invalid lookup cursor: {msg}"),
-                        }),
-                    )
-                        .into_response();
+            Some(c) => {
+                let mut offsets = match decode_replay_cursor(c) {
+                    Ok(m) => m,
+                    Err(msg) => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Json(ErrorResponse {
+                                error: format!("invalid lookup cursor: {msg}"),
+                            }),
+                        )
+                            .into_response();
+                    }
+                };
+                let watermarks = match backend.scan_topic_watermarks(&events_topic).await {
+                    Ok(w) => w,
+                    Err(acteon_bus::BusError::TopicNotFound(_)) => {
+                        return (
+                            StatusCode::NOT_FOUND,
+                            Json(ErrorResponse {
+                                error: format!("events topic {events_topic} not found"),
+                            }),
+                        )
+                            .into_response();
+                    }
+                    Err(e) => {
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(ErrorResponse {
+                                error: e.to_string(),
+                            }),
+                        )
+                            .into_response();
+                    }
+                };
+                for (&p, &hwm) in &watermarks.high_water_marks {
+                    // `hwm - 1` → kafka backend resumes at `hwm`
+                    // (next-to-be-produced), the same logic the
+                    // replay handler uses for unseeded partitions.
+                    offsets.entry(p).or_insert(hwm - 1);
                 }
-            },
+                acteon_bus::ScanFrom::FromOffsets(offsets)
+            }
             None => acteon_bus::ScanFrom::Latest,
         };
         let mut stream = match backend.scan_topic(&events_topic, scan_from).await {

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -2185,6 +2185,89 @@ async fn ensure_schema_in_validator(
     }
 }
 
+/// Apply Phase 3 schema validation to a payload destined for
+/// `kafka_topic`. Used by every publish-style handler that doesn't
+/// already inline the validation block (the original `/v1/bus/publish`
+/// handler still does it inline; the conversation-layer handlers —
+/// tool calls, tool results — call this so a schema-bound events
+/// topic enforces uniformly).
+///
+/// No-ops cleanly when the topic record is missing or has no
+/// `(schema_subject, schema_version)` binding. On a binding mismatch,
+/// returns a 400 with the same `SchemaValidationErrorResponse` shape
+/// the publish handler uses, so SDK consumers see consistent errors.
+#[cfg(feature = "bus")]
+async fn validate_payload_against_topic_schema(
+    state: &AppState,
+    namespace: &str,
+    tenant: &str,
+    kafka_topic: &str,
+    payload: &serde_json::Value,
+) -> Result<(), axum::response::Response> {
+    // Clone the `Arc<dyn StateStore>` and drop the gateway guard
+    // before any `.await` — same lock-amplification rule the rest of
+    // the bus handlers follow.
+    let store: std::sync::Arc<dyn acteon_state::StateStore> = {
+        let gw = state.gateway.read().await;
+        gw.state_store().clone()
+    };
+    let key = StateKey::new(
+        namespace.to_string(),
+        tenant.to_string(),
+        KeyKind::BusTopic,
+        kafka_topic,
+    );
+    let topic: Topic = match store.get(&key).await {
+        Ok(Some(raw)) => match serde_json::from_str(&raw) {
+            Ok(t) => t,
+            // Corrupt row — skip validation, let the underlying
+            // produce surface the issue. This mirrors the publish
+            // handler's resilience.
+            Err(_) => return Ok(()),
+        },
+        // Missing topic row (someone deleted it out of band): no
+        // binding to enforce. The underlying produce will fail
+        // separately if Kafka has lost the topic too.
+        Ok(None) | Err(_) => return Ok(()),
+    };
+    let (Some(subject), Some(version)) = (&topic.schema_subject, topic.schema_version) else {
+        return Ok(());
+    };
+    ensure_schema_in_validator(state, &topic.namespace, &topic.tenant, subject, version).await?;
+    match state.bus_schema_validator.validate(
+        &topic.namespace,
+        &topic.tenant,
+        subject,
+        version,
+        payload,
+    ) {
+        Ok(()) => Ok(()),
+        Err(acteon_bus::SchemaValidatorError::InvalidPayload(issues)) => Err((
+            StatusCode::BAD_REQUEST,
+            Json(SchemaValidationErrorResponse {
+                error: format!("payload does not match schema '{subject}' v{version}"),
+                subject: subject.clone(),
+                version,
+                issues: issues
+                    .into_iter()
+                    .map(|i| SchemaValidationIssueDto {
+                        path: i.path,
+                        message: i.message,
+                    })
+                    .collect(),
+            }),
+        )
+            .into_response()),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response()),
+    }
+}
+
 #[utoipa::path(
     post,
     path = "/v1/bus/schemas",
@@ -5380,6 +5463,14 @@ pub struct ToolEnvelopeReceipt {
     pub partition: i32,
     pub offset: i64,
     pub produced_at: DateTime<Utc>,
+    /// Opaque resume cursor encoding `{partition: offset}`. Pass it
+    /// back to `GET /v1/bus/tool-calls/{...}/result` as `?cursor=`
+    /// so the lookup scans only messages produced *after* this
+    /// envelope. Without a cursor, the lookup defaults to scanning
+    /// from the tail (which races with the result landing) or has
+    /// to do a full-history scan — neither is acceptable on a busy
+    /// cluster.
+    pub cursor: String,
 }
 
 /// Result of a `GET /v1/bus/tool-calls/{ns}/{t}/{call_id}/result` —
@@ -5399,13 +5490,22 @@ pub struct ToolResultLookupResponse {
 
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ToolResultLookupParams {
-    /// Specific conversation to scan. When omitted, the bus scans
-    /// the tenant's default conversation events topic
-    /// (`{ns}.{tenant}.conversations-events`). For `reply_to`
-    /// patterns that route results to a different thread, set this
-    /// to that conversation id.
+    /// **Required.** The conversation to scan for the matching
+    /// result. For `reply_to`-routed flows, set this to the
+    /// `reply_to` conversation. Required (rather than defaulting to
+    /// the tenant's shared events topic) so a conversation
+    /// registered with a custom `events_topic` is scanned at the
+    /// right Kafka topic — falling back to the default would have
+    /// silently looked at the wrong place.
+    pub conversation_id: String,
+    /// Resume cursor from the originating
+    /// `POST /tool-calls` receipt — encodes the per-partition
+    /// offset where the call was produced. Without it, the scan
+    /// defaults to `Latest` (cheap on a busy cluster, but races
+    /// with the result landing) — passing the receipt's `cursor`
+    /// is strongly recommended for production flows.
     #[serde(default)]
-    pub conversation_id: Option<String>,
+    pub cursor: Option<String>,
     /// How long to wait for a matching result. Default 5s; max 30s.
     #[serde(default)]
     pub timeout_ms: Option<u64>,
@@ -5564,6 +5664,21 @@ pub async fn post_tool_call(
             }
         };
         let events_topic = conv.effective_events_topic();
+        // Phase 3 schema validation. If the conversation events topic
+        // has a schema binding, the payload must match — otherwise
+        // tool envelopes would silently bypass the publish-edge gate
+        // that `/v1/bus/publish` enforces.
+        if let Err(resp) = validate_payload_against_topic_schema(
+            &state,
+            &conv.namespace,
+            &conv.tenant,
+            &events_topic,
+            &payload,
+        )
+        .await
+        {
+            return resp;
+        }
         let mut msg = acteon_bus::BusMessage::new(events_topic.clone(), payload)
             .with_key(&conv.conversation_id);
         // Conversation-level routing headers, mirroring
@@ -5584,18 +5699,57 @@ pub async fn post_tool_call(
             envelope.reply_to.as_deref(),
         );
         match backend.produce(msg).await {
-            Ok(receipt) => (
-                StatusCode::OK,
-                Json(ToolEnvelopeReceipt {
-                    events_topic: receipt.topic,
-                    conversation_id: conv.conversation_id,
-                    call_id: envelope.call_id,
-                    partition: receipt.partition,
-                    offset: receipt.offset,
-                    produced_at: receipt.timestamp,
-                }),
-            )
-                .into_response(),
+            Ok(receipt) => {
+                // Include a cursor pointing at this envelope's
+                // partition+offset so the caller can scan
+                // strictly-newer messages on a follow-up
+                // `lookup_tool_result` without re-reading topic
+                // history. Same encoding as Phase 5 replay cursors.
+                let mut cursor_map = std::collections::BTreeMap::new();
+                cursor_map.insert(receipt.partition, receipt.offset);
+                let cursor = encode_replay_cursor(&cursor_map);
+                let conv_id_for_bump = conv.conversation_id.clone();
+                let resp = (
+                    StatusCode::OK,
+                    Json(ToolEnvelopeReceipt {
+                        events_topic: receipt.topic,
+                        conversation_id: conv.conversation_id,
+                        call_id: envelope.call_id,
+                        partition: receipt.partition,
+                        offset: receipt.offset,
+                        produced_at: receipt.timestamp,
+                        cursor,
+                    }),
+                );
+                // Bump conversation `updated_at` so list/sort by
+                // activity sees tool-driven traffic. Best-effort: if
+                // the CAS contends out, the message is already on
+                // Kafka; we log and return success rather than fail
+                // the produce.
+                let bump_key = StateKey::new(
+                    namespace.clone(),
+                    tenant.clone(),
+                    KeyKind::BusConversation,
+                    &conv_id_for_bump,
+                );
+                let bump = cas_update::<acteon_core::Conversation, _>(
+                    &state,
+                    &bump_key,
+                    "conversation gone",
+                    |c| {
+                        c.updated_at = Utc::now();
+                        Ok(())
+                    },
+                )
+                .await;
+                if bump.is_err() {
+                    tracing::warn!(
+                        conversation_id = %conv_id_for_bump,
+                        "tool-envelope produced but conversation updated_at bump failed (CAS contention exhausted or backend error); list/sort will see a stale timestamp",
+                    );
+                }
+                resp.into_response()
+            }
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {
@@ -5649,7 +5803,7 @@ pub async fn post_tool_result(
         if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::Publish) {
             return resp;
         }
-        let mut envelope = acteon_core::ToolResult {
+        let envelope = acteon_core::ToolResult {
             call_id: req.call_id.clone(),
             status: req.status,
             output: req.output.clone(),
@@ -5716,11 +5870,11 @@ pub async fn post_tool_result(
                 }
             }
         }
-        // Re-stamp `created_at` here so the response carries the
-        // server-anchored time rather than whatever the client put in
-        // the envelope (clients can't be trusted to be honest about
-        // when a tool ran).
-        envelope.created_at = Utc::now();
+        // `created_at` was server-stamped at construction (see the
+        // `Utc::now()` in the struct literal above). The previous
+        // version re-stamped it here as well — a copy-paste artifact
+        // from when the request type briefly carried a client-
+        // supplied timestamp. Removed.
         let payload = match serde_json::to_value(&envelope) {
             Ok(v) => v,
             Err(e) => {
@@ -5734,6 +5888,19 @@ pub async fn post_tool_result(
             }
         };
         let events_topic = conv.effective_events_topic();
+        // Same Phase 3 schema-validation gate as `post_tool_call`;
+        // see the matching comment there.
+        if let Err(resp) = validate_payload_against_topic_schema(
+            &state,
+            &conv.namespace,
+            &conv.tenant,
+            &events_topic,
+            &payload,
+        )
+        .await
+        {
+            return resp;
+        }
         let mut msg = acteon_bus::BusMessage::new(events_topic.clone(), payload)
             .with_key(&conv.conversation_id);
         msg.headers.insert(
@@ -5752,18 +5919,57 @@ pub async fn post_tool_result(
             None, // results don't carry a reply_to
         );
         match backend.produce(msg).await {
-            Ok(receipt) => (
-                StatusCode::OK,
-                Json(ToolEnvelopeReceipt {
-                    events_topic: receipt.topic,
-                    conversation_id: conv.conversation_id,
-                    call_id: envelope.call_id,
-                    partition: receipt.partition,
-                    offset: receipt.offset,
-                    produced_at: receipt.timestamp,
-                }),
-            )
-                .into_response(),
+            Ok(receipt) => {
+                // Include a cursor pointing at this envelope's
+                // partition+offset so the caller can scan
+                // strictly-newer messages on a follow-up
+                // `lookup_tool_result` without re-reading topic
+                // history. Same encoding as Phase 5 replay cursors.
+                let mut cursor_map = std::collections::BTreeMap::new();
+                cursor_map.insert(receipt.partition, receipt.offset);
+                let cursor = encode_replay_cursor(&cursor_map);
+                let conv_id_for_bump = conv.conversation_id.clone();
+                let resp = (
+                    StatusCode::OK,
+                    Json(ToolEnvelopeReceipt {
+                        events_topic: receipt.topic,
+                        conversation_id: conv.conversation_id,
+                        call_id: envelope.call_id,
+                        partition: receipt.partition,
+                        offset: receipt.offset,
+                        produced_at: receipt.timestamp,
+                        cursor,
+                    }),
+                );
+                // Bump conversation `updated_at` so list/sort by
+                // activity sees tool-driven traffic. Best-effort: if
+                // the CAS contends out, the message is already on
+                // Kafka; we log and return success rather than fail
+                // the produce.
+                let bump_key = StateKey::new(
+                    namespace.clone(),
+                    tenant.clone(),
+                    KeyKind::BusConversation,
+                    &conv_id_for_bump,
+                );
+                let bump = cas_update::<acteon_core::Conversation, _>(
+                    &state,
+                    &bump_key,
+                    "conversation gone",
+                    |c| {
+                        c.updated_at = Utc::now();
+                        Ok(())
+                    },
+                )
+                .await;
+                if bump.is_err() {
+                    tracing::warn!(
+                        conversation_id = %conv_id_for_bump,
+                        "tool-envelope produced but conversation updated_at bump failed (CAS contention exhausted or backend error); list/sort will see a stale timestamp",
+                    );
+                }
+                resp.into_response()
+            }
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {
@@ -5823,31 +6029,42 @@ pub async fn lookup_tool_result(
             )
                 .into_response();
         }
-        // Resolve which conversation's events topic to scan. By
-        // default we use the tenant's shared events topic; callers
-        // who routed `reply_to` to a different thread point at it
-        // explicitly via `?conversation_id=`.
-        let events_topic = if let Some(conv_id) = &params.conversation_id {
-            match load_conversation(&state, &namespace, &tenant, conv_id).await {
+        // Resolve the conversation's events topic from its actual
+        // record. `conversation_id` is required (rather than
+        // defaulting to the tenant's shared events topic) because a
+        // conversation registered with a custom `events_topic`
+        // (Phase 5) would otherwise silently look at the wrong
+        // place — the scan would never find a matching record and
+        // every lookup would 408.
+        let events_topic =
+            match load_conversation(&state, &namespace, &tenant, &params.conversation_id).await {
                 Ok(c) => c.effective_events_topic(),
                 Err(resp) => return resp,
-            }
-        } else {
-            format!(
-                "{}.{}.{}",
-                namespace,
-                tenant,
-                acteon_core::DEFAULT_CONVERSATIONS_EVENTS_SUFFIX
-            )
-        };
+            };
         let timeout_ms = params.timeout_ms.unwrap_or(5_000).min(30_000);
-        // Scan from earliest using the same `assign()`-based
-        // primitive replay uses. No consumer-group leak; bounded
-        // by the timeout budget.
-        let mut stream = match backend
-            .scan_topic(&events_topic, acteon_bus::ScanFrom::Earliest)
-            .await
-        {
+        // Resolve scan position. With a cursor (the typical flow:
+        // caller passes back the receipt's `cursor`), scan strictly
+        // *after* the call was produced. Without one, default to
+        // `Latest` — cheap on a busy cluster, but races with the
+        // result landing. Earlier the default was `Earliest`, which
+        // turned every lookup into a full-history scan and was a
+        // straightforward DoS vector.
+        let scan_from = match &params.cursor {
+            Some(c) => match decode_replay_cursor(c) {
+                Ok(offsets) => acteon_bus::ScanFrom::FromOffsets(offsets),
+                Err(msg) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!("invalid lookup cursor: {msg}"),
+                        }),
+                    )
+                        .into_response();
+                }
+            },
+            None => acteon_bus::ScanFrom::Latest,
+        };
+        let mut stream = match backend.scan_topic(&events_topic, scan_from).await {
             Ok(s) => s,
             Err(acteon_bus::BusError::TopicNotFound(_)) => {
                 return (
@@ -5907,21 +6124,24 @@ pub async fn lookup_tool_result(
                                 match serde_json::from_value(msg.payload.clone()) {
                                     Ok(r) => r,
                                     Err(e) => {
-                                        // Header said it was a tool
-                                        // result for our call_id, but
-                                        // the payload doesn't
-                                        // deserialize. Surface the
-                                        // corruption rather than time
-                                        // out silently.
-                                        return (
-                                            StatusCode::INTERNAL_SERVER_ERROR,
-                                            Json(ErrorResponse {
-                                                error: format!(
-                                                    "matched tool-result envelope for call_id '{call_id}' but payload is not a ToolResult: {e}"
-                                                ),
-                                            }),
-                                        )
-                                            .into_response();
+                                        // Poison-pill: header said this
+                                        // is a tool-result for our
+                                        // `call_id`, but the payload
+                                        // doesn't parse. Treat as
+                                        // garbage and keep scanning —
+                                        // a duplicate or malformed
+                                        // record must not permanently
+                                        // break lookups for that
+                                        // `call_id`. Log loudly so
+                                        // operators notice.
+                                        tracing::warn!(
+                                            call_id = %call_id,
+                                            partition = ?msg.partition,
+                                            offset = ?msg.offset,
+                                            error = %e,
+                                            "skipping malformed tool-result envelope; payload failed to deserialize",
+                                        );
+                                        continue;
                                     }
                                 };
                             // The scan key carries the conversation

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -5314,3 +5314,666 @@ async fn load_conversation(
             .into_response()),
     }
 }
+
+// =============================================================================
+// Phase 6a: tool-call envelopes layered on conversation messages
+// =============================================================================
+
+/// Body of `POST /v1/bus/conversations/{ns}/{t}/{id}/tool-calls`.
+/// Wraps a [`acteon_core::ToolCall`] and produces a conversation
+/// message with envelope kind `"tool_call"`. The bus stamps routing
+/// headers (`acteon.envelope.kind`, `acteon.tool.call_id`,
+/// `acteon.correlation_id`, `acteon.reply_to`) so subscribers can
+/// filter without parsing the payload.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct PostToolCallRequest {
+    pub call_id: String,
+    pub tool: String,
+    /// Tool arguments. Free-form JSON; if the events topic is
+    /// schema-bound (Phase 3), validation runs at the underlying
+    /// publish edge.
+    #[schema(value_type = Object)]
+    #[serde(default)]
+    pub arguments: serde_json::Value,
+    /// Optional correlation token, propagated to the eventual
+    /// [`PostToolResultRequest`]. Stamped as `acteon.correlation_id`.
+    #[serde(default)]
+    pub correlation_id: Option<String>,
+    /// Override the conversation the matching result should land in.
+    /// Empty / null = "same conversation" (the reply lands here).
+    /// Stamped as `acteon.reply_to`.
+    #[serde(default)]
+    pub reply_to: Option<String>,
+    /// Sender agent id. Stamped as both
+    /// `acteon.conversation.sender` and on the envelope.
+    #[serde(default)]
+    pub sender: Option<String>,
+    /// Free-form tool metadata. Bounded by the publish path's label
+    /// caps (max 32 entries / 256B keys / 4KB values).
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+/// Body of `POST /v1/bus/conversations/{ns}/{t}/{id}/tool-results`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct PostToolResultRequest {
+    pub call_id: String,
+    pub status: acteon_core::ToolResultStatus,
+    #[schema(value_type = Object)]
+    #[serde(default)]
+    pub output: serde_json::Value,
+    #[serde(default)]
+    pub error_message: Option<String>,
+    #[serde(default)]
+    pub correlation_id: Option<String>,
+    #[serde(default)]
+    pub sender: Option<String>,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ToolEnvelopeReceipt {
+    pub events_topic: String,
+    pub conversation_id: String,
+    pub call_id: String,
+    pub partition: i32,
+    pub offset: i64,
+    pub produced_at: DateTime<Utc>,
+}
+
+/// Result of a `GET /v1/bus/tool-calls/{ns}/{t}/{call_id}/result` —
+/// either the matching [`acteon_core::ToolResult`] envelope plus a
+/// few bus coordinates, or a 408 if the timeout elapsed without a
+/// match.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ToolResultLookupResponse {
+    pub call_id: String,
+    pub events_topic: String,
+    pub conversation_id: String,
+    pub partition: i32,
+    pub offset: i64,
+    pub produced_at: DateTime<Utc>,
+    pub result: acteon_core::ToolResult,
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ToolResultLookupParams {
+    /// Specific conversation to scan. When omitted, the bus scans
+    /// the tenant's default conversation events topic
+    /// (`{ns}.{tenant}.conversations-events`). For `reply_to`
+    /// patterns that route results to a different thread, set this
+    /// to that conversation id.
+    #[serde(default)]
+    pub conversation_id: Option<String>,
+    /// How long to wait for a matching result. Default 5s; max 30s.
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}
+
+/// Envelope-kind header values. Server-stamped so subscribers can
+/// route on a single header lookup.
+#[cfg(feature = "bus")]
+const ENVELOPE_KIND_TOOL_CALL: &str = "tool_call";
+#[cfg(feature = "bus")]
+const ENVELOPE_KIND_TOOL_RESULT: &str = "tool_result";
+
+/// Helper: stamp the standard envelope routing headers on a
+/// `BusMessage`. Reserved `acteon.*` keys are inserted directly
+/// (`with_header` strips them on user input by design).
+#[cfg(feature = "bus")]
+fn stamp_tool_envelope_headers(
+    msg: &mut acteon_bus::BusMessage,
+    kind: &'static str,
+    call_id: &str,
+    correlation_id: Option<&str>,
+    reply_to: Option<&str>,
+) {
+    msg.headers
+        .insert("acteon.envelope.kind".into(), kind.to_string());
+    msg.headers
+        .insert("acteon.tool.call_id".into(), call_id.to_string());
+    if let Some(c) = correlation_id {
+        msg.headers
+            .insert("acteon.correlation_id".into(), c.to_string());
+    }
+    if let Some(r) = reply_to {
+        msg.headers.insert("acteon.reply_to".into(), r.to_string());
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}/tool-calls",
+    tag = "bus",
+    request_body = PostToolCallRequest,
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("conversation_id" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Tool-call envelope appended", body = ToolEnvelopeReceipt),
+        (status = 400, description = "Invalid envelope, sender ACL, or archived conversation", body = ErrorResponse),
+        (status = 404, description = "Conversation not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+#[allow(clippy::too_many_lines)]
+pub async fn post_tool_call(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, conversation_id)): Path<(String, String, String)>,
+    Json(req): Json<PostToolCallRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        let Some(backend) = state.bus_backend.as_ref() else {
+            return service_unavailable("bus feature not enabled");
+        };
+        // Same two-level auth as `append_conversation_message`: must
+        // be allowed to manage conversations *and* publish on the
+        // tenant. A registry-only role can't quietly inject tool
+        // traffic onto the events topic.
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::Publish) {
+            return resp;
+        }
+        // Construct the typed envelope first so validation runs
+        // before we do any bus or state I/O.
+        let mut envelope =
+            acteon_core::ToolCall::new(&req.call_id, &req.tool, req.arguments.clone());
+        envelope.correlation_id = req.correlation_id.clone();
+        envelope.reply_to = req.reply_to.clone();
+        envelope.sender = req.sender.clone();
+        envelope.metadata = req.metadata.clone();
+        if let Err(e) = envelope.validate() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        if let Err(resp) = validate_user_labels(&envelope.metadata) {
+            return resp;
+        }
+        let conv = match load_conversation(&state, &namespace, &tenant, &conversation_id).await {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
+        if !conv.accepts_messages() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "conversation {} is archived; reopen via /transition before posting tool calls",
+                        conv.conversation_id
+                    ),
+                }),
+            )
+                .into_response();
+        }
+        // Same participant ACL as plain conversation messages: a
+        // sender outside the participant list is rejected; if the
+        // ACL is set and `sender` is omitted, reject explicitly.
+        if !conv.participants.is_empty() {
+            match envelope.sender.as_deref() {
+                Some(s) if conv.participants.iter().any(|p| p == s) => {}
+                Some(s) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "sender '{s}' is not a participant of conversation {}",
+                                conv.conversation_id
+                            ),
+                        }),
+                    )
+                        .into_response();
+                }
+                None => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "conversation {} has a participant ACL; tool-call sender is required",
+                                conv.conversation_id
+                            ),
+                        }),
+                    )
+                        .into_response();
+                }
+            }
+        }
+        let payload = match serde_json::to_value(&envelope) {
+            Ok(v) => v,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let events_topic = conv.effective_events_topic();
+        let mut msg = acteon_bus::BusMessage::new(events_topic.clone(), payload)
+            .with_key(&conv.conversation_id);
+        // Conversation-level routing headers, mirroring
+        // `append_conversation_message`.
+        msg.headers.insert(
+            "acteon.conversation.id".into(),
+            conv.conversation_id.clone(),
+        );
+        if let Some(s) = &envelope.sender {
+            msg.headers
+                .insert("acteon.conversation.sender".into(), s.clone());
+        }
+        stamp_tool_envelope_headers(
+            &mut msg,
+            ENVELOPE_KIND_TOOL_CALL,
+            &envelope.call_id,
+            envelope.correlation_id.as_deref(),
+            envelope.reply_to.as_deref(),
+        );
+        match backend.produce(msg).await {
+            Ok(receipt) => (
+                StatusCode::OK,
+                Json(ToolEnvelopeReceipt {
+                    events_topic: receipt.topic,
+                    conversation_id: conv.conversation_id,
+                    call_id: envelope.call_id,
+                    partition: receipt.partition,
+                    offset: receipt.offset,
+                    produced_at: receipt.timestamp,
+                }),
+            )
+                .into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response(),
+        }
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, conversation_id, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}/tool-results",
+    tag = "bus",
+    request_body = PostToolResultRequest,
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("conversation_id" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Tool-result envelope appended", body = ToolEnvelopeReceipt),
+        (status = 400, description = "Invalid envelope or archived conversation", body = ErrorResponse),
+        (status = 404, description = "Conversation not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+#[allow(clippy::too_many_lines)]
+pub async fn post_tool_result(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, conversation_id)): Path<(String, String, String)>,
+    Json(req): Json<PostToolResultRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        let Some(backend) = state.bus_backend.as_ref() else {
+            return service_unavailable("bus feature not enabled");
+        };
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::Publish) {
+            return resp;
+        }
+        let mut envelope = acteon_core::ToolResult {
+            call_id: req.call_id.clone(),
+            status: req.status,
+            output: req.output.clone(),
+            error_message: req.error_message.clone(),
+            correlation_id: req.correlation_id.clone(),
+            sender: req.sender.clone(),
+            metadata: req.metadata.clone(),
+            created_at: Utc::now(),
+        };
+        if let Err(e) = envelope.validate() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        if let Err(resp) = validate_user_labels(&envelope.metadata) {
+            return resp;
+        }
+        let conv = match load_conversation(&state, &namespace, &tenant, &conversation_id).await {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
+        if !conv.accepts_messages() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "conversation {} is archived; reopen via /transition before posting tool results",
+                        conv.conversation_id
+                    ),
+                }),
+            )
+                .into_response();
+        }
+        if !conv.participants.is_empty() {
+            match envelope.sender.as_deref() {
+                Some(s) if conv.participants.iter().any(|p| p == s) => {}
+                Some(s) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "sender '{s}' is not a participant of conversation {}",
+                                conv.conversation_id
+                            ),
+                        }),
+                    )
+                        .into_response();
+                }
+                None => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "conversation {} has a participant ACL; tool-result sender is required",
+                                conv.conversation_id
+                            ),
+                        }),
+                    )
+                        .into_response();
+                }
+            }
+        }
+        // Re-stamp `created_at` here so the response carries the
+        // server-anchored time rather than whatever the client put in
+        // the envelope (clients can't be trusted to be honest about
+        // when a tool ran).
+        envelope.created_at = Utc::now();
+        let payload = match serde_json::to_value(&envelope) {
+            Ok(v) => v,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let events_topic = conv.effective_events_topic();
+        let mut msg = acteon_bus::BusMessage::new(events_topic.clone(), payload)
+            .with_key(&conv.conversation_id);
+        msg.headers.insert(
+            "acteon.conversation.id".into(),
+            conv.conversation_id.clone(),
+        );
+        if let Some(s) = &envelope.sender {
+            msg.headers
+                .insert("acteon.conversation.sender".into(), s.clone());
+        }
+        stamp_tool_envelope_headers(
+            &mut msg,
+            ENVELOPE_KIND_TOOL_RESULT,
+            &envelope.call_id,
+            envelope.correlation_id.as_deref(),
+            None, // results don't carry a reply_to
+        );
+        match backend.produce(msg).await {
+            Ok(receipt) => (
+                StatusCode::OK,
+                Json(ToolEnvelopeReceipt {
+                    events_topic: receipt.topic,
+                    conversation_id: conv.conversation_id,
+                    call_id: envelope.call_id,
+                    partition: receipt.partition,
+                    offset: receipt.offset,
+                    produced_at: receipt.timestamp,
+                }),
+            )
+                .into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response(),
+        }
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, conversation_id, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/bus/tool-calls/{namespace}/{tenant}/{call_id}/result",
+    tag = "bus",
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("call_id" = String, Path),
+        ToolResultLookupParams,
+    ),
+    responses(
+        (status = 200, description = "Matching tool result", body = ToolResultLookupResponse),
+        (status = 408, description = "Timed out before a matching result arrived", body = ErrorResponse),
+        (status = 404, description = "Events topic not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+#[allow(clippy::too_many_lines)]
+pub async fn lookup_tool_result(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, call_id)): Path<(String, String, String)>,
+    Query(params): Query<ToolResultLookupParams>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        let Some(backend) = state.bus_backend.clone() else {
+            return service_unavailable("bus feature not enabled");
+        };
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        if let Err(e) = acteon_core::ToolCall::validate_id_field("call_id", &call_id) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        // Resolve which conversation's events topic to scan. By
+        // default we use the tenant's shared events topic; callers
+        // who routed `reply_to` to a different thread point at it
+        // explicitly via `?conversation_id=`.
+        let events_topic = if let Some(conv_id) = &params.conversation_id {
+            match load_conversation(&state, &namespace, &tenant, conv_id).await {
+                Ok(c) => c.effective_events_topic(),
+                Err(resp) => return resp,
+            }
+        } else {
+            format!(
+                "{}.{}.{}",
+                namespace,
+                tenant,
+                acteon_core::DEFAULT_CONVERSATIONS_EVENTS_SUFFIX
+            )
+        };
+        let timeout_ms = params.timeout_ms.unwrap_or(5_000).min(30_000);
+        // Scan from earliest using the same `assign()`-based
+        // primitive replay uses. No consumer-group leak; bounded
+        // by the timeout budget.
+        let mut stream = match backend
+            .scan_topic(&events_topic, acteon_bus::ScanFrom::Earliest)
+            .await
+        {
+            Ok(s) => s,
+            Err(acteon_bus::BusError::TopicNotFound(_)) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse {
+                        error: format!("events topic {events_topic} not found"),
+                    }),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(timeout_ms);
+        loop {
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return (
+                    StatusCode::REQUEST_TIMEOUT,
+                    Json(ErrorResponse {
+                        error: format!(
+                            "no tool result for call_id '{call_id}' arrived within {timeout_ms}ms"
+                        ),
+                    }),
+                )
+                    .into_response();
+            }
+            let remaining = deadline - now;
+            tokio::select! {
+                next = stream.next() => {
+                    match next {
+                        Some(Ok(msg)) => {
+                            // Header-only filter: only inspect the
+                            // payload when this is *the* tool result
+                            // we're waiting for. Saves
+                            // serde-deserializing every record on a
+                            // busy topic.
+                            let is_result = msg
+                                .headers
+                                .get("acteon.envelope.kind")
+                                .is_some_and(|v| v == ENVELOPE_KIND_TOOL_RESULT);
+                            let matches_call = msg
+                                .headers
+                                .get("acteon.tool.call_id")
+                                .is_some_and(|v| v == &call_id);
+                            if !is_result || !matches_call {
+                                continue;
+                            }
+                            let result: acteon_core::ToolResult =
+                                match serde_json::from_value(msg.payload.clone()) {
+                                    Ok(r) => r,
+                                    Err(e) => {
+                                        // Header said it was a tool
+                                        // result for our call_id, but
+                                        // the payload doesn't
+                                        // deserialize. Surface the
+                                        // corruption rather than time
+                                        // out silently.
+                                        return (
+                                            StatusCode::INTERNAL_SERVER_ERROR,
+                                            Json(ErrorResponse {
+                                                error: format!(
+                                                    "matched tool-result envelope for call_id '{call_id}' but payload is not a ToolResult: {e}"
+                                                ),
+                                            }),
+                                        )
+                                            .into_response();
+                                    }
+                                };
+                            // The scan key carries the conversation
+                            // id; surface it on the response so the
+                            // caller doesn't have to re-derive it.
+                            let conv_id = msg.key.clone().unwrap_or_default();
+                            return (
+                                StatusCode::OK,
+                                Json(ToolResultLookupResponse {
+                                    call_id: result.call_id.clone(),
+                                    events_topic,
+                                    conversation_id: conv_id,
+                                    partition: msg.partition.unwrap_or(0),
+                                    offset: msg.offset.unwrap_or(0),
+                                    produced_at: msg.timestamp.unwrap_or_else(Utc::now),
+                                    result,
+                                }),
+                            )
+                                .into_response();
+                        }
+                        Some(Err(_)) | None => {
+                            // Stream ended without a match. Treat as
+                            // timeout — clients retry.
+                            return (
+                                StatusCode::REQUEST_TIMEOUT,
+                                Json(ErrorResponse {
+                                    error: format!(
+                                        "stream ended without a tool result for call_id '{call_id}'"
+                                    ),
+                                }),
+                            )
+                                .into_response();
+                        }
+                    }
+                }
+                () = tokio::time::sleep(remaining) => {
+                    return (
+                        StatusCode::REQUEST_TIMEOUT,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "no tool result for call_id '{call_id}' arrived within {timeout_ms}ms"
+                            ),
+                        }),
+                    )
+                        .into_response();
+                }
+            }
+        }
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, call_id, params);
+        service_unavailable("bus feature not compiled")
+    }
+}

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -6136,71 +6136,33 @@ pub async fn lookup_tool_result(
         }
         let events_topic = conv.effective_events_topic();
         let timeout_ms = params.timeout_ms.unwrap_or(5_000).min(30_000);
-        // Resolve scan position. With a cursor (the typical flow:
-        // caller passes back the receipt's `cursor`), scan strictly
-        // *after* the call was produced. Without one, default to
-        // `Latest` — cheap on a busy cluster, but races with the
-        // result landing. Earlier the default was `Earliest`, which
-        // turned every lookup into a full-history scan and was a
-        // straightforward DoS vector.
+        // Resolve scan position.
         //
-        // **Cursor + reply_to caveat**: the cursor from a `ToolCall`
-        // receipt only covers the partition the call landed on. If
-        // the result is routed via `reply_to` to a different
-        // conversation, it lands on a partition the cursor doesn't
-        // cover, and a strict `FromOffsets(cursor)` scan would
-        // exclude that partition entirely (its contract is "skip
-        // partitions absent from the map"). To make cursor-based
-        // lookups work across the reply_to flow, we fill the
-        // partitions the cursor doesn't cover with the topic's
-        // current high-water mark — i.e. "scan the call's
-        // partition from the recorded offset onward, and every
-        // other partition from the moment the lookup began." This
-        // makes the cursor a "starting hint" for the call's
-        // partition and `Latest` for the rest.
+        // With a cursor (the typical flow: caller passes back the
+        // receipt's `cursor`), the call's partition resumes from
+        // the recorded offset; partitions the cursor doesn't cover
+        // default to `Latest` *inside the backend* (see the
+        // `ScanFrom::FromOffsets` doc). That keeps single-partition
+        // cursors valid for `reply_to` flows where the result
+        // lands on a different partition.
+        //
+        // Without a cursor, default to `Latest` — cheap on a busy
+        // cluster, but races with the result landing. Earlier the
+        // default was `Earliest`, which turned every lookup into a
+        // full-history scan and was a straightforward DoS vector.
         let scan_from = match &params.cursor {
-            Some(c) => {
-                let mut offsets = match decode_replay_cursor(c) {
-                    Ok(m) => m,
-                    Err(msg) => {
-                        return (
-                            StatusCode::BAD_REQUEST,
-                            Json(ErrorResponse {
-                                error: format!("invalid lookup cursor: {msg}"),
-                            }),
-                        )
-                            .into_response();
-                    }
-                };
-                let watermarks = match backend.scan_topic_watermarks(&events_topic).await {
-                    Ok(w) => w,
-                    Err(acteon_bus::BusError::TopicNotFound(_)) => {
-                        return (
-                            StatusCode::NOT_FOUND,
-                            Json(ErrorResponse {
-                                error: format!("events topic {events_topic} not found"),
-                            }),
-                        )
-                            .into_response();
-                    }
-                    Err(e) => {
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ErrorResponse {
-                                error: e.to_string(),
-                            }),
-                        )
-                            .into_response();
-                    }
-                };
-                for (&p, &hwm) in &watermarks.high_water_marks {
-                    // `hwm - 1` → kafka backend resumes at `hwm`
-                    // (next-to-be-produced), the same logic the
-                    // replay handler uses for unseeded partitions.
-                    offsets.entry(p).or_insert(hwm - 1);
+            Some(c) => match decode_replay_cursor(c) {
+                Ok(offsets) => acteon_bus::ScanFrom::FromOffsets(offsets),
+                Err(msg) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!("invalid lookup cursor: {msg}"),
+                        }),
+                    )
+                        .into_response();
                 }
-                acteon_bus::ScanFrom::FromOffsets(offsets)
-            }
+            },
             None => acteon_bus::ScanFrom::Latest,
         };
         let mut stream = match backend.scan_topic(&events_topic, scan_from).await {

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -161,6 +161,15 @@ const MAX_USER_HEADER_VALUE_BYTES: usize = 4096;
 #[cfg(feature = "bus")]
 const MAX_CAS_RETRY_ATTEMPTS: u32 = 8;
 
+/// How often the busy scan loops in `lookup_tool_result` and
+/// `replay_conversation_messages` yield back to the tokio executor
+/// while skipping non-matching records. `stream.next()` may return
+/// `Poll::Ready` repeatedly when the consumer has buffered data, so
+/// without an explicit yield a long lookup on a busy topic could
+/// monopolize a single-threaded executor and starve other tasks.
+#[cfg(feature = "bus")]
+const SCAN_YIELD_EVERY: u32 = 256;
+
 /// Read-modify-write a JSON-serialized state row atomically via
 /// `compare_and_swap`. The mutator closure runs on a freshly-loaded
 /// copy each iteration; if the underlying row changed mid-loop, the
@@ -2185,6 +2194,56 @@ async fn ensure_schema_in_validator(
     }
 }
 
+/// Enforce read-side participant ACL. The write-side handlers
+/// (`append_conversation_message`, `post_tool_call`,
+/// `post_tool_result`) already gate on the envelope's `sender`; the
+/// read paths used to skip the equivalent check, so any caller with
+/// the tenant-level `ManageConversation` grant could read a
+/// "private" conversation just by knowing its id. This helper
+/// closes that gap.
+///
+/// Contract:
+/// - Empty participants list → ACL is open; no `as_agent` required.
+/// - Non-empty list → caller must supply `as_agent`, and it must be
+///   on the list. Otherwise 403.
+///
+/// V1 read-isolation: the asserted `as_agent` is taken at face value
+/// once the caller has the tenant grant. A future iteration can
+/// derive the agent identity from the API-key grant directly so
+/// callers can't claim arbitrary agent identities.
+#[cfg(feature = "bus")]
+fn enforce_conversation_read_acl(
+    conv: &acteon_core::Conversation,
+    as_agent: Option<&str>,
+) -> Result<(), axum::response::Response> {
+    if conv.participants.is_empty() {
+        return Ok(());
+    }
+    match as_agent {
+        Some(a) if conv.participants.iter().any(|p| p == a) => Ok(()),
+        Some(a) => Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse {
+                error: format!(
+                    "as_agent '{a}' is not a participant of conversation {}; cannot read",
+                    conv.conversation_id
+                ),
+            }),
+        )
+            .into_response()),
+        None => Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse {
+                error: format!(
+                    "conversation {} has a participant ACL; pass `as_agent` matching one of the participants",
+                    conv.conversation_id
+                ),
+            }),
+        )
+            .into_response()),
+    }
+}
+
 /// Apply Phase 3 schema validation to a payload destined for
 /// `kafka_topic`. Used by every publish-style handler that doesn't
 /// already inline the validation block (the original `/v1/bus/publish`
@@ -4171,6 +4230,12 @@ pub struct ReplayConversationParams {
     /// offsets the previous call left off at.
     #[serde(default)]
     pub cursor: Option<String>,
+    /// `agent_id` the caller is acting as. Required when the
+    /// conversation has a non-empty `participants` ACL — must be
+    /// on the list. Same V1 read-isolation model as
+    /// [`ToolResultLookupParams::as_agent`].
+    #[serde(default)]
+    pub as_agent: Option<String>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -5115,6 +5180,11 @@ pub async fn replay_conversation_messages(
             Ok(c) => c,
             Err(resp) => return resp,
         };
+        // Read-side participant ACL. Without this, any caller with
+        // the tenant grant could replay a private thread by id.
+        if let Err(resp) = enforce_conversation_read_acl(&conv, params.as_agent.as_deref()) {
+            return resp;
+        }
         let limit = params.limit.unwrap_or(200).min(1000);
         let timeout_ms = params.timeout_ms.unwrap_or(1500);
         let events_topic = conv.effective_events_topic();
@@ -5249,7 +5319,11 @@ pub async fn replay_conversation_messages(
         // exhaustiveness without an unread initial value.
         // Fetch `limit + 1` so we can distinguish "exactly `limit`
         // messages exist" from "more exist" (the latter yields
-        // `Limit`).
+        // `Limit`). Yield to the scheduler every `SCAN_YIELD_EVERY`
+        // skipped records (those that belong to other conversations
+        // on the shared events topic) so a busy tenant can't starve
+        // other tasks on a single-threaded executor.
+        let mut replay_skipped: u32 = 0;
         let exit_reason: ReplayExitReason = loop {
             if messages.len() > limit {
                 messages.truncate(limit);
@@ -5302,6 +5376,10 @@ pub async fn replay_conversation_messages(
                                 .get("acteon.conversation.id")
                                 .is_some_and(|v| v == &conv.conversation_id);
                             if !belongs {
+                                replay_skipped = replay_skipped.wrapping_add(1);
+                                if replay_skipped.is_multiple_of(SCAN_YIELD_EVERY) {
+                                    tokio::task::yield_now().await;
+                                }
                                 continue;
                             }
                             messages.push(ReplayMessageEntry {
@@ -5509,6 +5587,16 @@ pub struct ToolResultLookupParams {
     /// How long to wait for a matching result. Default 5s; max 30s.
     #[serde(default)]
     pub timeout_ms: Option<u64>,
+    /// `agent_id` the caller is acting as. Required when the target
+    /// conversation has a non-empty `participants` ACL — must be on
+    /// the list, otherwise the request is rejected. Without it (or
+    /// when the conversation is open), any caller with the
+    /// tenant-level grant can read; this is the V1 read-isolation
+    /// model. Future work: derive the agent identity from the
+    /// caller's API-key grant rather than a self-asserted query
+    /// param.
+    #[serde(default)]
+    pub as_agent: Option<String>,
 }
 
 /// Envelope-kind header values. Server-stamped so subscribers can
@@ -6036,11 +6124,17 @@ pub async fn lookup_tool_result(
         // (Phase 5) would otherwise silently look at the wrong
         // place — the scan would never find a matching record and
         // every lookup would 408.
-        let events_topic =
+        let conv =
             match load_conversation(&state, &namespace, &tenant, &params.conversation_id).await {
-                Ok(c) => c.effective_events_topic(),
+                Ok(c) => c,
                 Err(resp) => return resp,
             };
+        // Read-side participant ACL — match the gate the write-side
+        // tool handlers already enforce.
+        if let Err(resp) = enforce_conversation_read_acl(&conv, params.as_agent.as_deref()) {
+            return resp;
+        }
+        let events_topic = conv.effective_events_topic();
         let timeout_ms = params.timeout_ms.unwrap_or(5_000).min(30_000);
         // Resolve scan position. With a cursor (the typical flow:
         // caller passes back the receipt's `cursor`), scan strictly
@@ -6086,6 +6180,13 @@ pub async fn lookup_tool_result(
             }
         };
         let deadline = tokio::time::Instant::now() + Duration::from_millis(timeout_ms);
+        // Yield to the scheduler every `SCAN_YIELD_EVERY` skipped
+        // messages so a busy topic with no matches doesn't starve
+        // other tasks on a single-threaded executor. `stream.next()`
+        // may return `Poll::Ready` repeatedly when the consumer has
+        // buffered data; without a manual yield, the loop body has
+        // no other `.await` points that surrender the worker.
+        let mut skipped: u32 = 0;
         loop {
             let now = tokio::time::Instant::now();
             if now >= deadline {
@@ -6118,6 +6219,10 @@ pub async fn lookup_tool_result(
                                 .get("acteon.tool.call_id")
                                 .is_some_and(|v| v == &call_id);
                             if !is_result || !matches_call {
+                                skipped = skipped.wrapping_add(1);
+                                if skipped.is_multiple_of(SCAN_YIELD_EVERY) {
+                                    tokio::task::yield_now().await;
+                                }
                                 continue;
                             }
                             let result: acteon_core::ToolResult =

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -393,6 +393,22 @@ pub fn router(state: AppState) -> Router {
             "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}/messages",
             get(bus::replay_conversation_messages).post(bus::append_conversation_message),
         )
+        // Phase 6a: tool-call envelopes (ride on top of conversation
+        // events; server stamps `acteon.envelope.kind`,
+        // `acteon.tool.call_id`, `acteon.correlation_id`,
+        // `acteon.reply_to`).
+        .route(
+            "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}/tool-calls",
+            post(bus::post_tool_call),
+        )
+        .route(
+            "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}/tool-results",
+            post(bus::post_tool_result),
+        )
+        .route(
+            "/v1/bus/tool-calls/{namespace}/{tenant}/{call_id}/result",
+            get(bus::lookup_tool_result),
+        )
         // Swarm runs
         .route("/v1/swarm/runs", get(swarm::list_swarm_runs))
         .route("/v1/swarm/runs/{run_id}", get(swarm::get_swarm_run))

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -191,6 +191,9 @@ use acteon_core::{
         super::bus::transition_conversation,
         super::bus::append_conversation_message,
         super::bus::replay_conversation_messages,
+        super::bus::post_tool_call,
+        super::bus::post_tool_result,
+        super::bus::lookup_tool_result,
     ),
     components(schemas(
         Action, ActionOutcome, ProviderResponse, ResponseStatus, ActionError,
@@ -270,6 +273,10 @@ use acteon_core::{
         super::bus::ReplayMessageEntry, super::bus::ReplayConversationResponse,
         super::bus::ReplayExitReason,
         acteon_core::ConversationState, acteon_core::ConversationTransition,
+        super::bus::PostToolCallRequest, super::bus::PostToolResultRequest,
+        super::bus::ToolEnvelopeReceipt, super::bus::ToolResultLookupResponse,
+        acteon_core::ToolCall, acteon_core::ToolResult,
+        acteon_core::ToolResultStatus,
     ))
 )]
 pub struct ApiDoc;

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -224,5 +224,9 @@ required-features = ["bus"]
 name = "bus_conversation_simulation"
 required-features = ["bus"]
 
+[[example]]
+name = "bus_tool_call_simulation"
+required-features = ["bus"]
+
 [lints]
 workspace = true

--- a/crates/simulation/examples/bus_tool_call_simulation.rs
+++ b/crates/simulation/examples/bus_tool_call_simulation.rs
@@ -1,0 +1,200 @@
+//! Phase 6a tool-call envelope demo.
+//!
+//! Two agents share an inbox; one calls a tool on the other and
+//! retrieves the result by `call_id`. Drives the in-memory bus
+//! backend directly so no Kafka or HTTP server is required — the
+//! production handlers `POST /v1/bus/conversations/.../tool-calls`,
+//! `POST .../tool-results`, and
+//! `GET /v1/bus/tool-calls/.../result` delegate to the same types
+//! and the same shared events topic.
+//!
+//! Scenarios:
+//!
+//! 1. Build a `ToolCall` envelope, wrap it in a conversation message
+//!    keyed by `conversation_id`, stamp the standard envelope
+//!    headers, and produce.
+//! 2. Build a matching `ToolResult` and produce — same conversation,
+//!    same correlation token.
+//! 3. Scan the events topic, filter on the server-style headers
+//!    (`acteon.envelope.kind`, `acteon.tool.call_id`), and recover
+//!    the original `ToolResult` payload. The `correlation_id` and
+//!    `call_id` propagated through cleanly.
+//!
+//! Run with:
+//! ```text
+//! cargo run -p acteon-simulation --features bus --example bus_tool_call_simulation
+//! ```
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use serde_json::json;
+use tracing::{Level, info};
+
+use acteon_bus::{BusMessage, MemoryBackend, ScanFrom};
+use acteon_core::{Conversation, ToolCall, ToolResult, ToolResultStatus, Topic};
+
+#[tokio::main]
+#[allow(clippy::too_many_lines)]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::INFO)
+        .with_env_filter("info,acteon_bus=info")
+        .init();
+
+    let backend: acteon_bus::SharedBackend = MemoryBackend::new();
+
+    // Provision the shared events topic the way agent-registration
+    // would (Phase 4) — single tenant, single topic.
+    let events = Topic::new("conversations-events", "agents", "demo");
+    backend.create_topic(&events).await?;
+
+    let conv = Conversation::new("planning-thread", "agents", "demo");
+    let topic = conv.effective_events_topic();
+
+    // -----------------------------------------------------------------
+    // 1. Caller produces a ToolCall envelope
+    // -----------------------------------------------------------------
+
+    let mut call = ToolCall::new(
+        "call-001",
+        "calendar.list_events",
+        json!({"day": "2026-04-28", "limit": 5}),
+    );
+    call.sender = Some("planner-1".into());
+    call.correlation_id = Some("trace-42".into());
+    call.validate()?;
+
+    let payload = serde_json::to_value(&call)?;
+    let mut call_msg = BusMessage::new(topic.clone(), payload).with_key(&conv.conversation_id);
+    // Server-stamped routing headers — `with_header` strips reserved
+    // `acteon.*` keys on user input, so the bus handlers (and this
+    // simulation) populate them via direct `headers.insert`.
+    call_msg.headers.insert(
+        "acteon.conversation.id".into(),
+        conv.conversation_id.clone(),
+    );
+    call_msg.headers.insert(
+        "acteon.conversation.sender".into(),
+        call.sender.clone().unwrap_or_default(),
+    );
+    call_msg
+        .headers
+        .insert("acteon.envelope.kind".into(), "tool_call".into());
+    call_msg
+        .headers
+        .insert("acteon.tool.call_id".into(), call.call_id.clone());
+    if let Some(c) = &call.correlation_id {
+        call_msg
+            .headers
+            .insert("acteon.correlation_id".into(), c.clone());
+    }
+    backend.produce(call_msg).await?;
+    info!(
+        call_id = %call.call_id,
+        tool = %call.tool,
+        correlation = %call.correlation_id.clone().unwrap_or_default(),
+        "tool-call envelope produced"
+    );
+
+    // -----------------------------------------------------------------
+    // 2. Responder produces a matching ToolResult envelope
+    // -----------------------------------------------------------------
+
+    let mut result = ToolResult::ok(
+        &call.call_id,
+        json!({
+            "events": [
+                {"id": "ev-1", "title": "1:1"},
+                {"id": "ev-2", "title": "design review"}
+            ]
+        }),
+    );
+    result.sender = Some("calendar-svc".into());
+    result.correlation_id = call.correlation_id.clone();
+    result.validate()?;
+
+    let result_payload = serde_json::to_value(&result)?;
+    let mut result_msg =
+        BusMessage::new(topic.clone(), result_payload).with_key(&conv.conversation_id);
+    result_msg.headers.insert(
+        "acteon.conversation.id".into(),
+        conv.conversation_id.clone(),
+    );
+    result_msg.headers.insert(
+        "acteon.conversation.sender".into(),
+        result.sender.clone().unwrap_or_default(),
+    );
+    result_msg
+        .headers
+        .insert("acteon.envelope.kind".into(), "tool_result".into());
+    result_msg
+        .headers
+        .insert("acteon.tool.call_id".into(), result.call_id.clone());
+    if let Some(c) = &result.correlation_id {
+        result_msg
+            .headers
+            .insert("acteon.correlation_id".into(), c.clone());
+    }
+    backend.produce(result_msg).await?;
+    info!(
+        call_id = %result.call_id,
+        status = ?result.status,
+        "tool-result envelope produced"
+    );
+
+    // -----------------------------------------------------------------
+    // 3. Caller scans for the matching result
+    // -----------------------------------------------------------------
+
+    // Same primitive the `lookup_tool_result` HTTP handler uses:
+    // `scan_topic` reads via Kafka's `assign()` (no consumer-group
+    // metadata leak) and we filter on the server-stamped headers
+    // before deserializing.
+    let mut stream = backend.scan_topic(&topic, ScanFrom::Earliest).await?;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let recovered: ToolResult = loop {
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return Err("timed out waiting for tool result".into());
+        }
+        let remaining = deadline - now;
+        tokio::select! {
+            next = stream.next() => {
+                match next {
+                    Some(Ok(msg)) => {
+                        let is_result = msg
+                            .headers
+                            .get("acteon.envelope.kind")
+                            .is_some_and(|v| v == "tool_result");
+                        let matches = msg
+                            .headers
+                            .get("acteon.tool.call_id")
+                            .is_some_and(|v| v == &call.call_id);
+                        if !is_result || !matches {
+                            continue;
+                        }
+                        break serde_json::from_value(msg.payload.clone())?;
+                    }
+                    Some(Err(_)) | None => return Err("stream ended without match".into()),
+                }
+            }
+            () = tokio::time::sleep(remaining) => {
+                return Err("scan timeout".into());
+            }
+        }
+    };
+
+    assert_eq!(recovered.call_id, call.call_id);
+    assert_eq!(recovered.status, ToolResultStatus::Ok);
+    assert_eq!(recovered.correlation_id, call.correlation_id);
+    info!(
+        call_id = %recovered.call_id,
+        correlation = %recovered.correlation_id.clone().unwrap_or_default(),
+        sender = %recovered.sender.clone().unwrap_or_default(),
+        "tool-result recovered by call_id; correlation_id propagated"
+    );
+
+    info!("tool-call simulation complete");
+    Ok(())
+}

--- a/docs/book/features/bus-phase-6a.md
+++ b/docs/book/features/bus-phase-6a.md
@@ -1,0 +1,210 @@
+# Agentic Bus — Phase 6a
+
+> **Scope**: typed `ToolCall` / `ToolResult` envelopes layered on
+> conversation messages, with `correlation_id` and `reply_to`
+> semantics. Streaming chunks land in 6b; HITL pre-publish approvals
+> in 6c. See the [master plan](../concepts/bus-master-plan.md).
+
+Phase 5 made the bus thread-aware. Phase 6a makes it *protocol-aware*:
+the dominant agent-to-agent pattern (call a tool, get a result) now
+has typed envelopes, server-stamped routing headers, and a
+"wait-for-result-by-id" lookup endpoint. No parallel Kafka pipeline —
+tool envelopes ride on the existing conversation events topic.
+
+## What ships in Phase 6a
+
+| Surface | Shape |
+|---|---|
+| Core types | `acteon_core::ToolCall`, `acteon_core::ToolResult`, `acteon_core::ToolResultStatus ∈ {Ok, Error, Canceled}` |
+| HTTP | `POST /v1/bus/conversations/{ns}/{t}/{id}/tool-calls`, `POST .../tool-results`, `GET /v1/bus/tool-calls/{ns}/{t}/{call_id}/result?conversation_id=&timeout_ms=` |
+| Headers | Server-stamped: `acteon.envelope.kind ∈ {tool_call, tool_result}`, `acteon.tool.call_id`, `acteon.correlation_id`, `acteon.reply_to`. Reuses Phase 5's reserved-prefix machinery. |
+| Rust client | `post_bus_tool_call`, `post_bus_tool_result`, `lookup_bus_tool_result` |
+| Tests | 9 core unit tests covering envelope validation + serde roundtrips |
+| Simulation | `bus_tool_call_simulation.rs` — caller produces a tool-call, responder produces a result, caller recovers it via the same header-filter primitive the lookup endpoint uses |
+
+## Model
+
+### Layered, not parallel
+
+Tool envelopes are conventions on top of conversation messages:
+
+```
+agents.demo.conversations-events
+├── partition 1 ── conv=planning-thread
+│       ├─ {kind=tool_call,    call_id=call-001, sender=planner-1}
+│       ├─ {kind=tool_result,  call_id=call-001, sender=calendar-svc}
+│       ├─ {kind=tool_call,    call_id=call-002, sender=planner-1}
+│       └─ {kind=tool_result,  call_id=call-002, sender=ocr-svc}
+```
+
+Same partitioning rules (`key = conversation_id`), same audit, same
+replay, same governance — operators don't see a new pipeline. The
+typed envelopes are an addition to the wire format, not a replacement.
+
+### `correlation_id` and `reply_to`
+
+Both are first-class envelope fields. The bus stamps them as headers
+so subscribers can route locally without parsing JSON:
+
+- **`correlation_id`** — opaque token a caller chooses to thread
+  request and response together across hops. The matching
+  `ToolResult` mirrors it. Subscribers filter on
+  `acteon.correlation_id`.
+- **`reply_to`** — when a caller wants the result to land in a
+  *different* conversation than the call (a fan-out dispatcher
+  collecting results in a dedicated thread, for example), they set
+  this on the `ToolCall`. The bus stamps `acteon.reply_to`; the
+  responder honors it by posting their `tool-result` to that thread.
+  Empty / unset = "same conversation".
+
+### Wait-for-result lookup
+
+`GET /v1/bus/tool-calls/{ns}/{t}/{call_id}/result` blocks for up to
+`timeout_ms` waiting for a matching `ToolResult` to land on the
+events topic. Internally:
+
+1. Reads the relevant events topic via `BusBackend::scan_topic`
+   (Kafka `assign()`, no consumer-group leak).
+2. Header-filters on `acteon.envelope.kind == tool_result` AND
+   `acteon.tool.call_id == call_id`. Only payloads that pass the
+   header filter get deserialized.
+3. Returns the typed `ToolResult` plus bus coordinates
+   (`partition`, `offset`, `produced_at`, `events_topic`,
+   `conversation_id`).
+4. On timeout, returns `408 Request Timeout` so retrying clients
+   know they didn't miss the result — they just need to wait longer
+   or check again.
+
+`?conversation_id=` overrides the default-tenant events topic when
+the caller routed the result to a different thread via `reply_to`.
+
+## API shape
+
+### Post a tool-call
+
+```http
+POST /v1/bus/conversations/agents/demo/planning-thread/tool-calls
+{
+  "call_id": "call-001",
+  "tool": "calendar.list_events",
+  "arguments": {"day": "2026-04-28", "limit": 5},
+  "sender": "planner-1",
+  "correlation_id": "trace-42"
+}
+→ 200 ToolEnvelopeReceipt {
+  "events_topic": "agents.demo.conversations-events",
+  "conversation_id": "planning-thread",
+  "call_id": "call-001",
+  "partition": 0,
+  "offset": 17,
+  "produced_at": "..."
+}
+```
+
+### Post a tool-result
+
+```http
+POST /v1/bus/conversations/agents/demo/planning-thread/tool-results
+{
+  "call_id": "call-001",
+  "status": "ok",
+  "output": {"events": [...]},
+  "sender": "calendar-svc",
+  "correlation_id": "trace-42"
+}
+→ 200 ToolEnvelopeReceipt
+```
+
+### Wait for a result
+
+```http
+GET /v1/bus/tool-calls/agents/demo/call-001/result?timeout_ms=5000
+→ 200 ToolResultLookupResponse {
+  "call_id": "call-001",
+  "result": {"status": "ok", "output": {...}, ...},
+  "events_topic": "...",
+  "partition": 0,
+  "offset": 18,
+  ...
+}
+```
+
+`408 Request Timeout` if no result lands in `timeout_ms`. Default 5s,
+max 30s.
+
+## SDK example
+
+```rust
+use acteon_client::{
+    ActeonClient, BusToolResultLookupParams, BusToolResultStatus,
+    PostBusToolCall, PostBusToolResult,
+};
+
+let client = ActeonClient::new("http://localhost:3000")?;
+
+// Caller emits a tool call.
+client.post_bus_tool_call("agents", "demo", "planning-thread",
+    &PostBusToolCall {
+        call_id: "call-001".into(),
+        tool: "calendar.list_events".into(),
+        arguments: serde_json::json!({"day": "2026-04-28"}),
+        sender: Some("planner-1".into()),
+        correlation_id: Some("trace-42".into()),
+        ..Default::default()
+    }
+).await?;
+
+// Responder emits the result.
+client.post_bus_tool_result("agents", "demo", "planning-thread",
+    &PostBusToolResult {
+        call_id: "call-001".into(),
+        status: BusToolResultStatus::Ok,
+        output: serde_json::json!({"events": [...]}),
+        sender: Some("calendar-svc".into()),
+        correlation_id: Some("trace-42".into()),
+        ..Default::default()
+    }
+).await?;
+
+// Caller waits for the result.
+let lookup = client.lookup_bus_tool_result("agents", "demo", "call-001",
+    &BusToolResultLookupParams {
+        timeout_ms: Some(5_000),
+        ..Default::default()
+    }).await?;
+assert_eq!(lookup.result.call_id, "call-001");
+```
+
+## Authorization
+
+All endpoints flow through `BusOp::ManageConversation` (Dispatch
+permission, verb `conversation`). The two `POST` paths additionally
+require `BusOp::Publish`, mirroring `append_conversation_message` —
+operators can split read/write ACLs.
+
+Participant ACL applies to `tool-calls` and `tool-results`: when the
+conversation has a non-empty `participants` list, the envelope's
+`sender` is required and must be on the list. Same gate as
+`append_conversation_message`.
+
+## Design decisions
+
+- **Layered, not parallel.** Tool envelopes are typed conventions
+  over conversation messages — one pipeline, one source of truth,
+  one set of operational levers.
+- **Server-stamped routing headers.** Subscribers route on a single
+  header lookup; payload deserialization happens only on the
+  envelopes the caller actually wants.
+- **Lookup via topic scan, not a side index.** Same trade-off as
+  conversation replay (Phase 5): one source of truth, no consistency
+  window. A future secondary index makes sense once tool-call
+  volume is high enough that scan latency dominates.
+- **Result fetch returns 408 on timeout, not 404.** The result may
+  arrive any moment; 408 is the honest signal "not yet, retry."
+
+## What comes next
+
+- **Phase 6b** — Streaming chunks (per-chunk Kafka records with a
+  terminal marker) for LLM token streams and partial tool results.
+- **Phase 6c** — HITL pre-publish approvals: park a tool-call in
+  state, await operator approval, then commit to Kafka.

--- a/docs/book/features/bus-phase-6a.md
+++ b/docs/book/features/bus-phase-6a.md
@@ -202,9 +202,58 @@ conversation has a non-empty `participants` list, the envelope's
 - **Result fetch returns 408 on timeout, not 404.** The result may
   arrive any moment; 408 is the honest signal "not yet, retry."
 
+## Trust model and limits
+
+The bus does not maintain a state-store record of in-flight tool
+calls (the layered design keeps the call/result envelopes on Kafka,
+not in Acteon state). That has two consequences operators should
+plan around:
+
+### `call_id` is not a uniqueness gate
+
+`lookup_tool_result` returns the **first** record on the topic that
+matches `(envelope.kind=tool_result, tool.call_id=<id>)`. Acteon
+does not verify that only one responder produced a result for that
+call. If two participants race to post results for the same
+`call_id`, the lookup returns whichever the broker stored first.
+
+In practice the participant ACL bounds the threat: only conversation
+participants can post tool results, and operators control who's on
+the list. A mutually-untrusting set of participants in the same
+thread is unusual; if you have one, sign your tool-result payloads
+end-to-end and verify on the consumer side.
+
+### `correlation_id` is operator-asserted
+
+The bus does not verify that a `ToolResult.correlation_id` matches
+the originating `ToolCall.correlation_id`. The server stamps
+whatever the responder claims as `acteon.correlation_id`. This is
+fine for tracing — the field is informational and audited — but
+treat it as the responder's claim, not as an authenticated link.
+
+If you need an authenticated request/response link, sign payloads
+or use a mutually-trusted ID generator and verify on the consumer.
+
+### Read-side participant ACL
+
+The write-side handlers gate on `sender ∈ participants`. The
+read-side (`lookup_tool_result`, `replay_conversation_messages`)
+gates on `as_agent ∈ participants` when the conversation has a
+non-empty list. Pass `as_agent` to identify which participant
+you're acting as. Without `as_agent` on a private thread, the
+server returns 403.
+
+`as_agent` is operator-asserted under the tenant grant — anyone with
+the tenant grant can claim any agent identity in the tenant. A
+future iteration will derive the agent identity from the API-key
+grant directly so this can't be spoofed.
+
 ## What comes next
 
 - **Phase 6b** — Streaming chunks (per-chunk Kafka records with a
   terminal marker) for LLM token streams and partial tool results.
 - **Phase 6c** — HITL pre-publish approvals: park a tool-call in
   state, await operator approval, then commit to Kafka.
+- **Future** — derive agent identity from API-key grant (replaces
+  the `as_agent` self-assertion); state-store-tracked `call_id`
+  uniqueness for environments where participant ACL isn't enough.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -188,6 +188,7 @@ nav:
     - Phase 3 (Schemas + Publish Validation): features/bus-phase-3.md
     - Phase 4 (Agents + Shared Inbox + Heartbeat): features/bus-phase-4.md
     - Phase 5 (Conversations + Threads): features/bus-phase-5.md
+    - Phase 6a (Tool-call envelopes): features/bus-phase-6a.md
   - Guides:
     - guides/index.md
     - AI Agent Swarm Coordination: guides/agent-swarm-coordination.md


### PR DESCRIPTION
## Summary

Phase 6a of the agentic bus. Typed \`ToolCall\` / \`ToolResult\` envelopes layered on top of the Phase 5 conversation pipeline — same architectural pattern as the agent inbox in Phase 4, the conversation thread in Phase 5: one Kafka topic, server-stamped routing headers, no parallel pipeline.

- **Core types** \`acteon_core::ToolCall\`, \`ToolResult\`, \`ToolResultStatus ∈ {Ok, Error, Canceled}\`. \`correlation_id\` and \`reply_to\` are first-class envelope fields, server-stamped as \`acteon.correlation_id\` and \`acteon.reply_to\` headers.
- **HTTP** — three new endpoints under existing conversation paths:
  - \`POST /v1/bus/conversations/{ns}/{t}/{id}/tool-calls\` — wraps a \`ToolCall\` in a conversation message; bus stamps \`acteon.envelope.kind = tool_call\`, \`acteon.tool.call_id\`, etc.
  - \`POST /v1/bus/conversations/{ns}/{t}/{id}/tool-results\` — same shape for results; \`created_at\` is rewritten server-side so agents can't lie about timing.
  - \`GET /v1/bus/tool-calls/{ns}/{t}/{call_id}/result?conversation_id=&timeout_ms=\` — scans the events topic via \`BusBackend::scan_topic\` (no consumer-group leak), header-filters on \`acteon.envelope.kind == tool_result\` AND matching \`call_id\`, returns the typed result + bus coordinates. 408 on timeout (default 5s, max 30s).
- **Authorization** — \`BusOp::ManageConversation\` on all three; the two \`POST\` paths additionally require \`BusOp::Publish\`. Participant ACL applies when set.
- **Rust SDK** — \`post_bus_tool_call\`, \`post_bus_tool_result\`, \`lookup_bus_tool_result\` with full DTOs.
- **9 new core unit tests** + simulation showing roundtrip retrieval by \`call_id\` (no Kafka required).

## Design notes

- **Layered, not parallel.** Tool envelopes are typed conventions over conversation messages. One pipeline, one source of truth, all the existing audit/replay/governance carries over transparently. If the events topic has a Phase 3 schema binding, validation runs at the publish edge as usual.
- **Server-stamped routing headers.** Subscribers route on a single header lookup; payloads are only deserialized for envelopes the caller actually wants.
- **Lookup via topic scan, not a side index.** Same trade-off as conversation replay (Phase 5). One source of truth, no consistency window. Future: secondary index when tool-call volume makes scan latency dominate.
- **Result fetch returns 408 on timeout, not 404.** The result may arrive any moment; 408 is the honest signal "not yet, retry."

## Out of scope (next sub-PRs)

- **Phase 6b** — streaming chunks (per-chunk records with terminal marker) for LLM token streams and partial tool results.
- **Phase 6c** — HITL pre-publish approvals: park a tool-call in state, await operator approval, then commit to Kafka.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --no-deps -- -D warnings\`
- [x] \`cargo clippy -p acteon-server --features bus --no-deps -- -D warnings\`
- [x] \`cargo test --workspace --lib --bins --tests\` — 2526 passed, 0 failed
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps\`
- [x] \`cargo check --all-targets\`
- [x] \`ACTEON_KAFKA_BOOTSTRAP=localhost:9092 cargo test -p acteon-bus --test kafka_integration\` — 3/3
- [x] \`cargo run -p acteon-simulation --features bus --example bus_tool_call_simulation\` — green

## Polyglot SDKs

Per the [master plan](../blob/main/docs/book/concepts/bus-master-plan.md), Python/Node/Go/Java parity for the entire bus surface lands together in Phase 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)