### PR TITLE
feat(bus): Phase 6b — streaming chunks on conversations

### DIFF
--- a/crates/client/src/bus.rs
+++ b/crates/client/src/bus.rs
@@ -1175,6 +1175,83 @@ impl ActeonClient {
         )
         .await
     }
+
+    // ----- Phase 6b: streaming envelopes -----
+
+    /// Append a stream-chunk envelope to a conversation. The bus
+    /// stamps `acteon.envelope.kind = stream_chunk`, `acteon.stream.id`,
+    /// and `acteon.stream.seq` headers so subscribers can header-filter
+    /// without parsing the chunk body.
+    pub async fn post_bus_stream_chunk(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        conversation_id: &str,
+        req: &PostBusStreamChunk,
+    ) -> Result<BusStreamEnvelopeReceipt, Error> {
+        let url = self.conversation_url(namespace, tenant, conversation_id, Some("stream-chunks"));
+        let resp = self
+            .add_auth(self.client.post(&url))
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusStreamEnvelopeReceipt>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Append the terminal `stream_end` marker. Once produced, SSE
+    /// consumers of `GET /v1/bus/streams/.../{stream_id}` close their
+    /// connection on observing this record.
+    pub async fn post_bus_stream_end(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        conversation_id: &str,
+        req: &PostBusStreamEnd,
+    ) -> Result<BusStreamEnvelopeReceipt, Error> {
+        let url = self.conversation_url(namespace, tenant, conversation_id, Some("stream-end"));
+        let resp = self
+            .add_auth(self.client.post(&url))
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusStreamEnvelopeReceipt>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Build the SSE consume URL for a stream. Useful when the caller
+    /// wants to plug it into a browser `EventSource`, `curl
+    /// -N --header 'accept: text/event-stream'`, or any other
+    /// SSE-aware client. Encodes path segments per the bus URL rules.
+    #[must_use]
+    pub fn bus_stream_consume_url(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        conversation_id: &str,
+        stream_id: &str,
+    ) -> String {
+        format!(
+            "{}/v1/bus/streams/{}/{}/{}/{}",
+            self.base_url,
+            encode_segment(namespace),
+            encode_segment(tenant),
+            encode_segment(conversation_id),
+            encode_segment(stream_id),
+        )
+    }
 }
 
 // ----- Phase 3: DTOs -----
@@ -1606,6 +1683,56 @@ pub struct BusToolResultLookup {
     pub offset: i64,
     pub produced_at: String,
     pub result: BusToolResult,
+}
+
+// ----- Phase 6b: streaming-envelope DTOs -----
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct PostBusStreamChunk {
+    pub stream_id: String,
+    pub chunk_seq: i64,
+    #[serde(default)]
+    pub body: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sender: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BusStreamEndStatus {
+    Complete,
+    Aborted,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PostBusStreamEnd {
+    pub stream_id: String,
+    pub chunk_seq: i64,
+    pub status: BusStreamEndStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BusStreamEnvelopeReceipt {
+    pub events_topic: String,
+    pub conversation_id: String,
+    pub stream_id: String,
+    pub chunk_seq: i64,
+    pub partition: i32,
+    pub offset: i64,
+    pub produced_at: String,
+    /// Opaque resume cursor encoding `{partition: offset}`. Pass it
+    /// to the SSE consumer as `?cursor=` to scan from strictly after
+    /// this envelope.
+    pub cursor: String,
 }
 
 async fn map_error(resp: reqwest::Response) -> Error {

--- a/crates/core/src/bus_stream.rs
+++ b/crates/core/src/bus_stream.rs
@@ -1,0 +1,307 @@
+//! Bus streaming envelopes — `StreamChunk` / `StreamEnd` (Phase 6b).
+//!
+//! Streaming is the natural protocol for LLM token output, partial
+//! tool results, progressive search hits, and any other "produce
+//! incremental, signal completion" pattern. Acteon ships streaming as
+//! a typed convention over the existing conversation events topic
+//! (same architectural pattern as Phase 6a tool envelopes): each
+//! chunk is its own Kafka record carrying `(stream_id, chunk_seq)`,
+//! and a terminal `StreamEnd` record marks the stream complete.
+//!
+//! Subscribers route on `acteon.envelope.kind` and `acteon.stream.id`
+//! headers — no payload deserialization until they've matched the
+//! stream they care about.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Terminal status for a stream. `Complete` is the happy path —
+/// every chunk made it. `Aborted` is producer-side cancellation
+/// (the agent gave up cleanly). `Error` carries the reason the
+/// stream failed mid-flight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum StreamEndStatus {
+    /// All chunks delivered successfully.
+    Complete,
+    /// Producer canceled the stream cleanly. Distinct from `Error`
+    /// so consumers can retry vs. surface differently.
+    Aborted,
+    /// Stream failed mid-flight. `error_message` carries detail.
+    Error,
+}
+
+/// A single chunk in a stream. Each chunk lives in its own bus
+/// message; consumers re-stitch them into a contiguous stream by
+/// `stream_id` and `chunk_seq`. The `body` is opaque to the bus —
+/// LLM tokens, partial JSON, raw bytes encoded as a string, whatever
+/// the producer and consumer agree on.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct StreamChunk {
+    /// Stable identifier for the stream this chunk belongs to.
+    /// Stamped as `acteon.stream.id` on the underlying Kafka message
+    /// so subscribers can header-filter.
+    pub stream_id: String,
+    /// Monotonic sequence number within the stream. The bus does not
+    /// enforce ordering on its own — consumers may sort by this
+    /// field when reassembling a partitioned scan. (For
+    /// single-conversation streams keyed by `conversation_id`,
+    /// Kafka's per-partition ordering already gives FIFO; `chunk_seq`
+    /// is mostly diagnostic.)
+    pub chunk_seq: i64,
+    /// Chunk payload. Free-form JSON to match the rest of the bus —
+    /// callers convention-encode tokens, partial structured results,
+    /// or whatever shape they need.
+    #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub body: serde_json::Value,
+    /// `agent_id` of the producer. Mirrors the conversation-message
+    /// `sender` on the underlying record; carried on the envelope so
+    /// audit and replay see it without parsing the conversation
+    /// header.
+    #[serde(default)]
+    pub sender: Option<String>,
+    /// Free-form metadata (e.g. trace IDs). Bounded by the publish
+    /// path's label caps.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, String>,
+    /// When the chunk envelope was constructed. Distinct from the
+    /// broker-stamped `produced_at`.
+    pub created_at: DateTime<Utc>,
+}
+
+impl StreamChunk {
+    /// Construct a fresh chunk envelope.
+    #[must_use]
+    pub fn new(stream_id: impl Into<String>, chunk_seq: i64, body: serde_json::Value) -> Self {
+        Self {
+            stream_id: stream_id.into(),
+            chunk_seq,
+            body,
+            sender: None,
+            metadata: HashMap::new(),
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Validate identity fields. Reuses the same alphabet rules as
+    /// the rest of the bus envelopes — `[a-zA-Z0-9._-]`, max 120
+    /// chars on `stream_id` / `sender`. Rejects negative
+    /// `chunk_seq` so consumers can sort with confidence that
+    /// non-negative is the only reachable shape.
+    pub fn validate(&self) -> Result<(), StreamEnvelopeValidationError> {
+        validate_id_field("stream_id", &self.stream_id)?;
+        if self.chunk_seq < 0 {
+            return Err(StreamEnvelopeValidationError::NegativeChunkSeq(
+                self.chunk_seq,
+            ));
+        }
+        if let Some(s) = &self.sender {
+            validate_id_field("sender", s)?;
+        }
+        Ok(())
+    }
+}
+
+/// Terminal record for a stream. Marks the stream complete (or not)
+/// and carries an optional error message. Consumers stop reading
+/// once they see this for their `stream_id`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct StreamEnd {
+    /// The stream this terminal marker closes.
+    pub stream_id: String,
+    /// Sequence number of the terminal record. Conventionally
+    /// `last_chunk_seq + 1`, though the bus does not enforce this —
+    /// a producer that knows its tail can use any non-negative
+    /// number for diagnostic clarity.
+    pub chunk_seq: i64,
+    /// How the stream ended.
+    pub status: StreamEndStatus,
+    /// Human-readable detail. Required for `Error`; optional
+    /// otherwise. Always capped at 4096 bytes regardless of status —
+    /// a malicious caller could otherwise ship a multi-MB string
+    /// alongside `Complete` and bypass the limit.
+    #[serde(default)]
+    pub error_message: Option<String>,
+    /// `agent_id` of the producer. Same as on `StreamChunk`.
+    #[serde(default)]
+    pub sender: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, String>,
+    pub created_at: DateTime<Utc>,
+}
+
+impl StreamEnd {
+    /// Construct a terminal marker for a successful stream.
+    #[must_use]
+    pub fn complete(stream_id: impl Into<String>, chunk_seq: i64) -> Self {
+        Self {
+            stream_id: stream_id.into(),
+            chunk_seq,
+            status: StreamEndStatus::Complete,
+            error_message: None,
+            sender: None,
+            metadata: HashMap::new(),
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Construct a terminal marker for a failed stream.
+    #[must_use]
+    pub fn error(stream_id: impl Into<String>, chunk_seq: i64, message: impl Into<String>) -> Self {
+        Self {
+            stream_id: stream_id.into(),
+            chunk_seq,
+            status: StreamEndStatus::Error,
+            error_message: Some(message.into()),
+            sender: None,
+            metadata: HashMap::new(),
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Validate identity fields and the bounded `error_message`.
+    pub fn validate(&self) -> Result<(), StreamEnvelopeValidationError> {
+        validate_id_field("stream_id", &self.stream_id)?;
+        if self.chunk_seq < 0 {
+            return Err(StreamEnvelopeValidationError::NegativeChunkSeq(
+                self.chunk_seq,
+            ));
+        }
+        if let Some(s) = &self.sender {
+            validate_id_field("sender", s)?;
+        }
+        // Cap unconditionally — same reasoning as `ToolResult`. A
+        // caller could otherwise ship a megabyte of `error_message`
+        // alongside `status: complete` to dodge the limit.
+        if let Some(m) = &self.error_message
+            && m.len() > 4096
+        {
+            return Err(StreamEnvelopeValidationError::ErrorMessageTooLong);
+        }
+        Ok(())
+    }
+}
+
+/// Shared id-field validation used across `StreamChunk` and
+/// `StreamEnd`. Mirrors the rule applied to `ToolCall` / `Agent` /
+/// `Conversation` ids: alphanumeric plus `[._-]`, 1..=120 bytes.
+pub fn validate_id_field(field: &str, s: &str) -> Result<(), StreamEnvelopeValidationError> {
+    if s.is_empty() {
+        return Err(StreamEnvelopeValidationError::EmptyId(field.to_string()));
+    }
+    if s.len() > 120 {
+        return Err(StreamEnvelopeValidationError::IdTooLong(field.to_string()));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err(StreamEnvelopeValidationError::InvalidIdChar {
+            field: field.to_string(),
+            value: s.to_string(),
+        });
+    }
+    Ok(())
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum StreamEnvelopeValidationError {
+    #[error("{0} must not be empty")]
+    EmptyId(String),
+    #[error("{0} exceeds 120 characters")]
+    IdTooLong(String),
+    #[error("{field} '{value}' contains characters outside [a-zA-Z0-9._-]")]
+    InvalidIdChar { field: String, value: String },
+    #[error("chunk_seq must be non-negative (got {0})")]
+    NegativeChunkSeq(i64),
+    #[error("error_message exceeds 4096 characters")]
+    ErrorMessageTooLong,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn chunk_basic_validate() {
+        let mut c = StreamChunk::new("stream-1", 0, json!({"token": "hello"}));
+        c.sender = Some("planner-1".into());
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn chunk_rejects_negative_seq() {
+        let c = StreamChunk::new("s", -1, json!({}));
+        assert_eq!(
+            c.validate(),
+            Err(StreamEnvelopeValidationError::NegativeChunkSeq(-1))
+        );
+    }
+
+    #[test]
+    fn chunk_rejects_invalid_id() {
+        let c = StreamChunk::new("a/b", 0, json!({}));
+        assert!(matches!(
+            c.validate(),
+            Err(StreamEnvelopeValidationError::InvalidIdChar { .. })
+        ));
+    }
+
+    #[test]
+    fn end_complete_validate() {
+        let e = StreamEnd::complete("stream-1", 42);
+        e.validate().unwrap();
+        assert_eq!(e.status, StreamEndStatus::Complete);
+        assert!(e.error_message.is_none());
+    }
+
+    #[test]
+    fn end_error_validate() {
+        let e = StreamEnd::error("stream-1", 7, "upstream gave up");
+        e.validate().unwrap();
+        assert_eq!(e.status, StreamEndStatus::Error);
+    }
+
+    #[test]
+    fn end_caps_error_message_unconditionally() {
+        // The cap fires even on `Complete` — a caller that ships a
+        // megabyte of `error_message` with status=complete would
+        // otherwise bypass the limit.
+        let mut e = StreamEnd::complete("s", 0);
+        e.error_message = Some("x".repeat(5000));
+        assert_eq!(
+            e.validate(),
+            Err(StreamEnvelopeValidationError::ErrorMessageTooLong)
+        );
+    }
+
+    #[test]
+    fn roundtrip_serde_chunk() {
+        let mut c = StreamChunk::new("s-1", 5, json!({"k": "v"}));
+        c.sender = Some("a-1".into());
+        c.metadata.insert("trace".into(), "abc".into());
+        let j = serde_json::to_string(&c).unwrap();
+        let back: StreamChunk = serde_json::from_str(&j).unwrap();
+        assert_eq!(back.stream_id, c.stream_id);
+        assert_eq!(back.chunk_seq, c.chunk_seq);
+        assert_eq!(back.metadata.get("trace"), Some(&"abc".into()));
+    }
+
+    #[test]
+    fn roundtrip_serde_end_aborted() {
+        let mut e = StreamEnd::complete("s", 10);
+        e.status = StreamEndStatus::Aborted;
+        e.error_message = Some("user canceled".into());
+        let j = serde_json::to_string(&e).unwrap();
+        let back: StreamEnd = serde_json::from_str(&j).unwrap();
+        assert_eq!(back.status, StreamEndStatus::Aborted);
+        assert_eq!(back.error_message.as_deref(), Some("user canceled"));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod attachment;
 pub mod bus_agent;
 pub mod bus_conversation;
 pub mod bus_schema;
+pub mod bus_stream;
 pub mod bus_subscription;
 pub mod bus_tool;
 pub mod bus_topic;
@@ -45,6 +46,7 @@ pub use bus_conversation::{
     DEFAULT_CONVERSATIONS_EVENTS_SUFFIX,
 };
 pub use bus_schema::{Schema, SchemaFormat, SchemaValidationError};
+pub use bus_stream::{StreamChunk, StreamEnd, StreamEndStatus, StreamEnvelopeValidationError};
 pub use bus_subscription::{
     AckMode, PartitionLag, StartOffset as SubscriptionStartOffset, Subscription,
     SubscriptionStatus, SubscriptionValidationError,

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -6930,7 +6930,7 @@ pub async fn consume_stream(
                     .into_response();
             }
         };
-        let stream = sse_stream_for_stream_id(inner, stream_id);
+        let stream = sse_stream_for_stream_id(inner, conv.conversation_id.clone(), stream_id);
         Sse::new(stream)
             .keep_alive(
                 // `KeepAlive::text` is implemented in axum as
@@ -6953,20 +6953,28 @@ pub async fn consume_stream(
 }
 
 /// Build the SSE event stream for `consume_stream`. Filters the raw
-/// scan to `(envelope.kind ∈ stream_chunk|stream_end, stream.id ==
-/// target)`, emits a typed SSE event per match, and closes after a
-/// terminal `stream_end`. Header-only filter — payload deserialization
-/// happens *after* the kind/id match, so unrelated traffic on the
-/// conversation events topic costs only a hashmap lookup.
+/// scan to `(envelope.kind ∈ stream_chunk|stream_end, conversation.id
+/// == target_conv, stream.id == target_stream)`, emits a typed SSE
+/// event per match, and closes after a terminal `stream_end`.
+/// Header-only filter — payload deserialization happens *after* the
+/// triple match, so unrelated traffic on the shared events topic
+/// costs only a few hashmap lookups.
+///
+/// The `acteon.conversation.id` check is load-bearing for tenant
+/// isolation: by default every conversation in a tenant rides the
+/// same Kafka events topic, so two conversations using the same
+/// `stream_id` (`current-llm-run`, etc.) would otherwise leak each
+/// other's chunks to a consumer authorized only for one of them.
 #[cfg(feature = "bus")]
 fn sse_stream_for_stream_id(
     inner: acteon_bus::SubscribeStream,
+    target_conversation_id: String,
     target_stream_id: String,
 ) -> impl Stream<Item = Result<Event, Infallible>> + Send + 'static {
     use futures::stream::StreamExt as _;
     futures::stream::unfold(
-        (inner, target_stream_id, false, 0u32),
-        |(mut inner, target, mut terminated, mut skipped)| async move {
+        (inner, target_conversation_id, target_stream_id, false, 0u32),
+        |(mut inner, target_conv, target_stream, mut terminated, mut skipped)| async move {
             if terminated {
                 return None;
             }
@@ -6980,11 +6988,15 @@ fn sse_stream_for_stream_id(
                             .unwrap_or_default();
                         let is_chunk = kind == ENVELOPE_KIND_STREAM_CHUNK;
                         let is_end = kind == ENVELOPE_KIND_STREAM_END;
-                        let matches = msg
+                        let matches_conv = msg
+                            .headers
+                            .get("acteon.conversation.id")
+                            .is_some_and(|v| v == &target_conv);
+                        let matches_stream = msg
                             .headers
                             .get("acteon.stream.id")
-                            .is_some_and(|v| v == &target);
-                        if !(is_chunk || is_end) || !matches {
+                            .is_some_and(|v| v == &target_stream);
+                        if !(is_chunk || is_end) || !matches_conv || !matches_stream {
                             // Yield to the executor every
                             // `SCAN_YIELD_EVERY` non-matching records
                             // so a busy events topic with traffic for
@@ -7012,7 +7024,7 @@ fn sse_stream_for_stream_id(
                         let ev = Event::default().event(event_name).id(id).data(data);
                         return Some((
                             Ok::<_, Infallible>(ev),
-                            (inner, target, terminated, skipped),
+                            (inner, target_conv, target_stream, terminated, skipped),
                         ));
                     }
                     Some(Err(e)) => {
@@ -7029,7 +7041,7 @@ fn sse_stream_for_stream_id(
                         let ev = Event::default().event("bus.stream.error").data(data);
                         return Some((
                             Ok::<_, Infallible>(ev),
-                            (inner, target, true, skipped),
+                            (inner, target_conv, target_stream, true, skipped),
                         ));
                     }
                     None => return None,

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -6933,6 +6933,12 @@ pub async fn consume_stream(
         let stream = sse_stream_for_stream_id(inner, stream_id);
         Sse::new(stream)
             .keep_alive(
+                // `KeepAlive::text` is implemented in axum as
+                // `Event::default().comment(text)`, so this serializes
+                // as the comment-style heartbeat (`: keep-alive\n\n`)
+                // that strict SSE consumers and intermediate proxies
+                // prefer over a `data: ...` line that would fire a
+                // no-op event handler.
                 KeepAlive::new()
                     .interval(Duration::from_secs(15))
                     .text("keep-alive"),
@@ -6959,8 +6965,8 @@ fn sse_stream_for_stream_id(
 ) -> impl Stream<Item = Result<Event, Infallible>> + Send + 'static {
     use futures::stream::StreamExt as _;
     futures::stream::unfold(
-        (inner, target_stream_id, false),
-        |(mut inner, target, mut terminated)| async move {
+        (inner, target_stream_id, false, 0u32),
+        |(mut inner, target, mut terminated, mut skipped)| async move {
             if terminated {
                 return None;
             }
@@ -6974,14 +6980,22 @@ fn sse_stream_for_stream_id(
                             .unwrap_or_default();
                         let is_chunk = kind == ENVELOPE_KIND_STREAM_CHUNK;
                         let is_end = kind == ENVELOPE_KIND_STREAM_END;
-                        if !is_chunk && !is_end {
-                            continue;
-                        }
                         let matches = msg
                             .headers
                             .get("acteon.stream.id")
                             .is_some_and(|v| v == &target);
-                        if !matches {
+                        if !(is_chunk || is_end) || !matches {
+                            // Yield to the executor every
+                            // `SCAN_YIELD_EVERY` non-matching records
+                            // so a busy events topic with traffic for
+                            // other streams doesn't starve other
+                            // tasks on a single-threaded runtime.
+                            // Same rationale as `lookup_tool_result`
+                            // / `replay_conversation_messages`.
+                            skipped = skipped.wrapping_add(1);
+                            if skipped.is_multiple_of(SCAN_YIELD_EVERY) {
+                                tokio::task::yield_now().await;
+                            }
                             continue;
                         }
                         let id = msg.offset.unwrap_or_default().to_string();
@@ -6996,13 +7010,27 @@ fn sse_stream_for_stream_id(
                             terminated = true;
                         }
                         let ev = Event::default().event(event_name).id(id).data(data);
-                        return Some((Ok::<_, Infallible>(ev), (inner, target, terminated)));
+                        return Some((
+                            Ok::<_, Infallible>(ev),
+                            (inner, target, terminated, skipped),
+                        ));
                     }
                     Some(Err(e)) => {
-                        let ev = Event::default()
-                            .event("bus.stream.error")
-                            .data(format!("{{\"error\":\"{e}\"}}"));
-                        return Some((Ok::<_, Infallible>(ev), (inner, target, true)));
+                        // `serde_json::to_string` on a `{"error": str}`
+                        // map handles all the JSON escaping (quotes,
+                        // backslashes, control chars). Hand-rolled
+                        // `format!("{{\"error\":\"{e}\"}}")` would
+                        // emit invalid JSON for any error message
+                        // containing those characters, breaking
+                        // EventSource parsers downstream.
+                        let body = serde_json::json!({"error": e.to_string()});
+                        let data =
+                            serde_json::to_string(&body).unwrap_or_else(|_| "{}".into());
+                        let ev = Event::default().event("bus.stream.error").data(data);
+                        return Some((
+                            Ok::<_, Infallible>(ev),
+                            (inner, target, true, skipped),
+                        ));
                     }
                     None => return None,
                 }

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -6819,11 +6819,14 @@ pub async fn post_stream_end(
 
 /// SSE consume of a single stream — header-filters the conversation
 /// events topic for `(envelope.kind ∈ {stream_chunk, stream_end},
-/// stream.id == stream_id)`. Emits one SSE event per matching record
-/// (`event: bus.stream.chunk` or `bus.stream.end`) and closes the
-/// stream when a terminal `stream_end` is observed. Reuses
-/// [`BusBackend::scan_topic`] (Kafka `assign()`, no consumer-group
-/// leak) — same primitive `lookup_tool_result` uses.
+/// conversation.id == conversation_id, stream.id == stream_id)`.
+/// Emits one SSE event per matching record (`event: bus.stream.chunk`
+/// or `bus.stream.end`) and closes the stream when a terminal
+/// `stream_end` is observed. Reuses `BusBackend::scan_topic` (Kafka
+/// `assign()`, no consumer-group leak) — same primitive
+/// `lookup_tool_result` uses. Plain code span rather than an
+/// intra-doc link because `acteon_bus` is only in scope with the
+/// `bus` feature, and CI's `cargo doc` builds without it.
 #[utoipa::path(
     get,
     path = "/v1/bus/streams/{namespace}/{tenant}/{conversation_id}/{stream_id}",
@@ -7036,8 +7039,7 @@ fn sse_stream_for_stream_id(
                         // containing those characters, breaking
                         // EventSource parsers downstream.
                         let body = serde_json::json!({"error": e.to_string()});
-                        let data =
-                            serde_json::to_string(&body).unwrap_or_else(|_| "{}".into());
+                        let data = serde_json::to_string(&body).unwrap_or_else(|_| "{}".into());
                         let ev = Event::default().event("bus.stream.error").data(data);
                         return Some((
                             Ok::<_, Infallible>(ev),

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -6309,3 +6309,704 @@ pub async fn lookup_tool_result(
         service_unavailable("bus feature not compiled")
     }
 }
+
+// =============================================================================
+// Phase 6b: streaming chunks layered on conversation messages
+// =============================================================================
+
+/// Body of `POST /v1/bus/conversations/{ns}/{t}/{id}/stream-chunks`.
+/// Wraps a [`acteon_core::StreamChunk`] and produces a conversation
+/// message with envelope kind `"stream_chunk"`. The bus stamps routing
+/// headers (`acteon.envelope.kind`, `acteon.stream.id`,
+/// `acteon.stream.seq`) so subscribers can header-filter without
+/// parsing the payload.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct PostStreamChunkRequest {
+    pub stream_id: String,
+    pub chunk_seq: i64,
+    /// Chunk payload — opaque to the bus. Token, partial JSON, raw
+    /// bytes encoded as a string, whatever the producer and consumer
+    /// agree on.
+    #[schema(value_type = Object)]
+    #[serde(default)]
+    pub body: serde_json::Value,
+    #[serde(default)]
+    pub sender: Option<String>,
+    /// Free-form metadata. Bounded by the publish path's label caps.
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+/// Body of `POST /v1/bus/conversations/{ns}/{t}/{id}/stream-end`.
+/// Marks the stream complete (or not) and carries an optional error
+/// message. Consumers stop reading once they observe this for their
+/// `stream_id`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct PostStreamEndRequest {
+    pub stream_id: String,
+    pub chunk_seq: i64,
+    pub status: acteon_core::StreamEndStatus,
+    #[serde(default)]
+    pub error_message: Option<String>,
+    #[serde(default)]
+    pub sender: Option<String>,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct StreamEnvelopeReceipt {
+    pub events_topic: String,
+    pub conversation_id: String,
+    pub stream_id: String,
+    pub chunk_seq: i64,
+    pub partition: i32,
+    pub offset: i64,
+    pub produced_at: DateTime<Utc>,
+    /// Opaque resume cursor encoding `{partition: offset}`. Pass it
+    /// back to `GET /v1/bus/streams/...` as `?cursor=` to scan only
+    /// records produced *after* this envelope. Without a cursor, the
+    /// SSE consume defaults to `Latest` (cheap, but may miss earlier
+    /// chunks of a long-lived stream).
+    pub cursor: String,
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct StreamConsumeParams {
+    /// Resume cursor from a `POST /stream-chunks` receipt — encodes
+    /// the per-partition offset where the chunk was produced.
+    /// Strongly recommended for production flows: a producer should
+    /// pass the receipt's `cursor` from chunk 0 to consumers so they
+    /// see the full stream. Without it, the scan defaults to `Latest`
+    /// (cheap, races with chunks landing). Earlier the default would
+    /// have been `Earliest`, which is a full-history scan and a clear
+    /// `DoS` vector — same trade-off as the tool-result lookup.
+    #[serde(default)]
+    pub cursor: Option<String>,
+    /// Override `cursor`-driven scan position. `earliest` scans from
+    /// topic head — only useful for short-lived test topics or
+    /// recovering a known-old stream. `latest` is the default.
+    #[serde(default)]
+    pub from: Option<String>,
+    /// `agent_id` the caller is acting as — required when the
+    /// conversation has a non-empty `participants` ACL. Mirrors the
+    /// `as_agent` semantics used elsewhere in Phase 5/6a.
+    #[serde(default)]
+    pub as_agent: Option<String>,
+}
+
+#[cfg(feature = "bus")]
+const ENVELOPE_KIND_STREAM_CHUNK: &str = "stream_chunk";
+#[cfg(feature = "bus")]
+const ENVELOPE_KIND_STREAM_END: &str = "stream_end";
+
+/// Stamp the standard streaming routing headers on a `BusMessage`.
+/// Reserved `acteon.*` keys are inserted directly (`with_header`
+/// strips them on user input by design).
+#[cfg(feature = "bus")]
+fn stamp_stream_envelope_headers(
+    msg: &mut acteon_bus::BusMessage,
+    kind: &'static str,
+    stream_id: &str,
+    chunk_seq: i64,
+) {
+    msg.headers
+        .insert("acteon.envelope.kind".into(), kind.to_string());
+    msg.headers
+        .insert("acteon.stream.id".into(), stream_id.to_string());
+    msg.headers
+        .insert("acteon.stream.seq".into(), chunk_seq.to_string());
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}/stream-chunks",
+    tag = "bus",
+    request_body = PostStreamChunkRequest,
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("conversation_id" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Stream chunk appended", body = StreamEnvelopeReceipt),
+        (status = 400, description = "Invalid envelope, sender ACL, or archived conversation", body = ErrorResponse),
+        (status = 404, description = "Conversation not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+#[allow(clippy::too_many_lines)]
+pub async fn post_stream_chunk(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, conversation_id)): Path<(String, String, String)>,
+    Json(req): Json<PostStreamChunkRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        let Some(backend) = state.bus_backend.as_ref() else {
+            return service_unavailable("bus feature not enabled");
+        };
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::Publish) {
+            return resp;
+        }
+        let mut envelope =
+            acteon_core::StreamChunk::new(&req.stream_id, req.chunk_seq, req.body.clone());
+        envelope.sender = req.sender.clone();
+        envelope.metadata = req.metadata.clone();
+        if let Err(e) = envelope.validate() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        if let Err(resp) = validate_user_labels(&envelope.metadata) {
+            return resp;
+        }
+        let conv = match load_conversation(&state, &namespace, &tenant, &conversation_id).await {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
+        if !conv.accepts_messages() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "conversation {} is archived; reopen via /transition before posting stream chunks",
+                        conv.conversation_id
+                    ),
+                }),
+            )
+                .into_response();
+        }
+        if !conv.participants.is_empty() {
+            match envelope.sender.as_deref() {
+                Some(s) if conv.participants.iter().any(|p| p == s) => {}
+                Some(s) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "sender '{s}' is not a participant of conversation {}",
+                                conv.conversation_id
+                            ),
+                        }),
+                    )
+                        .into_response();
+                }
+                None => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "conversation {} has a participant ACL; stream-chunk sender is required",
+                                conv.conversation_id
+                            ),
+                        }),
+                    )
+                        .into_response();
+                }
+            }
+        }
+        let payload = match serde_json::to_value(&envelope) {
+            Ok(v) => v,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let events_topic = conv.effective_events_topic();
+        if let Err(resp) = validate_payload_against_topic_schema(
+            &state,
+            &conv.namespace,
+            &conv.tenant,
+            &events_topic,
+            &payload,
+        )
+        .await
+        {
+            return resp;
+        }
+        let mut msg = acteon_bus::BusMessage::new(events_topic.clone(), payload)
+            .with_key(&conv.conversation_id);
+        msg.headers.insert(
+            "acteon.conversation.id".into(),
+            conv.conversation_id.clone(),
+        );
+        if let Some(s) = &envelope.sender {
+            msg.headers
+                .insert("acteon.conversation.sender".into(), s.clone());
+        }
+        stamp_stream_envelope_headers(
+            &mut msg,
+            ENVELOPE_KIND_STREAM_CHUNK,
+            &envelope.stream_id,
+            envelope.chunk_seq,
+        );
+        match backend.produce(msg).await {
+            Ok(receipt) => {
+                let mut cursor_map = std::collections::BTreeMap::new();
+                cursor_map.insert(receipt.partition, receipt.offset);
+                let cursor = encode_replay_cursor(&cursor_map);
+                let conv_id_for_bump = conv.conversation_id.clone();
+                let resp = (
+                    StatusCode::OK,
+                    Json(StreamEnvelopeReceipt {
+                        events_topic: receipt.topic,
+                        conversation_id: conv.conversation_id,
+                        stream_id: envelope.stream_id,
+                        chunk_seq: envelope.chunk_seq,
+                        partition: receipt.partition,
+                        offset: receipt.offset,
+                        produced_at: receipt.timestamp,
+                        cursor,
+                    }),
+                );
+                let bump_key = StateKey::new(
+                    namespace.clone(),
+                    tenant.clone(),
+                    KeyKind::BusConversation,
+                    &conv_id_for_bump,
+                );
+                let bump = cas_update::<acteon_core::Conversation, _>(
+                    &state,
+                    &bump_key,
+                    "conversation gone",
+                    |c| {
+                        c.updated_at = Utc::now();
+                        Ok(())
+                    },
+                )
+                .await;
+                if bump.is_err() {
+                    tracing::warn!(
+                        conversation_id = %conv_id_for_bump,
+                        "stream-chunk produced but conversation updated_at bump failed",
+                    );
+                }
+                resp.into_response()
+            }
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response(),
+        }
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, conversation_id, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}/stream-end",
+    tag = "bus",
+    request_body = PostStreamEndRequest,
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("conversation_id" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Stream terminator appended", body = StreamEnvelopeReceipt),
+        (status = 400, description = "Invalid envelope or archived conversation", body = ErrorResponse),
+        (status = 404, description = "Conversation not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+#[allow(clippy::too_many_lines)]
+pub async fn post_stream_end(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, conversation_id)): Path<(String, String, String)>,
+    Json(req): Json<PostStreamEndRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        let Some(backend) = state.bus_backend.as_ref() else {
+            return service_unavailable("bus feature not enabled");
+        };
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::Publish) {
+            return resp;
+        }
+        let envelope = acteon_core::StreamEnd {
+            stream_id: req.stream_id.clone(),
+            chunk_seq: req.chunk_seq,
+            status: req.status,
+            error_message: req.error_message.clone(),
+            sender: req.sender.clone(),
+            metadata: req.metadata.clone(),
+            created_at: Utc::now(),
+        };
+        if let Err(e) = envelope.validate() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        if let Err(resp) = validate_user_labels(&envelope.metadata) {
+            return resp;
+        }
+        let conv = match load_conversation(&state, &namespace, &tenant, &conversation_id).await {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
+        if !conv.accepts_messages() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "conversation {} is archived; reopen via /transition before posting stream-end",
+                        conv.conversation_id
+                    ),
+                }),
+            )
+                .into_response();
+        }
+        if !conv.participants.is_empty() {
+            match envelope.sender.as_deref() {
+                Some(s) if conv.participants.iter().any(|p| p == s) => {}
+                Some(s) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "sender '{s}' is not a participant of conversation {}",
+                                conv.conversation_id
+                            ),
+                        }),
+                    )
+                        .into_response();
+                }
+                None => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "conversation {} has a participant ACL; stream-end sender is required",
+                                conv.conversation_id
+                            ),
+                        }),
+                    )
+                        .into_response();
+                }
+            }
+        }
+        let payload = match serde_json::to_value(&envelope) {
+            Ok(v) => v,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let events_topic = conv.effective_events_topic();
+        if let Err(resp) = validate_payload_against_topic_schema(
+            &state,
+            &conv.namespace,
+            &conv.tenant,
+            &events_topic,
+            &payload,
+        )
+        .await
+        {
+            return resp;
+        }
+        let mut msg = acteon_bus::BusMessage::new(events_topic.clone(), payload)
+            .with_key(&conv.conversation_id);
+        msg.headers.insert(
+            "acteon.conversation.id".into(),
+            conv.conversation_id.clone(),
+        );
+        if let Some(s) = &envelope.sender {
+            msg.headers
+                .insert("acteon.conversation.sender".into(), s.clone());
+        }
+        stamp_stream_envelope_headers(
+            &mut msg,
+            ENVELOPE_KIND_STREAM_END,
+            &envelope.stream_id,
+            envelope.chunk_seq,
+        );
+        match backend.produce(msg).await {
+            Ok(receipt) => {
+                let mut cursor_map = std::collections::BTreeMap::new();
+                cursor_map.insert(receipt.partition, receipt.offset);
+                let cursor = encode_replay_cursor(&cursor_map);
+                let conv_id_for_bump = conv.conversation_id.clone();
+                let resp = (
+                    StatusCode::OK,
+                    Json(StreamEnvelopeReceipt {
+                        events_topic: receipt.topic,
+                        conversation_id: conv.conversation_id,
+                        stream_id: envelope.stream_id,
+                        chunk_seq: envelope.chunk_seq,
+                        partition: receipt.partition,
+                        offset: receipt.offset,
+                        produced_at: receipt.timestamp,
+                        cursor,
+                    }),
+                );
+                let bump_key = StateKey::new(
+                    namespace.clone(),
+                    tenant.clone(),
+                    KeyKind::BusConversation,
+                    &conv_id_for_bump,
+                );
+                let bump = cas_update::<acteon_core::Conversation, _>(
+                    &state,
+                    &bump_key,
+                    "conversation gone",
+                    |c| {
+                        c.updated_at = Utc::now();
+                        Ok(())
+                    },
+                )
+                .await;
+                if bump.is_err() {
+                    tracing::warn!(
+                        conversation_id = %conv_id_for_bump,
+                        "stream-end produced but conversation updated_at bump failed",
+                    );
+                }
+                resp.into_response()
+            }
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response(),
+        }
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, conversation_id, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+/// SSE consume of a single stream — header-filters the conversation
+/// events topic for `(envelope.kind ∈ {stream_chunk, stream_end},
+/// stream.id == stream_id)`. Emits one SSE event per matching record
+/// (`event: bus.stream.chunk` or `bus.stream.end`) and closes the
+/// stream when a terminal `stream_end` is observed. Reuses
+/// [`BusBackend::scan_topic`] (Kafka `assign()`, no consumer-group
+/// leak) — same primitive `lookup_tool_result` uses.
+#[utoipa::path(
+    get,
+    path = "/v1/bus/streams/{namespace}/{tenant}/{conversation_id}/{stream_id}",
+    tag = "bus",
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("conversation_id" = String, Path),
+        ("stream_id" = String, Path),
+        StreamConsumeParams,
+    ),
+    responses(
+        (status = 200, description = "SSE stream of stream_chunk/stream_end envelopes"),
+        (status = 400, description = "Invalid stream_id or cursor", body = ErrorResponse),
+        (status = 403, description = "as_agent not permitted on private conversation", body = ErrorResponse),
+        (status = 404, description = "Conversation or events topic not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+#[allow(clippy::too_many_lines)]
+pub async fn consume_stream(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, conversation_id, stream_id)): Path<(String, String, String, String)>,
+    Query(params): Query<StreamConsumeParams>,
+) -> axum::response::Response {
+    #[cfg(feature = "bus")]
+    {
+        let Some(backend) = state.bus_backend.clone() else {
+            return service_unavailable("bus feature not enabled");
+        };
+        // Streaming consume is a read; gate on Subscribe + the
+        // conversation-management grant (matches replay/lookup).
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::Subscribe) {
+            return resp;
+        }
+        if let Err(e) = acteon_core::bus_stream::validate_id_field("stream_id", &stream_id) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+        let conv = match load_conversation(&state, &namespace, &tenant, &conversation_id).await {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
+        if let Err(resp) = enforce_conversation_read_acl(&conv, params.as_agent.as_deref()) {
+            return resp;
+        }
+        let events_topic = conv.effective_events_topic();
+        // Resolve scan position. Cursor wins; otherwise honor `from`;
+        // default `Latest`. Same DoS reasoning as `lookup_tool_result`.
+        let scan_from = match (&params.cursor, params.from.as_deref()) {
+            (Some(c), _) => match decode_replay_cursor(c) {
+                Ok(offsets) => acteon_bus::ScanFrom::FromOffsets(offsets),
+                Err(msg) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!("invalid stream cursor: {msg}"),
+                        }),
+                    )
+                        .into_response();
+                }
+            },
+            (None, Some("earliest")) => acteon_bus::ScanFrom::Earliest,
+            (None, Some("latest") | None) => acteon_bus::ScanFrom::Latest,
+            (None, Some(other)) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse {
+                        error: format!("unknown 'from' value '{other}' (expected earliest|latest)"),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let inner = match backend.scan_topic(&events_topic, scan_from).await {
+            Ok(s) => s,
+            Err(acteon_bus::BusError::TopicNotFound(_)) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse {
+                        error: format!("events topic {events_topic} not found"),
+                    }),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let stream = sse_stream_for_stream_id(inner, stream_id);
+        Sse::new(stream)
+            .keep_alive(
+                KeepAlive::new()
+                    .interval(Duration::from_secs(15))
+                    .text("keep-alive"),
+            )
+            .into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, conversation_id, stream_id, params);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+/// Build the SSE event stream for `consume_stream`. Filters the raw
+/// scan to `(envelope.kind ∈ stream_chunk|stream_end, stream.id ==
+/// target)`, emits a typed SSE event per match, and closes after a
+/// terminal `stream_end`. Header-only filter — payload deserialization
+/// happens *after* the kind/id match, so unrelated traffic on the
+/// conversation events topic costs only a hashmap lookup.
+#[cfg(feature = "bus")]
+fn sse_stream_for_stream_id(
+    inner: acteon_bus::SubscribeStream,
+    target_stream_id: String,
+) -> impl Stream<Item = Result<Event, Infallible>> + Send + 'static {
+    use futures::stream::StreamExt as _;
+    futures::stream::unfold(
+        (inner, target_stream_id, false),
+        |(mut inner, target, mut terminated)| async move {
+            if terminated {
+                return None;
+            }
+            loop {
+                match inner.next().await {
+                    Some(Ok(msg)) => {
+                        let kind = msg
+                            .headers
+                            .get("acteon.envelope.kind")
+                            .map(String::as_str)
+                            .unwrap_or_default();
+                        let is_chunk = kind == ENVELOPE_KIND_STREAM_CHUNK;
+                        let is_end = kind == ENVELOPE_KIND_STREAM_END;
+                        if !is_chunk && !is_end {
+                            continue;
+                        }
+                        let matches = msg
+                            .headers
+                            .get("acteon.stream.id")
+                            .is_some_and(|v| v == &target);
+                        if !matches {
+                            continue;
+                        }
+                        let id = msg.offset.unwrap_or_default().to_string();
+                        let event_name = if is_end {
+                            "bus.stream.end"
+                        } else {
+                            "bus.stream.chunk"
+                        };
+                        let data =
+                            serde_json::to_string(&msg.payload).unwrap_or_else(|_| "{}".into());
+                        if is_end {
+                            terminated = true;
+                        }
+                        let ev = Event::default().event(event_name).id(id).data(data);
+                        return Some((Ok::<_, Infallible>(ev), (inner, target, terminated)));
+                    }
+                    Some(Err(e)) => {
+                        let ev = Event::default()
+                            .event("bus.stream.error")
+                            .data(format!("{{\"error\":\"{e}\"}}"));
+                        return Some((Ok::<_, Infallible>(ev), (inner, target, true)));
+                    }
+                    None => return None,
+                }
+            }
+        },
+    )
+}

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -409,6 +409,21 @@ pub fn router(state: AppState) -> Router {
             "/v1/bus/tool-calls/{namespace}/{tenant}/{call_id}/result",
             get(bus::lookup_tool_result),
         )
+        // Phase 6b: streaming chunks (server stamps
+        // `acteon.envelope.kind ∈ stream_chunk|stream_end`,
+        // `acteon.stream.id`, `acteon.stream.seq`).
+        .route(
+            "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}/stream-chunks",
+            post(bus::post_stream_chunk),
+        )
+        .route(
+            "/v1/bus/conversations/{namespace}/{tenant}/{conversation_id}/stream-end",
+            post(bus::post_stream_end),
+        )
+        .route(
+            "/v1/bus/streams/{namespace}/{tenant}/{conversation_id}/{stream_id}",
+            get(bus::consume_stream),
+        )
         // Swarm runs
         .route("/v1/swarm/runs", get(swarm::list_swarm_runs))
         .route("/v1/swarm/runs/{run_id}", get(swarm::get_swarm_run))

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -194,6 +194,9 @@ use acteon_core::{
         super::bus::post_tool_call,
         super::bus::post_tool_result,
         super::bus::lookup_tool_result,
+        super::bus::post_stream_chunk,
+        super::bus::post_stream_end,
+        super::bus::consume_stream,
     ),
     components(schemas(
         Action, ActionOutcome, ProviderResponse, ResponseStatus, ActionError,
@@ -277,6 +280,9 @@ use acteon_core::{
         super::bus::ToolEnvelopeReceipt, super::bus::ToolResultLookupResponse,
         acteon_core::ToolCall, acteon_core::ToolResult,
         acteon_core::ToolResultStatus,
+        super::bus::PostStreamChunkRequest, super::bus::PostStreamEndRequest,
+        super::bus::StreamEnvelopeReceipt,
+        acteon_core::StreamChunk, acteon_core::StreamEnd, acteon_core::StreamEndStatus,
     ))
 )]
 pub struct ApiDoc;

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -228,5 +228,9 @@ required-features = ["bus"]
 name = "bus_tool_call_simulation"
 required-features = ["bus"]
 
+[[example]]
+name = "bus_stream_simulation"
+required-features = ["bus"]
+
 [lints]
 workspace = true

--- a/crates/simulation/examples/bus_stream_simulation.rs
+++ b/crates/simulation/examples/bus_stream_simulation.rs
@@ -1,0 +1,187 @@
+//! Phase 6b streaming-envelope demo.
+//!
+//! A producer streams a sequence of token chunks for a single
+//! `stream_id` and emits a terminal `stream_end`. A consumer scans
+//! the events topic, header-filters on the stream id, and stitches
+//! the tokens back into a contiguous output until it observes the
+//! terminator. Drives the in-memory bus backend directly so no
+//! Kafka or HTTP server is required — the production handlers
+//! `POST /v1/bus/conversations/.../stream-chunks`, `POST .../stream-end`,
+//! and `GET /v1/bus/streams/.../{stream_id}` delegate to the same
+//! types and ride the same shared events topic.
+//!
+//! Scenarios:
+//!
+//! 1. Producer emits five `StreamChunk` envelopes (`chunk_seq` 0..=4)
+//!    plus a terminal `StreamEnd { status: Complete }`.
+//! 2. Consumer scans the events topic, header-filters on
+//!    `acteon.envelope.kind ∈ {stream_chunk, stream_end}` and
+//!    `acteon.stream.id == story-1`, and reassembles the chunks in
+//!    order.
+//! 3. Stream stops cleanly when `stream_end` is observed.
+//!
+//! Run with:
+//! ```text
+//! cargo run -p acteon-simulation --features bus --example bus_stream_simulation
+//! ```
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use serde_json::json;
+use tracing::{Level, info};
+
+use acteon_bus::{BusMessage, MemoryBackend, ScanFrom};
+use acteon_core::{Conversation, StreamChunk, StreamEnd, StreamEndStatus, Topic};
+
+#[tokio::main]
+#[allow(clippy::too_many_lines)]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::INFO)
+        .with_env_filter("info,acteon_bus=info")
+        .init();
+
+    let backend: acteon_bus::SharedBackend = MemoryBackend::new();
+
+    let events = Topic::new("conversations-events", "agents", "demo");
+    backend.create_topic(&events).await?;
+
+    let conv = Conversation::new("storytelling-thread", "agents", "demo");
+    let topic = conv.effective_events_topic();
+
+    // -----------------------------------------------------------------
+    // 1. Producer emits a 5-chunk stream + terminal end
+    // -----------------------------------------------------------------
+
+    let stream_id = "story-1";
+    let tokens = ["Once ", "upon ", "a ", "time ", "in a far-off land."];
+
+    for (seq, tok) in tokens.iter().enumerate() {
+        let mut chunk = StreamChunk::new(
+            stream_id,
+            i64::try_from(seq).unwrap(),
+            json!({"token": tok}),
+        );
+        chunk.sender = Some("storyteller-1".into());
+        chunk.validate()?;
+
+        let payload = serde_json::to_value(&chunk)?;
+        let mut msg = BusMessage::new(topic.clone(), payload).with_key(&conv.conversation_id);
+        // Conversation-level headers, mirroring the production
+        // `post_stream_chunk` handler.
+        msg.headers.insert(
+            "acteon.conversation.id".into(),
+            conv.conversation_id.clone(),
+        );
+        msg.headers.insert(
+            "acteon.conversation.sender".into(),
+            chunk.sender.clone().unwrap_or_default(),
+        );
+        msg.headers
+            .insert("acteon.envelope.kind".into(), "stream_chunk".into());
+        msg.headers
+            .insert("acteon.stream.id".into(), chunk.stream_id.clone());
+        msg.headers
+            .insert("acteon.stream.seq".into(), chunk.chunk_seq.to_string());
+        backend.produce(msg).await?;
+        info!(stream_id = %chunk.stream_id, seq = chunk.chunk_seq, "chunk produced");
+    }
+
+    let mut end = StreamEnd::complete(stream_id, i64::try_from(tokens.len()).unwrap());
+    end.sender = Some("storyteller-1".into());
+    end.validate()?;
+    let end_payload = serde_json::to_value(&end)?;
+    let mut end_msg = BusMessage::new(topic.clone(), end_payload).with_key(&conv.conversation_id);
+    end_msg.headers.insert(
+        "acteon.conversation.id".into(),
+        conv.conversation_id.clone(),
+    );
+    end_msg.headers.insert(
+        "acteon.conversation.sender".into(),
+        end.sender.clone().unwrap_or_default(),
+    );
+    end_msg
+        .headers
+        .insert("acteon.envelope.kind".into(), "stream_end".into());
+    end_msg
+        .headers
+        .insert("acteon.stream.id".into(), end.stream_id.clone());
+    end_msg
+        .headers
+        .insert("acteon.stream.seq".into(), end.chunk_seq.to_string());
+    backend.produce(end_msg).await?;
+    info!(stream_id = %end.stream_id, status = ?end.status, "stream_end produced");
+
+    // -----------------------------------------------------------------
+    // 2. Consumer reassembles by scanning + header-filtering
+    // -----------------------------------------------------------------
+
+    // Same primitive the `consume_stream` SSE handler uses internally:
+    // `scan_topic` (Kafka `assign()`, no consumer-group leak), then
+    // we filter on `acteon.envelope.kind` and `acteon.stream.id`
+    // before deserializing each payload.
+    let mut scan = backend.scan_topic(&topic, ScanFrom::Earliest).await?;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let mut chunks: Vec<StreamChunk> = Vec::new();
+    let recovered_end: StreamEnd = loop {
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return Err("timed out reassembling stream".into());
+        }
+        let remaining = deadline - now;
+        tokio::select! {
+            next = scan.next() => {
+                match next {
+                    Some(Ok(msg)) => {
+                        let kind = msg
+                            .headers
+                            .get("acteon.envelope.kind")
+                            .map(String::as_str)
+                            .unwrap_or_default();
+                        let matches = msg
+                            .headers
+                            .get("acteon.stream.id")
+                            .is_some_and(|v| v == stream_id);
+                        if !matches {
+                            continue;
+                        }
+                        match kind {
+                            "stream_chunk" => {
+                                let c: StreamChunk = serde_json::from_value(msg.payload.clone())?;
+                                chunks.push(c);
+                            }
+                            "stream_end" => {
+                                let e: StreamEnd = serde_json::from_value(msg.payload.clone())?;
+                                break e;
+                            }
+                            _ => continue,
+                        }
+                    }
+                    Some(Err(_)) | None => return Err("stream ended without terminator".into()),
+                }
+            }
+            () = tokio::time::sleep(remaining) => {
+                return Err("scan timeout".into());
+            }
+        }
+    };
+
+    assert_eq!(chunks.len(), tokens.len());
+    assert_eq!(recovered_end.status, StreamEndStatus::Complete);
+    assert_eq!(recovered_end.stream_id, stream_id);
+
+    // Re-stitch by chunk_seq just like a real consumer would on a
+    // partitioned topic where in-partition order is FIFO but cross-
+    // partition order is not.
+    chunks.sort_by_key(|c| c.chunk_seq);
+    let reassembled: String = chunks
+        .iter()
+        .filter_map(|c| c.body.get("token").and_then(|v| v.as_str()))
+        .collect();
+    info!(reassembled = %reassembled, chunk_count = chunks.len(), "stream reassembled");
+    assert_eq!(reassembled, "Once upon a time in a far-off land.");
+
+    info!("stream simulation complete");
+    Ok(())
+}

--- a/crates/simulation/examples/bus_stream_simulation.rs
+++ b/crates/simulation/examples/bus_stream_simulation.rs
@@ -14,11 +14,20 @@
 //!
 //! 1. Producer emits five `StreamChunk` envelopes (`chunk_seq` 0..=4)
 //!    plus a terminal `StreamEnd { status: Complete }`.
-//! 2. Consumer scans the events topic, header-filters on
-//!    `acteon.envelope.kind ∈ {stream_chunk, stream_end}` and
+//! 2. A *second* conversation produces a chunk with the *same*
+//!    `stream_id`. This is the cross-conversation isolation
+//!    regression: by default every conversation in a tenant rides
+//!    the same Kafka events topic, so two conversations using the
+//!    same `stream_id` (`current-llm-run`, etc.) would otherwise
+//!    leak each other's chunks to a consumer authorized only for
+//!    one of them. The SSE filter must check both
+//!    `acteon.conversation.id` and `acteon.stream.id`.
+//! 3. Consumer scans the events topic, header-filters on
+//!    `acteon.envelope.kind ∈ {stream_chunk, stream_end}`,
+//!    `acteon.conversation.id == storytelling-thread`, and
 //!    `acteon.stream.id == story-1`, and reassembles the chunks in
-//!    order.
-//! 3. Stream stops cleanly when `stream_end` is observed.
+//!    order. The other conversation's chunk is silently skipped.
+//! 4. Stream stops cleanly when `stream_end` is observed.
 //!
 //! Run with:
 //! ```text
@@ -114,13 +123,48 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!(stream_id = %end.stream_id, status = ?end.status, "stream_end produced");
 
     // -----------------------------------------------------------------
+    // 1b. Decoy: a *different* conversation produces a chunk with the
+    //     *same* stream_id. The consumer below must not see it. This
+    //     exercises the cross-conversation isolation gate added in
+    //     review pass 2.
+    // -----------------------------------------------------------------
+
+    let other_conv = Conversation::new("other-thread", "agents", "demo");
+    let mut decoy = StreamChunk::new(stream_id, 0, json!({"token": "LEAK_FROM_OTHER_CONV"}));
+    decoy.sender = Some("storyteller-2".into());
+    decoy.validate()?;
+    let decoy_payload = serde_json::to_value(&decoy)?;
+    let mut decoy_msg =
+        BusMessage::new(topic.clone(), decoy_payload).with_key(&other_conv.conversation_id);
+    decoy_msg.headers.insert(
+        "acteon.conversation.id".into(),
+        other_conv.conversation_id.clone(),
+    );
+    decoy_msg.headers.insert(
+        "acteon.conversation.sender".into(),
+        decoy.sender.clone().unwrap_or_default(),
+    );
+    decoy_msg
+        .headers
+        .insert("acteon.envelope.kind".into(), "stream_chunk".into());
+    decoy_msg
+        .headers
+        .insert("acteon.stream.id".into(), decoy.stream_id.clone());
+    decoy_msg
+        .headers
+        .insert("acteon.stream.seq".into(), decoy.chunk_seq.to_string());
+    backend.produce(decoy_msg).await?;
+    info!(stream_id = %decoy.stream_id, conversation = %other_conv.conversation_id, "decoy chunk in different conversation produced");
+
+    // -----------------------------------------------------------------
     // 2. Consumer reassembles by scanning + header-filtering
     // -----------------------------------------------------------------
 
     // Same primitive the `consume_stream` SSE handler uses internally:
     // `scan_topic` (Kafka `assign()`, no consumer-group leak), then
-    // we filter on `acteon.envelope.kind` and `acteon.stream.id`
-    // before deserializing each payload.
+    // we filter on `acteon.envelope.kind`, `acteon.conversation.id`
+    // (cross-conversation isolation — see scenario 1b above), and
+    // `acteon.stream.id` before deserializing each payload.
     let mut scan = backend.scan_topic(&topic, ScanFrom::Earliest).await?;
     let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
     let mut chunks: Vec<StreamChunk> = Vec::new();
@@ -139,11 +183,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             .get("acteon.envelope.kind")
                             .map(String::as_str)
                             .unwrap_or_default();
-                        let matches = msg
+                        let matches_conv = msg
+                            .headers
+                            .get("acteon.conversation.id")
+                            .is_some_and(|v| v == &conv.conversation_id);
+                        let matches_stream = msg
                             .headers
                             .get("acteon.stream.id")
                             .is_some_and(|v| v == stream_id);
-                        if !matches {
+                        if !matches_conv || !matches_stream {
                             continue;
                         }
                         match kind {
@@ -181,6 +229,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .collect();
     info!(reassembled = %reassembled, chunk_count = chunks.len(), "stream reassembled");
     assert_eq!(reassembled, "Once upon a time in a far-off land.");
+    // Cross-conversation isolation regression: the decoy chunk
+    // produced under `other-thread` carried the same `stream_id`,
+    // but the conversation-id header check kept it out of our
+    // reassembly.
+    assert!(
+        !reassembled.contains("LEAK_FROM_OTHER_CONV"),
+        "consumer leaked a chunk from a different conversation",
+    );
 
     info!("stream simulation complete");
     Ok(())

--- a/docs/book/concepts/bus-master-plan.md
+++ b/docs/book/concepts/bus-master-plan.md
@@ -105,7 +105,11 @@ Migration will be opt-in, per-feature, never forced.
 
 ## Phase status
 
-- **Phase 1** — in progress (PR #1)
-- Phase 2–9 — not started
-
-See [phase-1 feature doc](../features/bus-phase-1.md) for current-state details.
+- **Phase 1** — shipped — see [phase-1 feature doc](../features/bus-phase-1.md)
+- **Phase 2** — shipped — see [phase-2 feature doc](../features/bus-phase-2.md)
+- **Phase 3** — shipped — see [phase-3 feature doc](../features/bus-phase-3.md)
+- **Phase 4** — shipped — see [phase-4 feature doc](../features/bus-phase-4.md)
+- **Phase 5** — shipped — see [phase-5 feature doc](../features/bus-phase-5.md)
+- **Phase 6a** (typed tool envelopes) — shipped — see [phase-6a feature doc](../features/bus-phase-6a.md)
+- **Phase 6b** (streaming chunks) — shipped — see [phase-6b feature doc](../features/bus-phase-6b.md)
+- Phases 6c, 7, 8, 9 — not started

--- a/docs/book/features/bus-phase-6b.md
+++ b/docs/book/features/bus-phase-6b.md
@@ -82,8 +82,14 @@ connection. The handler:
 2. Reads the events topic via `BusBackend::scan_topic` (Kafka
    `assign()`, no consumer-group leak).
 3. Header-filters on `acteon.envelope.kind ∈ {stream_chunk, stream_end}`
-   AND `acteon.stream.id == stream_id`. Payload deserialization
-   doesn't run on records that fail the filter.
+   AND `acteon.conversation.id == conversation_id` AND
+   `acteon.stream.id == stream_id`. Payload deserialization
+   doesn't run on records that fail the filter. The
+   conversation-id check is load-bearing: by default every
+   conversation in a tenant rides the same Kafka events topic, so
+   two conversations using the same `stream_id`
+   (`current-llm-run`, etc.) would otherwise leak each other's
+   chunks to a consumer authorized only for one of them.
 4. Emits an SSE event per match: `event: bus.stream.chunk` for chunks,
    `event: bus.stream.end` for the terminal record.
 5. Closes the connection cleanly when a `stream_end` for the target

--- a/docs/book/features/bus-phase-6b.md
+++ b/docs/book/features/bus-phase-6b.md
@@ -1,0 +1,296 @@
+# Agentic Bus — Phase 6b
+
+> **Scope**: typed `StreamChunk` / `StreamEnd` envelopes layered on
+> conversation messages, with header-based stream identity and an SSE
+> consume endpoint that closes on the terminal record. HITL pre-publish
+> approvals land in 6c. See the [master plan](../concepts/bus-master-plan.md).
+
+Phase 6a gave the bus a typed request/response protocol; Phase 6b adds
+the natural complement — *progressive output*. LLM token streams,
+partial tool results, progressive search hits, anything that follows
+the "produce incremental, signal completion" pattern now has a typed
+envelope and a header-filtered SSE consumer. Same architectural pattern
+as 6a: tool-style envelopes ride the existing conversation events
+topic, not a parallel pipeline.
+
+## What ships in Phase 6b
+
+| Surface | Shape |
+|---|---|
+| Core types | `acteon_core::StreamChunk`, `acteon_core::StreamEnd`, `acteon_core::StreamEndStatus ∈ {Complete, Aborted, Error}` |
+| HTTP | `POST /v1/bus/conversations/{ns}/{t}/{id}/stream-chunks`, `POST .../stream-end`, `GET /v1/bus/streams/{ns}/{t}/{conv_id}/{stream_id}` (SSE) |
+| Headers | Server-stamped: `acteon.envelope.kind ∈ {stream_chunk, stream_end}`, `acteon.stream.id`, `acteon.stream.seq`. Reuses Phase 5's reserved-prefix machinery. |
+| Rust client | `post_bus_stream_chunk`, `post_bus_stream_end`, `bus_stream_consume_url` |
+| Tests | 8 core unit tests covering envelope validation + serde roundtrips |
+| Simulation | `bus_stream_simulation.rs` — producer streams 5 token chunks plus a terminal `complete`, consumer scans the events topic, header-filters by stream id, reassembles in chunk-seq order |
+
+## Model
+
+### Layered, not parallel
+
+Stream envelopes are conventions on top of conversation messages —
+identical to Phase 6a:
+
+```
+agents.demo.conversations-events
+├── partition 1 ── conv=storytelling-thread
+│       ├─ {kind=stream_chunk, stream.id=story-1, stream.seq=0}
+│       ├─ {kind=stream_chunk, stream.id=story-1, stream.seq=1}
+│       ├─ {kind=stream_chunk, stream.id=story-1, stream.seq=2}
+│       └─ {kind=stream_end,   stream.id=story-1, status=complete}
+```
+
+Same partitioning rules (`key = conversation_id`), same audit, same
+replay, same governance. Per-conversation Kafka ordering means a
+single-conversation stream is naturally FIFO; `chunk_seq` is mostly
+diagnostic in that case but becomes load-bearing when consumers
+fan-out across partitions or stream from multiple conversations.
+
+### `chunk_seq` and ordering
+
+`chunk_seq` is operator-asserted, monotonic, non-negative. The bus
+does not enforce monotonicity — a producer that emits out of order
+will round-trip out-of-order chunks to consumers. Consumers that need
+total order should sort by `chunk_seq` after collection (the
+simulation example does this).
+
+The terminal `StreamEnd` typically uses `chunk_seq = last + 1`, but
+this is convention only. Consumers should detect end-of-stream via the
+`acteon.envelope.kind == stream_end` header, not via a sequence-number
+heuristic.
+
+### `StreamEndStatus`
+
+| Status | Meaning |
+|---|---|
+| `complete` | All chunks delivered. The happy path. |
+| `aborted` | Producer canceled cleanly (operator stop, user canceled). Distinct from `error` so consumers can retry-or-surface differently. |
+| `error` | Stream failed mid-flight. `error_message` carries detail. |
+
+`error_message` is unconditionally capped at 4096 bytes — even on
+`complete`. A producer that ships a megabyte of `error_message`
+alongside `status: complete` would otherwise bypass the cap; same
+trust-the-payload-not-the-status reasoning as Phase 6a's `ToolResult`.
+
+### SSE consume
+
+`GET /v1/bus/streams/{ns}/{t}/{conv_id}/{stream_id}` opens an SSE
+connection. The handler:
+
+1. Resolves the conversation's events topic (honors a custom
+   `events_topic` set during `create_conversation`).
+2. Reads the events topic via `BusBackend::scan_topic` (Kafka
+   `assign()`, no consumer-group leak).
+3. Header-filters on `acteon.envelope.kind ∈ {stream_chunk, stream_end}`
+   AND `acteon.stream.id == stream_id`. Payload deserialization
+   doesn't run on records that fail the filter.
+4. Emits an SSE event per match: `event: bus.stream.chunk` for chunks,
+   `event: bus.stream.end` for the terminal record.
+5. Closes the connection cleanly when a `stream_end` for the target
+   stream is observed.
+
+A 15-second `keep-alive` pings the client between chunks so idle
+streams don't trip intermediate proxies.
+
+### Resume cursors
+
+`POST /stream-chunks` and `POST /stream-end` both return a `cursor`
+encoding the chunk's `partition:offset`. Pass the cursor returned
+from chunk 0 to a consumer (via `?cursor=...` on the SSE URL) so it
+scans from strictly after the chunk lands rather than from the topic
+tail (the default — cheap on a busy cluster, but races with chunks
+landing).
+
+Same encoding as Phase 5 replay cursors and Phase 6a tool-result
+lookup cursors: URL-safe base64 of a JSON `{partition: offset}` map,
+capped at 8 KB.
+
+## API shape
+
+### Post a stream chunk
+
+```http
+POST /v1/bus/conversations/agents/demo/storytelling-thread/stream-chunks
+{
+  "stream_id": "story-1",
+  "chunk_seq": 0,
+  "body": {"token": "Once "},
+  "sender": "storyteller-1"
+}
+→ 200 StreamEnvelopeReceipt {
+  "events_topic": "agents.demo.conversations-events",
+  "conversation_id": "storytelling-thread",
+  "stream_id": "story-1",
+  "chunk_seq": 0,
+  "partition": 0,
+  "offset": 17,
+  "produced_at": "...",
+  "cursor": "eyIwIjogMTd9"
+}
+```
+
+### Post the terminator
+
+```http
+POST /v1/bus/conversations/agents/demo/storytelling-thread/stream-end
+{
+  "stream_id": "story-1",
+  "chunk_seq": 5,
+  "status": "complete",
+  "sender": "storyteller-1"
+}
+→ 200 StreamEnvelopeReceipt
+```
+
+For a failure terminator:
+
+```http
+{
+  "stream_id": "story-1",
+  "chunk_seq": 3,
+  "status": "error",
+  "error_message": "upstream gave up",
+  "sender": "storyteller-1"
+}
+```
+
+### Consume
+
+```http
+GET /v1/bus/streams/agents/demo/storytelling-thread/story-1?cursor=eyIwIjogMTd9
+Accept: text/event-stream
+→ 200 OK
+
+event: bus.stream.chunk
+id: 17
+data: {"stream_id":"story-1","chunk_seq":0,"body":{"token":"Once "},...}
+
+event: bus.stream.chunk
+id: 18
+data: {"stream_id":"story-1","chunk_seq":1,"body":{"token":"upon "},...}
+
+...
+
+event: bus.stream.end
+id: 22
+data: {"stream_id":"story-1","chunk_seq":5,"status":"complete",...}
+
+(connection closes)
+```
+
+For a private conversation (non-empty `participants`), pass
+`?as_agent=<agent_id>` to identify which participant the consumer is
+acting as. Same V1 read-isolation model as Phase 5 / 6a.
+
+## SDK example
+
+```rust
+use acteon_client::{
+    ActeonClient, BusStreamEndStatus, PostBusStreamChunk, PostBusStreamEnd,
+};
+use serde_json::json;
+
+let client = ActeonClient::new("http://localhost:3000");
+
+// Producer streams chunks.
+for (seq, tok) in ["Once ", "upon ", "a ", "time."].iter().enumerate() {
+    client.post_bus_stream_chunk("agents", "demo", "storytelling-thread",
+        &PostBusStreamChunk {
+            stream_id: "story-1".into(),
+            chunk_seq: seq as i64,
+            body: json!({"token": tok}),
+            sender: Some("storyteller-1".into()),
+            ..Default::default()
+        }
+    ).await?;
+}
+
+// Terminator.
+client.post_bus_stream_end("agents", "demo", "storytelling-thread",
+    &PostBusStreamEnd {
+        stream_id: "story-1".into(),
+        chunk_seq: 4,
+        status: BusStreamEndStatus::Complete,
+        error_message: None,
+        sender: Some("storyteller-1".into()),
+        metadata: Default::default(),
+    }
+).await?;
+
+// SSE consume URL — wire it to your preferred client (browser
+// EventSource, eventsource-stream, curl -N, etc.). The Rust client
+// exposes the URL builder; SSE parsing is handled by the consuming
+// runtime.
+let url = client.bus_stream_consume_url(
+    "agents", "demo", "storytelling-thread", "story-1",
+);
+```
+
+## Authorization
+
+All endpoints flow through `BusOp::ManageConversation`. The two
+`POST` paths additionally require `BusOp::Publish`; the SSE consume
+requires `BusOp::Subscribe`. Mirrors the Phase 5/6a split — operators
+can lock down stream production independently from consumption.
+
+Participant ACL applies to both write paths: when the conversation
+has a non-empty `participants` list, the envelope's `sender` is
+required and must be on the list. Read-side ACL on `consume_stream`
+gates on `as_agent`, matching Phase 6a's lookup-result behavior.
+
+## Design decisions
+
+- **One pipeline, not two.** Stream envelopes ride the conversation
+  events topic. No new Kafka topic, no new state-store rows for
+  in-flight streams, one set of operational levers.
+- **Server-stamped routing headers.** Subscribers route on a single
+  header lookup; payload deserialization happens only on the chunks
+  the caller actually wants. The same header-filter discipline that
+  kept Phase 6a tool lookup cheap on a busy topic applies here.
+- **SSE stops on terminator.** No client-side bookkeeping needed —
+  observing `stream_end` for the target stream closes the connection.
+  Producers that abandon streams without emitting `stream_end` will
+  leave consumers hanging until the keep-alive eventually fails;
+  document and lint accordingly.
+- **`error_message` capped unconditionally.** Same lesson as Phase 6a:
+  a per-status cap creates a bypass via `status: complete`. One cap
+  for all statuses keeps the trust model simple.
+
+## Trust model and limits
+
+### `stream_id` is not a uniqueness gate
+
+Two producers racing on the same `(conversation_id, stream_id)` will
+interleave chunks on the topic. The bus does not enforce single-writer
+semantics for a stream. In practice the participant ACL bounds the
+threat — only conversation participants can produce to a private
+thread — and operators control the participant list. If you need
+mutually-exclusive producers, lease `stream_id` ownership at the
+application layer.
+
+### `chunk_seq` is not validated
+
+The bus does not check monotonicity, contiguity, or that
+`StreamEnd.chunk_seq == last_chunk + 1`. Consumers that need total
+order should re-sort after collection. Consumers that need to detect
+holes (a missing `chunk_seq`) should track the high-water mark and
+raise a gap alarm at the application layer.
+
+### Producers that abandon streams
+
+A producer that emits chunks but never emits `StreamEnd` leaves
+consumers with an open SSE connection until the underlying scan
+errors out. This is a producer bug, not a bus bug — the bus has no
+way to distinguish "stream still in flight" from "producer crashed."
+For long-running streams, consider an upstream watchdog that emits
+`StreamEnd { status: aborted }` on producer death.
+
+## What comes next
+
+- **Phase 6c** — HITL pre-publish approvals: park a tool-call (or
+  stream chunk) in state, await operator approval, then commit to
+  Kafka.
+- **Phase 7** — UI: stream viewer in the conversation detail page,
+  with live-tail and replay-from-cursor.
+- **Phase 8** — 5-SDK parity for the bus surface (Python, Node, Go,
+  Java).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -189,6 +189,7 @@ nav:
     - Phase 4 (Agents + Shared Inbox + Heartbeat): features/bus-phase-4.md
     - Phase 5 (Conversations + Threads): features/bus-phase-5.md
     - Phase 6a (Tool-call envelopes): features/bus-phase-6a.md
+    - Phase 6b (Streaming chunks): features/bus-phase-6b.md
   - Guides:
     - guides/index.md
     - AI Agent Swarm Coordination: guides/agent-swarm-coordination.md


### PR DESCRIPTION
## Summary
- Typed `StreamChunk` / `StreamEnd` envelopes layered on the conversation events topic — same architectural pattern as Phase 6a tool envelopes (no parallel Kafka pipeline).
- Server stamps `acteon.envelope.kind ∈ {stream_chunk, stream_end}`, `acteon.stream.id`, `acteon.stream.seq` so subscribers route without parsing payloads.
- SSE consume endpoint that closes cleanly on observing the terminal record. Resume via the receipt cursor — same encoding as Phase 5/6a.

## What ships
- **Core**: `StreamChunk`, `StreamEnd`, `StreamEndStatus ∈ {Complete, Aborted, Error}`, 8 unit tests including the unconditional `error_message` cap (a producer could otherwise ship megabytes alongside `status: complete` to bypass the limit — same trust lesson as `ToolResult`).
- **HTTP**:
  - `POST /v1/bus/conversations/{ns}/{t}/{id}/stream-chunks`
  - `POST /v1/bus/conversations/{ns}/{t}/{id}/stream-end`
  - `GET /v1/bus/streams/{ns}/{t}/{conv_id}/{stream_id}` (SSE, header-filtered, stops on terminator)
- **SDK**: `post_bus_stream_chunk`, `post_bus_stream_end`, `bus_stream_consume_url` (builds the SSE URL — caller plugs into their preferred SSE client).
- **Simulation**: `bus_stream_simulation.rs` — producer emits 5 chunks + terminator, consumer header-filters and reassembles by `chunk_seq`.
- **Docs**: `bus-phase-6b.md` feature doc + master plan phase status refresh + mkdocs nav.

## Trust model (documented in the feature doc)
- `stream_id` is **not** a uniqueness gate — two producers racing on the same stream interleave chunks. Participant ACL bounds the threat; lease ownership at the app layer if you need single-writer.
- `chunk_seq` is **not** validated — consumers that need contiguous order should re-sort and detect gaps at the application layer.
- Stream-abandonment is a producer-side concern; the bus has no way to distinguish "in flight" from "crashed."

## Polyglot SDKs
Deferred to Phase 8 per the master plan, consistent with Phase 6a.

## Test plan
- [x] `cargo test -p acteon-core --lib bus_stream` — 8 tests pass
- [x] `cargo test --workspace --lib --bins --tests` — green
- [x] `cargo clippy --workspace --no-deps --features bus -- -D warnings` — clean
- [x] `cargo check --all-targets` — clean
- [x] `cd ui && npm run lint && npm run build` — clean
- [x] `cargo run -p acteon-simulation --features bus --example bus_stream_simulation` — reassembles "Once upon a time in a far-off land." end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)