### PR TITLE
feat(bus): Phase 6c — pre-publish HITL approvals for tool-calls

### DIFF
--- a/crates/client/src/bus.rs
+++ b/crates/client/src/bus.rs
@@ -1057,7 +1057,7 @@ impl ActeonClient {
         tenant: &str,
         conversation_id: &str,
         req: &PostBusToolCall,
-    ) -> Result<BusToolEnvelopeReceipt, Error> {
+    ) -> Result<PostBusToolCallOutcome, Error> {
         let url = self.conversation_url(namespace, tenant, conversation_id, Some("tool-calls"));
         let resp = self
             .add_auth(self.client.post(&url))
@@ -1065,12 +1065,23 @@ impl ActeonClient {
             .send()
             .await
             .map_err(|e| Error::Connection(e.to_string()))?;
-        if resp.status().is_success() {
-            resp.json::<BusToolEnvelopeReceipt>()
+        let status = resp.status();
+        if !status.is_success() {
+            return Err(map_error(resp).await);
+        }
+        // 202 → parked approval; 200 → produced. The server uses the
+        // `require_approval` flag on the request to choose; the
+        // status code is the load-bearing distinction here.
+        if status == reqwest::StatusCode::ACCEPTED {
+            resp.json::<BusApprovalParkedReceipt>()
                 .await
+                .map(PostBusToolCallOutcome::Parked)
                 .map_err(|e| Error::Deserialization(e.to_string()))
         } else {
-            Err(map_error(resp).await)
+            resp.json::<BusToolEnvelopeReceipt>()
+                .await
+                .map(PostBusToolCallOutcome::Produced)
+                .map_err(|e| Error::Deserialization(e.to_string()))
         }
     }
 
@@ -1154,9 +1165,23 @@ impl ActeonClient {
         req: &PostBusToolCall,
         timeout_ms: Option<u64>,
     ) -> Result<BusToolResultLookup, Error> {
-        let receipt = self
+        let outcome = self
             .post_bus_tool_call(namespace, tenant, conversation_id, req)
             .await?;
+        let receipt = match outcome {
+            PostBusToolCallOutcome::Produced(r) => r,
+            // A parked approval means no Kafka record exists yet.
+            // The natural request/response wait would never resolve.
+            // Surface a typed error so callers don't time out
+            // mysteriously.
+            PostBusToolCallOutcome::Parked(p) => {
+                return Err(Error::Configuration(format!(
+                    "tool-call parked for approval (id {}); cannot wait for result \
+                     until an operator calls approve",
+                    p.approval_id,
+                )));
+            }
+        };
         self.lookup_bus_tool_result(
             namespace,
             tenant,
@@ -1224,6 +1249,122 @@ impl ActeonClient {
             .map_err(|e| Error::Connection(e.to_string()))?;
         if resp.status().is_success() {
             resp.json::<BusStreamEnvelopeReceipt>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    // ----- Phase 6c: pre-publish HITL approvals -----
+
+    /// List parked approvals for a tenant. Filter by status or
+    /// conversation via `params`.
+    pub async fn list_bus_approvals(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        params: &ListBusApprovalsParams,
+    ) -> Result<ListBusApprovalsResponse, Error> {
+        let url = format!(
+            "{}/v1/bus/approvals/{}/{}",
+            self.base_url,
+            encode_segment(namespace),
+            encode_segment(tenant),
+        );
+        let resp = self
+            .add_auth(self.client.get(&url))
+            .query(params)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<ListBusApprovalsResponse>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Fetch a single approval by id.
+    pub async fn get_bus_approval(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        approval_id: &str,
+    ) -> Result<BusApprovalView, Error> {
+        let url = format!(
+            "{}/v1/bus/approvals/{}/{}/{}",
+            self.base_url,
+            encode_segment(namespace),
+            encode_segment(tenant),
+            encode_segment(approval_id),
+        );
+        let resp = self
+            .add_auth(self.client.get(&url))
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusApprovalView>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
+    /// Approve a parked tool-call. The server produces the original
+    /// envelope to Kafka with the same headers it would have stamped
+    /// on a non-gated post, plus an `acteon.approval.id` audit
+    /// header.
+    pub async fn approve_bus_approval(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        approval_id: &str,
+        req: &BusApprovalDecisionRequest,
+    ) -> Result<BusApprovalDecisionResponse, Error> {
+        self.post_bus_approval_decision(namespace, tenant, approval_id, "approve", req)
+            .await
+    }
+
+    /// Reject a parked tool-call. No Kafka record is produced.
+    pub async fn reject_bus_approval(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        approval_id: &str,
+        req: &BusApprovalDecisionRequest,
+    ) -> Result<BusApprovalDecisionResponse, Error> {
+        self.post_bus_approval_decision(namespace, tenant, approval_id, "reject", req)
+            .await
+    }
+
+    async fn post_bus_approval_decision(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        approval_id: &str,
+        verb: &str,
+        req: &BusApprovalDecisionRequest,
+    ) -> Result<BusApprovalDecisionResponse, Error> {
+        let url = format!(
+            "{}/v1/bus/approvals/{}/{}/{}/{verb}",
+            self.base_url,
+            encode_segment(namespace),
+            encode_segment(tenant),
+            encode_segment(approval_id),
+        );
+        let resp = self
+            .add_auth(self.client.post(&url))
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusApprovalDecisionResponse>()
                 .await
                 .map_err(|e| Error::Deserialization(e.to_string()))
         } else {
@@ -1589,6 +1730,21 @@ pub struct PostBusToolCall {
     pub sender: Option<String>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub metadata: HashMap<String, String>,
+    /// Phase 6c: gate this tool-call behind a human-in-the-loop
+    /// approval. When true, the server parks the envelope under a
+    /// `BusApproval` row and responds with `202 Accepted` plus the
+    /// approval id; nothing reaches Kafka until an operator
+    /// approves via [`ActeonClient::approve_bus_approval`].
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub require_approval: bool,
+    /// Free-form rationale for the approval request. Persisted on
+    /// the row for the operator UX. Capped at 4 KB.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_reason: Option<String>,
+    /// Override the default approval TTL (24h). Capped at 7d. Ignored
+    /// when `require_approval` is false.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_ttl_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -1718,6 +1874,94 @@ pub struct PostBusStreamEnd {
     pub sender: Option<String>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub metadata: HashMap<String, String>,
+}
+
+// ----- Phase 6c: HITL approval DTOs -----
+
+#[derive(Debug, Clone)]
+pub enum PostBusToolCallOutcome {
+    /// Posted directly: tool-call landed on Kafka.
+    Produced(BusToolEnvelopeReceipt),
+    /// Parked under a `BusApproval` row pending a human decision.
+    Parked(BusApprovalParkedReceipt),
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BusApprovalStatus {
+    Pending,
+    Approved,
+    Rejected,
+    Expired,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BusApprovalParkedReceipt {
+    pub approval_id: String,
+    pub namespace: String,
+    pub tenant: String,
+    pub conversation_id: String,
+    pub correlation_token: String,
+    pub status: BusApprovalStatus,
+    pub created_at: String,
+    pub expires_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BusApprovalView {
+    pub approval_id: String,
+    pub namespace: String,
+    pub tenant: String,
+    pub conversation_id: String,
+    pub correlation_token: String,
+    pub envelope_kind: String,
+    pub status: BusApprovalStatus,
+    #[serde(default)]
+    pub reason: Option<String>,
+    pub created_at: String,
+    pub expires_at: String,
+    #[serde(default)]
+    pub decided_by: Option<String>,
+    #[serde(default)]
+    pub decided_at: Option<String>,
+    #[serde(default)]
+    pub decision_note: Option<String>,
+    #[serde(default)]
+    pub produced_partition: Option<i32>,
+    #[serde(default)]
+    pub produced_offset: Option<i64>,
+    #[serde(default)]
+    pub produced_at: Option<String>,
+    #[serde(default)]
+    pub envelope: serde_json::Value,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct ListBusApprovalsParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<BusApprovalStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListBusApprovalsResponse {
+    pub approvals: Vec<BusApprovalView>,
+    pub count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BusApprovalDecisionRequest {
+    pub decided_by: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decision_note: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BusApprovalDecisionResponse {
+    pub approval: BusApprovalView,
+    #[serde(default)]
+    pub receipt: Option<BusToolEnvelopeReceipt>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/core/src/bus_approval.rs
+++ b/crates/core/src/bus_approval.rs
@@ -1,0 +1,329 @@
+//! Bus pre-publish HITL approvals (Phase 6c).
+//!
+//! Some tool-calls shouldn't ride straight onto Kafka — sensitive
+//! operations want a human-in-the-loop gate first. Phase 6c parks
+//! the would-be envelope in Acteon state under a `BusApproval` row
+//! with `status = pending`; the matching Kafka record only lands
+//! after an operator approves. Reject (or expire) leaves no Kafka
+//! footprint at all.
+//!
+//! V1 scope: tool-calls only. Stream chunks are excluded by
+//! construction — gating each token of a stream defeats the point
+//! of streaming.
+//!
+//! V1 trust model: the parked envelope is a state-store row, the
+//! eventual Kafka record is a separate produce. The two writes are
+//! not atomic. If the produce fails after a successful approval we
+//! surface the error and leave the row in `pending` so an operator
+//! can retry. If the produce succeeds but the row update fails the
+//! idempotent producer + per-`call_id` uniqueness on the consumer
+//! side keeps the topic clean. A future iteration can use a Kafka
+//! transactional producer to close the window completely.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::bus_tool::ToolCall;
+
+/// Lifecycle status for a pre-publish approval. Transitions:
+/// `Pending` → `Approved` (commits to Kafka) | `Rejected` (no Kafka)
+/// | `Expired` (TTL elapsed, treated as a soft reject).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum BusApprovalStatus {
+    /// Awaiting an operator decision.
+    Pending,
+    /// Approved; the parked envelope has been (or is being) produced
+    /// to Kafka.
+    Approved,
+    /// Rejected; the parked envelope will never reach Kafka.
+    Rejected,
+    /// TTL elapsed before any decision — same outcome as `Rejected`
+    /// but distinguishable for audit and UX purposes.
+    Expired,
+}
+
+impl BusApprovalStatus {
+    #[must_use]
+    pub fn is_terminal(self) -> bool {
+        !matches!(self, BusApprovalStatus::Pending)
+    }
+}
+
+/// The bus envelope being held back. Tagged so the type system makes
+/// it impossible to mix call/stream payloads into the same approval
+/// row, and so a future expansion (e.g. `StreamEnd` for a guarded
+/// terminal record) doesn't require a schema migration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "payload", rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum BusApprovalEnvelope {
+    /// A tool-call awaiting publish approval. The bus stamps the
+    /// usual `acteon.tool.call_id` / `acteon.correlation_id` headers
+    /// at produce time, after the envelope is approved.
+    ToolCall(ToolCall),
+}
+
+impl BusApprovalEnvelope {
+    /// Return the underlying envelope's `call_id` / `stream_id` for
+    /// audit + log correlation. Tool-calls expose `call_id`; future
+    /// variants can return their own correlation token.
+    #[must_use]
+    pub fn correlation_token(&self) -> &str {
+        match self {
+            BusApprovalEnvelope::ToolCall(c) => &c.call_id,
+        }
+    }
+}
+
+/// Parked approval row. Lives at `KeyKind::BusApproval` keyed by
+/// `approval_id`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct BusApproval {
+    /// Stable identifier (server-generated UUID).
+    pub approval_id: String,
+    pub namespace: String,
+    pub tenant: String,
+    /// Conversation the parked envelope was destined for. The
+    /// approve handler reads this to resolve the right events topic
+    /// at produce time, including any `events_topic` override on
+    /// the conversation record.
+    pub conversation_id: String,
+    /// Free-form rationale supplied by the requester. Bounded so a
+    /// hostile caller can't bloat the row.
+    #[serde(default)]
+    pub reason: Option<String>,
+    pub envelope: BusApprovalEnvelope,
+    pub status: BusApprovalStatus,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    /// Set when the approval transitions out of `Pending`.
+    #[serde(default)]
+    pub decided_by: Option<String>,
+    #[serde(default)]
+    pub decided_at: Option<DateTime<Utc>>,
+    /// Operator-supplied note attached to the decision.
+    #[serde(default)]
+    pub decision_note: Option<String>,
+    /// Bus coordinates set after a successful produce on approval.
+    /// `None` until the approve handler commits to Kafka.
+    #[serde(default)]
+    pub produced_partition: Option<i32>,
+    #[serde(default)]
+    pub produced_offset: Option<i64>,
+    #[serde(default)]
+    pub produced_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub labels: HashMap<String, String>,
+}
+
+/// Default TTL for a parked approval. Tunable per-request via
+/// `approval_ttl_ms`; capped at [`MAX_APPROVAL_TTL_MS`].
+pub const DEFAULT_APPROVAL_TTL_MS: u64 = 24 * 60 * 60 * 1000; // 24h
+
+/// Hard cap on approval TTL. A pending row sits in state until it
+/// decays; without a ceiling, an operator could write a row that
+/// never expires and bloats the listing.
+pub const MAX_APPROVAL_TTL_MS: u64 = 7 * 24 * 60 * 60 * 1000; // 7d
+
+/// Cap on the `reason` and `decision_note` fields. Same rationale as
+/// the `error_message` cap on `StreamEnd` / `ToolResult`: a single
+/// malicious caller could otherwise bloat the row to MB.
+pub const MAX_APPROVAL_NOTE_BYTES: usize = 4096;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum BusApprovalValidationError {
+    #[error("approval_id must not be empty")]
+    EmptyId,
+    #[error("approval_id exceeds 120 characters")]
+    IdTooLong,
+    #[error("approval_id '{0}' contains characters outside [a-zA-Z0-9._-]")]
+    InvalidIdChar(String),
+    #[error("approval_ttl_ms {0} exceeds the {MAX_APPROVAL_TTL_MS}ms cap")]
+    TtlTooLong(u64),
+    #[error("approval_ttl_ms must be > 0")]
+    TtlZero,
+    #[error("{field} exceeds {MAX_APPROVAL_NOTE_BYTES} bytes")]
+    NoteTooLong { field: &'static str },
+}
+
+impl BusApproval {
+    /// Validate identity + bounded fields. Run before persisting the
+    /// row.
+    pub fn validate(&self) -> Result<(), BusApprovalValidationError> {
+        validate_approval_id(&self.approval_id)?;
+        if let Some(r) = &self.reason
+            && r.len() > MAX_APPROVAL_NOTE_BYTES
+        {
+            return Err(BusApprovalValidationError::NoteTooLong { field: "reason" });
+        }
+        if let Some(n) = &self.decision_note
+            && n.len() > MAX_APPROVAL_NOTE_BYTES
+        {
+            return Err(BusApprovalValidationError::NoteTooLong {
+                field: "decision_note",
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Shared id-validation. Mirrors the rule used across the rest of
+/// the bus: alphanumeric + `[._-]`, 1..=120 bytes.
+pub fn validate_approval_id(s: &str) -> Result<(), BusApprovalValidationError> {
+    if s.is_empty() {
+        return Err(BusApprovalValidationError::EmptyId);
+    }
+    if s.len() > 120 {
+        return Err(BusApprovalValidationError::IdTooLong);
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err(BusApprovalValidationError::InvalidIdChar(s.to_string()));
+    }
+    Ok(())
+}
+
+/// Validate a caller-supplied TTL against [`MAX_APPROVAL_TTL_MS`].
+pub fn validate_approval_ttl(ttl_ms: u64) -> Result<(), BusApprovalValidationError> {
+    if ttl_ms == 0 {
+        return Err(BusApprovalValidationError::TtlZero);
+    }
+    if ttl_ms > MAX_APPROVAL_TTL_MS {
+        return Err(BusApprovalValidationError::TtlTooLong(ttl_ms));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample() -> BusApproval {
+        let mut call = ToolCall::new("call-1", "calendar.list", json!({}));
+        call.sender = Some("planner-1".into());
+        let now = Utc::now();
+        BusApproval {
+            approval_id: "appr-1".into(),
+            namespace: "agents".into(),
+            tenant: "demo".into(),
+            conversation_id: "thread-1".into(),
+            reason: Some("paid action".into()),
+            envelope: BusApprovalEnvelope::ToolCall(call),
+            status: BusApprovalStatus::Pending,
+            created_at: now,
+            expires_at: now + chrono::Duration::hours(1),
+            decided_by: None,
+            decided_at: None,
+            decision_note: None,
+            produced_partition: None,
+            produced_offset: None,
+            produced_at: None,
+            labels: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn validate_basic() {
+        sample().validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_empty_id() {
+        let mut a = sample();
+        a.approval_id = String::new();
+        assert_eq!(a.validate(), Err(BusApprovalValidationError::EmptyId));
+    }
+
+    #[test]
+    fn rejects_long_id() {
+        let mut a = sample();
+        a.approval_id = "x".repeat(121);
+        assert_eq!(a.validate(), Err(BusApprovalValidationError::IdTooLong));
+    }
+
+    #[test]
+    fn rejects_bad_id_char() {
+        let mut a = sample();
+        a.approval_id = "appr/1".into();
+        assert!(matches!(
+            a.validate(),
+            Err(BusApprovalValidationError::InvalidIdChar(_))
+        ));
+    }
+
+    #[test]
+    fn caps_reason_length() {
+        let mut a = sample();
+        a.reason = Some("x".repeat(MAX_APPROVAL_NOTE_BYTES + 1));
+        assert_eq!(
+            a.validate(),
+            Err(BusApprovalValidationError::NoteTooLong { field: "reason" })
+        );
+    }
+
+    #[test]
+    fn caps_decision_note_length() {
+        let mut a = sample();
+        a.decision_note = Some("x".repeat(MAX_APPROVAL_NOTE_BYTES + 1));
+        assert_eq!(
+            a.validate(),
+            Err(BusApprovalValidationError::NoteTooLong {
+                field: "decision_note"
+            })
+        );
+    }
+
+    #[test]
+    fn ttl_zero_rejected() {
+        assert_eq!(
+            validate_approval_ttl(0),
+            Err(BusApprovalValidationError::TtlZero)
+        );
+    }
+
+    #[test]
+    fn ttl_above_cap_rejected() {
+        assert!(matches!(
+            validate_approval_ttl(MAX_APPROVAL_TTL_MS + 1),
+            Err(BusApprovalValidationError::TtlTooLong(_))
+        ));
+    }
+
+    #[test]
+    fn ttl_at_cap_accepted() {
+        validate_approval_ttl(MAX_APPROVAL_TTL_MS).unwrap();
+    }
+
+    #[test]
+    fn status_terminal_helpers() {
+        assert!(!BusApprovalStatus::Pending.is_terminal());
+        assert!(BusApprovalStatus::Approved.is_terminal());
+        assert!(BusApprovalStatus::Rejected.is_terminal());
+        assert!(BusApprovalStatus::Expired.is_terminal());
+    }
+
+    #[test]
+    fn envelope_correlation_token() {
+        let env = BusApprovalEnvelope::ToolCall(ToolCall::new("call-77", "x", json!({})));
+        assert_eq!(env.correlation_token(), "call-77");
+    }
+
+    #[test]
+    fn roundtrip_serde() {
+        let a = sample();
+        let j = serde_json::to_string(&a).unwrap();
+        let back: BusApproval = serde_json::from_str(&j).unwrap();
+        assert_eq!(back.approval_id, a.approval_id);
+        match back.envelope {
+            BusApprovalEnvelope::ToolCall(c) => assert_eq!(c.call_id, "call-1"),
+        }
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod action;
 pub mod analytics;
 pub mod attachment;
 pub mod bus_agent;
+pub mod bus_approval;
 pub mod bus_conversation;
 pub mod bus_schema;
 pub mod bus_stream;
@@ -40,6 +41,11 @@ pub use analytics::{
 pub use attachment::{Attachment, ResolvedAttachment};
 pub use bus_agent::{
     Agent, AgentStatus, AgentValidationError, DEFAULT_AGENT_INBOX_SUFFIX, DEFAULT_HEARTBEAT_TTL_MS,
+};
+pub use bus_approval::{
+    BusApproval, BusApprovalEnvelope, BusApprovalStatus, BusApprovalValidationError,
+    DEFAULT_APPROVAL_TTL_MS, MAX_APPROVAL_NOTE_BYTES, MAX_APPROVAL_TTL_MS, validate_approval_id,
+    validate_approval_ttl,
 };
 pub use bus_conversation::{
     Conversation, ConversationState, ConversationTransition, ConversationValidationError,

--- a/crates/gcp/src/pubsub.rs
+++ b/crates/gcp/src/pubsub.rs
@@ -64,6 +64,15 @@ impl PubSubConfig {
         self.gcp.credentials_path = Some(path.into());
         self
     }
+
+    /// Set inline service account JSON credentials. Mutually
+    /// exclusive with `with_credentials_path` — whichever was set
+    /// last wins, mirroring `GcpBaseConfig::with_credentials_json`.
+    #[must_use]
+    pub fn with_credentials_json(mut self, json: impl Into<String>) -> Self {
+        self.gcp = self.gcp.with_credentials_json(json);
+        self
+    }
 }
 
 /// Payload for the `publish` action type.

--- a/crates/gcp/src/storage.rs
+++ b/crates/gcp/src/storage.rs
@@ -72,6 +72,15 @@ impl StorageConfig {
         self.gcp.credentials_path = Some(path.into());
         self
     }
+
+    /// Set inline service account JSON credentials. Mutually
+    /// exclusive with `with_credentials_path` — whichever was set
+    /// last wins, mirroring `GcpBaseConfig::with_credentials_json`.
+    #[must_use]
+    pub fn with_credentials_json(mut self, json: impl Into<String>) -> Self {
+        self.gcp = self.gcp.with_credentials_json(json);
+        self
+    }
 }
 
 /// Payload for the `upload_object` action type.

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -5513,6 +5513,23 @@ pub struct PostToolCallRequest {
     /// caps (max 32 entries / 256B keys / 4KB values).
     #[serde(default)]
     pub metadata: HashMap<String, String>,
+    /// Phase 6c: gate this tool-call behind a human-in-the-loop
+    /// approval. When true, the envelope is parked in state under a
+    /// `BusApproval` row and the response is `202 Accepted` with the
+    /// approval id; the matching Kafka record only lands after a
+    /// `POST /v1/bus/approvals/{ns}/{t}/{id}/approve`. Default false.
+    #[serde(default)]
+    pub require_approval: bool,
+    /// Free-form rationale for the approval request. Required by
+    /// some operator UX, optional in the API. Capped at
+    /// `MAX_APPROVAL_NOTE_BYTES` (4 KB). Ignored when
+    /// `require_approval` is false.
+    #[serde(default)]
+    pub approval_reason: Option<String>,
+    /// Override the default approval TTL (24h). Capped at 7d. Ignored
+    /// when `require_approval` is false.
+    #[serde(default)]
+    pub approval_ttl_ms: Option<u64>,
 }
 
 /// Body of `POST /v1/bus/conversations/{ns}/{t}/{id}/tool-results`.
@@ -5766,6 +5783,24 @@ pub async fn post_tool_call(
         .await
         {
             return resp;
+        }
+        // Phase 6c HITL fork: when the requester sets
+        // `require_approval`, park the envelope under a `BusApproval`
+        // row instead of producing to Kafka. The parked row carries
+        // the *validated* envelope (so the approval handler doesn't
+        // re-run validation rules that may have drifted since
+        // parking) plus the original conversation context.
+        if req.require_approval {
+            return park_tool_call_for_approval(
+                &state,
+                &namespace,
+                &tenant,
+                &conv,
+                envelope,
+                req.approval_reason.clone(),
+                req.approval_ttl_ms,
+            )
+            .await;
         }
         let mut msg = acteon_bus::BusMessage::new(events_topic.clone(), payload)
             .with_key(&conv.conversation_id);
@@ -7051,4 +7086,734 @@ fn sse_stream_for_stream_id(
             }
         },
     )
+}
+
+// =============================================================================
+// Phase 6c: pre-publish HITL approvals for tool-calls
+// =============================================================================
+
+/// Receipt for a parked tool-call awaiting approval (`202 Accepted`
+/// shape). The envelope is in state, not on Kafka — `partition` /
+/// `offset` are only populated after `approve` commits the row.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct BusApprovalParkedReceipt {
+    pub approval_id: String,
+    pub namespace: String,
+    pub tenant: String,
+    pub conversation_id: String,
+    /// `call_id` (or future-variant correlation token) on the
+    /// parked envelope, surfaced for log correlation.
+    pub correlation_token: String,
+    pub status: acteon_core::BusApprovalStatus,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Public-facing view of an approval row. Separate from the on-disk
+/// representation so the response shape doesn't leak whatever
+/// internal fields the row gains over time.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct BusApprovalView {
+    pub approval_id: String,
+    pub namespace: String,
+    pub tenant: String,
+    pub conversation_id: String,
+    pub correlation_token: String,
+    pub envelope_kind: String,
+    pub status: acteon_core::BusApprovalStatus,
+    pub reason: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub decided_by: Option<String>,
+    pub decided_at: Option<DateTime<Utc>>,
+    pub decision_note: Option<String>,
+    pub produced_partition: Option<i32>,
+    pub produced_offset: Option<i64>,
+    pub produced_at: Option<DateTime<Utc>>,
+    /// Full envelope payload for operator review. Returned as
+    /// free-form JSON (the underlying tool-call shape is already in
+    /// the `OpenAPI` schema via `BusApprovalEnvelope`).
+    #[schema(value_type = Object)]
+    pub envelope: serde_json::Value,
+}
+
+#[cfg(feature = "bus")]
+fn approval_to_view(a: &acteon_core::BusApproval) -> BusApprovalView {
+    let envelope_kind = match &a.envelope {
+        acteon_core::BusApprovalEnvelope::ToolCall(_) => "tool_call".to_string(),
+    };
+    BusApprovalView {
+        approval_id: a.approval_id.clone(),
+        namespace: a.namespace.clone(),
+        tenant: a.tenant.clone(),
+        conversation_id: a.conversation_id.clone(),
+        correlation_token: a.envelope.correlation_token().to_string(),
+        envelope_kind,
+        status: a.status,
+        reason: a.reason.clone(),
+        created_at: a.created_at,
+        expires_at: a.expires_at,
+        decided_by: a.decided_by.clone(),
+        decided_at: a.decided_at,
+        decision_note: a.decision_note.clone(),
+        produced_partition: a.produced_partition,
+        produced_offset: a.produced_offset,
+        produced_at: a.produced_at,
+        envelope: serde_json::to_value(&a.envelope).unwrap_or(serde_json::Value::Null),
+    }
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListBusApprovalsParams {
+    /// Filter by lifecycle status. Omit to list all.
+    #[serde(default)]
+    pub status: Option<acteon_core::BusApprovalStatus>,
+    /// Filter by conversation id.
+    #[serde(default)]
+    pub conversation_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListBusApprovalsResponse {
+    pub approvals: Vec<BusApprovalView>,
+    pub count: usize,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct BusApprovalDecisionRequest {
+    /// Operator id making the decision. Persisted on the row for
+    /// audit. Required: a decision without an actor would defeat
+    /// HITL.
+    pub decided_by: String,
+    /// Free-form note attached to the decision. Capped at 4 KB.
+    #[serde(default)]
+    pub decision_note: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct BusApprovalDecisionResponse {
+    pub approval: BusApprovalView,
+    /// Receipt from the resulting Kafka produce. Populated only on
+    /// `approve`; `None` for `reject`.
+    pub receipt: Option<ToolEnvelopeReceipt>,
+}
+
+/// Park a validated `ToolCall` envelope under a `BusApproval` row.
+/// The eventual approve handler picks up the row, re-stamps the
+/// envelope headers, and produces to Kafka.
+#[cfg(feature = "bus")]
+async fn park_tool_call_for_approval(
+    state: &AppState,
+    namespace: &str,
+    tenant: &str,
+    conv: &acteon_core::Conversation,
+    envelope: acteon_core::ToolCall,
+    reason: Option<String>,
+    ttl_ms: Option<u64>,
+) -> axum::response::Response {
+    let ttl_ms = ttl_ms.unwrap_or(acteon_core::DEFAULT_APPROVAL_TTL_MS);
+    if let Err(e) = acteon_core::validate_approval_ttl(ttl_ms) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response();
+    }
+    let approval_id = uuid::Uuid::now_v7().to_string();
+    let now = Utc::now();
+    let expires_at =
+        now + chrono::Duration::milliseconds(i64::try_from(ttl_ms).unwrap_or(i64::MAX));
+    let approval = acteon_core::BusApproval {
+        approval_id: approval_id.clone(),
+        namespace: namespace.to_string(),
+        tenant: tenant.to_string(),
+        conversation_id: conv.conversation_id.clone(),
+        reason,
+        envelope: acteon_core::BusApprovalEnvelope::ToolCall(envelope.clone()),
+        status: acteon_core::BusApprovalStatus::Pending,
+        created_at: now,
+        expires_at,
+        decided_by: None,
+        decided_at: None,
+        decision_note: None,
+        produced_partition: None,
+        produced_offset: None,
+        produced_at: None,
+        labels: HashMap::new(),
+    };
+    if let Err(e) = approval.validate() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response();
+    }
+    let raw = match serde_json::to_string(&approval) {
+        Ok(s) => s,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
+    let store: std::sync::Arc<dyn acteon_state::StateStore> = {
+        let gw = state.gateway.read().await;
+        gw.state_store().clone()
+    };
+    let key = StateKey::new(
+        namespace.to_string(),
+        tenant.to_string(),
+        KeyKind::BusApproval,
+        &approval_id,
+    );
+    // `check_and_set` rather than `set` so a duplicate UUID (vanishingly
+    // unlikely with v7 but the contract is "do not silently
+    // overwrite") fails loudly instead of corrupting an existing
+    // pending row.
+    match store.check_and_set(&key, &raw, None).await {
+        Ok(true) => {}
+        Ok(false) => {
+            return (
+                StatusCode::CONFLICT,
+                Json(ErrorResponse {
+                    error: format!("approval id collision at {}", key.canonical()),
+                }),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+    }
+    (
+        StatusCode::ACCEPTED,
+        Json(BusApprovalParkedReceipt {
+            approval_id,
+            namespace: namespace.to_string(),
+            tenant: tenant.to_string(),
+            conversation_id: conv.conversation_id.clone(),
+            correlation_token: envelope.call_id,
+            status: acteon_core::BusApprovalStatus::Pending,
+            created_at: now,
+            expires_at,
+        }),
+    )
+        .into_response()
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/bus/approvals/{namespace}/{tenant}",
+    tag = "bus",
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ListBusApprovalsParams,
+    ),
+    responses(
+        (status = 200, description = "Approvals for the tenant", body = ListBusApprovalsResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn list_bus_approvals(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant)): Path<(String, String)>,
+    Query(params): Query<ListBusApprovalsParams>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        let store: std::sync::Arc<dyn acteon_state::StateStore> = {
+            let gw = state.gateway.read().await;
+            gw.state_store().clone()
+        };
+        let entries = match store
+            .scan_keys(&namespace, &tenant, KeyKind::BusApproval, None)
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let mut approvals = Vec::with_capacity(entries.len());
+        for (_k, raw) in entries {
+            let Ok(a) = serde_json::from_str::<acteon_core::BusApproval>(&raw) else {
+                continue;
+            };
+            if let Some(s) = params.status
+                && a.status != s
+            {
+                continue;
+            }
+            if let Some(c) = &params.conversation_id
+                && &a.conversation_id != c
+            {
+                continue;
+            }
+            approvals.push(approval_to_view(&a));
+        }
+        let count = approvals.len();
+        (
+            StatusCode::OK,
+            Json(ListBusApprovalsResponse { approvals, count }),
+        )
+            .into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, params);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/bus/approvals/{namespace}/{tenant}/{approval_id}",
+    tag = "bus",
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("approval_id" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Approval", body = BusApprovalView),
+        (status = 404, description = "Approval not found", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn get_bus_approval(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, approval_id)): Path<(String, String, String)>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        match load_approval(&state, &namespace, &tenant, &approval_id).await {
+            Ok(a) => (StatusCode::OK, Json(approval_to_view(&a))).into_response(),
+            Err(resp) => resp,
+        }
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, approval_id);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[cfg(feature = "bus")]
+async fn load_approval(
+    state: &AppState,
+    namespace: &str,
+    tenant: &str,
+    approval_id: &str,
+) -> Result<acteon_core::BusApproval, axum::response::Response> {
+    if let Err(e) = acteon_core::validate_approval_id(approval_id) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response());
+    }
+    let key = StateKey::new(
+        namespace.to_string(),
+        tenant.to_string(),
+        KeyKind::BusApproval,
+        approval_id,
+    );
+    let store: std::sync::Arc<dyn acteon_state::StateStore> = {
+        let gw = state.gateway.read().await;
+        gw.state_store().clone()
+    };
+    match store.get(&key).await {
+        Ok(Some(raw)) => serde_json::from_str(&raw).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("corrupt approval record at {}: {e}", key.canonical()),
+                }),
+            )
+                .into_response()
+        }),
+        Ok(None) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("approval {namespace}.{tenant}.{approval_id} not found"),
+            }),
+        )
+            .into_response()),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response()),
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/approvals/{namespace}/{tenant}/{approval_id}/approve",
+    tag = "bus",
+    request_body = BusApprovalDecisionRequest,
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("approval_id" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Approved and produced", body = BusApprovalDecisionResponse),
+        (status = 400, description = "Invalid decision body", body = ErrorResponse),
+        (status = 404, description = "Approval not found", body = ErrorResponse),
+        (status = 409, description = "Approval already decided", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+#[allow(clippy::too_many_lines)]
+pub async fn approve_bus_approval(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, approval_id)): Path<(String, String, String)>,
+    Json(req): Json<BusApprovalDecisionRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        let Some(backend) = state.bus_backend.clone() else {
+            return service_unavailable("bus feature not enabled");
+        };
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::Publish) {
+            return resp;
+        }
+        if let Err(resp) = validate_decision_note(req.decision_note.as_deref()) {
+            return resp;
+        }
+        let approval = match load_approval(&state, &namespace, &tenant, &approval_id).await {
+            Ok(a) => a,
+            Err(resp) => return resp,
+        };
+        if approval.status.is_terminal() {
+            return (
+                StatusCode::CONFLICT,
+                Json(ErrorResponse {
+                    error: format!(
+                        "approval {approval_id} already in terminal status {:?}",
+                        approval.status
+                    ),
+                }),
+            )
+                .into_response();
+        }
+        if approval.expires_at < Utc::now() {
+            // Soft-expire on read so a stale row can never be
+            // approved past its TTL. The reaper will mark it
+            // separately; this avoids racing the reaper.
+            return (
+                StatusCode::CONFLICT,
+                Json(ErrorResponse {
+                    error: format!("approval {approval_id} expired at {}", approval.expires_at),
+                }),
+            )
+                .into_response();
+        }
+        // Resolve the conversation that owns this approval — its
+        // `effective_events_topic()` is what the produce targets.
+        let conv =
+            match load_conversation(&state, &namespace, &tenant, &approval.conversation_id).await {
+                Ok(c) => c,
+                Err(resp) => return resp,
+            };
+        let envelope = match &approval.envelope {
+            acteon_core::BusApprovalEnvelope::ToolCall(c) => c.clone(),
+        };
+        let payload = match serde_json::to_value(&envelope) {
+            Ok(v) => v,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        let events_topic = conv.effective_events_topic();
+        // Re-validate against the topic schema in case the binding
+        // changed while the row was parked.
+        if let Err(resp) = validate_payload_against_topic_schema(
+            &state,
+            &conv.namespace,
+            &conv.tenant,
+            &events_topic,
+            &payload,
+        )
+        .await
+        {
+            return resp;
+        }
+        let mut msg = acteon_bus::BusMessage::new(events_topic.clone(), payload)
+            .with_key(&conv.conversation_id);
+        msg.headers.insert(
+            "acteon.conversation.id".into(),
+            conv.conversation_id.clone(),
+        );
+        if let Some(s) = &envelope.sender {
+            msg.headers
+                .insert("acteon.conversation.sender".into(), s.clone());
+        }
+        stamp_tool_envelope_headers(
+            &mut msg,
+            ENVELOPE_KIND_TOOL_CALL,
+            &envelope.call_id,
+            envelope.correlation_id.as_deref(),
+            envelope.reply_to.as_deref(),
+        );
+        // Stamp an additional approval-trace header so audit
+        // pipelines can correlate the produced record back to the
+        // approval row that gated it.
+        msg.headers
+            .insert("acteon.approval.id".into(), approval.approval_id.clone());
+        let receipt = match backend.produce(msg).await {
+            Ok(r) => r,
+            Err(e) => {
+                // V1 trust model: the row stays `pending` so an
+                // operator can retry. Don't transition the row
+                // until the produce succeeds.
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: format!("produce failed; approval row left pending: {e}"),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+        // Best-effort CAS to record the decision. If contention
+        // exhausts (an unlikely double-approve race), the message is
+        // already on Kafka — log loudly and keep the response 200.
+        let key = StateKey::new(
+            namespace.clone(),
+            tenant.clone(),
+            KeyKind::BusApproval,
+            &approval_id,
+        );
+        let updated =
+            cas_update::<acteon_core::BusApproval, _>(&state, &key, "approval gone", |a| {
+                if a.status.is_terminal() {
+                    return Err((
+                        StatusCode::CONFLICT,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "approval transitioned to {:?} between read and write",
+                                a.status
+                            ),
+                        }),
+                    )
+                        .into_response());
+                }
+                a.status = acteon_core::BusApprovalStatus::Approved;
+                a.decided_by = Some(req.decided_by.clone());
+                a.decided_at = Some(Utc::now());
+                a.decision_note.clone_from(&req.decision_note);
+                a.produced_partition = Some(receipt.partition);
+                a.produced_offset = Some(receipt.offset);
+                a.produced_at = Some(receipt.timestamp);
+                Ok(())
+            })
+            .await;
+        let approval_view = match updated {
+            Ok(a) => approval_to_view(&a),
+            Err(_resp) => {
+                // The Kafka record landed; the row update lost a CAS
+                // race or the row vanished. Surface the produce
+                // receipt anyway (the bus is the source of truth)
+                // and log the inconsistency.
+                tracing::warn!(
+                    approval_id = %approval_id,
+                    partition = receipt.partition,
+                    offset = receipt.offset,
+                    "approve produced to Kafka but approval row update failed; row may be stale",
+                );
+                let mut a = approval.clone();
+                a.status = acteon_core::BusApprovalStatus::Approved;
+                a.decided_by = Some(req.decided_by.clone());
+                a.decided_at = Some(Utc::now());
+                a.decision_note.clone_from(&req.decision_note);
+                a.produced_partition = Some(receipt.partition);
+                a.produced_offset = Some(receipt.offset);
+                a.produced_at = Some(receipt.timestamp);
+                approval_to_view(&a)
+            }
+        };
+        let mut cursor_map = std::collections::BTreeMap::new();
+        cursor_map.insert(receipt.partition, receipt.offset);
+        let cursor = encode_replay_cursor(&cursor_map);
+        (
+            StatusCode::OK,
+            Json(BusApprovalDecisionResponse {
+                approval: approval_view,
+                receipt: Some(ToolEnvelopeReceipt {
+                    events_topic: receipt.topic,
+                    conversation_id: conv.conversation_id,
+                    call_id: envelope.call_id,
+                    partition: receipt.partition,
+                    offset: receipt.offset,
+                    produced_at: receipt.timestamp,
+                    cursor,
+                }),
+            }),
+        )
+            .into_response()
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, approval_id, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/bus/approvals/{namespace}/{tenant}/{approval_id}/reject",
+    tag = "bus",
+    request_body = BusApprovalDecisionRequest,
+    params(
+        ("namespace" = String, Path),
+        ("tenant" = String, Path),
+        ("approval_id" = String, Path),
+    ),
+    responses(
+        (status = 200, description = "Rejected", body = BusApprovalDecisionResponse),
+        (status = 400, description = "Invalid decision body", body = ErrorResponse),
+        (status = 404, description = "Approval not found", body = ErrorResponse),
+        (status = 409, description = "Approval already decided", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn reject_bus_approval(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, approval_id)): Path<(String, String, String)>,
+    Json(req): Json<BusApprovalDecisionRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        if let Err(resp) =
+            authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageConversation)
+        {
+            return resp;
+        }
+        if let Err(resp) = validate_decision_note(req.decision_note.as_deref()) {
+            return resp;
+        }
+        let key = StateKey::new(
+            namespace.clone(),
+            tenant.clone(),
+            KeyKind::BusApproval,
+            &approval_id,
+        );
+        let updated =
+            cas_update::<acteon_core::BusApproval, _>(&state, &key, "approval not found", |a| {
+                if a.status.is_terminal() {
+                    return Err((
+                        StatusCode::CONFLICT,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "approval {} already in terminal status {:?}",
+                                a.approval_id, a.status
+                            ),
+                        }),
+                    )
+                        .into_response());
+                }
+                a.status = acteon_core::BusApprovalStatus::Rejected;
+                a.decided_by = Some(req.decided_by.clone());
+                a.decided_at = Some(Utc::now());
+                a.decision_note.clone_from(&req.decision_note);
+                Ok(())
+            })
+            .await;
+        match updated {
+            Ok(a) => (
+                StatusCode::OK,
+                Json(BusApprovalDecisionResponse {
+                    approval: approval_to_view(&a),
+                    receipt: None,
+                }),
+            )
+                .into_response(),
+            Err(resp) => resp,
+        }
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, approval_id, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+#[cfg(feature = "bus")]
+fn validate_decision_note(note: Option<&str>) -> Result<(), axum::response::Response> {
+    if let Some(n) = note
+        && n.len() > acteon_core::MAX_APPROVAL_NOTE_BYTES
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!(
+                    "decision_note exceeds {} bytes",
+                    acteon_core::MAX_APPROVAL_NOTE_BYTES
+                ),
+            }),
+        )
+            .into_response());
+    }
+    Ok(())
 }

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -424,6 +424,23 @@ pub fn router(state: AppState) -> Router {
             "/v1/bus/streams/{namespace}/{tenant}/{conversation_id}/{stream_id}",
             get(bus::consume_stream),
         )
+        // Phase 6c: pre-publish HITL approvals for tool-calls.
+        .route(
+            "/v1/bus/approvals/{namespace}/{tenant}",
+            get(bus::list_bus_approvals),
+        )
+        .route(
+            "/v1/bus/approvals/{namespace}/{tenant}/{approval_id}",
+            get(bus::get_bus_approval),
+        )
+        .route(
+            "/v1/bus/approvals/{namespace}/{tenant}/{approval_id}/approve",
+            post(bus::approve_bus_approval),
+        )
+        .route(
+            "/v1/bus/approvals/{namespace}/{tenant}/{approval_id}/reject",
+            post(bus::reject_bus_approval),
+        )
         // Swarm runs
         .route("/v1/swarm/runs", get(swarm::list_swarm_runs))
         .route("/v1/swarm/runs/{run_id}", get(swarm::get_swarm_run))

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -197,6 +197,10 @@ use acteon_core::{
         super::bus::post_stream_chunk,
         super::bus::post_stream_end,
         super::bus::consume_stream,
+        super::bus::list_bus_approvals,
+        super::bus::get_bus_approval,
+        super::bus::approve_bus_approval,
+        super::bus::reject_bus_approval,
     ),
     components(schemas(
         Action, ActionOutcome, ProviderResponse, ResponseStatus, ActionError,
@@ -283,6 +287,11 @@ use acteon_core::{
         super::bus::PostStreamChunkRequest, super::bus::PostStreamEndRequest,
         super::bus::StreamEnvelopeReceipt,
         acteon_core::StreamChunk, acteon_core::StreamEnd, acteon_core::StreamEndStatus,
+        super::bus::BusApprovalParkedReceipt, super::bus::BusApprovalView,
+        super::bus::ListBusApprovalsResponse,
+        super::bus::BusApprovalDecisionRequest, super::bus::BusApprovalDecisionResponse,
+        acteon_core::BusApproval, acteon_core::BusApprovalEnvelope,
+        acteon_core::BusApprovalStatus,
     ))
 )]
 pub struct ApiDoc;

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -122,6 +122,8 @@ fn build_test_state_with_audit_and_analytics(
         swarm_registry: None,
         #[cfg(feature = "bus")]
         bus_backend: None,
+        #[cfg(feature = "bus")]
+        bus_schema_validator: acteon_bus::SchemaValidator::new(),
     }
 }
 
@@ -1192,6 +1194,8 @@ fn build_approval_state_with_providers(
         swarm_registry: None,
         #[cfg(feature = "bus")]
         bus_backend: None,
+        #[cfg(feature = "bus")]
+        bus_schema_validator: acteon_bus::SchemaValidator::new(),
     }
 }
 

--- a/crates/server/tests/ui_tests.rs
+++ b/crates/server/tests/ui_tests.rs
@@ -55,6 +55,8 @@ async fn ui_serves_index_html() {
         swarm_registry: None,
         #[cfg(feature = "bus")]
         bus_backend: None,
+        #[cfg(feature = "bus")]
+        bus_schema_validator: acteon_bus::SchemaValidator::new(),
     };
 
     let app = acteon_server::api::router(state);

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -66,7 +66,7 @@ dynamodb = ["dep:acteon-state-dynamodb"]
 postgres = ["dep:acteon-state-postgres", "dep:acteon-audit-postgres"]
 clickhouse = ["dep:acteon-audit-clickhouse"]
 swarm = ["dep:acteon-swarm", "dep:acteon-swarm-provider"]
-bus = ["dep:acteon-bus"]
+bus = ["dep:acteon-bus", "acteon-server/bus"]
 
 [[bench]]
 name = "throughput"

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -232,5 +232,9 @@ required-features = ["bus"]
 name = "bus_stream_simulation"
 required-features = ["bus"]
 
+[[example]]
+name = "bus_approval_simulation"
+required-features = ["bus"]
+
 [lints]
 workspace = true

--- a/crates/simulation/examples/bus_approval_simulation.rs
+++ b/crates/simulation/examples/bus_approval_simulation.rs
@@ -1,0 +1,320 @@
+//! Phase 6c HITL approvals demo.
+//!
+//! Models the full lifecycle of a pre-publish gate over in-memory
+//! state + bus backends — no Kafka or HTTP server required:
+//!
+//! 1. A requester builds a `ToolCall` and parks it under a
+//!    `BusApproval` row (mirrors what the production
+//!    `POST /v1/bus/conversations/.../tool-calls` handler does when
+//!    `require_approval = true`).
+//! 2. The events topic stays empty — nothing has been produced yet.
+//! 3. An operator reads the row, attaches a decision note, and
+//!    "approves" it by writing the parked envelope onto the events
+//!    topic with the standard `acteon.envelope.kind` /
+//!    `acteon.tool.call_id` / `acteon.approval.id` audit headers.
+//! 4. A second requester parks another tool-call; an operator
+//!    rejects this one. The events topic remains empty for that
+//!    `call_id`.
+//! 5. We scan the events topic and confirm only the approved record
+//!    is present.
+//!
+//! Run with:
+//! ```text
+//! cargo run -p acteon-simulation --features bus --example bus_approval_simulation
+//! ```
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use serde_json::json;
+use tracing::{Level, info};
+
+use acteon_bus::{BusMessage, MemoryBackend, ScanFrom};
+use acteon_core::{
+    BusApproval, BusApprovalEnvelope, BusApprovalStatus, Conversation, ToolCall, Topic,
+};
+use acteon_state::{KeyKind, StateKey, StateStore};
+use acteon_state_memory::MemoryStateStore;
+
+const NS: &str = "agents";
+const TENANT: &str = "demo";
+const CONV: &str = "planning-thread";
+
+#[tokio::main]
+#[allow(clippy::too_many_lines)]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::INFO)
+        .with_env_filter("info,acteon_bus=info")
+        .init();
+
+    let backend: acteon_bus::SharedBackend = MemoryBackend::new();
+    let state: std::sync::Arc<dyn StateStore> = std::sync::Arc::new(MemoryStateStore::new());
+
+    let events = Topic::new("conversations-events", NS, TENANT);
+    backend.create_topic(&events).await?;
+    let conv = Conversation::new(CONV, NS, TENANT);
+    let topic = conv.effective_events_topic();
+
+    // -----------------------------------------------------------------
+    // 1. Park two tool-calls under separate BusApproval rows.
+    // -----------------------------------------------------------------
+
+    let approval_pay = park_tool_call(
+        &state,
+        &conv,
+        ToolCall::new("call-pay-1", "billing.charge", json!({"usd": 42})),
+        Some("paid action — operator must approve"),
+    )
+    .await?;
+    info!(approval_id = %approval_pay, "parked paid tool-call (will approve)");
+
+    let approval_export = park_tool_call(
+        &state,
+        &conv,
+        ToolCall::new(
+            "call-export-1",
+            "users.export",
+            json!({"format": "csv", "scope": "all"}),
+        ),
+        Some("data export — operator must approve"),
+    )
+    .await?;
+    info!(approval_id = %approval_export, "parked export tool-call (will reject)");
+
+    // -----------------------------------------------------------------
+    // 2. Verify nothing has been produced yet.
+    // -----------------------------------------------------------------
+
+    let pre_count = scan_count_tool_calls(&backend, &topic).await?;
+    assert_eq!(
+        pre_count, 0,
+        "events topic should be empty before approvals decide"
+    );
+
+    // -----------------------------------------------------------------
+    // 3. Operator approves the first row → produce + transition.
+    // -----------------------------------------------------------------
+
+    decide_approval(
+        &state,
+        &backend,
+        &topic,
+        &approval_pay,
+        Decision::Approve,
+        "ops-1",
+        Some("verified PO #4711"),
+    )
+    .await?;
+    info!(approval_id = %approval_pay, "approval committed; record produced");
+
+    // -----------------------------------------------------------------
+    // 4. Operator rejects the second row → no Kafka record.
+    // -----------------------------------------------------------------
+
+    decide_approval(
+        &state,
+        &backend,
+        &topic,
+        &approval_export,
+        Decision::Reject,
+        "ops-1",
+        Some("scope too broad"),
+    )
+    .await?;
+    info!(approval_id = %approval_export, "approval rejected; no record produced");
+
+    // -----------------------------------------------------------------
+    // 5. Confirm the events topic has exactly one tool-call record,
+    //    and it's the approved one. Also confirm the row carries the
+    //    expected audit metadata.
+    // -----------------------------------------------------------------
+
+    let mut scan = backend.scan_topic(&topic, ScanFrom::Earliest).await?;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let mut produced_call_ids: Vec<String> = Vec::new();
+    loop {
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            break;
+        }
+        tokio::select! {
+            next = scan.next() => {
+                match next {
+                    Some(Ok(msg)) => {
+                        let kind = msg.headers.get("acteon.envelope.kind").map(String::as_str).unwrap_or_default();
+                        if kind != "tool_call" { continue; }
+                        let cid = msg.headers.get("acteon.tool.call_id").cloned().unwrap_or_default();
+                        let approval = msg.headers.get("acteon.approval.id").cloned().unwrap_or_default();
+                        info!(call_id = %cid, approval_id = %approval, "produced tool-call observed");
+                        produced_call_ids.push(cid);
+                    }
+                    Some(Err(_)) | None => break,
+                }
+            }
+            () = tokio::time::sleep(deadline - now) => break,
+        }
+    }
+    assert_eq!(produced_call_ids, vec!["call-pay-1".to_string()]);
+
+    let approved: BusApproval = load_approval(&state, &approval_pay).await?;
+    assert_eq!(approved.status, BusApprovalStatus::Approved);
+    assert_eq!(approved.decided_by.as_deref(), Some("ops-1"));
+    assert!(approved.produced_offset.is_some());
+
+    let rejected: BusApproval = load_approval(&state, &approval_export).await?;
+    assert_eq!(rejected.status, BusApprovalStatus::Rejected);
+    assert!(rejected.produced_offset.is_none());
+
+    info!("approval simulation complete");
+    Ok(())
+}
+
+async fn park_tool_call(
+    state: &std::sync::Arc<dyn StateStore>,
+    conv: &Conversation,
+    mut call: ToolCall,
+    reason: Option<&str>,
+) -> Result<String, Box<dyn std::error::Error>> {
+    call.sender = Some("planner-1".into());
+    call.validate()?;
+    let approval_id = uuid::Uuid::now_v7().to_string();
+    let now = chrono::Utc::now();
+    let approval = BusApproval {
+        approval_id: approval_id.clone(),
+        namespace: conv.namespace.clone(),
+        tenant: conv.tenant.clone(),
+        conversation_id: conv.conversation_id.clone(),
+        reason: reason.map(str::to_string),
+        envelope: BusApprovalEnvelope::ToolCall(call),
+        status: BusApprovalStatus::Pending,
+        created_at: now,
+        expires_at: now + chrono::Duration::hours(1),
+        decided_by: None,
+        decided_at: None,
+        decision_note: None,
+        produced_partition: None,
+        produced_offset: None,
+        produced_at: None,
+        labels: Default::default(),
+    };
+    approval.validate()?;
+    let key = StateKey::new(
+        conv.namespace.clone(),
+        conv.tenant.clone(),
+        KeyKind::BusApproval,
+        &approval_id,
+    );
+    state
+        .set(&key, &serde_json::to_string(&approval)?, None)
+        .await?;
+    Ok(approval_id)
+}
+
+async fn load_approval(
+    state: &std::sync::Arc<dyn StateStore>,
+    approval_id: &str,
+) -> Result<BusApproval, Box<dyn std::error::Error>> {
+    let key = StateKey::new(NS, TENANT, KeyKind::BusApproval, approval_id);
+    let raw = state
+        .get(&key)
+        .await?
+        .ok_or_else(|| format!("approval {approval_id} missing"))?;
+    Ok(serde_json::from_str(&raw)?)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Decision {
+    Approve,
+    Reject,
+}
+
+async fn decide_approval(
+    state: &std::sync::Arc<dyn StateStore>,
+    backend: &acteon_bus::SharedBackend,
+    topic: &str,
+    approval_id: &str,
+    decision: Decision,
+    decided_by: &str,
+    decision_note: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut approval = load_approval(state, approval_id).await?;
+    if approval.status != BusApprovalStatus::Pending {
+        return Err(format!("approval {approval_id} not pending").into());
+    }
+    let now = chrono::Utc::now();
+    match decision {
+        Decision::Approve => {
+            // Reproduce what the server's `approve_bus_approval`
+            // handler does: re-stamp the envelope headers, produce
+            // to the events topic with the same key + audit
+            // metadata, then transition the row.
+            let BusApprovalEnvelope::ToolCall(envelope) = &approval.envelope;
+            let payload = serde_json::to_value(envelope)?;
+            let mut msg =
+                BusMessage::new(topic.to_string(), payload).with_key(&approval.conversation_id);
+            msg.headers.insert(
+                "acteon.conversation.id".into(),
+                approval.conversation_id.clone(),
+            );
+            if let Some(s) = &envelope.sender {
+                msg.headers
+                    .insert("acteon.conversation.sender".into(), s.clone());
+            }
+            msg.headers
+                .insert("acteon.envelope.kind".into(), "tool_call".into());
+            msg.headers
+                .insert("acteon.tool.call_id".into(), envelope.call_id.clone());
+            if let Some(c) = &envelope.correlation_id {
+                msg.headers
+                    .insert("acteon.correlation_id".into(), c.clone());
+            }
+            msg.headers
+                .insert("acteon.approval.id".into(), approval.approval_id.clone());
+            let receipt = backend.produce(msg).await?;
+            approval.status = BusApprovalStatus::Approved;
+            approval.produced_partition = Some(receipt.partition);
+            approval.produced_offset = Some(receipt.offset);
+            approval.produced_at = Some(receipt.timestamp);
+        }
+        Decision::Reject => {
+            approval.status = BusApprovalStatus::Rejected;
+        }
+    }
+    approval.decided_by = Some(decided_by.into());
+    approval.decided_at = Some(now);
+    approval.decision_note = decision_note.map(str::to_string);
+    let key = StateKey::new(NS, TENANT, KeyKind::BusApproval, approval_id);
+    state
+        .set(&key, &serde_json::to_string(&approval)?, None)
+        .await?;
+    Ok(())
+}
+
+async fn scan_count_tool_calls(
+    backend: &acteon_bus::SharedBackend,
+    topic: &str,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    let mut scan = backend.scan_topic(topic, ScanFrom::Earliest).await?;
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(200);
+    let mut count = 0;
+    loop {
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return Ok(count);
+        }
+        tokio::select! {
+            next = scan.next() => {
+                match next {
+                    Some(Ok(msg)) => {
+                        if msg.headers.get("acteon.envelope.kind").map(String::as_str) == Some("tool_call") {
+                            count += 1;
+                        }
+                    }
+                    Some(Err(_)) | None => return Ok(count),
+                }
+            }
+            () = tokio::time::sleep(deadline - now) => return Ok(count),
+        }
+    }
+}

--- a/crates/simulation/examples/mixed_backends_simulation.rs
+++ b/crates/simulation/examples/mixed_backends_simulation.rs
@@ -312,6 +312,7 @@ async fn run_simulation(config: MixedBackendConfig) -> Result<(), Box<dyn std::e
                 prefix: "acteon_mixed_".to_string(),
                 pool_size: 10,
                 connection_timeout: std::time::Duration::from_secs(5),
+                ..Default::default()
             };
             let state = Arc::new(RedisStateStore::new(&redis_config)?) as Arc<dyn StateStore>;
             let lock =

--- a/crates/simulation/examples/polyglot_client_simulation.rs
+++ b/crates/simulation/examples/polyglot_client_simulation.rs
@@ -75,6 +75,12 @@ impl TestServer {
             cors_allowed_origins: Vec::new(),
             signature_verifier: None,
             replay_protection: None,
+            #[cfg(feature = "swarm")]
+            swarm_registry: None,
+            #[cfg(feature = "bus")]
+            bus_backend: None,
+            #[cfg(feature = "bus")]
+            bus_schema_validator: acteon_bus::SchemaValidator::new(),
         };
 
         // Build router

--- a/crates/simulation/examples/postgres_chain_simulation.rs
+++ b/crates/simulation/examples/postgres_chain_simulation.rs
@@ -48,6 +48,7 @@ fn pg_configs(prefix: &str) -> (PostgresConfig, PostgresAuditConfig) {
         pool_size: 10,
         schema: "public".to_string(),
         table_prefix: prefix.to_string(),
+        ..Default::default()
     };
 
     let audit_config = PostgresAuditConfig::new(&database_url).with_prefix(prefix);

--- a/crates/simulation/examples/postgres_simulation.rs
+++ b/crates/simulation/examples/postgres_simulation.rs
@@ -69,6 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         pool_size: 10,
         schema: "public".to_string(),
         table_prefix: "acteon_sim_".to_string(),
+        ..Default::default()
     };
 
     // Audit backend config

--- a/crates/simulation/examples/redis_simulation.rs
+++ b/crates/simulation/examples/redis_simulation.rs
@@ -59,6 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         prefix: "acteon-sim".to_string(),
         pool_size: 10,
         connection_timeout: Duration::from_secs(5),
+        ..Default::default()
     };
 
     info!("→ Connecting to Redis at {}...", redis_config.url);

--- a/crates/state/state/src/key.rs
+++ b/crates/state/state/src/key.rs
@@ -66,6 +66,10 @@ pub enum KeyKind {
     BusAgent,
     /// Bus conversation thread (Phase 5 of the agentic bus).
     BusConversation,
+    /// Bus pre-publish HITL approval (Phase 6c of the agentic bus).
+    BusApproval,
+    /// Index of pending bus approvals for fast list/expiry scans.
+    PendingBusApprovals,
     Custom(String),
 }
 
@@ -107,6 +111,8 @@ impl KeyKind {
             Self::BusSchema => "bus_schema",
             Self::BusAgent => "bus_agent",
             Self::BusConversation => "bus_conversation",
+            Self::BusApproval => "bus_approval",
+            Self::PendingBusApprovals => "pending_bus_approvals",
             Self::Custom(s) => s.as_str(),
         }
     }

--- a/docs/book/concepts/bus-master-plan.md
+++ b/docs/book/concepts/bus-master-plan.md
@@ -112,4 +112,5 @@ Migration will be opt-in, per-feature, never forced.
 - **Phase 5** — shipped — see [phase-5 feature doc](../features/bus-phase-5.md)
 - **Phase 6a** (typed tool envelopes) — shipped — see [phase-6a feature doc](../features/bus-phase-6a.md)
 - **Phase 6b** (streaming chunks) — shipped — see [phase-6b feature doc](../features/bus-phase-6b.md)
-- Phases 6c, 7, 8, 9 — not started
+- **Phase 6c** (HITL pre-publish approvals) — shipped — see [phase-6c feature doc](../features/bus-phase-6c.md)
+- Phases 7, 8, 9 — not started

--- a/docs/book/features/bus-phase-6c.md
+++ b/docs/book/features/bus-phase-6c.md
@@ -1,0 +1,262 @@
+# Agentic Bus — Phase 6c
+
+> **Scope**: pre-publish HITL approvals for tool-calls. A requester
+> opts in via `require_approval`; the envelope is parked under a
+> `BusApproval` row in state instead of going straight to Kafka. An
+> operator approves or rejects; only on approve does the record
+> land. Streaming chunks and stream-end markers are out of scope —
+> gating each token of a stream defeats the point of streaming. See
+> the [master plan](../concepts/bus-master-plan.md).
+
+Phase 6a and 6b made the bus protocol-aware (typed call/result
+envelopes) and stream-aware (token-by-token chunks). Phase 6c adds
+the missing safety primitive: the ability to require a human in the
+loop *before* a sensitive tool-call reaches Kafka — without forking
+the wire format or building a parallel pipeline.
+
+## What ships in Phase 6c
+
+| Surface | Shape |
+|---|---|
+| Core types | `acteon_core::BusApproval`, `acteon_core::BusApprovalEnvelope::ToolCall`, `acteon_core::BusApprovalStatus ∈ {Pending, Approved, Rejected, Expired}` |
+| State key | `KeyKind::BusApproval` keyed by server-generated UUID v7 |
+| HTTP | `POST /v1/bus/conversations/.../tool-calls` gains `require_approval` / `approval_reason` / `approval_ttl_ms`; `GET /v1/bus/approvals/{ns}/{t}`, `GET .../{id}`, `POST .../{id}/approve`, `POST .../{id}/reject` |
+| Headers | Approved records gain `acteon.approval.id` so audit pipelines can correlate the produced Kafka record back to the row that gated it |
+| Rust client | `post_bus_tool_call` returns `PostBusToolCallOutcome { Produced \| Parked }`; new `list_bus_approvals`, `get_bus_approval`, `approve_bus_approval`, `reject_bus_approval` |
+| Tests | 12 core unit tests covering validation + serde + status transitions |
+| Simulation | `bus_approval_simulation.rs` — parks two tool-calls, approves one, rejects the other, asserts the topic only contains the approved record |
+
+## Model
+
+### Park-then-produce
+
+`POST /v1/bus/conversations/{ns}/{t}/{id}/tool-calls` with
+`require_approval: true`:
+
+1. Validates the envelope as it would for an immediate produce
+   (envelope shape, sender ACL, schema binding, label caps).
+2. Generates an approval id (UUID v7) and writes a
+   `BusApproval { status: Pending }` row at
+   `KeyKind::BusApproval:<ns>:<tenant>:<approval_id>`.
+3. Returns `202 Accepted` with the approval id, `created_at`, and
+   `expires_at`. **Nothing has been produced to Kafka.**
+
+`POST /v1/bus/approvals/{ns}/{t}/{approval_id}/approve`:
+
+1. Loads the row. If terminal (`Approved` / `Rejected` / `Expired`)
+   → `409 Conflict`.
+2. Soft-expire on read: if `expires_at < now`, return `409` with
+   the expiry timestamp.
+3. Re-resolves the conversation (so a topic that has rotated its
+   `events_topic` since parking still publishes to the right place)
+   and re-runs schema validation against the now-current binding.
+4. Stamps the standard `acteon.envelope.kind = tool_call`,
+   `acteon.tool.call_id`, `acteon.correlation_id`, `acteon.reply_to`
+   headers — plus `acteon.approval.id` for audit correlation —
+   and produces.
+5. CAS-transitions the row to `Approved` with `decided_by`,
+   `decided_at`, `decision_note`, and the produced
+   `partition`/`offset`/`produced_at`.
+
+`POST /v1/bus/approvals/{ns}/{t}/{approval_id}/reject`:
+
+1. CAS-transitions the row from `Pending` to `Rejected` with the
+   decision metadata. No Kafka record is ever produced for that
+   `call_id`.
+
+### Why park in state, not Kafka
+
+The natural alternative — produce-then-tombstone — has a long lag
+window during which the Kafka record is visible to consumers, plus
+a tombstone-replication problem if the consumer doesn't honor it.
+Parking in the state store keeps the contract simple:
+
+- A `Pending` row never reaches Kafka. Consumers cannot observe
+  it, full stop.
+- The eventual produce only happens after a human decision.
+- Audit trails capture both the approval row history and the
+  resulting Kafka offset.
+
+### TTL and expiry
+
+Each parked approval carries `expires_at` (default 24h, max 7d).
+V1 expires rows on read (the `approve` handler returns 409 if the
+row is past its TTL; the list endpoint returns the row with its
+stored `Pending` status — operators can filter visually using
+`expires_at`). A future iteration can add a periodic reaper that
+sweeps stale rows to `Expired`. The semantic outcome is the same;
+the reaper just keeps the listing tidy.
+
+## API shape
+
+### Request approval
+
+```http
+POST /v1/bus/conversations/agents/demo/planning-thread/tool-calls
+{
+  "call_id": "call-pay-1",
+  "tool": "billing.charge",
+  "arguments": {"usd": 42},
+  "sender": "planner-1",
+  "require_approval": true,
+  "approval_reason": "paid action — operator must approve",
+  "approval_ttl_ms": 600000
+}
+→ 202 Accepted
+{
+  "approval_id": "019ddcea-be22-7781-ae90-4c496cb0d575",
+  "namespace": "agents",
+  "tenant": "demo",
+  "conversation_id": "planning-thread",
+  "correlation_token": "call-pay-1",
+  "status": "pending",
+  "created_at": "...",
+  "expires_at": "..."
+}
+```
+
+### List pending approvals
+
+```http
+GET /v1/bus/approvals/agents/demo?status=pending
+→ 200 OK
+{
+  "approvals": [
+    { "approval_id": "...", "status": "pending", "reason": "...", ... }
+  ],
+  "count": 1
+}
+```
+
+### Approve
+
+```http
+POST /v1/bus/approvals/agents/demo/{approval_id}/approve
+{
+  "decided_by": "ops-1",
+  "decision_note": "verified PO #4711"
+}
+→ 200 OK
+{
+  "approval": { "status": "approved", "produced_partition": 0, ... },
+  "receipt": {
+    "events_topic": "agents.demo.conversations-events",
+    "call_id": "call-pay-1",
+    "partition": 0,
+    "offset": 18,
+    "produced_at": "...",
+    "cursor": "..."
+  }
+}
+```
+
+The `cursor` on the receipt is identical in shape to the Phase 5/6a
+replay cursors — pass it to a follow-up `lookup_bus_tool_result` so
+the result scan starts strictly after the approved record landed.
+
+### Reject
+
+```http
+POST /v1/bus/approvals/agents/demo/{approval_id}/reject
+{ "decided_by": "ops-1", "decision_note": "scope too broad" }
+→ 200 OK
+{ "approval": { "status": "rejected", ... }, "receipt": null }
+```
+
+## SDK example
+
+```rust
+use acteon_client::{
+    ActeonClient, BusApprovalDecisionRequest, ListBusApprovalsParams,
+    PostBusToolCall, PostBusToolCallOutcome,
+};
+
+let client = ActeonClient::new("http://localhost:3000");
+
+let outcome = client.post_bus_tool_call("agents", "demo", "planning-thread",
+    &PostBusToolCall {
+        call_id: "call-pay-1".into(),
+        tool: "billing.charge".into(),
+        arguments: serde_json::json!({"usd": 42}),
+        sender: Some("planner-1".into()),
+        require_approval: true,
+        approval_reason: Some("paid action".into()),
+        ..Default::default()
+    }).await?;
+
+let approval_id = match outcome {
+    PostBusToolCallOutcome::Parked(p) => p.approval_id,
+    PostBusToolCallOutcome::Produced(_) => unreachable!(),
+};
+
+// ...operator UX...
+
+let decision = client.approve_bus_approval("agents", "demo", &approval_id,
+    &BusApprovalDecisionRequest {
+        decided_by: "ops-1".into(),
+        decision_note: Some("verified PO #4711".into()),
+    }).await?;
+
+let receipt = decision.receipt.expect("approve always returns a receipt");
+assert_eq!(receipt.call_id, "call-pay-1");
+```
+
+## Authorization
+
+- `require_approval` post still requires `BusOp::Publish` on the
+  parking POST — parking is a privileged action; an unprivileged
+  caller shouldn't be able to fill the approval queue.
+- `list`, `get` require `BusOp::ManageConversation` (operator
+  surface).
+- `approve` requires both `ManageConversation` and `Publish` —
+  approving *is* a produce, just gated.
+- `reject` requires `ManageConversation` only.
+
+Participant ACL on the originating conversation applies at park
+time (the envelope's `sender` must be on the participants list when
+the conversation is private). The approve handler does not re-check
+participant ACL — the approval id is the trust token at that point,
+and operators are by construction allowed to act outside the
+participant set when servicing the approval queue.
+
+## Trust model and limits (V1)
+
+### Park-and-produce is not atomic
+
+V1 does not use a Kafka transactional producer. The two writes
+(state-row update + Kafka produce) happen separately:
+
+- **If the produce fails after a successful approve decision:** the
+  state row stays `Pending` so an operator can retry. The handler
+  returns `500` with the produce error; no `Approved` transition
+  occurs.
+- **If the produce succeeds but the row update fails:** the message
+  is on Kafka; the row update is best-effort with an in-handler CAS
+  retry. We log loudly when the row update gives up, but the response
+  is still `200` because the bus is the source of truth. Idempotent
+  producer semantics + per-`call_id` uniqueness on the consumer side
+  (see Phase 6a trust model) keep the topic clean across retries.
+
+A future iteration can use a Kafka transactional producer + outbox
+pattern to close this window completely. The master plan calls this
+out under the *Exactly-once edge* section.
+
+### `require_approval` is per-call, not per-tenant policy
+
+There's no server-side rule that *forces* a tool-call to require
+approval. Phase 6c is a primitive — the requester opts in. A
+follow-up phase can layer a policy engine that auto-flags certain
+`tool` names or argument shapes by matching against rule
+definitions, then injects `require_approval = true` server-side.
+
+### Rejection is final
+
+A `Rejected` row cannot transition back to `Pending` or to
+`Approved`. The terminal-status check on both decision handlers
+makes this explicit; double-decision races land on `409 Conflict`.
+
+## What comes next
+
+- **Phase 7** — UI: an approvals queue page, plus inline approve/reject from the conversation thread view.
+- **Phase 8** — 5-SDK parity for the bus surface (Python, Node, Go, Java) including the new approval flow.
+- **Future** — policy-driven auto-flagging of risky tool-calls; transactional producer + outbox for atomic park-then-produce.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,6 +190,7 @@ nav:
     - Phase 5 (Conversations + Threads): features/bus-phase-5.md
     - Phase 6a (Tool-call envelopes): features/bus-phase-6a.md
     - Phase 6b (Streaming chunks): features/bus-phase-6b.md
+    - Phase 6c (HITL approvals): features/bus-phase-6c.md
   - Guides:
     - guides/index.md
     - AI Agent Swarm Coordination: guides/agent-swarm-coordination.md


### PR DESCRIPTION
## Summary
- A tool-call with `require_approval: true` is parked under a `BusApproval` state row instead of going to Kafka. An operator approves (or rejects) via a separate endpoint; only on approve does the record land.
- Same layered pattern as 6a/6b — no parallel pipeline, no wire-format fork. Approved produces gain an `acteon.approval.id` header so audit pipelines can correlate the produced offset back to the row that gated it.
- Streaming chunks and stream-end markers are deliberately out of scope (gating each token of a stream defeats the point of streaming).

## What ships
- **Core**: `BusApproval`, `BusApprovalEnvelope::ToolCall`, `BusApprovalStatus ∈ {Pending, Approved, Rejected, Expired}`. 12 unit tests cover id/ttl/note caps and serde roundtrips.
- **State**: `KeyKind::BusApproval` (+ `PendingBusApprovals` reserved for a future reaper index).
- **HTTP**:
  - `POST /v1/bus/conversations/{ns}/{t}/{id}/tool-calls` gains `require_approval` / `approval_reason` / `approval_ttl_ms`. With it set, parks the validated envelope and returns `202 Accepted` + `approval_id`.
  - `GET /v1/bus/approvals/{ns}/{t}` (filter by `status` / `conversation_id`)
  - `GET /v1/bus/approvals/{ns}/{t}/{approval_id}`
  - `POST /v1/bus/approvals/{ns}/{t}/{approval_id}/approve` — re-resolves the conversation, re-runs schema validation, stamps headers + `acteon.approval.id`, produces, CAS-transitions the row.
  - `POST /v1/bus/approvals/{ns}/{t}/{approval_id}/reject` — CAS-transitions to `Rejected`. No Kafka record.
  - Soft-expire on read so a stale row can never be approved past its TTL.
- **SDK**: `post_bus_tool_call` now returns `PostBusToolCallOutcome { Produced | Parked }`. New helpers `list_bus_approvals`, `get_bus_approval`, `approve_bus_approval`, `reject_bus_approval`. `post_bus_tool_call_and_wait` errors with a clear configuration message when the call is parked.
- **Simulation**: `bus_approval_simulation.rs` parks two tool-calls (paid action + data export), approves one and rejects the other, asserts the events topic only contains the approved record.
- **Docs**: `bus-phase-6c.md` covers model, API shape, SDK example, full trust model (V1 park-and-produce isn't atomic — explicit failure-mode docs + idempotent-producer mitigation), and limits. Master plan phase-status + mkdocs nav refreshed.

## Trust model (V1)
- **Park-and-produce isn't atomic.** Two writes (state row + Kafka). Produce-failure leaves the row `Pending` for retry. Row-update-failure after a successful produce is logged loud; idempotent producer + `call_id` uniqueness keep the topic clean. A future iteration can use a Kafka transactional producer + outbox for atomicity (called out in the master plan's *Exactly-once edge* section).
- **`require_approval` is per-call, not policy.** Phase 6c is the primitive; a follow-up phase can layer auto-flagging based on rule definitions.
- **Rejection is final.** Terminal-status check on both decision handlers; double-decision races land on `409 Conflict`.

## Deferred
- Background expiry reaper (V1 soft-expires on read; reaper would just keep listings tidy).
- Polyglot SDKs (Phase 8 per master plan).

## Test plan
- [x] `cargo test -p acteon-core --lib bus_approval` — 12 tests pass
- [x] `cargo clippy --workspace --no-deps --features bus -- -D warnings` — clean
- [x] `cargo check --all-targets` — clean
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps` — clean
- [x] `cd ui && npm run lint && npm run build` — clean
- [x] `cargo run -p acteon-simulation --features bus --example bus_approval_simulation` — approves paid call, rejects export, only the approved record appears on the events topic

🤖 Generated with [Claude Code](https://claude.com/claude-code)