### PR TITLE
feat(go-sdk): Phase 8c — bus surface parity

### DIFF
--- a/clients/go/acteon/bus.go
+++ b/clients/go/acteon/bus.go
@@ -1,0 +1,637 @@
+package acteon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// Phase 8c: agentic bus surface (Phases 1-6c).
+//
+// Method names match the existing Go SDK convention (exported
+// PascalCase); wire payloads match the Rust + Python + Node SDKs
+// byte-for-byte.
+
+// busSeg percent-encodes a single path segment so reserved
+// characters like `/` don't slip into the URL grammar. Acteon's
+// bus REST surface treats namespace / tenant / name slots as
+// opaque strings.
+func busSeg(s string) string {
+	return url.PathEscape(s)
+}
+
+// busDoJSON is a thin helper around `doRequest` that reads the
+// response body and surfaces structured Acteon errors as `*APIError`
+// (or falls back to `*HTTPError` when the body isn't structured).
+// Successful responses get unmarshalled into `out` (when non-nil).
+func (c *Client) busDoJSON(
+	ctx context.Context,
+	method, path string,
+	body, out any,
+) (*http.Response, error) {
+	resp, err := c.doRequest(ctx, method, path, body)
+	if err != nil {
+		return nil, err
+	}
+	respBody, readErr := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if readErr != nil {
+		return resp, &ConnectionError{Message: readErr.Error()}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var errResp struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+			Error   string `json:"error"`
+		}
+		if jsonErr := json.Unmarshal(respBody, &errResp); jsonErr == nil {
+			msg := errResp.Error
+			if msg == "" {
+				msg = errResp.Message
+			}
+			if msg == "" {
+				msg = "bus error"
+			}
+			code := errResp.Code
+			if code == "" {
+				code = "BUS"
+			}
+			return resp, &APIError{Code: code, Message: msg, Retryable: false}
+		}
+		return resp, &HTTPError{Status: resp.StatusCode, Message: string(respBody)}
+	}
+	if out != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return resp, &ConnectionError{Message: err.Error()}
+		}
+	}
+	return resp, nil
+}
+
+// =============================================================================
+// Phase 1: Topics + publish
+// =============================================================================
+
+func (c *Client) CreateBusTopic(ctx context.Context, req *CreateBusTopic) (*BusTopic, error) {
+	var out BusTopic
+	if _, err := c.busDoJSON(ctx, http.MethodPost, "/v1/bus/topics", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) ListBusTopics(ctx context.Context, filter *ListBusTopicsFilter) ([]BusTopic, error) {
+	path := "/v1/bus/topics"
+	if filter != nil {
+		params := url.Values{}
+		if filter.Namespace != "" {
+			params.Set("namespace", filter.Namespace)
+		}
+		if filter.Tenant != "" {
+			params.Set("tenant", filter.Tenant)
+		}
+		if len(params) > 0 {
+			path += "?" + params.Encode()
+		}
+	}
+	var out ListBusTopicsResponse
+	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Topics, nil
+}
+
+func (c *Client) GetBusTopic(ctx context.Context, namespace, tenant, name string) (*BusTopic, error) {
+	path := fmt.Sprintf("/v1/bus/topics/%s/%s/%s", busSeg(namespace), busSeg(tenant), busSeg(name))
+	var out BusTopic
+	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) DeleteBusTopic(ctx context.Context, namespace, tenant, name string) error {
+	path := fmt.Sprintf("/v1/bus/topics/%s/%s/%s", busSeg(namespace), busSeg(tenant), busSeg(name))
+	_, err := c.busDoJSON(ctx, http.MethodDelete, path, nil, nil)
+	return err
+}
+
+func (c *Client) PublishBusMessage(ctx context.Context, req *PublishBusMessage) (*PublishReceipt, error) {
+	var out PublishReceipt
+	if _, err := c.busDoJSON(ctx, http.MethodPost, "/v1/bus/publish", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// =============================================================================
+// Phase 2: Subscriptions + lag
+// =============================================================================
+
+func (c *Client) CreateBusSubscription(ctx context.Context, req *CreateBusSubscription) (*BusSubscription, error) {
+	var out BusSubscription
+	if _, err := c.busDoJSON(ctx, http.MethodPost, "/v1/bus/subscriptions", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) ListBusSubscriptions(ctx context.Context, filter *ListBusSubscriptionsFilter) ([]BusSubscription, error) {
+	path := "/v1/bus/subscriptions"
+	if filter != nil {
+		params := url.Values{}
+		if filter.Namespace != "" {
+			params.Set("namespace", filter.Namespace)
+		}
+		if filter.Tenant != "" {
+			params.Set("tenant", filter.Tenant)
+		}
+		if filter.Topic != "" {
+			params.Set("topic", filter.Topic)
+		}
+		if len(params) > 0 {
+			path += "?" + params.Encode()
+		}
+	}
+	var out ListBusSubscriptionsResponse
+	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Subscriptions, nil
+}
+
+func (c *Client) GetBusSubscription(ctx context.Context, subID string) (*BusSubscription, error) {
+	path := fmt.Sprintf("/v1/bus/subscriptions/%s", busSeg(subID))
+	var out BusSubscription
+	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) DeleteBusSubscription(ctx context.Context, subID string) error {
+	path := fmt.Sprintf("/v1/bus/subscriptions/%s", busSeg(subID))
+	_, err := c.busDoJSON(ctx, http.MethodDelete, path, nil, nil)
+	return err
+}
+
+func (c *Client) GetBusSubscriptionLag(ctx context.Context, subID string) (*BusLag, error) {
+	path := fmt.Sprintf("/v1/bus/subscriptions/%s/lag", busSeg(subID))
+	var out BusLag
+	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// =============================================================================
+// Phase 3: Schemas
+// =============================================================================
+
+func (c *Client) RegisterBusSchema(ctx context.Context, req *RegisterBusSchema) (*BusSchema, error) {
+	var out BusSchema
+	if _, err := c.busDoJSON(ctx, http.MethodPost, "/v1/bus/schemas", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) ListBusSchemas(ctx context.Context, filter *ListBusSchemasFilter) ([]BusSchema, error) {
+	path := "/v1/bus/schemas"
+	if filter != nil {
+		params := url.Values{}
+		if filter.Namespace != "" {
+			params.Set("namespace", filter.Namespace)
+		}
+		if filter.Tenant != "" {
+			params.Set("tenant", filter.Tenant)
+		}
+		if filter.Subject != "" {
+			params.Set("subject", filter.Subject)
+		}
+		if filter.LatestOnly {
+			params.Set("latest_only", "true")
+		}
+		if len(params) > 0 {
+			path += "?" + params.Encode()
+		}
+	}
+	var out ListBusSchemasResponse
+	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Schemas, nil
+}
+
+func (c *Client) GetBusSchema(ctx context.Context, namespace, tenant, subject string, version int) (*BusSchema, error) {
+	path := fmt.Sprintf("/v1/bus/schemas/%s/%s/%s/%d",
+		busSeg(namespace), busSeg(tenant), busSeg(subject), version)
+	var out BusSchema
+	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) DeleteBusSchema(ctx context.Context, namespace, tenant, subject string, version int) error {
+	path := fmt.Sprintf("/v1/bus/schemas/%s/%s/%s/%d",
+		busSeg(namespace), busSeg(tenant), busSeg(subject), version)
+	_, err := c.busDoJSON(ctx, http.MethodDelete, path, nil, nil)
+	return err
+}
+
+// =============================================================================
+// Phase 4: Agents + heartbeat
+// =============================================================================
+
+func (c *Client) RegisterBusAgent(ctx context.Context, req *RegisterBusAgent) (*BusAgent, error) {
+	var out BusAgent
+	if _, err := c.busDoJSON(ctx, http.MethodPost, "/v1/bus/agents", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) ListBusAgents(ctx context.Context, filter *ListBusAgentsFilter) ([]BusAgent, error) {
+	path := "/v1/bus/agents"
+	if filter != nil {
+		params := url.Values{}
+		if filter.Namespace != "" {
+			params.Set("namespace", filter.Namespace)
+		}
+		if filter.Tenant != "" {
+			params.Set("tenant", filter.Tenant)
+		}
+		if len(params) > 0 {
+			path += "?" + params.Encode()
+		}
+	}
+	var out ListBusAgentsResponse
+	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Agents, nil
+}
+
+func (c *Client) GetBusAgent(ctx context.Context, namespace, tenant, agentID string) (*BusAgent, error) {
+	path := fmt.Sprintf("/v1/bus/agents/%s/%s/%s",
+		busSeg(namespace), busSeg(tenant), busSeg(agentID))
+	var out BusAgent
+	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) DeleteBusAgent(ctx context.Context, namespace, tenant, agentID string) error {
+	path := fmt.Sprintf("/v1/bus/agents/%s/%s/%s",
+		busSeg(namespace), busSeg(tenant), busSeg(agentID))
+	_, err := c.busDoJSON(ctx, http.MethodDelete, path, nil, nil)
+	return err
+}
+
+func (c *Client) HeartbeatBusAgent(ctx context.Context, namespace, tenant, agentID string) (*BusAgent, error) {
+	path := fmt.Sprintf("/v1/bus/agents/%s/%s/%s/heartbeat",
+		busSeg(namespace), busSeg(tenant), busSeg(agentID))
+	var out BusAgent
+	if _, err := c.busDoJSON(ctx, http.MethodPatch, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// =============================================================================
+// Phase 5: Conversations
+// =============================================================================
+
+func (c *Client) CreateBusConversation(ctx context.Context, req *CreateBusConversation) (*BusConversation, error) {
+	var out BusConversation
+	if _, err := c.busDoJSON(ctx, http.MethodPost, "/v1/bus/conversations", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) ListBusConversations(ctx context.Context, filter *ListBusConversationsFilter) ([]BusConversation, error) {
+	path := "/v1/bus/conversations"
+	if filter != nil {
+		params := url.Values{}
+		if filter.Namespace != "" {
+			params.Set("namespace", filter.Namespace)
+		}
+		if filter.Tenant != "" {
+			params.Set("tenant", filter.Tenant)
+		}
+		if filter.State != "" {
+			params.Set("state", filter.State)
+		}
+		if filter.Participant != "" {
+			params.Set("participant", filter.Participant)
+		}
+		if len(params) > 0 {
+			path += "?" + params.Encode()
+		}
+	}
+	var out ListBusConversationsResponse
+	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Conversations, nil
+}
+
+func (c *Client) GetBusConversation(ctx context.Context, namespace, tenant, conversationID string) (*BusConversation, error) {
+	path := fmt.Sprintf("/v1/bus/conversations/%s/%s/%s",
+		busSeg(namespace), busSeg(tenant), busSeg(conversationID))
+	var out BusConversation
+	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) DeleteBusConversation(ctx context.Context, namespace, tenant, conversationID string) error {
+	path := fmt.Sprintf("/v1/bus/conversations/%s/%s/%s",
+		busSeg(namespace), busSeg(tenant), busSeg(conversationID))
+	_, err := c.busDoJSON(ctx, http.MethodDelete, path, nil, nil)
+	return err
+}
+
+func (c *Client) TransitionBusConversation(
+	ctx context.Context, namespace, tenant, conversationID, targetState string,
+) (*BusConversation, error) {
+	path := fmt.Sprintf("/v1/bus/conversations/%s/%s/%s/transition",
+		busSeg(namespace), busSeg(tenant), busSeg(conversationID))
+	body := TransitionBusConversationRequest{TargetState: targetState}
+	var out BusConversation
+	if _, err := c.busDoJSON(ctx, http.MethodPost, path, body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) AppendBusConversationMessage(
+	ctx context.Context,
+	namespace, tenant, conversationID string,
+	req *AppendBusConversationMessage,
+) (map[string]any, error) {
+	path := fmt.Sprintf("/v1/bus/conversations/%s/%s/%s/messages",
+		busSeg(namespace), busSeg(tenant), busSeg(conversationID))
+	out := make(map[string]any)
+	if _, err := c.busDoJSON(ctx, http.MethodPost, path, req, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *Client) ReplayBusConversationMessages(
+	ctx context.Context,
+	namespace, tenant, conversationID string,
+	params *ReplayBusConversationParams,
+) (*BusReplayResponse, error) {
+	path := fmt.Sprintf("/v1/bus/conversations/%s/%s/%s/messages",
+		busSeg(namespace), busSeg(tenant), busSeg(conversationID))
+	if params != nil {
+		q := url.Values{}
+		if params.Limit > 0 {
+			q.Set("limit", strconv.Itoa(params.Limit))
+		}
+		if params.Cursor != "" {
+			q.Set("cursor", params.Cursor)
+		}
+		if params.AsAgent != "" {
+			q.Set("as_agent", params.AsAgent)
+		}
+		if len(q) > 0 {
+			path += "?" + q.Encode()
+		}
+	}
+	var out BusReplayResponse
+	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// =============================================================================
+// Phase 6a: Tool envelopes
+// =============================================================================
+
+// PostBusToolCall appends a tool-call envelope. Returns a discriminated
+// outcome — `Produced` non-nil when the call landed on Kafka,
+// `Parked` non-nil when the server parked it under a Phase 6c HITL
+// approval (driven by `req.RequireApproval`).
+func (c *Client) PostBusToolCall(
+	ctx context.Context,
+	namespace, tenant, conversationID string,
+	req *PostBusToolCall,
+) (*PostBusToolCallOutcome, error) {
+	path := fmt.Sprintf("/v1/bus/conversations/%s/%s/%s/tool-calls",
+		busSeg(namespace), busSeg(tenant), busSeg(conversationID))
+	resp, err := c.doRequest(ctx, http.MethodPost, path, req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, &ConnectionError{Message: readErr.Error()}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, parseBusError(resp.StatusCode, respBody)
+	}
+	if resp.StatusCode == http.StatusAccepted {
+		var parked BusApprovalParkedReceipt
+		if err := json.Unmarshal(respBody, &parked); err != nil {
+			return nil, &ConnectionError{Message: err.Error()}
+		}
+		return &PostBusToolCallOutcome{Parked: &parked}, nil
+	}
+	var produced BusToolEnvelopeReceipt
+	if err := json.Unmarshal(respBody, &produced); err != nil {
+		return nil, &ConnectionError{Message: err.Error()}
+	}
+	return &PostBusToolCallOutcome{Produced: &produced}, nil
+}
+
+func (c *Client) PostBusToolResult(
+	ctx context.Context,
+	namespace, tenant, conversationID string,
+	req *PostBusToolResult,
+) (*BusToolEnvelopeReceipt, error) {
+	path := fmt.Sprintf("/v1/bus/conversations/%s/%s/%s/tool-results",
+		busSeg(namespace), busSeg(tenant), busSeg(conversationID))
+	var out BusToolEnvelopeReceipt
+	if _, err := c.busDoJSON(ctx, http.MethodPost, path, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) LookupBusToolResult(
+	ctx context.Context,
+	namespace, tenant, callID string,
+	params *BusToolResultLookupParams,
+) (*BusToolResultLookup, error) {
+	path := fmt.Sprintf("/v1/bus/tool-calls/%s/%s/%s/result",
+		busSeg(namespace), busSeg(tenant), busSeg(callID))
+	if params != nil {
+		q := url.Values{}
+		q.Set("conversation_id", params.ConversationID)
+		if params.Cursor != "" {
+			q.Set("cursor", params.Cursor)
+		}
+		if params.TimeoutMs > 0 {
+			q.Set("timeout_ms", strconv.FormatUint(params.TimeoutMs, 10))
+		}
+		if params.AsAgent != "" {
+			q.Set("as_agent", params.AsAgent)
+		}
+		path += "?" + q.Encode()
+	}
+	var out BusToolResultLookup
+	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// =============================================================================
+// Phase 6b: Stream envelopes
+// =============================================================================
+
+func (c *Client) PostBusStreamChunk(
+	ctx context.Context,
+	namespace, tenant, conversationID string,
+	req *PostBusStreamChunk,
+) (*BusStreamEnvelopeReceipt, error) {
+	path := fmt.Sprintf("/v1/bus/conversations/%s/%s/%s/stream-chunks",
+		busSeg(namespace), busSeg(tenant), busSeg(conversationID))
+	var out BusStreamEnvelopeReceipt
+	if _, err := c.busDoJSON(ctx, http.MethodPost, path, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) PostBusStreamEnd(
+	ctx context.Context,
+	namespace, tenant, conversationID string,
+	req *PostBusStreamEnd,
+) (*BusStreamEnvelopeReceipt, error) {
+	path := fmt.Sprintf("/v1/bus/conversations/%s/%s/%s/stream-end",
+		busSeg(namespace), busSeg(tenant), busSeg(conversationID))
+	var out BusStreamEnvelopeReceipt
+	if _, err := c.busDoJSON(ctx, http.MethodPost, path, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// BusStreamConsumeURL returns the SSE consume URL for a stream. Plug
+// it into your preferred SSE client (`r3labs/sse`, the stdlib HTTP
+// streaming reader, etc.). Path segments are encoded the same way
+// the Rust + Python + Node SDKs encode them.
+func (c *Client) BusStreamConsumeURL(
+	namespace, tenant, conversationID, streamID string,
+) string {
+	return fmt.Sprintf("%s/v1/bus/streams/%s/%s/%s/%s",
+		c.baseURL,
+		busSeg(namespace), busSeg(tenant),
+		busSeg(conversationID), busSeg(streamID))
+}
+
+// =============================================================================
+// Phase 6c: HITL approvals
+// =============================================================================
+
+func (c *Client) ListBusApprovals(
+	ctx context.Context,
+	namespace, tenant string,
+	filter *ListBusApprovalsFilter,
+) ([]BusApprovalView, error) {
+	path := fmt.Sprintf("/v1/bus/approvals/%s/%s", busSeg(namespace), busSeg(tenant))
+	if filter != nil {
+		q := url.Values{}
+		if filter.Status != "" {
+			q.Set("status", filter.Status)
+		}
+		if filter.ConversationID != "" {
+			q.Set("conversation_id", filter.ConversationID)
+		}
+		if len(q) > 0 {
+			path += "?" + q.Encode()
+		}
+	}
+	var out ListBusApprovalsResponse
+	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Approvals, nil
+}
+
+func (c *Client) GetBusApproval(
+	ctx context.Context, namespace, tenant, approvalID string,
+) (*BusApprovalView, error) {
+	path := fmt.Sprintf("/v1/bus/approvals/%s/%s/%s",
+		busSeg(namespace), busSeg(tenant), busSeg(approvalID))
+	var out BusApprovalView
+	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) ApproveBusApproval(
+	ctx context.Context,
+	namespace, tenant, approvalID string,
+	decision *BusApprovalDecision,
+) (*BusApprovalDecisionResponse, error) {
+	path := fmt.Sprintf("/v1/bus/approvals/%s/%s/%s/approve",
+		busSeg(namespace), busSeg(tenant), busSeg(approvalID))
+	var out BusApprovalDecisionResponse
+	if _, err := c.busDoJSON(ctx, http.MethodPost, path, decision, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) RejectBusApproval(
+	ctx context.Context,
+	namespace, tenant, approvalID string,
+	decision *BusApprovalDecision,
+) (*BusApprovalDecisionResponse, error) {
+	path := fmt.Sprintf("/v1/bus/approvals/%s/%s/%s/reject",
+		busSeg(namespace), busSeg(tenant), busSeg(approvalID))
+	var out BusApprovalDecisionResponse
+	if _, err := c.busDoJSON(ctx, http.MethodPost, path, decision, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func parseBusError(status int, respBody []byte) error {
+	var errResp struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+		Error   string `json:"error"`
+	}
+	if jsonErr := json.Unmarshal(respBody, &errResp); jsonErr == nil {
+		msg := errResp.Error
+		if msg == "" {
+			msg = errResp.Message
+		}
+		if msg == "" {
+			msg = "bus error"
+		}
+		code := errResp.Code
+		if code == "" {
+			code = "BUS"
+		}
+		return &APIError{Code: code, Message: msg, Retryable: false}
+	}
+	return &HTTPError{Status: status, Message: string(respBody)}
+}

--- a/clients/go/acteon/bus_models.go
+++ b/clients/go/acteon/bus_models.go
@@ -1,0 +1,447 @@
+package acteon
+
+// DTOs for the Acteon agentic bus surface (Phases 1-6c).
+//
+// Field types are pointers wherever the server treats the field as
+// optional (`#[serde(default, skip_serializing_if = "Option::is_none")]`)
+// so callers can distinguish "unset" from "explicitly the zero value".
+// Slices and maps use `omitempty` instead — the server treats an
+// absent collection identically to an empty one.
+
+// =============================================================================
+// Phase 1: Topics + publish
+// =============================================================================
+
+type CreateBusTopic struct {
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace"`
+	Tenant            string            `json:"tenant"`
+	Partitions        *int              `json:"partitions,omitempty"`
+	ReplicationFactor *int              `json:"replication_factor,omitempty"`
+	RetentionMs       *int64            `json:"retention_ms,omitempty"`
+	Description       *string           `json:"description,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
+}
+
+type BusTopic struct {
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace"`
+	Tenant            string            `json:"tenant"`
+	KafkaName         string            `json:"kafka_name"`
+	Partitions        int               `json:"partitions"`
+	ReplicationFactor int               `json:"replication_factor"`
+	RetentionMs       *int64            `json:"retention_ms,omitempty"`
+	Description       *string           `json:"description,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	SchemaSubject     *string           `json:"schema_subject,omitempty"`
+	SchemaVersion     *int              `json:"schema_version,omitempty"`
+	CreatedAt         string            `json:"created_at"`
+	UpdatedAt         string            `json:"updated_at"`
+}
+
+type ListBusTopicsResponse struct {
+	Topics []BusTopic `json:"topics"`
+	Count  int        `json:"count"`
+}
+
+type ListBusTopicsFilter struct {
+	Namespace string
+	Tenant    string
+}
+
+type PublishBusMessage struct {
+	Topic     *string                `json:"topic,omitempty"`
+	Namespace *string                `json:"namespace,omitempty"`
+	Tenant    *string                `json:"tenant,omitempty"`
+	Name      *string                `json:"name,omitempty"`
+	Key       *string                `json:"key,omitempty"`
+	Payload   any                    `json:"payload"`
+	Headers   map[string]string      `json:"headers,omitempty"`
+}
+
+type PublishReceipt struct {
+	Topic      string `json:"topic"`
+	Partition  int32  `json:"partition"`
+	Offset     int64  `json:"offset"`
+	ProducedAt string `json:"produced_at"`
+}
+
+// =============================================================================
+// Phase 2: Subscriptions + lag
+// =============================================================================
+
+type CreateBusSubscription struct {
+	ID              string            `json:"id"`
+	Topic           string            `json:"topic"`
+	Namespace       string            `json:"namespace"`
+	Tenant          string            `json:"tenant"`
+	StartingOffset  *string           `json:"starting_offset,omitempty"`
+	AckMode         *string           `json:"ack_mode,omitempty"`
+	DeadLetterTopic *string           `json:"dead_letter_topic,omitempty"`
+	AckTimeoutMs    *uint64           `json:"ack_timeout_ms,omitempty"`
+	Description     *string           `json:"description,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty"`
+}
+
+type BusSubscription struct {
+	ID              string            `json:"id"`
+	Topic           string            `json:"topic"`
+	Namespace       string            `json:"namespace"`
+	Tenant          string            `json:"tenant"`
+	StartingOffset  string            `json:"starting_offset"`
+	AckMode         string            `json:"ack_mode"`
+	DeadLetterTopic *string           `json:"dead_letter_topic,omitempty"`
+	AckTimeoutMs    uint64            `json:"ack_timeout_ms"`
+	Description     *string           `json:"description,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty"`
+	CreatedAt       string            `json:"created_at"`
+	UpdatedAt       string            `json:"updated_at"`
+}
+
+type ListBusSubscriptionsResponse struct {
+	Subscriptions []BusSubscription `json:"subscriptions"`
+	Count         int               `json:"count"`
+}
+
+type ListBusSubscriptionsFilter struct {
+	Namespace string
+	Tenant    string
+	Topic     string
+}
+
+type BusLagPartition struct {
+	Partition      int32 `json:"partition"`
+	Committed      int64 `json:"committed"`
+	HighWaterMark  int64 `json:"high_water_mark"`
+	Lag            int64 `json:"lag"`
+}
+
+type BusLag struct {
+	SubscriptionID string            `json:"subscription_id"`
+	Topic          string            `json:"topic"`
+	Partitions     []BusLagPartition `json:"partitions"`
+	TotalLag       int64             `json:"total_lag"`
+}
+
+// =============================================================================
+// Phase 3: Schemas
+// =============================================================================
+
+type RegisterBusSchema struct {
+	Subject   string            `json:"subject"`
+	Namespace string            `json:"namespace"`
+	Tenant    string            `json:"tenant"`
+	Body      any               `json:"body"`
+	Labels    map[string]string `json:"labels,omitempty"`
+}
+
+type BusSchema struct {
+	Subject   string            `json:"subject"`
+	Version   int               `json:"version"`
+	Namespace string            `json:"namespace"`
+	Tenant    string            `json:"tenant"`
+	Body      any               `json:"body"`
+	Labels    map[string]string `json:"labels,omitempty"`
+	CreatedAt string            `json:"created_at"`
+}
+
+type ListBusSchemasResponse struct {
+	Schemas []BusSchema `json:"schemas"`
+	Count   int         `json:"count"`
+}
+
+type ListBusSchemasFilter struct {
+	Namespace  string
+	Tenant     string
+	Subject    string
+	LatestOnly bool
+}
+
+// =============================================================================
+// Phase 4: Agents + heartbeat
+// =============================================================================
+
+type RegisterBusAgent struct {
+	AgentID         string            `json:"agent_id"`
+	Namespace       string            `json:"namespace"`
+	Tenant          string            `json:"tenant"`
+	Capabilities    []string          `json:"capabilities,omitempty"`
+	InboxSuffix     *string           `json:"inbox_suffix,omitempty"`
+	HeartbeatTtlMs  *uint64           `json:"heartbeat_ttl_ms,omitempty"`
+	Description     *string           `json:"description,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty"`
+}
+
+type BusAgent struct {
+	AgentID          string            `json:"agent_id"`
+	Namespace        string            `json:"namespace"`
+	Tenant           string            `json:"tenant"`
+	Capabilities     []string          `json:"capabilities"`
+	InboxTopic       string            `json:"inbox_topic"`
+	Status           string            `json:"status"`
+	LastHeartbeatAt  *string           `json:"last_heartbeat_at,omitempty"`
+	HeartbeatTtlMs   uint64            `json:"heartbeat_ttl_ms"`
+	Description      *string           `json:"description,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	CreatedAt        string            `json:"created_at"`
+	UpdatedAt        string            `json:"updated_at"`
+}
+
+type ListBusAgentsResponse struct {
+	Agents []BusAgent `json:"agents"`
+	Count  int        `json:"count"`
+}
+
+type ListBusAgentsFilter struct {
+	Namespace string
+	Tenant    string
+}
+
+// =============================================================================
+// Phase 5: Conversations
+// =============================================================================
+
+type CreateBusConversation struct {
+	ConversationID string            `json:"conversation_id"`
+	Namespace      string            `json:"namespace"`
+	Tenant         string            `json:"tenant"`
+	Participants   []string          `json:"participants,omitempty"`
+	TopicSubject   *string           `json:"topic_subject,omitempty"`
+	EventsTopic    *string           `json:"events_topic,omitempty"`
+	Description    *string           `json:"description,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"`
+}
+
+type BusConversation struct {
+	ConversationID string            `json:"conversation_id"`
+	Namespace      string            `json:"namespace"`
+	Tenant         string            `json:"tenant"`
+	Participants   []string          `json:"participants"`
+	State          string            `json:"state"`
+	TopicSubject   *string           `json:"topic_subject,omitempty"`
+	EventsTopic    *string           `json:"events_topic,omitempty"`
+	Description    *string           `json:"description,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"`
+	CreatedAt      string            `json:"created_at"`
+	UpdatedAt      string            `json:"updated_at"`
+}
+
+type ListBusConversationsResponse struct {
+	Conversations []BusConversation `json:"conversations"`
+	Count         int               `json:"count"`
+}
+
+type ListBusConversationsFilter struct {
+	Namespace   string
+	Tenant      string
+	State       string
+	Participant string
+}
+
+type AppendBusConversationMessage struct {
+	Payload any               `json:"payload"`
+	Sender  *string           `json:"sender,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+type BusReplayMessage struct {
+	Partition  int32             `json:"partition"`
+	Offset     int64             `json:"offset"`
+	ProducedAt string            `json:"produced_at"`
+	Sender     *string           `json:"sender,omitempty"`
+	Payload    any               `json:"payload"`
+	Headers    map[string]string `json:"headers,omitempty"`
+}
+
+type BusReplayResponse struct {
+	ConversationID string             `json:"conversation_id"`
+	EventsTopic    string             `json:"events_topic"`
+	Messages       []BusReplayMessage `json:"messages"`
+	NextCursor     *string            `json:"next_cursor,omitempty"`
+	ExitReason     string             `json:"exit_reason"`
+}
+
+type ReplayBusConversationParams struct {
+	Limit   int
+	Cursor  string
+	AsAgent string
+}
+
+type TransitionBusConversationRequest struct {
+	TargetState string `json:"target_state"`
+}
+
+// =============================================================================
+// Phase 6a: Tool envelopes
+// =============================================================================
+
+type PostBusToolCall struct {
+	CallID        string            `json:"call_id"`
+	Tool          string            `json:"tool"`
+	Arguments     any               `json:"arguments"`
+	CorrelationID *string           `json:"correlation_id,omitempty"`
+	ReplyTo       *string           `json:"reply_to,omitempty"`
+	Sender        *string           `json:"sender,omitempty"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	// Phase 6c: opt into pre-publish HITL gating. When true, the
+	// server parks the envelope under a BusApproval row and the
+	// post returns a PostBusToolCallOutcome with Parked != nil.
+	RequireApproval bool    `json:"require_approval,omitempty"`
+	ApprovalReason  *string `json:"approval_reason,omitempty"`
+	ApprovalTtlMs   *uint64 `json:"approval_ttl_ms,omitempty"`
+}
+
+type PostBusToolResult struct {
+	CallID        string            `json:"call_id"`
+	Status        string            `json:"status"` // "ok" | "error" | "canceled"
+	Output        any               `json:"output"`
+	ErrorMessage  *string           `json:"error_message,omitempty"`
+	CorrelationID *string           `json:"correlation_id,omitempty"`
+	Sender        *string           `json:"sender,omitempty"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+}
+
+type BusToolEnvelopeReceipt struct {
+	EventsTopic    string `json:"events_topic"`
+	ConversationID string `json:"conversation_id"`
+	CallID         string `json:"call_id"`
+	Partition      int32  `json:"partition"`
+	Offset         int64  `json:"offset"`
+	ProducedAt     string `json:"produced_at"`
+	Cursor         string `json:"cursor"`
+}
+
+type BusToolResult struct {
+	CallID        string            `json:"call_id"`
+	Status        string            `json:"status"`
+	Output        any               `json:"output"`
+	ErrorMessage  *string           `json:"error_message,omitempty"`
+	CorrelationID *string           `json:"correlation_id,omitempty"`
+	Sender        *string           `json:"sender,omitempty"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	CreatedAt     string            `json:"created_at"`
+}
+
+type BusToolResultLookupParams struct {
+	ConversationID string
+	Cursor         string
+	TimeoutMs      uint64
+	AsAgent        string
+}
+
+type BusToolResultLookup struct {
+	CallID         string         `json:"call_id"`
+	EventsTopic    string         `json:"events_topic"`
+	ConversationID string         `json:"conversation_id"`
+	Partition      int32          `json:"partition"`
+	Offset         int64          `json:"offset"`
+	ProducedAt     string         `json:"produced_at"`
+	Result         BusToolResult `json:"result"`
+}
+
+// =============================================================================
+// Phase 6b: Stream envelopes
+// =============================================================================
+
+type PostBusStreamChunk struct {
+	StreamID string            `json:"stream_id"`
+	ChunkSeq int64             `json:"chunk_seq"`
+	Body     any               `json:"body"`
+	Sender   *string           `json:"sender,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+type PostBusStreamEnd struct {
+	StreamID     string            `json:"stream_id"`
+	ChunkSeq     int64             `json:"chunk_seq"`
+	Status       string            `json:"status"` // "complete" | "aborted" | "error"
+	ErrorMessage *string           `json:"error_message,omitempty"`
+	Sender       *string           `json:"sender,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+}
+
+type BusStreamEnvelopeReceipt struct {
+	EventsTopic    string `json:"events_topic"`
+	ConversationID string `json:"conversation_id"`
+	StreamID       string `json:"stream_id"`
+	ChunkSeq       int64  `json:"chunk_seq"`
+	Partition      int32  `json:"partition"`
+	Offset         int64  `json:"offset"`
+	ProducedAt     string `json:"produced_at"`
+	Cursor         string `json:"cursor"`
+}
+
+// =============================================================================
+// Phase 6c: HITL approvals
+// =============================================================================
+
+type BusApprovalParkedReceipt struct {
+	ApprovalID       string `json:"approval_id"`
+	Namespace        string `json:"namespace"`
+	Tenant           string `json:"tenant"`
+	ConversationID   string `json:"conversation_id"`
+	CorrelationToken string `json:"correlation_token"`
+	Status           string `json:"status"`
+	CreatedAt        string `json:"created_at"`
+	ExpiresAt        string `json:"expires_at"`
+}
+
+type BusApprovalView struct {
+	ApprovalID        string  `json:"approval_id"`
+	Namespace         string  `json:"namespace"`
+	Tenant            string  `json:"tenant"`
+	ConversationID    string  `json:"conversation_id"`
+	CorrelationToken  string  `json:"correlation_token"`
+	EnvelopeKind      string  `json:"envelope_kind"`
+	Status            string  `json:"status"`
+	Reason            *string `json:"reason,omitempty"`
+	CreatedAt         string  `json:"created_at"`
+	ExpiresAt         string  `json:"expires_at"`
+	DecidedBy         *string `json:"decided_by,omitempty"`
+	DecidedAt         *string `json:"decided_at,omitempty"`
+	DecisionNote      *string `json:"decision_note,omitempty"`
+	ProducedPartition *int32  `json:"produced_partition,omitempty"`
+	ProducedOffset    *int64  `json:"produced_offset,omitempty"`
+	ProducedAt        *string `json:"produced_at,omitempty"`
+	Envelope          any     `json:"envelope,omitempty"`
+}
+
+type ListBusApprovalsResponse struct {
+	Approvals []BusApprovalView `json:"approvals"`
+	Count     int               `json:"count"`
+}
+
+type ListBusApprovalsFilter struct {
+	Status         string
+	ConversationID string
+}
+
+type BusApprovalDecision struct {
+	DecidedBy    string  `json:"decided_by"`
+	DecisionNote *string `json:"decision_note,omitempty"`
+}
+
+type BusApprovalDecisionResponse struct {
+	Approval BusApprovalView         `json:"approval"`
+	Receipt  *BusToolEnvelopeReceipt `json:"receipt,omitempty"`
+}
+
+// =============================================================================
+// Sum type for PostBusToolCall — produced vs parked
+// =============================================================================
+
+// PostBusToolCallOutcome covers both branches of `PostBusToolCall`.
+// Exactly one of `Produced` or `Parked` is non-nil. When `Parked`
+// is set the call is awaiting a Phase 6c HITL decision. Go has no
+// native sum type so this is the idiomatic encoding — callers
+// branch on `if outcome.Parked != nil { ... }`.
+type PostBusToolCallOutcome struct {
+	Produced *BusToolEnvelopeReceipt
+	Parked   *BusApprovalParkedReceipt
+}
+
+// WasParked returns true iff the server parked the envelope under a
+// pending approval row instead of producing to Kafka.
+func (o *PostBusToolCallOutcome) WasParked() bool {
+	return o != nil && o.Parked != nil
+}

--- a/clients/go/acteon/bus_test.go
+++ b/clients/go/acteon/bus_test.go
@@ -1,0 +1,480 @@
+package acteon
+
+// Phase 8c: Go SDK bus surface tests.
+//
+// Live HTTP tests would need a running Acteon instance with the
+// bus feature enabled; these tests exercise wire-level serde and
+// URL encoding. The contract under test: every wire field
+// round-trips, optional fields drop cleanly, and path segments
+// are properly percent-encoded.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestCreateBusTopicSerde(t *testing.T) {
+	t.Run("minimal — drops every optional field", func(t *testing.T) {
+		req := CreateBusTopic{Name: "t", Namespace: "n", Tenant: "te"}
+		raw, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		// `omitempty` on the optional pointer fields means they
+		// don't appear in the wire form when nil.
+		if _, ok := got["partitions"]; ok {
+			t.Errorf("partitions should be omitted; got %v", got)
+		}
+		if _, ok := got["replication_factor"]; ok {
+			t.Errorf("replication_factor should be omitted; got %v", got)
+		}
+		if _, ok := got["labels"]; ok {
+			t.Errorf("empty labels should be omitted; got %v", got)
+		}
+	})
+
+	t.Run("full — snake-cases all field names", func(t *testing.T) {
+		req := CreateBusTopic{
+			Name:              "t",
+			Namespace:         "n",
+			Tenant:            "te",
+			Partitions:        ptr(4),
+			ReplicationFactor: ptr(2),
+			RetentionMs:       ptr[int64](86_400_000),
+			Description:       ptr("demo"),
+			Labels:            map[string]string{"env": "prod"},
+		}
+		raw, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		s := string(raw)
+		for _, want := range []string{
+			`"replication_factor":2`,
+			`"retention_ms":86400000`,
+			`"labels":{"env":"prod"}`,
+		} {
+			if !strings.Contains(s, want) {
+				t.Errorf("expected %s in body; got %s", want, s)
+			}
+		}
+	})
+}
+
+func TestPostBusToolCallSerde(t *testing.T) {
+	t.Run("basic — no approval gate fields", func(t *testing.T) {
+		req := PostBusToolCall{
+			CallID:    "call-1",
+			Tool:      "calendar.list",
+			Arguments: map[string]any{},
+		}
+		raw, _ := json.Marshal(req)
+		s := string(raw)
+		if strings.Contains(s, "require_approval") {
+			t.Errorf("require_approval should be omitted when false; got %s", s)
+		}
+	})
+
+	t.Run("Phase 6c gate — emits all approval fields", func(t *testing.T) {
+		req := PostBusToolCall{
+			CallID:          "call-1",
+			Tool:            "billing.charge",
+			Arguments:       map[string]any{"usd": 42},
+			Sender:          ptr("planner-1"),
+			RequireApproval: true,
+			ApprovalReason:  ptr("paid action"),
+			ApprovalTtlMs:   ptr[uint64](600_000),
+		}
+		raw, _ := json.Marshal(req)
+		s := string(raw)
+		for _, want := range []string{
+			`"require_approval":true`,
+			`"approval_reason":"paid action"`,
+			`"approval_ttl_ms":600000`,
+			`"call_id":"call-1"`,
+		} {
+			if !strings.Contains(s, want) {
+				t.Errorf("expected %s in body; got %s", want, s)
+			}
+		}
+	})
+}
+
+func TestPostBusToolResultSerde(t *testing.T) {
+	req := PostBusToolResult{
+		CallID:       "call-1",
+		Status:       "error",
+		Output:       map[string]any{},
+		ErrorMessage: ptr("upstream gave up"),
+		Sender:       ptr("calendar-svc"),
+	}
+	raw, _ := json.Marshal(req)
+	s := string(raw)
+	for _, want := range []string{
+		`"status":"error"`,
+		`"error_message":"upstream gave up"`,
+		`"sender":"calendar-svc"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("expected %s in body; got %s", want, s)
+		}
+	}
+}
+
+func TestPostBusStreamChunkSerde(t *testing.T) {
+	req := PostBusStreamChunk{
+		StreamID: "s1",
+		ChunkSeq: 0,
+		Body:     map[string]any{"token": "Once "},
+	}
+	raw, _ := json.Marshal(req)
+	s := string(raw)
+	if !strings.Contains(s, `"stream_id":"s1"`) {
+		t.Errorf("expected stream_id in body; got %s", s)
+	}
+	if !strings.Contains(s, `"chunk_seq":0`) {
+		t.Errorf("expected chunk_seq in body; got %s", s)
+	}
+	if !strings.Contains(s, `"body":{"token":"Once "}`) {
+		t.Errorf("expected body wrapping the token; got %s", s)
+	}
+}
+
+func TestBusApprovalDecisionSerde(t *testing.T) {
+	d := BusApprovalDecision{
+		DecidedBy:    "ops-1",
+		DecisionNote: ptr("verified PO"),
+	}
+	raw, _ := json.Marshal(d)
+	s := string(raw)
+	if !strings.Contains(s, `"decided_by":"ops-1"`) {
+		t.Errorf("expected decided_by; got %s", s)
+	}
+	if !strings.Contains(s, `"decision_note":"verified PO"`) {
+		t.Errorf("expected decision_note; got %s", s)
+	}
+}
+
+func TestBusTopicResponseRoundTrip(t *testing.T) {
+	body := []byte(`{
+		"name": "t", "namespace": "n", "tenant": "te",
+		"kafka_name": "n.te.t", "partitions": 4, "replication_factor": 2,
+		"created_at": "2026-01-01T00:00:00Z",
+		"updated_at": "2026-01-01T00:00:00Z"
+	}`)
+	var topic BusTopic
+	if err := json.Unmarshal(body, &topic); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if topic.KafkaName != "n.te.t" {
+		t.Errorf("kafka_name mismatch")
+	}
+	if topic.SchemaSubject != nil {
+		t.Errorf("schema_subject should be nil when omitted; got %v", topic.SchemaSubject)
+	}
+}
+
+func TestBusLagResponseRoundTrip(t *testing.T) {
+	body := []byte(`{
+		"subscription_id": "s1", "topic": "n.te.t",
+		"partitions": [
+			{"partition": 0, "committed": 10, "high_water_mark": 12, "lag": 2},
+			{"partition": 1, "committed": 0, "high_water_mark": 0, "lag": 0}
+		],
+		"total_lag": 2
+	}`)
+	var lag BusLag
+	if err := json.Unmarshal(body, &lag); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if lag.TotalLag != 2 {
+		t.Errorf("total_lag mismatch: %d", lag.TotalLag)
+	}
+	if len(lag.Partitions) != 2 {
+		t.Errorf("expected 2 partitions; got %d", len(lag.Partitions))
+	}
+	if lag.Partitions[0].HighWaterMark != 12 {
+		t.Errorf("high_water_mark mismatch: %d", lag.Partitions[0].HighWaterMark)
+	}
+}
+
+func TestBusApprovalViewRoundTrip(t *testing.T) {
+	body := []byte(`{
+		"approval_id": "appr-1", "namespace": "n", "tenant": "te",
+		"conversation_id": "c1", "correlation_token": "call-1",
+		"envelope_kind": "tool_call", "status": "pending",
+		"created_at": "2026-01-01T00:00:00Z",
+		"expires_at": "2026-01-02T00:00:00Z",
+		"envelope": {"kind": "tool_call"}
+	}`)
+	var v BusApprovalView
+	if err := json.Unmarshal(body, &v); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if v.Status != "pending" {
+		t.Errorf("status mismatch: %s", v.Status)
+	}
+	if v.DecidedBy != nil {
+		t.Errorf("decided_by should be nil before decision; got %v", v.DecidedBy)
+	}
+	if v.ProducedOffset != nil {
+		t.Errorf("produced_offset should be nil before approve; got %v", v.ProducedOffset)
+	}
+}
+
+func TestBusApprovalDecisionResponseRoundTrip(t *testing.T) {
+	t.Run("approved with receipt", func(t *testing.T) {
+		body := []byte(`{
+			"approval": {
+				"approval_id": "appr-1", "namespace": "n", "tenant": "te",
+				"conversation_id": "c1", "correlation_token": "call-1",
+				"envelope_kind": "tool_call", "status": "approved",
+				"created_at": "2026-01-01T00:00:00Z",
+				"expires_at": "2026-01-02T00:00:00Z",
+				"envelope": {},
+				"decided_by": "ops-1"
+			},
+			"receipt": {
+				"events_topic": "n.te.events",
+				"conversation_id": "c1", "call_id": "call-1",
+				"partition": 0, "offset": 99,
+				"produced_at": "2026-01-01T00:00:01Z",
+				"cursor": "xx"
+			}
+		}`)
+		var r BusApprovalDecisionResponse
+		if err := json.Unmarshal(body, &r); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if r.Approval.Status != "approved" {
+			t.Errorf("status mismatch")
+		}
+		if r.Receipt == nil || r.Receipt.Offset != 99 {
+			t.Errorf("expected receipt with offset 99; got %v", r.Receipt)
+		}
+	})
+
+	t.Run("rejected — receipt nil", func(t *testing.T) {
+		body := []byte(`{
+			"approval": {
+				"approval_id": "appr-1", "namespace": "n", "tenant": "te",
+				"conversation_id": "c1", "correlation_token": "call-1",
+				"envelope_kind": "tool_call", "status": "rejected",
+				"created_at": "2026-01-01T00:00:00Z",
+				"expires_at": "2026-01-02T00:00:00Z",
+				"envelope": {},
+				"decided_by": "ops-1",
+				"decision_note": "scope too broad"
+			},
+			"receipt": null
+		}`)
+		var r BusApprovalDecisionResponse
+		if err := json.Unmarshal(body, &r); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if r.Receipt != nil {
+			t.Errorf("expected nil receipt on reject; got %v", r.Receipt)
+		}
+	})
+}
+
+func TestBusStreamConsumeURL(t *testing.T) {
+	c := NewClient("http://localhost:3000")
+
+	t.Run("simple segments", func(t *testing.T) {
+		got := c.BusStreamConsumeURL("agents", "demo", "thread-1", "stream-1")
+		want := "http://localhost:3000/v1/bus/streams/agents/demo/thread-1/stream-1"
+		if got != want {
+			t.Errorf("simple URL mismatch:\n  want: %s\n   got: %s", want, got)
+		}
+	})
+
+	t.Run("encodes slashes and spaces", func(t *testing.T) {
+		got := c.BusStreamConsumeURL("agents/x", "demo", "thread/with/slashes", "story 1")
+		// Embedded slashes inside segments must be percent-encoded
+		// so they don't escape into URL grammar; spaces become %20.
+		for _, want := range []string{"agents%2Fx", "thread%2Fwith%2Fslashes", "story%201"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("expected %s in URL; got %s", want, got)
+			}
+		}
+	})
+}
+
+func TestBusToolCallOutcome(t *testing.T) {
+	t.Run("produced", func(t *testing.T) {
+		o := PostBusToolCallOutcome{
+			Produced: &BusToolEnvelopeReceipt{CallID: "call-1", Offset: 42},
+		}
+		if o.WasParked() {
+			t.Errorf("WasParked should be false for produced outcome")
+		}
+	})
+	t.Run("parked", func(t *testing.T) {
+		o := PostBusToolCallOutcome{
+			Parked: &BusApprovalParkedReceipt{ApprovalID: "appr-1"},
+		}
+		if !o.WasParked() {
+			t.Errorf("WasParked should be true for parked outcome")
+		}
+	})
+}
+
+// Server-driven tests — use httptest to assert that PostBusToolCall
+// branches correctly on 200 vs 202, ApproveBusApproval / RejectBusApproval
+// hit the right paths, and the URL builder honors the configured base.
+
+func TestPostBusToolCallBranchesOn202(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/tool-calls") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		// Decide based on the request body's `require_approval` flag.
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if v, _ := body["require_approval"].(bool); v {
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{
+				"approval_id": "appr-1",
+				"namespace": "n", "tenant": "te",
+				"conversation_id": "c1",
+				"correlation_token": "call-1",
+				"status": "pending",
+				"created_at": "2026-01-01T00:00:00Z",
+				"expires_at": "2026-01-02T00:00:00Z"
+			}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"events_topic": "n.te.events",
+			"conversation_id": "c1", "call_id": "call-1",
+			"partition": 0, "offset": 17,
+			"produced_at": "2026-01-01T00:00:00Z",
+			"cursor": "abc"
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	ctx := context.Background()
+
+	t.Run("immediate produce → kind=Produced", func(t *testing.T) {
+		out, err := client.PostBusToolCall(ctx, "n", "te", "c1", &PostBusToolCall{
+			CallID: "call-1", Tool: "calendar.list",
+		})
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		if out.WasParked() {
+			t.Errorf("expected immediate produce; got parked")
+		}
+		if out.Produced == nil || out.Produced.Offset != 17 {
+			t.Errorf("expected Produced.Offset==17; got %v", out.Produced)
+		}
+	})
+
+	t.Run("require_approval → kind=Parked", func(t *testing.T) {
+		out, err := client.PostBusToolCall(ctx, "n", "te", "c1", &PostBusToolCall{
+			CallID:          "call-1",
+			Tool:            "billing.charge",
+			Arguments:       map[string]any{"usd": 42},
+			RequireApproval: true,
+			ApprovalReason:  ptr("paid action"),
+		})
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		if !out.WasParked() {
+			t.Errorf("expected parked outcome; got produced")
+		}
+		if out.Parked == nil || out.Parked.ApprovalID != "appr-1" {
+			t.Errorf("expected Parked.ApprovalID=appr-1; got %v", out.Parked)
+		}
+	})
+}
+
+func TestApproveBusApprovalRoutesAndDecodes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The handler asserts the path the SDK builds matches the
+		// server's expected route.
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST; got %s", r.Method)
+		}
+		expected := "/v1/bus/approvals/" + url.PathEscape("agents") + "/" + url.PathEscape("demo") +
+			"/" + url.PathEscape("appr-1") + "/approve"
+		if r.URL.Path != expected {
+			t.Errorf("path mismatch: want %s, got %s", expected, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"approval": {
+				"approval_id": "appr-1",
+				"namespace": "agents", "tenant": "demo",
+				"conversation_id": "c1", "correlation_token": "call-1",
+				"envelope_kind": "tool_call", "status": "approved",
+				"created_at": "2026-01-01T00:00:00Z",
+				"expires_at": "2026-01-02T00:00:00Z",
+				"envelope": {},
+				"decided_by": "ops-1"
+			},
+			"receipt": {
+				"events_topic": "agents.demo.events",
+				"conversation_id": "c1", "call_id": "call-1",
+				"partition": 0, "offset": 99,
+				"produced_at": "2026-01-01T00:00:01Z",
+				"cursor": "xx"
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	resp, err := client.ApproveBusApproval(context.Background(), "agents", "demo", "appr-1",
+		&BusApprovalDecision{DecidedBy: "ops-1"})
+	if err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if resp.Approval.Status != "approved" {
+		t.Errorf("status mismatch: %s", resp.Approval.Status)
+	}
+	if resp.Receipt == nil || resp.Receipt.Offset != 99 {
+		t.Errorf("expected receipt with offset 99; got %v", resp.Receipt)
+	}
+}
+
+func TestBusErrorParsing(t *testing.T) {
+	// The bus error path should map structured `{"error": "..."}`
+	// bodies (the shape Acteon's bus handlers emit) to *APIError.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"sender 'alpha' is not a participant"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	_, err := client.CreateBusTopic(context.Background(), &CreateBusTopic{
+		Name: "t", Namespace: "n", Tenant: "te",
+	})
+	if err == nil {
+		t.Fatalf("expected error; got nil")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected *APIError; got %T: %v", err, err)
+	}
+	if !strings.Contains(apiErr.Message, "sender") {
+		t.Errorf("expected sender error; got %s", apiErr.Message)
+	}
+}

--- a/docs/book/concepts/bus-master-plan.md
+++ b/docs/book/concepts/bus-master-plan.md
@@ -117,6 +117,6 @@ Migration will be opt-in, per-feature, never forced.
 - **Phase 8** — in progress — see [phase-8 feature doc](../features/bus-phase-8.md)
   - 8a (Python) — shipped
   - 8b (Node) — shipped
-  - 8c (Go) — not started
+  - 8c (Go) — shipped
   - 8d (Java) — not started
 - Phase 9 — not started

--- a/docs/book/features/bus-phase-8.md
+++ b/docs/book/features/bus-phase-8.md
@@ -157,11 +157,64 @@ if (outcome.kind === "parked") {
 fully percent-encoded URL the caller plugs into their preferred SSE
 client (browser `EventSource`, the `eventsource` npm package, etc.).
 
-## What's deferred to Phase 8c/d
+## Phase 8c — Go
 
-Go and Java parity ship in follow-up PRs — same methodology, same
-flat method names, same DTO shapes. The Python and Node surfaces
-serve as the reference.
+Go parity uses the SDK's existing convention: methods on
+`*acteon.Client`, exported PascalCase
+(`CreateBusTopic`, `PostBusToolCall`, `ApproveBusApproval`, …),
+`context.Context` first parameter, `(*T, error)` return. DTOs
+live in `clients/go/acteon/bus_models.go`; the methods themselves
+live in `bus.go`. JSON tags use the snake-case server names; Go
+struct fields stay PascalCase.
+
+The Phase 6c "parked vs produced" branch surfaces as a struct
+with two pointer fields:
+
+```go
+import (
+    "context"
+    "github.com/penserai/acteon/clients/go/acteon"
+)
+
+client := acteon.NewClient("http://localhost:3000")
+ctx := context.Background()
+reason := "paid action"
+ttl := uint64(600_000)
+
+outcome, err := client.PostBusToolCall(ctx, "agents", "demo", "thread-1",
+    &acteon.PostBusToolCall{
+        CallID:          "call-1",
+        Tool:            "billing.charge",
+        Arguments:       map[string]any{"usd": 42},
+        Sender:          ptr("planner-1"),
+        RequireApproval: true,
+        ApprovalReason:  &reason,
+        ApprovalTtlMs:   &ttl,
+    })
+if err != nil { /* ... */ }
+
+if outcome.WasParked() {
+    fmt.Printf("awaiting approval: %s\n", outcome.Parked.ApprovalID)
+} else {
+    fmt.Printf("on Kafka at %d:%d\n", outcome.Produced.Partition, outcome.Produced.Offset)
+}
+```
+
+Optional fields use pointer types (`*string`, `*int`, `*uint64`,
+…) so callers can distinguish "unset" from the zero value — the
+right ergonomics for matching the server's
+`#[serde(default, skip_serializing_if = "Option::is_none")]`.
+Slices and maps use `omitempty` instead since the server treats
+absent and empty equivalently.
+
+`BusStreamConsumeURL(...)` mirrors the Python and Node helpers —
+returns the percent-encoded URL the caller plugs into a Go SSE
+client (`r3labs/sse`, the stdlib HTTP streaming reader, etc.).
+
+## What's deferred to Phase 8d
+
+Java parity ships next as a separate PR using the Rust + Python +
+Node + Go surfaces as the joint reference.
 
 ## Trust model carries through
 


### PR DESCRIPTION
## Summary
- 36 new methods on the Go `*acteon.Client` covering the full agentic bus surface from Phases 1–6c (topics, subscriptions, schemas, agents, conversations, tool-call envelopes, streams, HITL approvals).
- Go-idiomatic shapes: PascalCase method names, `context.Context` first, `(*T, error)` return; pointer fields for optional values.
- Phase 8 progress: Python ✓, Node ✓, Go ✓ (this PR), Java still to come.

## What ships
- **`clients/go/acteon/bus_models.go`** — struct DTOs with snake-case `json` tags. Optional fields use pointer types (`*string`, `*int`, `*uint64`, …) so callers distinguish "unset" from zero value. Slices and maps use `omitempty`.
- **`clients/go/acteon/bus.go`** — methods on `*Client`. Each takes `context.Context` first; structured error bodies map to `*APIError`, otherwise fall back to `*HTTPError`.
- **`PostBusToolCallOutcome`** — Go's idiomatic sum-type encoding with two nullable pointer fields (`Produced` / `Parked`). `WasParked()` helper for clean branching. Branches on the 200 vs 202 status the server emits for `RequireApproval: true`.
- **`BusStreamConsumeURL(...)`** — fully percent-encoded URL via `url.PathEscape`; SSE consumption delegated to the caller's preferred SSE client.
- **14 tests** — request/response serde across phases, httptest server asserting the 6c approval gate (200/202 branch), URL encoding for embedded slashes + spaces, structured error body parsing.
- **Docs** — `bus-phase-8.md` updated for 8c alongside Python + Node references; master plan phase status marked 8c shipped.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — passes (all existing + 14 new bus tests)
- [x] No Rust changes; safety-net `cargo clippy` clean
- [ ] Live HTTP smoke against a running Acteon with `--features bus` — deferred

## Deferred
- Java (8d) — final sub-phase, follow-up PR using Python + Node + Go as joint references.
- An opinionated SSE iterator on the SDK — V1 returns just the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)