### PR TITLE
feat(bus): Kafka transactional producer (opt-in, off by default)

### DIFF
--- a/crates/bus/src/config.rs
+++ b/crates/bus/src/config.rs
@@ -25,6 +25,32 @@ pub struct KafkaBusConfig {
     /// Milliseconds to wait for a produce to be acknowledged before
     /// returning `BusError::Timeout`.
     pub produce_timeout_ms: u64,
+    /// **Phase 10 add-on**: enable transactional produces by setting
+    /// a stable `transactional.id`. Required only by operators who
+    /// want broker-side fencing across server restarts. When
+    /// `Some`, every `produce` is wrapped in a Kafka transaction
+    /// (begin → send → commit, or abort on error). When `None`
+    /// (default), produces use the idempotent producer alone —
+    /// dedup within a session, no cross-restart fencing.
+    ///
+    /// Stable across restarts: pick one per server instance (e.g.
+    /// `acteon-server-1`, `acteon-server-2`). The broker uses this
+    /// to track epochs and fence out zombie producers.
+    ///
+    /// Cost: each transaction adds two broker round-trips (begin +
+    /// commit) on top of the produce itself. Worth it when the
+    /// downstream topic must be exactly-once even across restarts;
+    /// over-engineering when consumer-side dedup is already in
+    /// place (e.g. for tool-call envelopes that have `call_id`
+    /// dedup at lookup time).
+    #[serde(default)]
+    pub transactional_id: Option<String>,
+    /// Per-transaction timeout in milliseconds. Used when
+    /// `transactional_id` is `Some`; ignored otherwise. The broker
+    /// fences a transaction that exceeds this timeout, so set it
+    /// generously above the slowest `produce_timeout_ms` you
+    /// expect.
+    pub transaction_timeout_ms: u64,
     /// Additional rdkafka properties pass-through (e.g.
     /// `security.protocol`, `sasl.mechanism`, `ssl.ca.location`).
     #[serde(default)]
@@ -37,6 +63,8 @@ impl Default for KafkaBusConfig {
             bootstrap_servers: "localhost:9092".into(),
             client_id: "acteon-bus".into(),
             produce_timeout_ms: 5_000,
+            transactional_id: None,
+            transaction_timeout_ms: 60_000,
             extra: Vec::new(),
         }
     }

--- a/crates/bus/src/kafka.rs
+++ b/crates/bus/src/kafka.rs
@@ -18,7 +18,7 @@ use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{Consumer, StreamConsumer};
 use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 use rdkafka::message::{Header, Headers, Message, OwnedHeaders};
-use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
 use rdkafka::util::Timeout;
 
 use rdkafka::TopicPartitionList;
@@ -38,11 +38,33 @@ pub struct KafkaBackend {
     client_id: String,
     produce_timeout: Duration,
     extra: Vec<(String, String)>,
+    /// `Some` when the operator configured `transactional_id`. Drives
+    /// the per-produce begin/commit wrap. `None` (default) keeps the
+    /// idempotent-producer-only path that the bus has always used.
+    transactional: Option<TransactionalConfig>,
+}
+
+/// Snapshot of the transactional knobs taken at backend construction.
+/// Held so each produce can use the configured timeout without the
+/// caller threading it through.
+struct TransactionalConfig {
+    transaction_timeout: Duration,
 }
 
 impl KafkaBackend {
-    /// Build a new backend from config. Does not contact the broker —
-    /// connections are lazy on first produce/subscribe/admin call.
+    /// Build a new backend from config. Does not contact the broker
+    /// in non-transactional mode — connections are lazy on first
+    /// produce/subscribe/admin call.
+    ///
+    /// **Phase 10 add-on**: when `config.transactional_id` is `Some`,
+    /// the constructor calls `init_transactions` synchronously. That
+    /// IS a broker round-trip — startup will block waiting for the
+    /// broker to acknowledge the transactional registration. If the
+    /// broker is unreachable, the constructor returns
+    /// `BusError::Transport`. This is the right behavior in
+    /// transactional mode: the operator opted into broker-side
+    /// fencing, so a server that can't talk to the broker shouldn't
+    /// pretend to provide it.
     pub fn new(config: &KafkaBusConfig) -> Result<Arc<Self>, BusError> {
         let mut cfg = ClientConfig::new();
         cfg.set("bootstrap.servers", &config.bootstrap_servers);
@@ -52,6 +74,13 @@ impl KafkaBackend {
         }
         cfg.set("message.timeout.ms", config.produce_timeout_ms.to_string());
         cfg.set("enable.idempotence", "true");
+        if let Some(txn_id) = &config.transactional_id {
+            cfg.set("transactional.id", txn_id);
+            cfg.set(
+                "transaction.timeout.ms",
+                config.transaction_timeout_ms.to_string(),
+            );
+        }
 
         let producer: FutureProducer = cfg
             .create()
@@ -60,6 +89,23 @@ impl KafkaBackend {
             .create()
             .map_err(|e| BusError::Transport(format!("admin: {e}")))?;
 
+        let transactional = if config.transactional_id.is_some() {
+            let timeout = Duration::from_millis(config.transaction_timeout_ms);
+            // Synchronously register the transactional.id with the
+            // broker. Blocks until the broker responds or the timeout
+            // elapses. After this, every produce that uses this
+            // producer can be wrapped in begin_transaction /
+            // commit_transaction.
+            producer
+                .init_transactions(Timeout::After(timeout))
+                .map_err(|e| BusError::Transport(format!("init_transactions: {e}")))?;
+            Some(TransactionalConfig {
+                transaction_timeout: timeout,
+            })
+        } else {
+            None
+        };
+
         Ok(Arc::new(Self {
             producer,
             admin,
@@ -67,6 +113,7 @@ impl KafkaBackend {
             client_id: config.client_id.clone(),
             produce_timeout: Duration::from_millis(config.produce_timeout_ms),
             extra: config.extra.clone(),
+            transactional,
         }))
     }
 
@@ -214,16 +261,50 @@ impl BusBackend for KafkaBackend {
         if let Some(ref k) = key {
             record = record.key(k.as_str());
         }
-        let (partition, offset) = self
+        // Phase 10 add-on: wrap the produce in a Kafka transaction
+        // when the operator configured `transactional.id`. The broker
+        // tracks the producer's epoch, so a restart with the same
+        // transactional.id fences any zombie that might still try to
+        // commit — the cross-restart guarantee that idempotent-mode-
+        // alone can't provide.
+        if self.transactional.is_some() {
+            self.producer
+                .begin_transaction()
+                .map_err(|e| BusError::Transport(format!("begin_transaction: {e}")))?;
+        }
+        let send_result = self
             .producer
             .send(record, Timeout::After(self.produce_timeout))
-            .await
-            .map_err(|(e, _msg)| match e {
-                KafkaError::MessageProduction(RDKafkaErrorCode::MessageTimedOut) => {
-                    BusError::Timeout
+            .await;
+        let (partition, offset) = match send_result {
+            Ok(p) => {
+                if let Some(txn) = &self.transactional
+                    && let Err(e) = self
+                        .producer
+                        .commit_transaction(Timeout::After(txn.transaction_timeout))
+                {
+                    return Err(BusError::Transport(format!("commit_transaction: {e}")));
                 }
-                other => map_kafka_error(other),
-            })?;
+                p
+            }
+            Err((e, _msg)) => {
+                if let Some(txn) = &self.transactional {
+                    // Best-effort abort. If this fails too the broker
+                    // will eventually fence the transaction by
+                    // timeout. We still propagate the original send
+                    // error rather than the abort error.
+                    let _ = self
+                        .producer
+                        .abort_transaction(Timeout::After(txn.transaction_timeout));
+                }
+                return Err(match e {
+                    KafkaError::MessageProduction(RDKafkaErrorCode::MessageTimedOut) => {
+                        BusError::Timeout
+                    }
+                    other => map_kafka_error(other),
+                });
+            }
+        };
         Ok(DeliveryReceipt {
             topic,
             partition,

--- a/crates/bus/tests/kafka_integration.rs
+++ b/crates/bus/tests/kafka_integration.rs
@@ -20,7 +20,7 @@ fn make_backend(client_id: &str) -> std::sync::Arc<KafkaBackend> {
         bootstrap_servers: brokers().unwrap(),
         client_id: client_id.to_string(),
         produce_timeout_ms: 8_000,
-        extra: Vec::new(),
+        ..Default::default()
     };
     KafkaBackend::new(&cfg).expect("kafka backend")
 }

--- a/crates/server/src/config/bus.rs
+++ b/crates/server/src/config/bus.rs
@@ -25,6 +25,24 @@ pub struct KafkaClientConfig {
     pub client_id: String,
     /// Produce acknowledgement timeout (ms).
     pub produce_timeout_ms: u64,
+    /// **Phase 10 add-on**: opt into Kafka transactional produces by
+    /// setting a stable `transactional.id`. When set, every bus
+    /// produce is wrapped in a Kafka transaction (begin → send →
+    /// commit, or abort on error), giving broker-side fencing
+    /// across server restarts. Pick one per server instance (e.g.
+    /// `acteon-server-1`).
+    ///
+    /// Cost: each transaction adds two broker round-trips on top of
+    /// the produce. Worth it when downstream topics need exactly-
+    /// once semantics; over-engineering when consumer-side dedup
+    /// (e.g. Phase 6a's `call_id` lookup) already de-duplicates
+    /// duplicate produces.
+    #[serde(default)]
+    pub transactional_id: Option<String>,
+    /// Per-transaction timeout (ms). Used only when
+    /// `transactional_id` is set; ignored otherwise. Set generously
+    /// above `produce_timeout_ms`.
+    pub transaction_timeout_ms: u64,
     /// Pass-through properties for `librdkafka`.
     pub extra: Vec<(String, String)>,
 }
@@ -35,6 +53,8 @@ impl Default for KafkaClientConfig {
             bootstrap_servers: "localhost:9092".into(),
             client_id: "acteon-bus".into(),
             produce_timeout_ms: 5_000,
+            transactional_id: None,
+            transaction_timeout_ms: 60_000,
             extra: Vec::new(),
         }
     }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -2288,6 +2288,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             bootstrap_servers: config.bus.kafka.bootstrap_servers.clone(),
             client_id: config.bus.kafka.client_id.clone(),
             produce_timeout_ms: config.bus.kafka.produce_timeout_ms,
+            transactional_id: config.bus.kafka.transactional_id.clone(),
+            transaction_timeout_ms: config.bus.kafka.transaction_timeout_ms,
             extra: config.bus.kafka.extra.clone(),
         };
         match acteon_bus::KafkaBackend::new(&kcfg) {
@@ -2295,6 +2297,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 info!(
                     bootstrap = %kcfg.bootstrap_servers,
                     client_id = %kcfg.client_id,
+                    transactional = kcfg.transactional_id.is_some(),
+                    transactional_id = ?kcfg.transactional_id,
                     "agentic bus enabled (Kafka backend)"
                 );
                 Some(b as acteon_bus::SharedBackend)

--- a/crates/simulation/benches/bus_kafka_e2e.rs
+++ b/crates/simulation/benches/bus_kafka_e2e.rs
@@ -61,7 +61,7 @@ fn make_kafka_backend(rt: &Runtime, bootstrap: &str) -> Option<SharedBackend> {
         bootstrap_servers: bootstrap.to_string(),
         client_id: "acteon-bench".to_string(),
         produce_timeout_ms: 5_000,
-        extra: Default::default(),
+        ..Default::default()
     };
     let backend = match KafkaBackend::new(&cfg) {
         Ok(b) => b as SharedBackend,

--- a/crates/simulation/examples/bus_simulation.rs
+++ b/crates/simulation/examples/bus_simulation.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         bootstrap_servers: bootstrap,
         client_id: "bus-sim".into(),
         produce_timeout_ms: 8_000,
-        extra: Vec::new(),
+        ..Default::default()
     };
     let backend: Arc<dyn BusBackend> = KafkaBackend::new(&cfg)?;
 

--- a/crates/simulation/examples/bus_subscription_simulation.rs
+++ b/crates/simulation/examples/bus_subscription_simulation.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         bootstrap_servers: bootstrap,
         client_id: "bus-sub-sim".into(),
         produce_timeout_ms: 8_000,
-        extra: Vec::new(),
+        ..Default::default()
     };
     let backend: Arc<dyn BusBackend> = KafkaBackend::new(&cfg)?;
 

--- a/docs/book/concepts/bus-master-plan.md
+++ b/docs/book/concepts/bus-master-plan.md
@@ -154,14 +154,16 @@ Polish items that landed alongside Phase 10:
   `ACTEON_BENCH_KAFKA` isn't set; reports wall-clock numbers
   including broker round-trip when it is.
 
-Genuine follow-up not yet shipped:
+Kafka transactional producer (defensive depth) — **shipped**:
 
-- **Kafka transactional producer for full atomicity.** The
-  state-machine + reconciler + idempotent producer + consumer-
-  side `call_id` dedup combine to make duplicate produces
-  invisible to consumers in practice; Kafka transactions would
-  add defensive depth (per-approval `transactional.id`
-  management, `init_transactions` plumbing across the rdkafka
-  backend) but the marginal value is low. Tracked under the
-  [Exactly-once edge](#exactly-once-edge) section as
-  deferred-not-needed.
+- `[bus.kafka] transactional_id = "..."` opts the bus into
+  full Kafka transactions: every produce is wrapped in
+  begin/commit, with abort-on-error. The broker tracks
+  per-`transactional.id` epochs and fences zombie producers,
+  giving cross-restart guarantees that idempotent-mode-alone
+  can't provide. Off by default — consumer-side `call_id`
+  dedup makes the gap invisible in practice, so this is
+  defensive depth for workloads that need exactly-once
+  semantics independent of consumer behavior. See
+  [Phase 6c trust model](../features/bus-phase-6c.md) for
+  when to flip the knob.

--- a/docs/book/features/bus-phase-6c.md
+++ b/docs/book/features/bus-phase-6c.md
@@ -279,11 +279,17 @@ Trust model carry-overs:
   approve handler is still mid-flight. Tunable via
   `BusReconcilerConfig`; see `crates/server/src/bus_reconciler.rs`.
 
-A Kafka transactional producer + true outbox pattern remains a
-follow-up — that closes the *atomicity* gap (the state-row
-update + Kafka produce happen in one atomic transaction).
-Phase 10 closes the *visibility* and *liveness* gaps; the
-atomicity hardening is the next iteration.
+A Kafka transactional producer is also available as a
+configuration knob (`[bus.kafka] transactional_id = "..."`).
+Setting it wraps every bus produce in a Kafka transaction
+(begin → send → commit, abort on error), giving broker-side
+fencing across server restarts. The trade-off is two extra
+broker round-trips per produce; consumer-side `call_id` dedup
+already silently de-duplicates duplicate produces, so this is
+defensive depth rather than required correctness. Operators
+running workloads where downstream topics need exactly-once
+semantics independent of consumer behavior should turn it on;
+others can leave it off.
 
 ### `require_approval` is per-call, not per-tenant policy
 


### PR DESCRIPTION
## Summary
- Optional `transactional_id` on `KafkaBusConfig` and the server's `[bus.kafka]` TOML block.
- When set: every bus produce is wrapped in a Kafka transaction (begin → send → commit, abort on error). The broker tracks per-`transactional.id` epochs and fences zombie producers, providing cross-restart guarantees that idempotent-mode-alone can't.
- **Off by default.** Consumer-side `call_id` dedup (Phase 6a) already silently de-duplicates duplicate produces — this is defensive depth for workloads that publish arbitrary records (no per-record dedup key downstream) and need exactly-once semantics across server restarts.

## What ships
- **`acteon-bus`** — new fields, `init_transactions` at construction, per-produce begin/commit/abort.
- **`acteon-server`** — TOML pass-through, startup log line shows mode.
- **Existing `KafkaBusConfig {...}` literals** switched to struct-update syntax with `..Default::default()` so future fields don't break call sites.
- **Docs** — Phase 6c trust-model section and master plan updated; the deferred-not-needed item is now ship-when-needed.

## Trade-offs
- Cost: two extra broker round-trips per produce (begin + commit). Worth it when downstream needs exactly-once semantics independent of consumer behavior; over-engineering when consumer-side `call_id` dedup is already in place.
- Startup: transactional mode synchronously calls `init_transactions` — fails fast if the broker is unreachable. Right behavior for an operator who opted into broker-side fencing.

## Test plan
- [x] `cargo build -p acteon-bus` — clean
- [x] `cargo clippy --workspace --no-deps --features bus -- -D warnings` — clean
- [x] `cargo test -p acteon-server --features bus --lib bus_reconciler` — 3/3 pass; reconciler path unchanged
- [x] `cargo run -p acteon-simulation --features bus --example multi_agent_demo` — green (uses MemoryBackend; transactional knob doesn't apply)
- [x] `cargo run -p acteon-simulation --features bus --example bus_approval_simulation` — green
- [ ] Live Kafka transactional smoke — deferred to manual test against the Docker `kafka` profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)