### PR TITLE
feat(cli): bus subcommand parity with Rust client

### DIFF
--- a/crates/cli/src/commands/bus/agents.rs
+++ b/crates/cli/src/commands/bus/agents.rs
@@ -1,0 +1,273 @@
+use std::collections::HashMap;
+
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::{BusAgentFilter, RegisterBusAgent, SendToBusAgent, UpdateBusAgent};
+use clap::{Args, Subcommand};
+use tracing::info;
+
+use crate::OutputFormat;
+use crate::commands::bus::{parse_json_arg, parse_kv};
+
+#[derive(Args, Debug)]
+pub struct AgentsArgs {
+    #[command(subcommand)]
+    pub command: AgentsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AgentsCommand {
+    /// List agents, optionally filtered.
+    List {
+        #[arg(long)]
+        namespace: Option<String>,
+        #[arg(long)]
+        tenant: Option<String>,
+        #[arg(long)]
+        capability: Option<String>,
+        /// `online`, `idle`, `offline`.
+        #[arg(long)]
+        status: Option<String>,
+    },
+    /// Fetch a single agent record.
+    Get {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        agent_id: String,
+    },
+    /// Register an agent. First registration in a `(namespace, tenant)`
+    /// auto-creates the shared inbox topic.
+    Register {
+        #[arg(long)]
+        agent_id: String,
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        display_name: Option<String>,
+        /// Repeat for multiple capabilities: `--capability planner`.
+        #[arg(long = "capability")]
+        capabilities: Vec<String>,
+        #[arg(long)]
+        inbox_topic: Option<String>,
+        #[arg(long)]
+        heartbeat_ttl_ms: Option<i64>,
+        #[arg(long = "label", value_parser = parse_kv)]
+        labels: Vec<(String, String)>,
+    },
+    /// Update mutable fields on an agent. `inbox_topic` is fixed at
+    /// registration.
+    Update {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        agent_id: String,
+        #[arg(long)]
+        display_name: Option<String>,
+        #[arg(long = "capability")]
+        capabilities: Option<Vec<String>>,
+        #[arg(long)]
+        heartbeat_ttl_ms: Option<i64>,
+        #[arg(long = "label", value_parser = parse_kv)]
+        labels: Option<Vec<(String, String)>>,
+    },
+    /// Delete an agent record. The shared inbox topic is preserved.
+    Delete {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        agent_id: String,
+    },
+    /// Record a heartbeat. Agents typically call this once per
+    /// `heartbeat_ttl_ms / 3` to stay `Online`.
+    Heartbeat {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        agent_id: String,
+    },
+    /// Send a message to the agent's inbox.
+    Send {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        agent_id: String,
+        /// JSON payload, or `@path/to/file.json`.
+        #[arg(long)]
+        payload: String,
+        #[arg(long = "header", value_parser = parse_kv)]
+        headers: Vec<(String, String)>,
+    },
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn run(ops: &OpsClient, args: &AgentsArgs, format: &OutputFormat) -> anyhow::Result<()> {
+    match &args.command {
+        AgentsCommand::List {
+            namespace,
+            tenant,
+            capability,
+            status,
+        } => {
+            let filter = BusAgentFilter {
+                namespace: namespace.clone(),
+                tenant: tenant.clone(),
+                capability: capability.clone(),
+                status: status.clone(),
+            };
+            let resp = ops.client().list_bus_agents(&filter).await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&resp)?),
+                OutputFormat::Text => {
+                    info!(count = resp.count, "Bus agents");
+                    for a in &resp.agents {
+                        info!(
+                            agent_id = %a.agent_id,
+                            namespace = %a.namespace,
+                            tenant = %a.tenant,
+                            status = %a.status,
+                            inbox = %a.inbox_topic,
+                            capabilities = ?a.capabilities,
+                            "Agent"
+                        );
+                    }
+                }
+            }
+        }
+        AgentsCommand::Get {
+            namespace,
+            tenant,
+            agent_id,
+        } => {
+            let a = ops
+                .client()
+                .get_bus_agent(namespace, tenant, agent_id)
+                .await?;
+            info!("{}", serde_json::to_string_pretty(&a)?);
+        }
+        AgentsCommand::Register {
+            agent_id,
+            namespace,
+            tenant,
+            display_name,
+            capabilities,
+            inbox_topic,
+            heartbeat_ttl_ms,
+            labels,
+        } => {
+            let req = RegisterBusAgent {
+                agent_id: agent_id.clone(),
+                namespace: namespace.clone(),
+                tenant: tenant.clone(),
+                display_name: display_name.clone(),
+                capabilities: capabilities.clone(),
+                inbox_topic: inbox_topic.clone(),
+                heartbeat_ttl_ms: *heartbeat_ttl_ms,
+                labels: labels.iter().cloned().collect::<HashMap<_, _>>(),
+            };
+            let a = ops.client().register_bus_agent(&req).await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&a)?),
+                OutputFormat::Text => info!(
+                    agent_id = %a.agent_id,
+                    inbox = %a.inbox_topic,
+                    "Agent registered"
+                ),
+            }
+        }
+        AgentsCommand::Update {
+            namespace,
+            tenant,
+            agent_id,
+            display_name,
+            capabilities,
+            heartbeat_ttl_ms,
+            labels,
+        } => {
+            let req = UpdateBusAgent {
+                display_name: display_name.clone(),
+                capabilities: capabilities.clone(),
+                heartbeat_ttl_ms: *heartbeat_ttl_ms,
+                labels: labels
+                    .as_ref()
+                    .map(|kvs| kvs.iter().cloned().collect::<HashMap<_, _>>()),
+            };
+            let a = ops
+                .client()
+                .update_bus_agent(namespace, tenant, agent_id, &req)
+                .await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&a)?),
+                OutputFormat::Text => info!(agent_id = %a.agent_id, "Agent updated"),
+            }
+        }
+        AgentsCommand::Delete {
+            namespace,
+            tenant,
+            agent_id,
+        } => {
+            ops.client()
+                .delete_bus_agent(namespace, tenant, agent_id)
+                .await?;
+            info!(agent_id = %agent_id, "Agent deleted");
+        }
+        AgentsCommand::Heartbeat {
+            namespace,
+            tenant,
+            agent_id,
+        } => {
+            let h = ops
+                .client()
+                .heartbeat_bus_agent(namespace, tenant, agent_id)
+                .await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&h)?),
+                OutputFormat::Text => info!(
+                    agent_id = %h.agent_id,
+                    last_heartbeat_at = %h.last_heartbeat_at,
+                    status = %h.status,
+                    "Heartbeat recorded"
+                ),
+            }
+        }
+        AgentsCommand::Send {
+            namespace,
+            tenant,
+            agent_id,
+            payload,
+            headers,
+        } => {
+            let payload = parse_json_arg(payload)?;
+            let req = SendToBusAgent {
+                payload,
+                headers: headers.iter().cloned().collect(),
+            };
+            let receipt = ops
+                .client()
+                .send_to_bus_agent(namespace, tenant, agent_id, &req)
+                .await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&receipt)?),
+                OutputFormat::Text => info!(
+                    agent_id = %receipt.agent_id,
+                    inbox = %receipt.inbox_topic,
+                    partition = receipt.partition,
+                    offset = receipt.offset,
+                    "Message sent"
+                ),
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/bus/approvals.rs
+++ b/crates/cli/src/commands/bus/approvals.rs
@@ -1,0 +1,195 @@
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::{
+    BusApprovalDecisionRequest, BusApprovalStatus, ListBusApprovalsParams,
+};
+use clap::{Args, Subcommand};
+use tracing::info;
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct ApprovalsArgs {
+    #[command(subcommand)]
+    pub command: ApprovalsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ApprovalsCommand {
+    /// List parked approvals for a tenant.
+    List {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        /// Filter by status: `pending`, `approved`, `rejected`, `expired`.
+        #[arg(long)]
+        status: Option<ApprovalStatusKind>,
+        #[arg(long)]
+        conversation_id: Option<String>,
+    },
+    /// Fetch a single approval by id.
+    Get {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        approval_id: String,
+    },
+    /// Approve a parked tool-call. Produces the original envelope.
+    Approve {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        approval_id: String,
+        #[arg(long)]
+        decided_by: String,
+        #[arg(long)]
+        decision_note: Option<String>,
+    },
+    /// Reject a parked tool-call. No Kafka record is produced.
+    Reject {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        approval_id: String,
+        #[arg(long)]
+        decided_by: String,
+        #[arg(long)]
+        decision_note: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum ApprovalStatusKind {
+    Pending,
+    Approved,
+    Rejected,
+    Expired,
+}
+
+impl From<ApprovalStatusKind> for BusApprovalStatus {
+    fn from(s: ApprovalStatusKind) -> Self {
+        match s {
+            ApprovalStatusKind::Pending => Self::Pending,
+            ApprovalStatusKind::Approved => Self::Approved,
+            ApprovalStatusKind::Rejected => Self::Rejected,
+            ApprovalStatusKind::Expired => Self::Expired,
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn run(
+    ops: &OpsClient,
+    args: &ApprovalsArgs,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    match &args.command {
+        ApprovalsCommand::List {
+            namespace,
+            tenant,
+            status,
+            conversation_id,
+        } => {
+            let params = ListBusApprovalsParams {
+                status: status.clone().map(BusApprovalStatus::from),
+                conversation_id: conversation_id.clone(),
+            };
+            let resp = ops
+                .client()
+                .list_bus_approvals(namespace, tenant, &params)
+                .await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&resp)?),
+                OutputFormat::Text => {
+                    info!(count = resp.count, "Bus approvals");
+                    for a in &resp.approvals {
+                        info!(
+                            approval_id = %a.approval_id,
+                            status = ?a.status,
+                            envelope_kind = %a.envelope_kind,
+                            conversation_id = %a.conversation_id,
+                            expires_at = %a.expires_at,
+                            "Approval"
+                        );
+                    }
+                }
+            }
+        }
+        ApprovalsCommand::Get {
+            namespace,
+            tenant,
+            approval_id,
+        } => {
+            let a = ops
+                .client()
+                .get_bus_approval(namespace, tenant, approval_id)
+                .await?;
+            info!("{}", serde_json::to_string_pretty(&a)?);
+        }
+        ApprovalsCommand::Approve {
+            namespace,
+            tenant,
+            approval_id,
+            decided_by,
+            decision_note,
+        } => {
+            let req = BusApprovalDecisionRequest {
+                decided_by: decided_by.clone(),
+                decision_note: decision_note.clone(),
+            };
+            let resp = ops
+                .client()
+                .approve_bus_approval(namespace, tenant, approval_id, &req)
+                .await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&resp)?),
+                OutputFormat::Text => {
+                    info!(
+                        approval_id = %resp.approval.approval_id,
+                        status = ?resp.approval.status,
+                        "Approval approved"
+                    );
+                    if let Some(receipt) = &resp.receipt {
+                        info!(
+                            call_id = %receipt.call_id,
+                            partition = receipt.partition,
+                            offset = receipt.offset,
+                            "Produced envelope"
+                        );
+                    }
+                }
+            }
+        }
+        ApprovalsCommand::Reject {
+            namespace,
+            tenant,
+            approval_id,
+            decided_by,
+            decision_note,
+        } => {
+            let req = BusApprovalDecisionRequest {
+                decided_by: decided_by.clone(),
+                decision_note: decision_note.clone(),
+            };
+            let resp = ops
+                .client()
+                .reject_bus_approval(namespace, tenant, approval_id, &req)
+                .await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&resp)?),
+                OutputFormat::Text => info!(
+                    approval_id = %resp.approval.approval_id,
+                    status = ?resp.approval.status,
+                    "Approval rejected"
+                ),
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/bus/conversations.rs
+++ b/crates/cli/src/commands/bus/conversations.rs
@@ -1,0 +1,362 @@
+use std::collections::HashMap;
+
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::{
+    AppendBusConversationMessage, BusConversationFilter, BusConversationTransition,
+    RegisterBusConversation, ReplayBusConversationParams, UpdateBusConversation,
+};
+use clap::{Args, Subcommand};
+use tracing::info;
+
+use crate::OutputFormat;
+use crate::commands::bus::{parse_json_arg, parse_kv};
+
+#[derive(Args, Debug)]
+pub struct ConversationsArgs {
+    #[command(subcommand)]
+    pub command: ConversationsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ConversationsCommand {
+    /// List conversations, optionally filtered.
+    List {
+        #[arg(long)]
+        namespace: Option<String>,
+        #[arg(long)]
+        tenant: Option<String>,
+        /// `active`, `resolved`, or `archived`.
+        #[arg(long)]
+        state: Option<String>,
+        #[arg(long)]
+        participant: Option<String>,
+    },
+    /// Fetch a single conversation.
+    Get {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        conversation_id: String,
+    },
+    /// Register a conversation. First in a tenant auto-creates the
+    /// shared events topic.
+    Create {
+        #[arg(long)]
+        conversation_id: String,
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        title: Option<String>,
+        /// Repeat for multiple participants.
+        #[arg(long = "participant")]
+        participants: Vec<String>,
+        #[arg(long)]
+        events_topic: Option<String>,
+        #[arg(long = "label", value_parser = parse_kv)]
+        labels: Vec<(String, String)>,
+    },
+    /// Update mutable fields. Use `transition` for state changes.
+    Update {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        conversation_id: String,
+        #[arg(long)]
+        title: Option<String>,
+        #[arg(long = "participant")]
+        participants: Option<Vec<String>>,
+        #[arg(long = "label", value_parser = parse_kv)]
+        labels: Option<Vec<(String, String)>>,
+    },
+    /// Delete a conversation. Shared events topic is preserved.
+    Delete {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        conversation_id: String,
+    },
+    /// Drive the conversation through its state machine.
+    Transition {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        conversation_id: String,
+        /// `resolve`, `reopen`, or `archive`.
+        #[arg(long)]
+        transition: TransitionKind,
+    },
+    /// Append a message to the conversation thread (per-thread FIFO).
+    Append {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        conversation_id: String,
+        /// JSON payload, or `@path/to/file.json`.
+        #[arg(long)]
+        payload: String,
+        #[arg(long)]
+        sender: Option<String>,
+        #[arg(long = "header", value_parser = parse_kv)]
+        headers: Vec<(String, String)>,
+    },
+    /// Replay the message history for a conversation.
+    Replay {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        conversation_id: String,
+        /// Starting position label; ignored when `--cursor` is set.
+        #[arg(long)]
+        from: Option<String>,
+        /// Resume token from a prior response.
+        #[arg(long)]
+        cursor: Option<String>,
+        #[arg(long)]
+        limit: Option<usize>,
+        #[arg(long)]
+        timeout_ms: Option<u64>,
+    },
+}
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum TransitionKind {
+    Resolve,
+    Reopen,
+    Archive,
+}
+
+impl From<TransitionKind> for BusConversationTransition {
+    fn from(t: TransitionKind) -> Self {
+        match t {
+            TransitionKind::Resolve => Self::Resolve,
+            TransitionKind::Reopen => Self::Reopen,
+            TransitionKind::Archive => Self::Archive,
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn run(
+    ops: &OpsClient,
+    args: &ConversationsArgs,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    match &args.command {
+        ConversationsCommand::List {
+            namespace,
+            tenant,
+            state,
+            participant,
+        } => {
+            let filter = BusConversationFilter {
+                namespace: namespace.clone(),
+                tenant: tenant.clone(),
+                state: state.clone(),
+                participant: participant.clone(),
+            };
+            let resp = ops.client().list_bus_conversations(&filter).await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&resp)?),
+                OutputFormat::Text => {
+                    info!(count = resp.count, "Bus conversations");
+                    for c in &resp.conversations {
+                        info!(
+                            conversation_id = %c.conversation_id,
+                            namespace = %c.namespace,
+                            tenant = %c.tenant,
+                            state = ?c.state,
+                            participants = ?c.participants,
+                            "Conversation"
+                        );
+                    }
+                }
+            }
+        }
+        ConversationsCommand::Get {
+            namespace,
+            tenant,
+            conversation_id,
+        } => {
+            let c = ops
+                .client()
+                .get_bus_conversation(namespace, tenant, conversation_id)
+                .await?;
+            info!("{}", serde_json::to_string_pretty(&c)?);
+        }
+        ConversationsCommand::Create {
+            conversation_id,
+            namespace,
+            tenant,
+            title,
+            participants,
+            events_topic,
+            labels,
+        } => {
+            let req = RegisterBusConversation {
+                conversation_id: conversation_id.clone(),
+                namespace: namespace.clone(),
+                tenant: tenant.clone(),
+                title: title.clone(),
+                participants: participants.clone(),
+                events_topic: events_topic.clone(),
+                labels: labels.iter().cloned().collect::<HashMap<_, _>>(),
+            };
+            let c = ops.client().register_bus_conversation(&req).await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&c)?),
+                OutputFormat::Text => info!(
+                    conversation_id = %c.conversation_id,
+                    events_topic = %c.events_topic,
+                    "Conversation created"
+                ),
+            }
+        }
+        ConversationsCommand::Update {
+            namespace,
+            tenant,
+            conversation_id,
+            title,
+            participants,
+            labels,
+        } => {
+            let req = UpdateBusConversation {
+                title: title.clone(),
+                participants: participants.clone(),
+                labels: labels
+                    .as_ref()
+                    .map(|kvs| kvs.iter().cloned().collect::<HashMap<_, _>>()),
+            };
+            let c = ops
+                .client()
+                .update_bus_conversation(namespace, tenant, conversation_id, &req)
+                .await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&c)?),
+                OutputFormat::Text => info!(
+                    conversation_id = %c.conversation_id,
+                    "Conversation updated"
+                ),
+            }
+        }
+        ConversationsCommand::Delete {
+            namespace,
+            tenant,
+            conversation_id,
+        } => {
+            ops.client()
+                .delete_bus_conversation(namespace, tenant, conversation_id)
+                .await?;
+            info!(conversation_id = %conversation_id, "Conversation deleted");
+        }
+        ConversationsCommand::Transition {
+            namespace,
+            tenant,
+            conversation_id,
+            transition,
+        } => {
+            let c = ops
+                .client()
+                .transition_bus_conversation(
+                    namespace,
+                    tenant,
+                    conversation_id,
+                    BusConversationTransition::from(transition.clone()),
+                )
+                .await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&c)?),
+                OutputFormat::Text => info!(
+                    conversation_id = %c.conversation_id,
+                    state = ?c.state,
+                    "Conversation transitioned"
+                ),
+            }
+        }
+        ConversationsCommand::Append {
+            namespace,
+            tenant,
+            conversation_id,
+            payload,
+            sender,
+            headers,
+        } => {
+            let payload = parse_json_arg(payload)?;
+            let req = AppendBusConversationMessage {
+                payload,
+                sender: sender.clone(),
+                headers: headers.iter().cloned().collect(),
+            };
+            let receipt = ops
+                .client()
+                .append_bus_conversation_message(namespace, tenant, conversation_id, &req)
+                .await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&receipt)?),
+                OutputFormat::Text => info!(
+                    conversation_id = %receipt.conversation_id,
+                    events_topic = %receipt.events_topic,
+                    partition = receipt.partition,
+                    offset = receipt.offset,
+                    "Message appended"
+                ),
+            }
+        }
+        ConversationsCommand::Replay {
+            namespace,
+            tenant,
+            conversation_id,
+            from,
+            cursor,
+            limit,
+            timeout_ms,
+        } => {
+            let params = ReplayBusConversationParams {
+                from: from.clone(),
+                limit: *limit,
+                timeout_ms: *timeout_ms,
+                cursor: cursor.clone(),
+            };
+            let resp = ops
+                .client()
+                .replay_bus_conversation_messages(namespace, tenant, conversation_id, &params)
+                .await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&resp)?),
+                OutputFormat::Text => {
+                    info!(
+                        conversation_id = %resp.conversation_id,
+                        events_topic = %resp.events_topic,
+                        message_count = resp.messages.len(),
+                        exit_reason = ?resp.exit_reason,
+                        cursor = resp.cursor.as_deref().unwrap_or(""),
+                        "Conversation replay"
+                    );
+                    for m in &resp.messages {
+                        info!(
+                            partition = m.partition,
+                            offset = m.offset,
+                            timestamp = %m.timestamp,
+                            payload = %m.payload,
+                            "Message"
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/bus/mod.rs
+++ b/crates/cli/src/commands/bus/mod.rs
@@ -1,0 +1,78 @@
+//! `acteon bus` subcommand tree.
+//!
+//! Mirrors the agentic-bus HTTP surface (`/v1/bus/*`) so operators
+//! and CI scripts can drive every primitive without a custom client.
+
+pub mod agents;
+pub mod approvals;
+pub mod conversations;
+pub mod schemas;
+pub mod streams;
+pub mod subscriptions;
+pub mod tool_calls;
+pub mod topics;
+
+use acteon_ops::OpsClient;
+use clap::{Args, Subcommand};
+
+use crate::OutputFormat;
+
+#[derive(Args, Debug)]
+pub struct BusArgs {
+    #[command(subcommand)]
+    pub command: BusCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum BusCommand {
+    /// Manage bus topics (Kafka-backed).
+    Topics(topics::TopicsArgs),
+    /// Manage durable subscriptions and consumer-group state.
+    Subscriptions(subscriptions::SubscriptionsArgs),
+    /// Manage JSON Schema registry and topic-schema bindings.
+    Schemas(schemas::SchemasArgs),
+    /// Manage agents (shared inbox topic per `(namespace, tenant)`).
+    Agents(agents::AgentsArgs),
+    /// Manage conversations (per-thread FIFO on shared events topic).
+    Conversations(conversations::ConversationsArgs),
+    /// Post and look up tool-call / tool-result envelopes.
+    #[command(name = "tool-calls")]
+    ToolCalls(tool_calls::ToolCallsArgs),
+    /// Stream-chunk envelopes plus consume URLs.
+    Streams(streams::StreamsArgs),
+    /// HITL pre-publish approvals for parked tool-calls.
+    Approvals(approvals::ApprovalsArgs),
+}
+
+pub async fn run(ops: &OpsClient, args: &BusArgs, format: &OutputFormat) -> anyhow::Result<()> {
+    match &args.command {
+        BusCommand::Topics(a) => topics::run(ops, a, format).await,
+        BusCommand::Subscriptions(a) => subscriptions::run(ops, a, format).await,
+        BusCommand::Schemas(a) => schemas::run(ops, a, format).await,
+        BusCommand::Agents(a) => agents::run(ops, a, format).await,
+        BusCommand::Conversations(a) => conversations::run(ops, a, format).await,
+        BusCommand::ToolCalls(a) => tool_calls::run(ops, a, format).await,
+        BusCommand::Streams(a) => streams::run(ops, a, format).await,
+        BusCommand::Approvals(a) => approvals::run(ops, a, format).await,
+    }
+}
+
+/// Helper for parsing `key=value` flag inputs into a `HashMap`.
+pub(crate) fn parse_kv(s: &str) -> anyhow::Result<(String, String)> {
+    let (k, v) = s
+        .split_once('=')
+        .ok_or_else(|| anyhow::anyhow!("expected key=value, got {s:?}"))?;
+    Ok((k.to_string(), v.to_string()))
+}
+
+/// Helper for parsing JSON value inputs from `--payload @file.json` or
+/// `--payload '{"x": 1}'` style flags.
+pub(crate) fn parse_json_arg(input: &str) -> anyhow::Result<serde_json::Value> {
+    if let Some(path) = input.strip_prefix('@') {
+        let bytes =
+            std::fs::read(path).map_err(|e| anyhow::anyhow!("failed to read {path}: {e}"))?;
+        serde_json::from_slice(&bytes).map_err(|e| anyhow::anyhow!("invalid JSON in {path}: {e}"))
+    } else {
+        serde_json::from_str(input).map_err(|e| anyhow::anyhow!("invalid JSON: {e}"))
+    }
+}

--- a/crates/cli/src/commands/bus/schemas.rs
+++ b/crates/cli/src/commands/bus/schemas.rs
@@ -1,0 +1,241 @@
+use std::collections::HashMap;
+
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::{BusSchemaFilter, RegisterBusSchema};
+use clap::{Args, Subcommand};
+use tracing::info;
+
+use crate::OutputFormat;
+use crate::commands::bus::{parse_json_arg, parse_kv};
+
+#[derive(Args, Debug)]
+pub struct SchemasArgs {
+    #[command(subcommand)]
+    pub command: SchemasCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SchemasCommand {
+    /// List schemas, optionally filtered.
+    List {
+        #[arg(long)]
+        namespace: Option<String>,
+        #[arg(long)]
+        tenant: Option<String>,
+        #[arg(long)]
+        subject: Option<String>,
+        /// Show only the latest version per subject.
+        #[arg(long)]
+        latest_only: bool,
+    },
+    /// Fetch every version of a subject (oldest-to-newest).
+    Versions {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        subject: String,
+    },
+    /// Fetch a specific schema version. `--version` accepts `latest`
+    /// or any numeric version.
+    Get {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        subject: String,
+        #[arg(long, default_value = "latest")]
+        version: String,
+    },
+    /// Register (or bump) a schema subject. The server allocates the
+    /// next monotonic version.
+    Register {
+        #[arg(long)]
+        subject: String,
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        /// JSON Schema body, or `@path/to/schema.json`.
+        #[arg(long)]
+        body: String,
+        #[arg(long = "label", value_parser = parse_kv)]
+        labels: Vec<(String, String)>,
+    },
+    /// Delete a specific schema version. Fails with 409 if any topic
+    /// pins it.
+    Delete {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        subject: String,
+        #[arg(long)]
+        version: i32,
+    },
+    /// Bind a topic to a schema subject + version.
+    Bind {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        /// Logical topic name (no `namespace.tenant.` prefix).
+        #[arg(long)]
+        topic: String,
+        #[arg(long)]
+        subject: String,
+        #[arg(long)]
+        version: i32,
+    },
+    /// Drop a topic's schema binding.
+    Unbind {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        topic: String,
+    },
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn run(ops: &OpsClient, args: &SchemasArgs, format: &OutputFormat) -> anyhow::Result<()> {
+    match &args.command {
+        SchemasCommand::List {
+            namespace,
+            tenant,
+            subject,
+            latest_only,
+        } => {
+            let filter = BusSchemaFilter {
+                namespace: namespace.clone(),
+                tenant: tenant.clone(),
+                subject: subject.clone(),
+                latest_only: *latest_only,
+            };
+            let resp = ops.client().list_bus_schemas(&filter).await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&resp)?),
+                OutputFormat::Text => {
+                    info!(count = resp.count, "Bus schemas");
+                    for s in &resp.schemas {
+                        info!(
+                            subject = %s.subject,
+                            version = s.version,
+                            namespace = %s.namespace,
+                            tenant = %s.tenant,
+                            "Schema"
+                        );
+                    }
+                }
+            }
+        }
+        SchemasCommand::Versions {
+            namespace,
+            tenant,
+            subject,
+        } => {
+            let resp = ops
+                .client()
+                .get_bus_schema_versions(namespace, tenant, subject)
+                .await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&resp)?),
+                OutputFormat::Text => {
+                    info!(count = resp.count, subject = %subject, "Schema versions");
+                    for s in &resp.schemas {
+                        info!(
+                            subject = %s.subject,
+                            version = s.version,
+                            created_at = %s.created_at,
+                            "Schema"
+                        );
+                    }
+                }
+            }
+        }
+        SchemasCommand::Get {
+            namespace,
+            tenant,
+            subject,
+            version,
+        } => {
+            let s = ops
+                .client()
+                .get_bus_schema(namespace, tenant, subject, version)
+                .await?;
+            info!("{}", serde_json::to_string_pretty(&s)?);
+        }
+        SchemasCommand::Register {
+            subject,
+            namespace,
+            tenant,
+            body,
+            labels,
+        } => {
+            let body = parse_json_arg(body)?;
+            let req = RegisterBusSchema {
+                subject: subject.clone(),
+                namespace: namespace.clone(),
+                tenant: tenant.clone(),
+                body,
+                labels: labels.iter().cloned().collect::<HashMap<_, _>>(),
+            };
+            let s = ops.client().register_bus_schema(&req).await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&s)?),
+                OutputFormat::Text => info!(
+                    subject = %s.subject,
+                    version = s.version,
+                    "Schema registered"
+                ),
+            }
+        }
+        SchemasCommand::Delete {
+            namespace,
+            tenant,
+            subject,
+            version,
+        } => {
+            ops.client()
+                .delete_bus_schema(namespace, tenant, subject, *version)
+                .await?;
+            info!(subject = %subject, version = *version, "Schema deleted");
+        }
+        SchemasCommand::Bind {
+            namespace,
+            tenant,
+            topic,
+            subject,
+            version,
+        } => {
+            let resp = ops
+                .client()
+                .bind_topic_schema(namespace, tenant, topic, subject, *version)
+                .await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&resp)?),
+                OutputFormat::Text => info!(
+                    topic = %resp.topic,
+                    subject = %resp.subject,
+                    version = resp.version,
+                    "Topic bound to schema"
+                ),
+            }
+        }
+        SchemasCommand::Unbind {
+            namespace,
+            tenant,
+            topic,
+        } => {
+            ops.client()
+                .unbind_topic_schema(namespace, tenant, topic)
+                .await?;
+            info!(topic = %topic, "Topic schema binding removed");
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/bus/streams.rs
+++ b/crates/cli/src/commands/bus/streams.rs
@@ -1,0 +1,181 @@
+use std::collections::HashMap;
+
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::{BusStreamEndStatus, PostBusStreamChunk, PostBusStreamEnd};
+use clap::{Args, Subcommand};
+use tracing::info;
+
+use crate::OutputFormat;
+use crate::commands::bus::{parse_json_arg, parse_kv};
+
+#[derive(Args, Debug)]
+pub struct StreamsArgs {
+    #[command(subcommand)]
+    pub command: StreamsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum StreamsCommand {
+    /// Append a stream-chunk envelope.
+    Chunk {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        conversation_id: String,
+        #[arg(long)]
+        stream_id: String,
+        #[arg(long)]
+        chunk_seq: i64,
+        /// JSON body, or `@path/to/file.json`.
+        #[arg(long)]
+        body: Option<String>,
+        #[arg(long)]
+        sender: Option<String>,
+        #[arg(long = "metadata", value_parser = parse_kv)]
+        metadata: Vec<(String, String)>,
+    },
+    /// Append the terminal `stream_end` marker.
+    End {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        conversation_id: String,
+        #[arg(long)]
+        stream_id: String,
+        #[arg(long)]
+        chunk_seq: i64,
+        /// `complete`, `aborted`, or `error`.
+        #[arg(long)]
+        status: StreamEndStatusKind,
+        #[arg(long)]
+        error_message: Option<String>,
+        #[arg(long)]
+        sender: Option<String>,
+        #[arg(long = "metadata", value_parser = parse_kv)]
+        metadata: Vec<(String, String)>,
+    },
+    /// Print the SSE consume URL for a stream. Pipe into `curl -N
+    /// --header 'accept: text/event-stream' "$(...)"` to tail it.
+    ConsumeUrl {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        conversation_id: String,
+        #[arg(long)]
+        stream_id: String,
+    },
+}
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum StreamEndStatusKind {
+    Complete,
+    Aborted,
+    Error,
+}
+
+impl From<StreamEndStatusKind> for BusStreamEndStatus {
+    fn from(s: StreamEndStatusKind) -> Self {
+        match s {
+            StreamEndStatusKind::Complete => Self::Complete,
+            StreamEndStatusKind::Aborted => Self::Aborted,
+            StreamEndStatusKind::Error => Self::Error,
+        }
+    }
+}
+
+pub async fn run(ops: &OpsClient, args: &StreamsArgs, format: &OutputFormat) -> anyhow::Result<()> {
+    match &args.command {
+        StreamsCommand::Chunk {
+            namespace,
+            tenant,
+            conversation_id,
+            stream_id,
+            chunk_seq,
+            body,
+            sender,
+            metadata,
+        } => {
+            let body = body
+                .as_deref()
+                .map(parse_json_arg)
+                .transpose()?
+                .unwrap_or(serde_json::Value::Null);
+            let req = PostBusStreamChunk {
+                stream_id: stream_id.clone(),
+                chunk_seq: *chunk_seq,
+                body,
+                sender: sender.clone(),
+                metadata: metadata.iter().cloned().collect::<HashMap<_, _>>(),
+            };
+            let receipt = ops
+                .client()
+                .post_bus_stream_chunk(namespace, tenant, conversation_id, &req)
+                .await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&receipt)?),
+                OutputFormat::Text => info!(
+                    stream_id = %receipt.stream_id,
+                    chunk_seq = receipt.chunk_seq,
+                    partition = receipt.partition,
+                    offset = receipt.offset,
+                    cursor = %receipt.cursor,
+                    "Stream chunk produced"
+                ),
+            }
+        }
+        StreamsCommand::End {
+            namespace,
+            tenant,
+            conversation_id,
+            stream_id,
+            chunk_seq,
+            status,
+            error_message,
+            sender,
+            metadata,
+        } => {
+            let req = PostBusStreamEnd {
+                stream_id: stream_id.clone(),
+                chunk_seq: *chunk_seq,
+                status: BusStreamEndStatus::from(status.clone()),
+                error_message: error_message.clone(),
+                sender: sender.clone(),
+                metadata: metadata.iter().cloned().collect::<HashMap<_, _>>(),
+            };
+            let receipt = ops
+                .client()
+                .post_bus_stream_end(namespace, tenant, conversation_id, &req)
+                .await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&receipt)?),
+                OutputFormat::Text => info!(
+                    stream_id = %receipt.stream_id,
+                    chunk_seq = receipt.chunk_seq,
+                    partition = receipt.partition,
+                    offset = receipt.offset,
+                    "Stream end produced"
+                ),
+            }
+        }
+        StreamsCommand::ConsumeUrl {
+            namespace,
+            tenant,
+            conversation_id,
+            stream_id,
+        } => {
+            let url =
+                ops.client()
+                    .bus_stream_consume_url(namespace, tenant, conversation_id, stream_id);
+            // Print the URL to stdout so it can be piped without log
+            // formatting noise.
+            println!("{url}");
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/bus/subscriptions.rs
+++ b/crates/cli/src/commands/bus/subscriptions.rs
@@ -1,0 +1,225 @@
+use std::collections::HashMap;
+
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::{AckOffset, BusSubscriptionFilter, CreateSubscription};
+use clap::{Args, Subcommand};
+use tracing::info;
+
+use crate::OutputFormat;
+use crate::commands::bus::parse_kv;
+
+#[derive(Args, Debug)]
+pub struct SubscriptionsArgs {
+    #[command(subcommand)]
+    pub command: SubscriptionsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SubscriptionsCommand {
+    /// List subscriptions, optionally filtered.
+    List {
+        #[arg(long)]
+        namespace: Option<String>,
+        #[arg(long)]
+        tenant: Option<String>,
+        #[arg(long)]
+        topic: Option<String>,
+    },
+    /// Create a durable subscription (Kafka consumer group).
+    Create {
+        /// Subscription id (unique within `(namespace, tenant)`).
+        #[arg(long)]
+        id: String,
+        /// Topic Kafka name to consume.
+        #[arg(long)]
+        topic: String,
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        /// `earliest` or `latest`.
+        #[arg(long)]
+        starting_offset: Option<String>,
+        /// `auto` or `manual`.
+        #[arg(long)]
+        ack_mode: Option<String>,
+        /// Optional dead-letter topic Kafka name.
+        #[arg(long)]
+        dead_letter_topic: Option<String>,
+        #[arg(long)]
+        ack_timeout_ms: Option<u64>,
+        #[arg(long)]
+        description: Option<String>,
+        #[arg(long = "label", value_parser = parse_kv)]
+        labels: Vec<(String, String)>,
+    },
+    /// Delete a subscription by `(namespace, tenant, id)`.
+    Delete {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        id: String,
+    },
+    /// Report per-partition lag for a subscription's group.
+    Lag {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        id: String,
+    },
+    /// Commit an offset on behalf of the subscription's group.
+    /// **Performance warning**: full broker round-trip per call —
+    /// suitable for end-of-batch checkpoints, not per-record acks.
+    Ack {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        id: String,
+        #[arg(long)]
+        partition: i32,
+        #[arg(long)]
+        offset: i64,
+    },
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn run(
+    ops: &OpsClient,
+    args: &SubscriptionsArgs,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    match &args.command {
+        SubscriptionsCommand::List {
+            namespace,
+            tenant,
+            topic,
+        } => {
+            let filter = BusSubscriptionFilter {
+                namespace: namespace.clone(),
+                tenant: tenant.clone(),
+                topic: topic.clone(),
+            };
+            let resp = ops.client().list_bus_subscriptions(&filter).await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&resp)?),
+                OutputFormat::Text => {
+                    info!(count = resp.count, "Bus subscriptions");
+                    for s in &resp.subscriptions {
+                        info!(
+                            id = %s.id,
+                            topic = %s.topic,
+                            namespace = %s.namespace,
+                            tenant = %s.tenant,
+                            starting_offset = %s.starting_offset,
+                            ack_mode = %s.ack_mode,
+                            "Subscription"
+                        );
+                    }
+                }
+            }
+        }
+        SubscriptionsCommand::Create {
+            id,
+            topic,
+            namespace,
+            tenant,
+            starting_offset,
+            ack_mode,
+            dead_letter_topic,
+            ack_timeout_ms,
+            description,
+            labels,
+        } => {
+            let req = CreateSubscription {
+                id: id.clone(),
+                topic: topic.clone(),
+                namespace: namespace.clone(),
+                tenant: tenant.clone(),
+                starting_offset: starting_offset.clone(),
+                ack_mode: ack_mode.clone(),
+                dead_letter_topic: dead_letter_topic.clone(),
+                ack_timeout_ms: *ack_timeout_ms,
+                description: description.clone(),
+                labels: labels.iter().cloned().collect::<HashMap<_, _>>(),
+            };
+            let sub = ops.client().create_bus_subscription(&req).await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&sub)?),
+                OutputFormat::Text => info!(
+                    id = %sub.id,
+                    topic = %sub.topic,
+                    "Subscription created"
+                ),
+            }
+        }
+        SubscriptionsCommand::Delete {
+            namespace,
+            tenant,
+            id,
+        } => {
+            ops.client()
+                .delete_bus_subscription(namespace, tenant, id)
+                .await?;
+            info!(id = %id, "Subscription deleted");
+        }
+        SubscriptionsCommand::Lag {
+            namespace,
+            tenant,
+            id,
+        } => {
+            let lag = ops.client().get_bus_lag(namespace, tenant, id).await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&lag)?),
+                OutputFormat::Text => {
+                    info!(
+                        id = %lag.subscription_id,
+                        topic = %lag.topic,
+                        total_lag = lag.total_lag,
+                        "Subscription lag"
+                    );
+                    for p in &lag.partitions {
+                        info!(
+                            partition = p.partition,
+                            committed = p.committed,
+                            high_water = p.high_water_mark,
+                            lag = p.lag,
+                            "Partition"
+                        );
+                    }
+                }
+            }
+        }
+        SubscriptionsCommand::Ack {
+            namespace,
+            tenant,
+            id,
+            partition,
+            offset,
+        } => {
+            ops.client()
+                .ack_bus_subscription(
+                    namespace,
+                    tenant,
+                    id,
+                    AckOffset {
+                        partition: *partition,
+                        offset: *offset,
+                    },
+                )
+                .await?;
+            info!(
+                id = %id,
+                partition = *partition,
+                offset = *offset,
+                "Offset committed"
+            );
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/bus/tool_calls.rs
+++ b/crates/cli/src/commands/bus/tool_calls.rs
@@ -1,0 +1,260 @@
+use std::collections::HashMap;
+
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::{
+    BusToolResultLookupParams, BusToolResultStatus, PostBusToolCall, PostBusToolCallOutcome,
+    PostBusToolResult,
+};
+use clap::{Args, Subcommand};
+use tracing::info;
+
+use crate::OutputFormat;
+use crate::commands::bus::{parse_json_arg, parse_kv};
+
+#[derive(Args, Debug)]
+pub struct ToolCallsArgs {
+    #[command(subcommand)]
+    pub command: ToolCallsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ToolCallsCommand {
+    /// Post a tool-call envelope. With `--require-approval`, the
+    /// server parks it under a HITL approval row and returns 202.
+    Post {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        conversation_id: String,
+        #[arg(long)]
+        call_id: String,
+        /// Tool identifier, e.g. `billing.charge`.
+        #[arg(long)]
+        tool: String,
+        /// Tool arguments as JSON, or `@path/to/args.json`.
+        #[arg(long)]
+        arguments: Option<String>,
+        #[arg(long)]
+        sender: Option<String>,
+        #[arg(long)]
+        correlation_id: Option<String>,
+        /// Conversation id where the result is expected to land.
+        #[arg(long)]
+        reply_to: Option<String>,
+        #[arg(long = "metadata", value_parser = parse_kv)]
+        metadata: Vec<(String, String)>,
+        /// Park behind a human-in-the-loop approval.
+        #[arg(long)]
+        require_approval: bool,
+        /// Free-form rationale shown to the operator.
+        #[arg(long)]
+        approval_reason: Option<String>,
+        /// Override default 24h TTL (max 7d).
+        #[arg(long)]
+        approval_ttl_ms: Option<u64>,
+    },
+    /// Post a tool-result envelope.
+    PostResult {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        conversation_id: String,
+        #[arg(long)]
+        call_id: String,
+        /// `ok`, `error`, or `canceled`.
+        #[arg(long)]
+        status: ToolResultStatusKind,
+        /// JSON output, or `@path/to/file.json`.
+        #[arg(long)]
+        output: Option<String>,
+        #[arg(long)]
+        error_message: Option<String>,
+        #[arg(long)]
+        correlation_id: Option<String>,
+        #[arg(long)]
+        sender: Option<String>,
+        #[arg(long = "metadata", value_parser = parse_kv)]
+        metadata: Vec<(String, String)>,
+    },
+    /// Look up a tool result by `call_id`. Strongly recommend passing
+    /// `--cursor` from the originating call's receipt.
+    Lookup {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        call_id: String,
+        /// Required: which conversation to scan.
+        #[arg(long)]
+        conversation_id: String,
+        /// Resume cursor from the call receipt.
+        #[arg(long)]
+        cursor: Option<String>,
+        #[arg(long)]
+        timeout_ms: Option<u64>,
+    },
+}
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum ToolResultStatusKind {
+    Ok,
+    Error,
+    Canceled,
+}
+
+impl From<ToolResultStatusKind> for BusToolResultStatus {
+    fn from(s: ToolResultStatusKind) -> Self {
+        match s {
+            ToolResultStatusKind::Ok => Self::Ok,
+            ToolResultStatusKind::Error => Self::Error,
+            ToolResultStatusKind::Canceled => Self::Canceled,
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn run(
+    ops: &OpsClient,
+    args: &ToolCallsArgs,
+    format: &OutputFormat,
+) -> anyhow::Result<()> {
+    match &args.command {
+        ToolCallsCommand::Post {
+            namespace,
+            tenant,
+            conversation_id,
+            call_id,
+            tool,
+            arguments,
+            sender,
+            correlation_id,
+            reply_to,
+            metadata,
+            require_approval,
+            approval_reason,
+            approval_ttl_ms,
+        } => {
+            let arguments = arguments
+                .as_deref()
+                .map(parse_json_arg)
+                .transpose()?
+                .unwrap_or(serde_json::Value::Null);
+            let req = PostBusToolCall {
+                call_id: call_id.clone(),
+                tool: tool.clone(),
+                arguments,
+                correlation_id: correlation_id.clone(),
+                reply_to: reply_to.clone(),
+                sender: sender.clone(),
+                metadata: metadata.iter().cloned().collect::<HashMap<_, _>>(),
+                require_approval: *require_approval,
+                approval_reason: approval_reason.clone(),
+                approval_ttl_ms: *approval_ttl_ms,
+            };
+            let outcome = ops
+                .client()
+                .post_bus_tool_call(namespace, tenant, conversation_id, &req)
+                .await?;
+            match (format, outcome) {
+                (OutputFormat::Json, PostBusToolCallOutcome::Produced(r)) => {
+                    info!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "outcome": "produced",
+                            "receipt": r,
+                        }))?
+                    );
+                }
+                (OutputFormat::Json, PostBusToolCallOutcome::Parked(p)) => {
+                    info!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "outcome": "parked",
+                            "approval": p,
+                        }))?
+                    );
+                }
+                (OutputFormat::Text, PostBusToolCallOutcome::Produced(r)) => info!(
+                    call_id = %r.call_id,
+                    events_topic = %r.events_topic,
+                    partition = r.partition,
+                    offset = r.offset,
+                    cursor = %r.cursor,
+                    "Tool-call produced"
+                ),
+                (OutputFormat::Text, PostBusToolCallOutcome::Parked(p)) => info!(
+                    approval_id = %p.approval_id,
+                    correlation_token = %p.correlation_token,
+                    expires_at = %p.expires_at,
+                    "Tool-call parked for approval"
+                ),
+            }
+        }
+        ToolCallsCommand::PostResult {
+            namespace,
+            tenant,
+            conversation_id,
+            call_id,
+            status,
+            output,
+            error_message,
+            correlation_id,
+            sender,
+            metadata,
+        } => {
+            let output = output
+                .as_deref()
+                .map(parse_json_arg)
+                .transpose()?
+                .unwrap_or(serde_json::Value::Null);
+            let req = PostBusToolResult {
+                call_id: call_id.clone(),
+                status: BusToolResultStatus::from(status.clone()),
+                output,
+                error_message: error_message.clone(),
+                correlation_id: correlation_id.clone(),
+                sender: sender.clone(),
+                metadata: metadata.iter().cloned().collect::<HashMap<_, _>>(),
+            };
+            let receipt = ops
+                .client()
+                .post_bus_tool_result(namespace, tenant, conversation_id, &req)
+                .await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&receipt)?),
+                OutputFormat::Text => info!(
+                    call_id = %receipt.call_id,
+                    events_topic = %receipt.events_topic,
+                    partition = receipt.partition,
+                    offset = receipt.offset,
+                    "Tool-result produced"
+                ),
+            }
+        }
+        ToolCallsCommand::Lookup {
+            namespace,
+            tenant,
+            call_id,
+            conversation_id,
+            cursor,
+            timeout_ms,
+        } => {
+            let params = BusToolResultLookupParams {
+                conversation_id: conversation_id.clone(),
+                cursor: cursor.clone(),
+                timeout_ms: *timeout_ms,
+            };
+            let lookup = ops
+                .client()
+                .lookup_bus_tool_result(namespace, tenant, call_id, &params)
+                .await?;
+            info!("{}", serde_json::to_string_pretty(&lookup)?);
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/bus/topics.rs
+++ b/crates/cli/src/commands/bus/topics.rs
@@ -1,0 +1,172 @@
+use std::collections::HashMap;
+
+use acteon_ops::OpsClient;
+use acteon_ops::acteon_client::{BusTopicFilter, CreateBusTopic, PublishBusMessage};
+use clap::{Args, Subcommand};
+use tracing::info;
+
+use crate::OutputFormat;
+use crate::commands::bus::{parse_json_arg, parse_kv};
+
+#[derive(Args, Debug)]
+pub struct TopicsArgs {
+    #[command(subcommand)]
+    pub command: TopicsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TopicsCommand {
+    /// List bus topics, optionally filtered by namespace/tenant.
+    List {
+        #[arg(long)]
+        namespace: Option<String>,
+        #[arg(long)]
+        tenant: Option<String>,
+    },
+    /// Create a bus topic. Persists in Acteon state and creates the
+    /// backing Kafka topic.
+    Create {
+        /// Logical topic name (Kafka name is `namespace.tenant.name`).
+        #[arg(long)]
+        name: String,
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        tenant: String,
+        #[arg(long)]
+        partitions: Option<i32>,
+        #[arg(long)]
+        replication_factor: Option<i16>,
+        #[arg(long)]
+        retention_ms: Option<i64>,
+        #[arg(long)]
+        description: Option<String>,
+        /// Repeat for multiple labels: `--label key=value`.
+        #[arg(long = "label", value_parser = parse_kv)]
+        labels: Vec<(String, String)>,
+    },
+    /// Delete a bus topic by Kafka name (`namespace.tenant.name`).
+    Delete {
+        /// Kafka topic name, e.g. `agents.demo.events`.
+        kafka_name: String,
+    },
+    /// Publish a single message to a topic.
+    Publish {
+        /// Either the full `namespace.tenant.name` form...
+        #[arg(long)]
+        topic: Option<String>,
+        /// ...or the three parts spelled out separately.
+        #[arg(long)]
+        namespace: Option<String>,
+        #[arg(long)]
+        tenant: Option<String>,
+        #[arg(long)]
+        name: Option<String>,
+        /// Partition key (Kafka routes by this).
+        #[arg(long)]
+        key: Option<String>,
+        /// JSON payload, or `@path/to/file.json`.
+        #[arg(long)]
+        payload: String,
+        /// Repeat for multiple headers: `--header key=value`.
+        #[arg(long = "header", value_parser = parse_kv)]
+        headers: Vec<(String, String)>,
+    },
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn run(ops: &OpsClient, args: &TopicsArgs, format: &OutputFormat) -> anyhow::Result<()> {
+    match &args.command {
+        TopicsCommand::List { namespace, tenant } => {
+            let filter = BusTopicFilter {
+                namespace: namespace.clone(),
+                tenant: tenant.clone(),
+            };
+            let resp = ops.client().list_bus_topics(&filter).await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&resp)?),
+                OutputFormat::Text => {
+                    info!(count = resp.count, "Bus topics");
+                    for t in &resp.topics {
+                        info!(
+                            name = %t.name,
+                            namespace = %t.namespace,
+                            tenant = %t.tenant,
+                            kafka = %t.kafka_name,
+                            partitions = t.partitions,
+                            replication_factor = t.replication_factor,
+                            "Topic"
+                        );
+                    }
+                }
+            }
+        }
+        TopicsCommand::Create {
+            name,
+            namespace,
+            tenant,
+            partitions,
+            replication_factor,
+            retention_ms,
+            description,
+            labels,
+        } => {
+            let req = CreateBusTopic {
+                name: name.clone(),
+                namespace: namespace.clone(),
+                tenant: tenant.clone(),
+                partitions: *partitions,
+                replication_factor: *replication_factor,
+                retention_ms: *retention_ms,
+                description: description.clone(),
+                labels: labels.iter().cloned().collect::<HashMap<_, _>>(),
+            };
+            let topic = ops.client().create_bus_topic(&req).await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&topic)?),
+                OutputFormat::Text => info!(
+                    name = %topic.name,
+                    kafka = %topic.kafka_name,
+                    partitions = topic.partitions,
+                    "Topic created"
+                ),
+            }
+        }
+        TopicsCommand::Delete { kafka_name } => {
+            ops.client().delete_bus_topic(kafka_name).await?;
+            info!(kafka = %kafka_name, "Topic deleted");
+        }
+        TopicsCommand::Publish {
+            topic,
+            namespace,
+            tenant,
+            name,
+            key,
+            payload,
+            headers,
+        } => {
+            let payload = parse_json_arg(payload)?;
+            let msg = PublishBusMessage {
+                topic: topic.clone(),
+                namespace: namespace.clone(),
+                tenant: tenant.clone(),
+                name: name.clone(),
+                key: key.clone(),
+                payload,
+                headers: headers.iter().cloned().collect(),
+            };
+            let receipt = ops.client().publish_message(&msg).await?;
+            match format {
+                OutputFormat::Json => info!("{}", serde_json::to_string_pretty(&receipt)?),
+                OutputFormat::Text => info!(
+                    topic = %receipt.topic,
+                    partition = receipt.partition,
+                    offset = receipt.offset,
+                    produced_at = %receipt.produced_at,
+                    "Message published"
+                ),
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod approvals;
 pub mod audit;
+pub mod bus;
 pub mod chains;
 pub mod compliance;
 pub mod dispatch;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -53,6 +53,9 @@ enum Command {
     Events(commands::events::EventsArgs),
     /// Manage action chains.
     Chains(commands::chains::ChainsArgs),
+    /// Drive the agentic message bus (topics, subscriptions, schemas,
+    /// agents, conversations, tool-calls, streams, approvals).
+    Bus(commands::bus::BusArgs),
     /// Manage recurring actions.
     Recurring(commands::recurring::RecurringArgs),
     /// Manage tenant quotas.
@@ -104,6 +107,7 @@ async fn main() -> anyhow::Result<()> {
         Command::Rules(args) => commands::rules::run(&ops, &args, &cli.format).await,
         Command::Events(args) => commands::events::run(&ops, &args, &cli.format).await,
         Command::Chains(args) => commands::chains::run(&ops, &args, &cli.format).await,
+        Command::Bus(args) => commands::bus::run(&ops, &args, &cli.format).await,
         Command::Recurring(args) => commands::recurring::run(&ops, &args, &cli.format).await,
         Command::Quotas(args) => commands::quotas::run(&ops, &args, &cli.format).await,
         Command::Retention(args) => commands::retention::run(&ops, &args, &cli.format).await,

--- a/crates/client/src/bus.rs
+++ b/crates/client/src/bus.rs
@@ -67,7 +67,7 @@ pub struct BusTopic {
     pub updated_at: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListBusTopicsResponse {
     pub topics: Vec<BusTopic>,
     pub count: usize,
@@ -101,7 +101,7 @@ pub struct PublishBusMessage {
     pub headers: BTreeMap<String, String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PublishReceipt {
     pub topic: String,
     pub partition: i32,
@@ -150,7 +150,7 @@ pub struct BusSubscription {
     pub updated_at: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListBusSubscriptionsResponse {
     pub subscriptions: Vec<BusSubscription>,
     pub count: usize,
@@ -172,7 +172,7 @@ pub struct AckOffset {
     pub offset: i64,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LagPartition {
     pub partition: i32,
     pub committed: i64,
@@ -180,7 +180,7 @@ pub struct LagPartition {
     pub lag: i64,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BusLag {
     pub subscription_id: String,
     pub topic: String,
@@ -201,7 +201,7 @@ pub struct DeadLetterRequest {
     pub headers: BTreeMap<String, String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeadLetterReceipt {
     pub dlq_topic: String,
     pub partition: i32,
@@ -1418,7 +1418,7 @@ pub struct BusSchema {
     pub created_at: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListBusSchemasResponse {
     pub schemas: Vec<BusSchema>,
     pub count: usize,
@@ -1442,7 +1442,7 @@ struct BindTopicSchemaRequest {
     version: i32,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BindTopicSchemaResponse {
     pub topic: String,
     pub subject: String,
@@ -1518,7 +1518,7 @@ pub struct BusAgent {
     pub updated_at: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListBusAgentsResponse {
     pub agents: Vec<BusAgent>,
     pub count: usize,
@@ -1536,7 +1536,7 @@ pub struct BusAgentFilter {
     pub status: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BusAgentHeartbeat {
     pub agent_id: String,
     pub last_heartbeat_at: String,
@@ -1550,7 +1550,7 @@ pub struct SendToBusAgent {
     pub headers: BTreeMap<String, String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BusAgentSendReceipt {
     pub inbox_topic: String,
     pub agent_id: String,
@@ -1623,7 +1623,7 @@ pub struct BusConversation {
     pub updated_at: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListBusConversationsResponse {
     pub conversations: Vec<BusConversation>,
     pub count: usize,
@@ -1650,7 +1650,7 @@ pub struct AppendBusConversationMessage {
     pub headers: BTreeMap<String, String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BusConversationAppendReceipt {
     pub events_topic: String,
     pub conversation_id: String,
@@ -1673,7 +1673,7 @@ pub struct ReplayBusConversationParams {
     pub cursor: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BusConversationReplayMessage {
     pub partition: i32,
     pub offset: i64,
@@ -1688,7 +1688,7 @@ pub struct BusConversationReplayMessage {
 /// Why the server-side replay loop terminated. `Complete` = thread
 /// fully drained at scan time; `Limit` and `Timeout` = partial,
 /// follow-up needed via `cursor`.
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum BusReplayExitReason {
     Complete,
@@ -1696,7 +1696,7 @@ pub enum BusReplayExitReason {
     Timeout,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BusConversationReplay {
     pub conversation_id: String,
     pub events_topic: String,
@@ -1765,7 +1765,7 @@ pub struct PostBusToolResult {
     pub metadata: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BusToolEnvelopeReceipt {
     pub events_topic: String,
     pub conversation_id: String,
@@ -1800,7 +1800,7 @@ pub struct BusToolResultLookupParams {
     pub timeout_ms: Option<u64>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BusToolResult {
     pub call_id: String,
     pub status: BusToolResultStatus,
@@ -1817,7 +1817,7 @@ pub struct BusToolResult {
     pub created_at: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BusToolResultLookup {
     pub call_id: String,
     pub events_topic: String,
@@ -1882,7 +1882,7 @@ pub enum BusApprovalStatus {
     Expired,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BusApprovalParkedReceipt {
     pub approval_id: String,
     pub namespace: String,
@@ -1894,7 +1894,7 @@ pub struct BusApprovalParkedReceipt {
     pub expires_at: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BusApprovalView {
     pub approval_id: String,
     pub namespace: String,
@@ -1931,7 +1931,7 @@ pub struct ListBusApprovalsParams {
     pub conversation_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListBusApprovalsResponse {
     pub approvals: Vec<BusApprovalView>,
     pub count: usize,
@@ -1944,14 +1944,14 @@ pub struct BusApprovalDecisionRequest {
     pub decision_note: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BusApprovalDecisionResponse {
     pub approval: BusApprovalView,
     #[serde(default)]
     pub receipt: Option<BusToolEnvelopeReceipt>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BusStreamEnvelopeReceipt {
     pub events_topic: String,
     pub conversation_id: String,


### PR DESCRIPTION
## Summary

- Adds `acteon bus` subcommand tree mirroring the agentic-bus HTTP surface (`/v1/bus/*`) so operators and CI scripts can drive every primitive without writing a custom client.
- Eight categories: `topics`, `subscriptions`, `schemas`, `agents`, `conversations`, `tool-calls`, `streams`, `approvals` — each a thin shim over the existing `ActeonClient` bus methods.
- Bus client's response types now derive `Serialize` (already had `Deserialize`) so the global `--format json` flag works without intermediate conversions.

## Surface

```
acteon bus topics         {list, create, delete, publish}
acteon bus subscriptions  {list, create, delete, lag, ack}
acteon bus schemas        {list, versions, get, register, delete, bind, unbind}
acteon bus agents         {list, get, register, update, delete, heartbeat, send}
acteon bus conversations  {list, get, create, update, delete, transition, append, replay}
acteon bus tool-calls     {post, post-result, lookup}
acteon bus streams        {chunk, end, consume-url}
acteon bus approvals      {list, get, approve, reject}
```

JSON payload flags accept either inline JSON or `@path/to/file.json`. Repeatable `--label key=value` / `--header key=value` / `--metadata key=value` flags map to the corresponding map fields.

## Test plan

- [ ] `cargo fmt --all` — clean
- [ ] `cargo clippy --workspace --no-deps -- -D warnings` — clean
- [ ] `cargo test --workspace --lib --bins --tests` — all green
- [ ] `cargo check --all-targets` — clean
- [ ] `acteon bus --help` and per-subcommand `--help` parse correctly
- [ ] `acteon bus streams consume-url ...` prints the SSE URL without hitting the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)