### PR TITLE
feat(python-sdk): typed bus SSE consumers

### DIFF
--- a/clients/python/acteon_client/bus.py
+++ b/clients/python/acteon_client/bus.py
@@ -13,7 +13,8 @@ path, json=, params=)`` returning an ``httpx.Response``. The base
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+import json
+from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator, Optional
 from urllib.parse import quote
 
 from .bus_models import (
@@ -23,11 +24,14 @@ from .bus_models import (
     BusApprovalDecisionResponse,
     BusApprovalParkedReceipt,
     BusApprovalView,
+    BusConsumeItem,
+    BusConsumedMessage,
     BusConversation,
     BusLag,
     BusReplayResponse,
     BusSchema,
     BusStreamEnvelopeReceipt,
+    BusStreamItem,
     BusSubscription,
     BusToolEnvelopeReceipt,
     BusToolResultLookup,
@@ -45,6 +49,8 @@ from .bus_models import (
     PublishReceipt,
     RegisterBusAgent,
     RegisterBusSchema,
+    StreamChunkEnvelope,
+    StreamEndEnvelope,
 )
 from .errors import ApiError, HttpError
 
@@ -80,9 +86,9 @@ def _raise_for_status(resp: "httpx.Response") -> None:
 class _BusClientMixin:
     """Mixin providing the agentic bus REST surface."""
 
-    # The mixin doesn't define its own __init__; this attribute is
+    # The mixin doesn't define its own __init__; these attributes are
     # set by the concrete ``ActeonClient`` it gets mixed into. Stub
-    # the type so ``mypy`` (and humans) understand the contract.
+    # the types so ``mypy`` (and humans) understand the contract.
     if TYPE_CHECKING:
         def _request(  # noqa: D401
             self,
@@ -92,6 +98,10 @@ class _BusClientMixin:
             json: Optional[dict] = None,
             params: Optional[dict] = None,
         ) -> "httpx.Response": ...
+
+        def _headers(self) -> dict[str, str]: ...
+
+        _client: "httpx.Client"
         base_url: str
 
     # --------------- Phase 1: Topics + publish ---------------
@@ -481,6 +491,58 @@ class _BusClientMixin:
             f"{_seg(namespace)}/{_seg(tenant)}/{_seg(conversation_id)}/{_seg(stream_id)}"
         )
 
+    def consume_bus_subscription(
+        self,
+        subscription_id: str,
+        *,
+        topic: str,
+        from_offset: Optional[str] = None,
+    ) -> Iterator[BusConsumeItem]:
+        """Consume a bus subscription via SSE
+        (``GET /v1/bus/subscribe/{subscription_id}``). Yields one item
+        per Kafka record on the underlying topic. Server-side errors
+        surface as :attr:`BusConsumeItem.error`; SSE keep-alive
+        comments surface as :attr:`BusConsumeItem.is_keep_alive` so
+        callers can use them as a liveness signal.
+
+        Args:
+            subscription_id: Subscription id (Kafka consumer group).
+            topic: Full Kafka topic name (``namespace.tenant.name``).
+            from_offset: ``earliest`` or ``latest`` (server default).
+
+        Yields:
+            :class:`BusConsumeItem` per record.
+        """
+        params: dict[str, Any] = {"topic": topic}
+        if from_offset is not None:
+            params["from"] = from_offset
+        url = f"{self.base_url}/v1/bus/subscribe/{_seg(subscription_id)}"
+        for env in _open_bus_sse_stream(self._client, url, params, self._headers()):
+            yield _envelope_to_consume_item(env)
+
+    def consume_bus_stream(
+        self,
+        namespace: str,
+        tenant: str,
+        conversation_id: str,
+        stream_id: str,
+    ) -> Iterator[BusStreamItem]:
+        """Consume a typed stream via SSE
+        (``GET /v1/bus/streams/{ns}/{tenant}/{conv}/{stream_id}``). The
+        server filters by ``(envelope_kind, conversation_id, stream_id)``,
+        so this stream only emits chunks for the requested stream id and
+        closes after the terminal :class:`StreamEndEnvelope`.
+
+        Yields:
+            :class:`BusStreamItem` per chunk plus the terminal end marker.
+        """
+        url = self.bus_stream_consume_url(namespace, tenant, conversation_id, stream_id)
+        for env in _open_bus_sse_stream(self._client, url, None, self._headers()):
+            item = _envelope_to_stream_item(env)
+            yield item
+            if item.is_end:
+                break
+
     # --------------- Phase 6c: HITL approvals ---------------
 
     def list_bus_approvals(
@@ -571,6 +633,10 @@ class _AsyncBusClientMixin:
             json: Optional[dict] = None,
             params: Optional[dict] = None,
         ) -> "httpx.Response": ...
+
+        def _headers(self) -> dict[str, str]: ...
+
+        _client: "httpx.AsyncClient"
         base_url: str
 
     # --------------- Phase 1: Topics + publish ---------------
@@ -958,6 +1024,40 @@ class _AsyncBusClientMixin:
             f"{_seg(namespace)}/{_seg(tenant)}/{_seg(conversation_id)}/{_seg(stream_id)}"
         )
 
+    async def consume_bus_subscription(
+        self,
+        subscription_id: str,
+        *,
+        topic: str,
+        from_offset: Optional[str] = None,
+    ) -> AsyncIterator[BusConsumeItem]:
+        """Async version of :meth:`_BusClientMixin.consume_bus_subscription`."""
+        params: dict[str, Any] = {"topic": topic}
+        if from_offset is not None:
+            params["from"] = from_offset
+        url = f"{self.base_url}/v1/bus/subscribe/{_seg(subscription_id)}"
+        async for env in _async_open_bus_sse_stream(
+            self._client, url, params, self._headers()
+        ):
+            yield _envelope_to_consume_item(env)
+
+    async def consume_bus_stream(
+        self,
+        namespace: str,
+        tenant: str,
+        conversation_id: str,
+        stream_id: str,
+    ) -> AsyncIterator[BusStreamItem]:
+        """Async version of :meth:`_BusClientMixin.consume_bus_stream`."""
+        url = self.bus_stream_consume_url(namespace, tenant, conversation_id, stream_id)
+        async for env in _async_open_bus_sse_stream(
+            self._client, url, None, self._headers()
+        ):
+            item = _envelope_to_stream_item(env)
+            yield item
+            if item.is_end:
+                break
+
     # --------------- Phase 6c: HITL approvals ---------------
 
     async def list_bus_approvals(
@@ -1020,3 +1120,193 @@ class _AsyncBusClientMixin:
         )
         _raise_for_status(resp)
         return BusApprovalDecisionResponse.from_dict(resp.json())
+
+
+# ============================================================================
+# SSE protocol helpers — shared by sync + async consumers
+# ============================================================================
+#
+# The dispatch SSE parser in `models.py` silently drops keep-alive
+# comments. The bus consumers want to surface them as a liveness
+# signal, so we use a small private envelope type below and a
+# matching parser instead of layering on `_parse_sse_stream`.
+
+
+class _SseFrame:
+    """One parsed SSE frame: ``event`` (None means default ``message``),
+    ``id``, and ``data`` (the joined ``data:`` lines)."""
+
+    __slots__ = ("event", "id", "data")
+
+    def __init__(
+        self, event: Optional[str], id_: Optional[str], data: str,
+    ) -> None:
+        self.event = event
+        self.id = id_
+        self.data = data
+
+
+class _KeepAlive:
+    """Sentinel value yielded by the parsers for SSE comment lines."""
+
+    __slots__ = ()
+
+
+_KEEP_ALIVE = _KeepAlive()
+
+
+def _emit_frame(
+    event_type: Optional[str],
+    event_id: Optional[str],
+    data_parts: list[str],
+) -> Optional[_SseFrame]:
+    if not data_parts and event_type is None and event_id is None:
+        return None
+    return _SseFrame(event_type, event_id, "\n".join(data_parts))
+
+
+def _parse_sse_envelopes(lines: Iterator[str]) -> Iterator[Any]:
+    """Yields :class:`_SseFrame` for each frame and :data:`_KEEP_ALIVE`
+    for each comment. Mirrors the Rust client's ``sse_envelope_stream``."""
+    event_type: Optional[str] = None
+    event_id: Optional[str] = None
+    data_parts: list[str] = []
+    for line in lines:
+        if line.startswith(":"):
+            yield _KEEP_ALIVE
+            continue
+        if line == "":
+            frame = _emit_frame(event_type, event_id, data_parts)
+            if frame is not None:
+                yield frame
+            event_type = None
+            event_id = None
+            data_parts = []
+            continue
+        if line.startswith("event:"):
+            event_type = line[len("event:") :].strip()
+        elif line.startswith("id:"):
+            event_id = line[len("id:") :].strip()
+        elif line.startswith("data:"):
+            data_parts.append(line[len("data:") :].strip())
+
+
+async def _async_parse_sse_envelopes(
+    aiter_lines: AsyncIterator[str],
+) -> AsyncIterator[Any]:
+    """Async mirror of :func:`_parse_sse_envelopes`."""
+    event_type: Optional[str] = None
+    event_id: Optional[str] = None
+    data_parts: list[str] = []
+    async for line in aiter_lines:
+        if line.startswith(":"):
+            yield _KEEP_ALIVE
+            continue
+        if line == "":
+            frame = _emit_frame(event_type, event_id, data_parts)
+            if frame is not None:
+                yield frame
+            event_type = None
+            event_id = None
+            data_parts = []
+            continue
+        if line.startswith("event:"):
+            event_type = line[len("event:") :].strip()
+        elif line.startswith("id:"):
+            event_id = line[len("id:") :].strip()
+        elif line.startswith("data:"):
+            data_parts.append(line[len("data:") :].strip())
+
+
+def _open_bus_sse_stream(
+    client: "httpx.Client",
+    url: str,
+    params: Optional[dict[str, Any]],
+    headers: dict[str, str],
+) -> Iterator[Any]:
+    import httpx as _httpx
+
+    sse_headers = {**headers, "Accept": "text/event-stream"}
+    sse_headers.pop("Content-Type", None)
+    try:
+        with client.stream("GET", url, params=params, headers=sse_headers) as resp:
+            if resp.status_code != 200:
+                resp.read()
+                raise HttpError(resp.status_code, resp.text or "bus consume failed")
+            yield from _parse_sse_envelopes(resp.iter_lines())
+    except _httpx.ConnectError as e:  # pragma: no cover — network shape
+        raise ConnectionError(str(e)) from e
+    except _httpx.TimeoutException as e:  # pragma: no cover — network shape
+        raise ConnectionError(f"Request timed out: {e}") from e
+
+
+async def _async_open_bus_sse_stream(
+    client: "httpx.AsyncClient",
+    url: str,
+    params: Optional[dict[str, Any]],
+    headers: dict[str, str],
+) -> AsyncIterator[Any]:
+    import httpx as _httpx
+
+    sse_headers = {**headers, "Accept": "text/event-stream"}
+    sse_headers.pop("Content-Type", None)
+    try:
+        async with client.stream("GET", url, params=params, headers=sse_headers) as resp:
+            if resp.status_code != 200:
+                await resp.aread()
+                raise HttpError(resp.status_code, resp.text or "bus consume failed")
+            async for env in _async_parse_sse_envelopes(resp.aiter_lines()):
+                yield env
+    except _httpx.ConnectError as e:  # pragma: no cover — network shape
+        raise ConnectionError(str(e)) from e
+    except _httpx.TimeoutException as e:  # pragma: no cover — network shape
+        raise ConnectionError(f"Request timed out: {e}") from e
+
+
+def _decode_data_or_passthrough(data: str) -> Any:
+    try:
+        return json.loads(data)
+    except (json.JSONDecodeError, ValueError):
+        return data
+
+
+def _extract_error_message(data: str) -> str:
+    decoded = _decode_data_or_passthrough(data)
+    if isinstance(decoded, dict) and isinstance(decoded.get("error"), str):
+        return decoded["error"]
+    return data
+
+
+def _envelope_to_consume_item(env: Any) -> BusConsumeItem:
+    if isinstance(env, _KeepAlive):
+        return BusConsumeItem()
+    frame: _SseFrame = env
+    name = frame.event or "message"
+    if name in ("bus.message", "message"):
+        decoded = _decode_data_or_passthrough(frame.data)
+        if not isinstance(decoded, dict):
+            raise ValueError(f"invalid bus.message payload: {frame.data!r}")
+        return BusConsumeItem(message=BusConsumedMessage.from_dict(decoded))
+    if name == "bus.error":
+        return BusConsumeItem(error=_extract_error_message(frame.data))
+    raise ValueError(f"unexpected SSE event '{name}' on bus subscribe stream")
+
+
+def _envelope_to_stream_item(env: Any) -> BusStreamItem:
+    if isinstance(env, _KeepAlive):
+        return BusStreamItem()
+    frame: _SseFrame = env
+    name = frame.event or "message"
+    if name == "bus.stream.chunk":
+        decoded = _decode_data_or_passthrough(frame.data)
+        if not isinstance(decoded, dict):
+            raise ValueError(f"invalid stream chunk payload: {frame.data!r}")
+        return BusStreamItem(chunk=StreamChunkEnvelope.from_dict(decoded))
+    if name == "bus.stream.end":
+        decoded = _decode_data_or_passthrough(frame.data)
+        if not isinstance(decoded, dict):
+            raise ValueError(f"invalid stream end payload: {frame.data!r}")
+        return BusStreamItem(end=StreamEndEnvelope.from_dict(decoded))
+    if name == "bus.stream.error":
+        return BusStreamItem(error=_extract_error_message(frame.data))
+    raise ValueError(f"unexpected SSE event '{name}' on bus stream consumer")

--- a/clients/python/acteon_client/bus_models.py
+++ b/clients/python/acteon_client/bus_models.py
@@ -818,3 +818,136 @@ class PostBusToolCallOutcome:
     @property
     def was_parked(self) -> bool:
         return self.parked is not None
+
+
+# ============================================================================
+# SSE consumer DTOs — bus subscription tail + stream-id tail
+# ============================================================================
+
+
+@dataclass
+class BusConsumedMessage:
+    """A single Kafka record observed by a bus subscription consumer.
+    Mirrors ``acteon_bus::BusMessage`` on the wire — the typed shape
+    saves callers from peeling apart raw JSON.
+    """
+
+    topic: str
+    payload: Any = None
+    key: Optional[str] = None
+    headers: dict[str, str] = field(default_factory=dict)
+    partition: Optional[int] = None
+    offset: Optional[int] = None
+    timestamp: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "BusConsumedMessage":
+        return cls(
+            topic=data["topic"],
+            payload=data.get("payload"),
+            key=data.get("key"),
+            headers=data.get("headers") or {},
+            partition=data.get("partition"),
+            offset=data.get("offset"),
+            timestamp=data.get("timestamp"),
+        )
+
+
+@dataclass
+class BusConsumeItem:
+    """One item from :meth:`consume_bus_subscription`. Exactly one of
+    ``message`` or ``error`` is populated; both ``None`` is a keep-alive.
+    Inspect via :attr:`is_message` / :attr:`is_error` / :attr:`is_keep_alive`.
+    """
+
+    message: Optional[BusConsumedMessage] = None
+    error: Optional[str] = None
+
+    @property
+    def is_message(self) -> bool:
+        return self.message is not None
+
+    @property
+    def is_error(self) -> bool:
+        return self.error is not None
+
+    @property
+    def is_keep_alive(self) -> bool:
+        return self.message is None and self.error is None
+
+
+@dataclass
+class StreamChunkEnvelope:
+    """`StreamChunk` envelope as it appears on the SSE feed. Mirrors
+    ``acteon_core::StreamChunk``."""
+
+    stream_id: str
+    chunk_seq: int
+    body: Any = None
+    sender: Optional[str] = None
+    metadata: dict[str, str] = field(default_factory=dict)
+    created_at: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "StreamChunkEnvelope":
+        return cls(
+            stream_id=data["stream_id"],
+            chunk_seq=data["chunk_seq"],
+            body=data.get("body"),
+            sender=data.get("sender"),
+            metadata=data.get("metadata") or {},
+            created_at=data.get("created_at"),
+        )
+
+
+@dataclass
+class StreamEndEnvelope:
+    """`StreamEnd` envelope as it appears on the SSE feed. Mirrors
+    ``acteon_core::StreamEnd``."""
+
+    stream_id: str
+    chunk_seq: int
+    status: str
+    error_message: Optional[str] = None
+    sender: Optional[str] = None
+    metadata: dict[str, str] = field(default_factory=dict)
+    created_at: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "StreamEndEnvelope":
+        return cls(
+            stream_id=data["stream_id"],
+            chunk_seq=data["chunk_seq"],
+            status=data["status"],
+            error_message=data.get("error_message"),
+            sender=data.get("sender"),
+            metadata=data.get("metadata") or {},
+            created_at=data.get("created_at"),
+        )
+
+
+@dataclass
+class BusStreamItem:
+    """One item from :meth:`consume_bus_stream`. Exactly one of
+    ``chunk`` / ``end`` / ``error`` is populated; all ``None`` is a
+    keep-alive. The consumer closes once an ``end`` lands."""
+
+    chunk: Optional[StreamChunkEnvelope] = None
+    end: Optional[StreamEndEnvelope] = None
+    error: Optional[str] = None
+
+    @property
+    def is_chunk(self) -> bool:
+        return self.chunk is not None
+
+    @property
+    def is_end(self) -> bool:
+        return self.end is not None
+
+    @property
+    def is_error(self) -> bool:
+        return self.error is not None
+
+    @property
+    def is_keep_alive(self) -> bool:
+        return self.chunk is None and self.end is None and self.error is None

--- a/clients/python/tests/test_bus.py
+++ b/clients/python/tests/test_bus.py
@@ -415,5 +415,101 @@ class TestAsyncSurface(unittest.TestCase):
         self.assertFalse(inspect.iscoroutinefunction(method))
 
 
+class TestSseConsumerParsing(unittest.TestCase):
+    """Round-trip the SSE protocol parser on synthetic frame streams,
+    covering the four event shapes the bus emits plus keep-alives.
+    """
+
+    def test_envelope_parser_yields_frames_and_keep_alives(self):
+        from acteon_client.bus import _KEEP_ALIVE, _SseFrame, _parse_sse_envelopes
+
+        lines = [
+            ":keep-alive",
+            "event: bus.message",
+            "id: 42",
+            'data: {"topic":"agents.demo.events","offset":42}',
+            "",
+            "event: bus.error",
+            'data: {"error":"broker disconnected"}',
+            "",
+        ]
+        items = list(_parse_sse_envelopes(iter(lines)))
+        self.assertIs(items[0], _KEEP_ALIVE)
+        self.assertIsInstance(items[1], _SseFrame)
+        self.assertEqual(items[1].event, "bus.message")
+        self.assertEqual(items[1].id, "42")
+        self.assertIn("agents.demo.events", items[1].data)
+        self.assertIsInstance(items[2], _SseFrame)
+        self.assertEqual(items[2].event, "bus.error")
+
+    def test_subscribe_message_event(self):
+        from acteon_client.bus import _SseFrame, _envelope_to_consume_item
+
+        frame = _SseFrame(
+            "bus.message",
+            "1",
+            '{"topic":"agents.demo.events","payload":{"k":"v"},"partition":0,"offset":7}',
+        )
+        item = _envelope_to_consume_item(frame)
+        self.assertTrue(item.is_message)
+        self.assertEqual(item.message.topic, "agents.demo.events")
+        self.assertEqual(item.message.offset, 7)
+        self.assertEqual(item.message.payload, {"k": "v"})
+
+    def test_subscribe_error_event(self):
+        from acteon_client.bus import _SseFrame, _envelope_to_consume_item
+
+        frame = _SseFrame("bus.error", None, '{"error":"broker disconnected"}')
+        item = _envelope_to_consume_item(frame)
+        self.assertTrue(item.is_error)
+        self.assertEqual(item.error, "broker disconnected")
+
+    def test_subscribe_keep_alive(self):
+        from acteon_client.bus import _KEEP_ALIVE, _envelope_to_consume_item
+
+        item = _envelope_to_consume_item(_KEEP_ALIVE)
+        self.assertTrue(item.is_keep_alive)
+
+    def test_stream_chunk_and_end(self):
+        from acteon_client.bus import _SseFrame, _envelope_to_stream_item
+
+        chunk_frame = _SseFrame(
+            "bus.stream.chunk",
+            "0",
+            '{"stream_id":"s1","chunk_seq":3,"body":{"token":"hi"},'
+            '"created_at":"2026-05-02T12:00:00Z"}',
+        )
+        end_frame = _SseFrame(
+            "bus.stream.end",
+            "1",
+            '{"stream_id":"s1","chunk_seq":4,"status":"complete",'
+            '"created_at":"2026-05-02T12:00:01Z"}',
+        )
+        chunk_item = _envelope_to_stream_item(chunk_frame)
+        self.assertTrue(chunk_item.is_chunk)
+        self.assertEqual(chunk_item.chunk.stream_id, "s1")
+        self.assertEqual(chunk_item.chunk.chunk_seq, 3)
+        end_item = _envelope_to_stream_item(end_frame)
+        self.assertTrue(end_item.is_end)
+        self.assertEqual(end_item.end.status, "complete")
+
+    def test_stream_error_event_with_plain_data(self):
+        # Server emits `{"error": "..."}`, but if the JSON is malformed
+        # for some reason we still want a useful message back.
+        from acteon_client.bus import _SseFrame, _envelope_to_stream_item
+
+        frame = _SseFrame("bus.stream.error", None, "broker disconnected")
+        item = _envelope_to_stream_item(frame)
+        self.assertTrue(item.is_error)
+        self.assertEqual(item.error, "broker disconnected")
+
+    def test_stream_unknown_event_raises(self):
+        from acteon_client.bus import _SseFrame, _envelope_to_stream_item
+
+        frame = _SseFrame("bogus", None, "{}")
+        with self.assertRaises(ValueError):
+            _envelope_to_stream_item(frame)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Brings the Python SDK to parity with the Rust client's `consume_bus_subscription` and `consume_bus_stream` from PR #147.

## API

```python
# sync
for item in client.consume_bus_subscription(\"agent-A\", topic=\"agents.demo.events\", from_offset=\"earliest\"):
    if item.is_message:
        print(item.message.offset, item.message.payload)
    elif item.is_error:
        print(\"server error:\", item.error)
    # else: keep-alive

for item in client.consume_bus_stream(\"agents\", \"demo\", \"thread-1\", \"stream-42\"):
    if item.is_chunk:
        print(item.chunk.chunk_seq, item.chunk.body)
    elif item.is_end:
        print(\"done:\", item.end.status)
        break
```

`AsyncActeonClient` mirrors the sync surface with `async for`.

## Implementation

- New SSE protocol helper (`_parse_sse_envelopes` + async mirror) that surfaces keep-alive comments. The existing dispatch `_parse_sse_stream` silently drops them; bus consumers want keep-alives as a liveness signal, so a separate parser is the cleaner path.
- New DTOs in `bus_models.py`: `BusConsumedMessage`, `BusConsumeItem`, `StreamChunkEnvelope`, `StreamEndEnvelope`, `BusStreamItem`.
- Sum types use the project's existing convention (one optional field per variant + `is_*` properties), matching `PostBusToolCallOutcome`.

## Test plan

- [ ] `pytest tests/test_bus.py` — 40/40 pass (7 new SSE consumer tests)
- [ ] mypy: no new strict errors introduced in `bus.py`/`bus_models.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)