### PR TITLE
feat(go-sdk): typed bus SSE consumers

### DIFF
--- a/clients/go/acteon/bus.go
+++ b/clients/go/acteon/bus.go
@@ -1,6 +1,7 @@
 package acteon
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 // Phase 8c: agentic bus surface (Phases 1-6c).
@@ -536,6 +538,262 @@ func (c *Client) BusStreamConsumeURL(
 		c.baseURL,
 		busSeg(namespace), busSeg(tenant),
 		busSeg(conversationID), busSeg(streamID))
+}
+
+// ConsumeBusSubscriptionOptions configures the SSE topic tail.
+type ConsumeBusSubscriptionOptions struct {
+	// Topic is the full Kafka topic name (`namespace.tenant.name`).
+	Topic string
+	// From is "earliest" or "latest" (server defaults to latest if empty).
+	From string
+}
+
+// ConsumeBusSubscription opens an SSE stream against
+// `/v1/bus/subscribe/{subscription_id}` and returns a channel of typed
+// items. The channel is closed when the context is cancelled or the
+// connection drops.
+//
+// Server-side `bus.error` events surface as items with Kind == Error;
+// SSE keep-alive comments surface as Kind == KeepAlive so callers can
+// use them as a liveness signal.
+func (c *Client) ConsumeBusSubscription(
+	ctx context.Context,
+	subscriptionID string,
+	opts *ConsumeBusSubscriptionOptions,
+) (<-chan *BusConsumeItem, error) {
+	if opts == nil || opts.Topic == "" {
+		return nil, &ConnectionError{Message: "ConsumeBusSubscription: opts.Topic is required"}
+	}
+	q := url.Values{}
+	q.Set("topic", opts.Topic)
+	if opts.From != "" {
+		q.Set("from", opts.From)
+	}
+	path := fmt.Sprintf("/v1/bus/subscribe/%s?%s", busSeg(subscriptionID), q.Encode())
+	envCh, err := c.openBusSSE(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	out := make(chan *BusConsumeItem, 64)
+	go func() {
+		defer close(out)
+		for env := range envCh {
+			item, perr := parseBusConsumeEnvelope(env)
+			if perr != nil {
+				select {
+				case out <- &BusConsumeItem{Kind: BusConsumeKindError, Error: perr.Error()}:
+				case <-ctx.Done():
+					return
+				}
+				continue
+			}
+			select {
+			case out <- item:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out, nil
+}
+
+// ConsumeBusStream opens an SSE stream against
+// `/v1/bus/streams/{ns}/{tenant}/{conversation_id}/{stream_id}` and
+// returns a channel of typed items. The server filters records by
+// `(envelope_kind, conversation_id, stream_id)` so this consumer only
+// sees chunks for the requested stream id and the channel is closed
+// after the terminal `end` envelope is observed.
+func (c *Client) ConsumeBusStream(
+	ctx context.Context,
+	namespace, tenant, conversationID, streamID string,
+) (<-chan *BusStreamItem, error) {
+	path := fmt.Sprintf("/v1/bus/streams/%s/%s/%s/%s",
+		busSeg(namespace), busSeg(tenant),
+		busSeg(conversationID), busSeg(streamID))
+	envCh, err := c.openBusSSE(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	out := make(chan *BusStreamItem, 64)
+	go func() {
+		defer close(out)
+		for env := range envCh {
+			item, perr := parseBusStreamEnvelope(env)
+			if perr != nil {
+				select {
+				case out <- &BusStreamItem{Kind: BusStreamKindError, Error: perr.Error()}:
+				case <-ctx.Done():
+					return
+				}
+				continue
+			}
+			select {
+			case out <- item:
+			case <-ctx.Done():
+				return
+			}
+			if item.Kind == BusStreamKindEnd {
+				return
+			}
+		}
+	}()
+	return out, nil
+}
+
+// busSseEnvelope is the raw line-protocol output the bus consumers
+// post-process into typed items. Either a frame (event/id/data) or a
+// keep-alive comment.
+type busSseEnvelope struct {
+	keepAlive bool
+	event     string
+	id        string
+	data      string
+}
+
+func parseBusConsumeEnvelope(env *busSseEnvelope) (*BusConsumeItem, error) {
+	if env.keepAlive {
+		return &BusConsumeItem{Kind: BusConsumeKindKeepAlive}, nil
+	}
+	name := env.event
+	if name == "" {
+		name = "message"
+	}
+	switch name {
+	case "bus.message", "message":
+		var msg BusConsumedMessage
+		if err := json.Unmarshal([]byte(env.data), &msg); err != nil {
+			return nil, fmt.Errorf("invalid bus.message payload: %w", err)
+		}
+		return &BusConsumeItem{Kind: BusConsumeKindMessage, Message: &msg}, nil
+	case "bus.error":
+		return &BusConsumeItem{Kind: BusConsumeKindError, Error: extractBusErrorMessage(env.data)}, nil
+	default:
+		return nil, fmt.Errorf("unexpected SSE event %q on bus subscribe stream", name)
+	}
+}
+
+func parseBusStreamEnvelope(env *busSseEnvelope) (*BusStreamItem, error) {
+	if env.keepAlive {
+		return &BusStreamItem{Kind: BusStreamKindKeepAlive}, nil
+	}
+	name := env.event
+	if name == "" {
+		name = "message"
+	}
+	switch name {
+	case "bus.stream.chunk":
+		var chunk StreamChunkEnvelope
+		if err := json.Unmarshal([]byte(env.data), &chunk); err != nil {
+			return nil, fmt.Errorf("invalid stream chunk payload: %w", err)
+		}
+		return &BusStreamItem{Kind: BusStreamKindChunk, Chunk: &chunk}, nil
+	case "bus.stream.end":
+		var end StreamEndEnvelope
+		if err := json.Unmarshal([]byte(env.data), &end); err != nil {
+			return nil, fmt.Errorf("invalid stream end payload: %w", err)
+		}
+		return &BusStreamItem{Kind: BusStreamKindEnd, End: &end}, nil
+	case "bus.stream.error":
+		return &BusStreamItem{Kind: BusStreamKindError, Error: extractBusErrorMessage(env.data)}, nil
+	default:
+		return nil, fmt.Errorf("unexpected SSE event %q on bus stream consumer", name)
+	}
+}
+
+// extractBusErrorMessage pulls the `error` field from a JSON `{"error":
+// "..."}` body. Falls back to the raw data if the body isn't structured
+// — defensive against the server emitting a plain string for some
+// future error path.
+func extractBusErrorMessage(data string) string {
+	var body struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(data), &body); err == nil && body.Error != "" {
+		return body.Error
+	}
+	return data
+}
+
+// openBusSSE is a sibling of `openSSE` that surfaces SSE keep-alive
+// comments instead of swallowing them. Bus consumers want them as a
+// liveness signal so the surface is wider than the dispatch event
+// stream's.
+func (c *Client) openBusSSE(ctx context.Context, path string) (<-chan *busSseEnvelope, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return nil, &ConnectionError{Message: err.Error()}
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	// SSE is long-lived — bypass the client timeout the same way
+	// `openSSE` does.
+	sseClient := &http.Client{}
+	resp, err := sseClient.Do(req)
+	if err != nil {
+		return nil, &ConnectionError{Message: err.Error()}
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, parseBusError(resp.StatusCode, body)
+	}
+	ch := make(chan *busSseEnvelope, 64)
+	go func() {
+		defer close(ch)
+		defer resp.Body.Close()
+		scanner := bufio.NewScanner(resp.Body)
+		// Bus messages may exceed the default 64 KiB scanner buffer
+		// when payloads carry large strings. Bump to 1 MiB to match
+		// the dispatch stream comfort margin.
+		const maxLine = 1 << 20
+		scanner.Buffer(make([]byte, 0, 64*1024), maxLine)
+		var event, id string
+		var dataLines []string
+		flush := func() {
+			if len(dataLines) == 0 && event == "" && id == "" {
+				return
+			}
+			frame := &busSseEnvelope{
+				event: event,
+				id:    id,
+				data:  strings.Join(dataLines, "\n"),
+			}
+			select {
+			case ch <- frame:
+			case <-ctx.Done():
+			}
+			event = ""
+			id = ""
+			dataLines = nil
+		}
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, ":") {
+				select {
+				case ch <- &busSseEnvelope{keepAlive: true}:
+				case <-ctx.Done():
+					return
+				}
+				continue
+			}
+			if line == "" {
+				flush()
+				continue
+			}
+			switch {
+			case strings.HasPrefix(line, "id:"):
+				id = strings.TrimSpace(strings.TrimPrefix(line, "id:"))
+			case strings.HasPrefix(line, "event:"):
+				event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			case strings.HasPrefix(line, "data:"):
+				dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+			}
+		}
+	}()
+	return ch, nil
 }
 
 // =============================================================================

--- a/clients/go/acteon/bus_models.go
+++ b/clients/go/acteon/bus_models.go
@@ -1,5 +1,7 @@
 package acteon
 
+import "encoding/json"
+
 // DTOs for the Acteon agentic bus surface (Phases 1-6c).
 //
 // Field types are pointers wherever the server treats the field as
@@ -442,4 +444,82 @@ type PostBusToolCallOutcome struct {
 // pending approval row instead of producing to Kafka.
 func (o *PostBusToolCallOutcome) WasParked() bool {
 	return o != nil && o.Parked != nil
+}
+
+// =============================================================================
+// SSE consumer DTOs — bus subscription tail + stream-id tail
+// =============================================================================
+
+// BusConsumedMessage mirrors the wire shape of `acteon_bus::BusMessage`
+// without taking a dependency on the bus crate. Returned by
+// `Client.ConsumeBusSubscription` for each Kafka record.
+type BusConsumedMessage struct {
+	Topic     string            `json:"topic"`
+	Key       string            `json:"key,omitempty"`
+	Payload   json.RawMessage   `json:"payload,omitempty"`
+	Headers   map[string]string `json:"headers,omitempty"`
+	Partition *int32            `json:"partition,omitempty"`
+	Offset    *int64            `json:"offset,omitempty"`
+	Timestamp *string           `json:"timestamp,omitempty"`
+}
+
+// BusConsumeItemKind tags the variant in BusConsumeItem.
+type BusConsumeItemKind string
+
+const (
+	BusConsumeKindMessage   BusConsumeItemKind = "message"
+	BusConsumeKindError     BusConsumeItemKind = "error"
+	BusConsumeKindKeepAlive BusConsumeItemKind = "keepalive"
+)
+
+// BusConsumeItem is the per-record yield from ConsumeBusSubscription.
+// Inspect Kind, then the matching field. KeepAlive carries no extra
+// data and lets callers use the SSE comment frame as a liveness
+// signal.
+type BusConsumeItem struct {
+	Kind    BusConsumeItemKind
+	Message *BusConsumedMessage
+	Error   string
+}
+
+// StreamChunkEnvelope mirrors `acteon_core::StreamChunk`.
+type StreamChunkEnvelope struct {
+	StreamID  string            `json:"stream_id"`
+	ChunkSeq  int64             `json:"chunk_seq"`
+	Body      json.RawMessage   `json:"body,omitempty"`
+	Sender    string            `json:"sender,omitempty"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	CreatedAt string            `json:"created_at,omitempty"`
+}
+
+// StreamEndEnvelope mirrors `acteon_core::StreamEnd`. Status is one
+// of "complete", "aborted", or "error".
+type StreamEndEnvelope struct {
+	StreamID     string            `json:"stream_id"`
+	ChunkSeq     int64             `json:"chunk_seq"`
+	Status       string            `json:"status"`
+	ErrorMessage string            `json:"error_message,omitempty"`
+	Sender       string            `json:"sender,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+	CreatedAt    string            `json:"created_at,omitempty"`
+}
+
+// BusStreamItemKind tags the variant in BusStreamItem.
+type BusStreamItemKind string
+
+const (
+	BusStreamKindChunk     BusStreamItemKind = "chunk"
+	BusStreamKindEnd       BusStreamItemKind = "end"
+	BusStreamKindError     BusStreamItemKind = "error"
+	BusStreamKindKeepAlive BusStreamItemKind = "keepalive"
+)
+
+// BusStreamItem is the per-record yield from ConsumeBusStream. The
+// underlying channel closes automatically once an End item is
+// observed.
+type BusStreamItem struct {
+	Kind  BusStreamItemKind
+	Chunk *StreamChunkEnvelope
+	End   *StreamEndEnvelope
+	Error string
 }

--- a/clients/go/acteon/bus_test.go
+++ b/clients/go/acteon/bus_test.go
@@ -454,6 +454,127 @@ func TestApproveBusApprovalRoutesAndDecodes(t *testing.T) {
 	}
 }
 
+func TestParseBusConsumeEnvelope(t *testing.T) {
+	// Default `event: bus.message` decodes into BusConsumedMessage.
+	msg, err := parseBusConsumeEnvelope(&busSseEnvelope{
+		event: "bus.message",
+		data:  `{"topic":"agents.demo.events","payload":{"k":"v"},"partition":0,"offset":7}`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if msg.Kind != BusConsumeKindMessage {
+		t.Fatalf("kind: %v", msg.Kind)
+	}
+	if msg.Message.Topic != "agents.demo.events" || *msg.Message.Offset != 7 {
+		t.Errorf("topic/offset: %+v", msg.Message)
+	}
+
+	// `bus.error` lifts the `error` field.
+	errItem, perr := parseBusConsumeEnvelope(&busSseEnvelope{
+		event: "bus.error",
+		data:  `{"error":"broker disconnected"}`,
+	})
+	if perr != nil {
+		t.Fatalf("error parse: %v", perr)
+	}
+	if errItem.Kind != BusConsumeKindError || errItem.Error != "broker disconnected" {
+		t.Errorf("error item: %+v", errItem)
+	}
+
+	// Keep-alive surfaces as KeepAlive kind.
+	ka, _ := parseBusConsumeEnvelope(&busSseEnvelope{keepAlive: true})
+	if ka.Kind != BusConsumeKindKeepAlive {
+		t.Errorf("expected KeepAlive; got %v", ka.Kind)
+	}
+}
+
+func TestParseBusStreamEnvelope(t *testing.T) {
+	chunk, err := parseBusStreamEnvelope(&busSseEnvelope{
+		event: "bus.stream.chunk",
+		data:  `{"stream_id":"s1","chunk_seq":3,"body":{"token":"hi"},"created_at":"2026-05-02T12:00:00Z"}`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if chunk.Kind != BusStreamKindChunk || chunk.Chunk.StreamID != "s1" || chunk.Chunk.ChunkSeq != 3 {
+		t.Errorf("chunk: %+v", chunk.Chunk)
+	}
+
+	end, perr := parseBusStreamEnvelope(&busSseEnvelope{
+		event: "bus.stream.end",
+		data:  `{"stream_id":"s1","chunk_seq":4,"status":"complete","created_at":"2026-05-02T12:00:01Z"}`,
+	})
+	if perr != nil {
+		t.Fatalf("end: %v", perr)
+	}
+	if end.Kind != BusStreamKindEnd || end.End.Status != "complete" {
+		t.Errorf("end: %+v", end.End)
+	}
+
+	// Plain-string error data falls back to the raw text — defensive
+	// against a future server emitting non-JSON.
+	plain, _ := parseBusStreamEnvelope(&busSseEnvelope{
+		event: "bus.stream.error",
+		data:  "broker disconnected",
+	})
+	if plain.Kind != BusStreamKindError || plain.Error != "broker disconnected" {
+		t.Errorf("plain error: %+v", plain)
+	}
+
+	// Unknown events are surfaced as parse errors.
+	_, unknownErr := parseBusStreamEnvelope(&busSseEnvelope{event: "bogus", data: "{}"})
+	if unknownErr == nil {
+		t.Fatalf("expected error for unknown event")
+	}
+}
+
+func TestConsumeBusSubscriptionEndToEnd(t *testing.T) {
+	// Server emits one keep-alive (`:ping`), one message frame, and
+	// closes — the consumer should yield both items in order.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("topic") != "agents.demo.events" {
+			t.Errorf("unexpected topic param: %s", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		_, _ = w.Write([]byte(":keep-alive\n\n"))
+		_, _ = w.Write([]byte("event: bus.message\nid: 5\ndata: {\"topic\":\"agents.demo.events\",\"offset\":5}\n\n"))
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch, err := client.ConsumeBusSubscription(ctx, "agent-A", &ConsumeBusSubscriptionOptions{
+		Topic: "agents.demo.events",
+		From:  "earliest",
+	})
+	if err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	got := []*BusConsumeItem{}
+	for item := range ch {
+		got = append(got, item)
+		if len(got) >= 2 {
+			break
+		}
+	}
+	cancel()
+	if len(got) < 2 {
+		t.Fatalf("expected 2 items; got %d", len(got))
+	}
+	if got[0].Kind != BusConsumeKindKeepAlive {
+		t.Errorf("first item: %v", got[0].Kind)
+	}
+	if got[1].Kind != BusConsumeKindMessage || *got[1].Message.Offset != 5 {
+		t.Errorf("second item: %+v", got[1])
+	}
+}
+
 func TestBusErrorParsing(t *testing.T) {
 	// The bus error path should map structured `{"error": "..."}`
 	// bodies (the shape Acteon's bus handlers emit) to *APIError.


### PR DESCRIPTION
## Summary

PR 3 of 4 in the polyglot SSE-consumer parity work after #147 (Rust), #148 (Python), and #149 (Node).

## API

```go
ctx, cancel := context.WithCancel(context.Background())
defer cancel()

ch, err := client.ConsumeBusSubscription(ctx, \"agent-A\", &acteon.ConsumeBusSubscriptionOptions{
    Topic: \"agents.demo.events\",
    From:  \"earliest\",
})
for item := range ch {
    switch item.Kind {
    case acteon.BusConsumeKindMessage:
        log.Printf(\"offset=%v payload=%s\", item.Message.Offset, item.Message.Payload)
    case acteon.BusConsumeKindError:
        log.Printf(\"server error: %s\", item.Error)
    case acteon.BusConsumeKindKeepAlive:
        // liveness ping
    }
}

streamCh, err := client.ConsumeBusStream(ctx, \"agents\", \"demo\", \"thread-1\", \"stream-42\")
for item := range streamCh {
    if item.Kind == acteon.BusStreamKindEnd {
        return // channel closes after End
    }
}
```

Channel-based consumer pattern matches the existing `Stream` and `Subscribe` methods. The channel closes automatically when the context is cancelled, the connection drops, or (for `ConsumeBusStream`) the terminal `End` envelope arrives.

A private `openBusSSE` mirrors `openSSE` but surfaces SSE keep-alive comments — the dispatch SSE consumer silently drops them, but bus consumers want them as a liveness signal.

## Test plan

- [ ] `go build ./...` clean
- [ ] `go vet ./...` clean
- [ ] `go test ./...` green (3 new SSE consumer tests, end-to-end through `httptest.Server`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)