### PR TITLE
feat(java-sdk): typed bus SSE consumers

### DIFF
--- a/clients/java/src/main/java/com/acteon/client/ActeonClient.java
+++ b/clients/java/src/main/java/com/acteon/client/ActeonClient.java
@@ -3508,6 +3508,106 @@ public class ActeonClient implements AutoCloseable {
             + busSeg(conversationId) + "/" + busSeg(streamId);
     }
 
+    /**
+     * Consume a bus subscription via SSE
+     * ({@code GET /v1/bus/subscribe/{subscriptionId}}). Returns a
+     * {@link BusSseIterator} that yields typed
+     * {@link Bus.BusConsumeItem}s. Server-side {@code bus.error}
+     * events surface as {@code BusConsumeItem.Error}; SSE keep-alive
+     * comments surface as {@code BusConsumeItem.KeepAlive} so callers
+     * can use them as a liveness signal.
+     *
+     * <pre>{@code
+     * try (BusSseIterator iter = client.consumeBusSubscription(
+     *         "agent-A", "agents.demo.events", "earliest")) {
+     *     while (iter.hasNext()) {
+     *         switch (iter.next()) {
+     *             case Bus.BusConsumeItem.Message m -> System.out.println(m.message().offset());
+     *             case Bus.BusConsumeItem.Error e -> System.err.println(e.message());
+     *             case Bus.BusConsumeItem.KeepAlive __ -> {}
+     *         }
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param subscriptionId Subscription id (Kafka consumer group).
+     * @param topic Full Kafka topic name ({@code namespace.tenant.name}).
+     * @param from {@code "earliest"} or {@code "latest"}, or {@code null} for the server default.
+     */
+    public BusSseIterator consumeBusSubscription(
+        String subscriptionId, String topic, String from
+    ) throws ActeonException {
+        java.util.LinkedHashMap<String, String> params = new java.util.LinkedHashMap<>();
+        params.put("topic", topic);
+        if (from != null) params.put("from", from);
+        String path = appendQuery("/v1/bus/subscribe/" + busSeg(subscriptionId), params);
+        InputStream body = openSseStream(path);
+        return new BusSseIterator(body);
+    }
+
+    /**
+     * Consume a typed stream via SSE
+     * ({@code GET /v1/bus/streams/{ns}/{tenant}/{conversationId}/{streamId}}).
+     * The server filters records by
+     * {@code (envelope_kind, conversation_id, stream_id)}, so this
+     * iterator only yields chunks for the requested stream id and
+     * closes after the terminal {@code BusStreamItem.End}.
+     *
+     * <pre>{@code
+     * try (BusStreamSseIterator iter = client.consumeBusStream(
+     *         "agents", "demo", "thread-1", "stream-42")) {
+     *     while (iter.hasNext()) {
+     *         var item = iter.next();
+     *         if (item instanceof Bus.BusStreamItem.Chunk c) {
+     *             System.out.println(c.chunk().chunkSeq());
+     *         } else if (item instanceof Bus.BusStreamItem.End) {
+     *             break;
+     *         }
+     *     }
+     * }
+     * }</pre>
+     */
+    public BusStreamSseIterator consumeBusStream(
+        String namespace, String tenant, String conversationId, String streamId
+    ) throws ActeonException {
+        String path = "/v1/bus/streams/" + busSeg(namespace) + "/" + busSeg(tenant) + "/"
+            + busSeg(conversationId) + "/" + busSeg(streamId);
+        InputStream body = openSseStream(path);
+        return new BusStreamSseIterator(body);
+    }
+
+    /**
+     * Open an SSE-flavoured GET against the given path and return the
+     * raw response body. Caller wraps it in a typed iterator. Errors
+     * surface as {@link HttpException} with the response body inlined.
+     */
+    private InputStream openSseStream(String path) throws ActeonException {
+        try {
+            HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + path))
+                .header("Accept", "text/event-stream");
+            if (apiKey != null && !apiKey.isEmpty()) {
+                builder.header("Authorization", "Bearer " + apiKey);
+            }
+            HttpRequest request = builder.GET().build();
+            HttpResponse<InputStream> response = httpClient.send(
+                request, HttpResponse.BodyHandlers.ofInputStream());
+            if (response.statusCode() == 200) {
+                return response.body();
+            }
+            try (InputStream body = response.body()) {
+                String errorBody = new String(body.readAllBytes(), StandardCharsets.UTF_8);
+                throw new HttpException(
+                    response.statusCode(), "bus SSE connection failed: " + errorBody);
+            }
+        } catch (IOException e) {
+            throw new ConnectionException(e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ConnectionException("Request interrupted", e);
+        }
+    }
+
     // --------------- Phase 6c: HITL approvals ---------------
 
     public List<Bus.BusApprovalView> listBusApprovals(

--- a/clients/java/src/main/java/com/acteon/client/Bus.java
+++ b/clients/java/src/main/java/com/acteon/client/Bus.java
@@ -489,4 +489,77 @@ public final class Bus {
 
         default boolean isParked() { return this instanceof Parked; }
     }
+
+    // ============================================================================
+    // SSE consumer DTOs — bus subscription tail + stream-id tail
+    // ============================================================================
+
+    /**
+     * A single Kafka record observed by a bus subscription consumer.
+     * Mirrors the wire shape of {@code acteon_bus::BusMessage} so
+     * callers don't have to peel apart raw JSON.
+     */
+    public record BusConsumedMessage(
+        String topic,
+        String key,
+        com.fasterxml.jackson.databind.JsonNode payload,
+        java.util.Map<String, String> headers,
+        Integer partition,
+        Long offset,
+        String timestamp
+    ) {}
+
+    /**
+     * Sealed-interface union for items emitted by
+     * {@link ActeonClient#consumeBusSubscription}. Pattern-match in a
+     * {@code switch} on the result. {@code KeepAlive} carries no data
+     * but lets callers use the SSE comment frame as a liveness signal.
+     */
+    public sealed interface BusConsumeItem
+        permits BusConsumeItem.Message, BusConsumeItem.Error, BusConsumeItem.KeepAlive {
+
+        /** A consumed Kafka record. */
+        record Message(BusConsumedMessage message) implements BusConsumeItem {}
+
+        /** Server-side {@code bus.error} event. */
+        record Error(String message) implements BusConsumeItem {}
+
+        /** SSE comment frame from the server. */
+        record KeepAlive() implements BusConsumeItem {}
+    }
+
+    /** {@code StreamChunk} envelope as it appears on the SSE feed. Mirrors {@code acteon_core::StreamChunk}. */
+    public record StreamChunkEnvelope(
+        String streamId,
+        long chunkSeq,
+        com.fasterxml.jackson.databind.JsonNode body,
+        String sender,
+        java.util.Map<String, String> metadata,
+        String createdAt
+    ) {}
+
+    /** {@code StreamEnd} envelope as it appears on the SSE feed. Status is "complete", "aborted", or "error". */
+    public record StreamEndEnvelope(
+        String streamId,
+        long chunkSeq,
+        String status,
+        String errorMessage,
+        String sender,
+        java.util.Map<String, String> metadata,
+        String createdAt
+    ) {}
+
+    /**
+     * Sealed-interface union for items emitted by
+     * {@link ActeonClient#consumeBusStream}. The consumer closes the
+     * underlying HTTP stream once an {@code End} is observed.
+     */
+    public sealed interface BusStreamItem
+        permits BusStreamItem.Chunk, BusStreamItem.End, BusStreamItem.Error, BusStreamItem.KeepAlive {
+
+        record Chunk(StreamChunkEnvelope chunk) implements BusStreamItem {}
+        record End(StreamEndEnvelope end) implements BusStreamItem {}
+        record Error(String message) implements BusStreamItem {}
+        record KeepAlive() implements BusStreamItem {}
+    }
 }

--- a/clients/java/src/main/java/com/acteon/client/BusFrameReader.java
+++ b/clients/java/src/main/java/com/acteon/client/BusFrameReader.java
@@ -1,0 +1,105 @@
+package com.acteon.client;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+
+/**
+ * Line-protocol parser for bus SSE streams. Yields one envelope per
+ * {@link #readNext()} call: either a complete frame ({@code event} +
+ * {@code data}) or a keep-alive comment.
+ *
+ * <p>Distinct from {@link SseEventIterator}'s parser because the bus
+ * consumers want comment frames surfaced as a typed
+ * {@code KeepAlive} variant — the dispatch event stream silently
+ * drops them.</p>
+ */
+final class BusFrameReader {
+    private final BufferedReader reader;
+
+    BusFrameReader(BufferedReader reader) {
+        this.reader = reader;
+    }
+
+    /** Returns the next envelope, or {@code null} when the stream ends. */
+    Envelope readNext() {
+        try {
+            String event = null;
+            String id = null;
+            StringBuilder data = new StringBuilder();
+            boolean hasData = false;
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith(":")) {
+                    return Envelope.keepAlive();
+                }
+                if (line.isEmpty()) {
+                    if (hasData || event != null || id != null) {
+                        return Envelope.frame(event, id, hasData ? data.toString() : "");
+                    }
+                    continue;
+                }
+                int colon = line.indexOf(':');
+                String field;
+                String value;
+                if (colon >= 0) {
+                    field = line.substring(0, colon);
+                    value =
+                        (colon + 1 < line.length() && line.charAt(colon + 1) == ' ')
+                            ? line.substring(colon + 2)
+                            : line.substring(colon + 1);
+                } else {
+                    field = line;
+                    value = "";
+                }
+                switch (field) {
+                    case "id":
+                        id = value;
+                        break;
+                    case "event":
+                        event = value;
+                        break;
+                    case "data":
+                        if (hasData) {
+                            data.append('\n');
+                        }
+                        data.append(value);
+                        hasData = true;
+                        break;
+                    default:
+                        // Unknown fields are ignored per the SSE spec.
+                        break;
+                }
+            }
+            // End of stream — emit any partially buffered frame.
+            if (hasData || event != null || id != null) {
+                return Envelope.frame(event, id, hasData ? data.toString() : "");
+            }
+            return null;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    /** One line-protocol envelope: a frame or a keep-alive comment. */
+    static final class Envelope {
+        final boolean keepAlive;
+        final String event;
+        final String id;
+        final String data;
+
+        private Envelope(boolean keepAlive, String event, String id, String data) {
+            this.keepAlive = keepAlive;
+            this.event = event;
+            this.id = id;
+            this.data = data;
+        }
+
+        static Envelope keepAlive() {
+            return new Envelope(true, null, null, null);
+        }
+
+        static Envelope frame(String event, String id, String data) {
+            return new Envelope(false, event, id, data);
+        }
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/BusSseIterator.java
+++ b/clients/java/src/main/java/com/acteon/client/BusSseIterator.java
@@ -1,0 +1,150 @@
+package com.acteon.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.MapType;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * Iterator that lazily parses bus SSE frames and surfaces them as typed
+ * {@link Bus.BusConsumeItem}s.
+ *
+ * <p>The dispatch {@link SseEventIterator} silently drops SSE comment
+ * frames (keep-alives). Bus consumers want them as a liveness signal,
+ * so this iterator yields a typed {@code KeepAlive} variant for each
+ * one. Closes via {@link AutoCloseable} just like {@code SseEventIterator}.</p>
+ */
+public final class BusSseIterator
+    implements Iterator<Bus.BusConsumeItem>, AutoCloseable {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final BufferedReader reader;
+    private final BusFrameReader frames;
+    private Bus.BusConsumeItem nextItem;
+    private boolean closed;
+
+    public BusSseIterator(InputStream inputStream) {
+        this.reader =
+            new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+        this.frames = new BusFrameReader(reader);
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (closed) {
+            return false;
+        }
+        if (nextItem != null) {
+            return true;
+        }
+        nextItem = readNextItem();
+        return nextItem != null;
+    }
+
+    @Override
+    public Bus.BusConsumeItem next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException("No more bus SSE items");
+        }
+        Bus.BusConsumeItem item = nextItem;
+        nextItem = null;
+        return item;
+    }
+
+    @Override
+    public void close() {
+        if (!closed) {
+            closed = true;
+            try {
+                reader.close();
+            } catch (IOException ignored) {
+                // Best-effort close.
+            }
+        }
+    }
+
+    private Bus.BusConsumeItem readNextItem() {
+        BusFrameReader.Envelope env = frames.readNext();
+        if (env == null) return null;
+        if (env.keepAlive) return new Bus.BusConsumeItem.KeepAlive();
+        String name = env.event != null && !env.event.isEmpty() ? env.event : "message";
+        switch (name) {
+            case "bus.message":
+            case "message":
+                try {
+                    JsonNode root = MAPPER.readTree(env.data);
+                    return new Bus.BusConsumeItem.Message(parseConsumedMessage(root));
+                } catch (IOException e) {
+                    close();
+                    throw new IllegalStateException("invalid bus.message payload", e);
+                }
+            case "bus.error":
+                return new Bus.BusConsumeItem.Error(extractErrorMessage(env.data));
+            default:
+                close();
+                throw new IllegalStateException(
+                    "unexpected SSE event '" + name + "' on bus subscribe stream");
+        }
+    }
+
+    static Bus.BusConsumedMessage parseConsumedMessage(JsonNode node) {
+        return new Bus.BusConsumedMessage(
+            node.path("topic").asText(),
+            optString(node, "key"),
+            node.has("payload") ? node.get("payload") : null,
+            mapField(node, "headers"),
+            optInt(node, "partition"),
+            optLong(node, "offset"),
+            optString(node, "timestamp"));
+    }
+
+    static String optString(JsonNode node, String field) {
+        JsonNode v = node.get(field);
+        return v == null || v.isNull() ? null : v.asText();
+    }
+
+    static Integer optInt(JsonNode node, String field) {
+        JsonNode v = node.get(field);
+        return v == null || v.isNull() ? null : v.intValue();
+    }
+
+    static Long optLong(JsonNode node, String field) {
+        JsonNode v = node.get(field);
+        return v == null || v.isNull() ? null : v.longValue();
+    }
+
+    static Map<String, String> mapField(JsonNode node, String field) {
+        JsonNode v = node.get(field);
+        if (v == null || v.isNull()) return new HashMap<>();
+        try {
+            MapType t = MAPPER.getTypeFactory()
+                .constructMapType(HashMap.class, String.class, String.class);
+            return MAPPER.convertValue(v, t);
+        } catch (Exception e) {
+            return new HashMap<>();
+        }
+    }
+
+    static String extractErrorMessage(String data) {
+        try {
+            JsonNode root = MAPPER.readTree(data);
+            JsonNode err = root.get("error");
+            if (err != null && err.isTextual()) {
+                return err.asText();
+            }
+        } catch (IOException ignored) {
+            // Fall through and return the raw body.
+        }
+        return data;
+    }
+}

--- a/clients/java/src/main/java/com/acteon/client/BusStreamSseIterator.java
+++ b/clients/java/src/main/java/com/acteon/client/BusStreamSseIterator.java
@@ -1,0 +1,130 @@
+package com.acteon.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Iterator that lazily parses bus stream-id SSE frames and surfaces
+ * them as typed {@link Bus.BusStreamItem}s.
+ *
+ * <p>Closes once a terminal {@code End} envelope is observed so the
+ * caller's {@code while (iter.hasNext())} loop drops out cleanly.</p>
+ */
+public final class BusStreamSseIterator
+    implements Iterator<Bus.BusStreamItem>, AutoCloseable {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final BufferedReader reader;
+    private final BusFrameReader frames;
+    private Bus.BusStreamItem nextItem;
+    private boolean closed;
+    private boolean terminated;
+
+    public BusStreamSseIterator(InputStream inputStream) {
+        this.reader =
+            new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+        this.frames = new BusFrameReader(reader);
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (closed) {
+            return false;
+        }
+        if (nextItem != null) {
+            return true;
+        }
+        if (terminated) {
+            close();
+            return false;
+        }
+        nextItem = readNextItem();
+        return nextItem != null;
+    }
+
+    @Override
+    public Bus.BusStreamItem next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException("No more bus stream items");
+        }
+        Bus.BusStreamItem item = nextItem;
+        nextItem = null;
+        if (item instanceof Bus.BusStreamItem.End) {
+            terminated = true;
+        }
+        return item;
+    }
+
+    @Override
+    public void close() {
+        if (!closed) {
+            closed = true;
+            try {
+                reader.close();
+            } catch (IOException ignored) {
+                // Best-effort close.
+            }
+        }
+    }
+
+    private Bus.BusStreamItem readNextItem() {
+        BusFrameReader.Envelope env = frames.readNext();
+        if (env == null) return null;
+        if (env.keepAlive) return new Bus.BusStreamItem.KeepAlive();
+        String name = env.event != null && !env.event.isEmpty() ? env.event : "message";
+        switch (name) {
+            case "bus.stream.chunk":
+                try {
+                    JsonNode root = MAPPER.readTree(env.data);
+                    return new Bus.BusStreamItem.Chunk(parseChunk(root));
+                } catch (IOException e) {
+                    close();
+                    throw new IllegalStateException("invalid stream chunk payload", e);
+                }
+            case "bus.stream.end":
+                try {
+                    JsonNode root = MAPPER.readTree(env.data);
+                    return new Bus.BusStreamItem.End(parseEnd(root));
+                } catch (IOException e) {
+                    close();
+                    throw new IllegalStateException("invalid stream end payload", e);
+                }
+            case "bus.stream.error":
+                return new Bus.BusStreamItem.Error(BusSseIterator.extractErrorMessage(env.data));
+            default:
+                close();
+                throw new IllegalStateException(
+                    "unexpected SSE event '" + name + "' on bus stream consumer");
+        }
+    }
+
+    static Bus.StreamChunkEnvelope parseChunk(JsonNode node) {
+        return new Bus.StreamChunkEnvelope(
+            node.path("stream_id").asText(),
+            node.path("chunk_seq").asLong(),
+            node.has("body") ? node.get("body") : null,
+            BusSseIterator.optString(node, "sender"),
+            BusSseIterator.mapField(node, "metadata"),
+            BusSseIterator.optString(node, "created_at"));
+    }
+
+    static Bus.StreamEndEnvelope parseEnd(JsonNode node) {
+        return new Bus.StreamEndEnvelope(
+            node.path("stream_id").asText(),
+            node.path("chunk_seq").asLong(),
+            node.path("status").asText(),
+            BusSseIterator.optString(node, "error_message"),
+            BusSseIterator.optString(node, "sender"),
+            BusSseIterator.mapField(node, "metadata"),
+            BusSseIterator.optString(node, "created_at"));
+    }
+}

--- a/clients/java/src/test/java/com/acteon/client/BusTest.java
+++ b/clients/java/src/test/java/com/acteon/client/BusTest.java
@@ -404,4 +404,81 @@ class BusTest {
             server.stop(0);
         }
     }
+
+    // -------------------------------------------------------------------------
+    // SSE consumer parsing
+    // -------------------------------------------------------------------------
+
+    @Test
+    void busSseIteratorYieldsKeepAliveThenMessage() throws Exception {
+        // Server emits: keep-alive comment, then a `bus.message` frame, then closes.
+        String sse =
+            ":keep-alive\n\n"
+            + "event: bus.message\nid: 5\n"
+            + "data: {\"topic\":\"agents.demo.events\",\"offset\":5,\"payload\":{\"k\":\"v\"}}\n\n";
+        try (BusSseIterator iter = new BusSseIterator(
+                new java.io.ByteArrayInputStream(sse.getBytes(StandardCharsets.UTF_8)))) {
+            assertTrue(iter.hasNext());
+            Bus.BusConsumeItem first = iter.next();
+            assertInstanceOf(Bus.BusConsumeItem.KeepAlive.class, first);
+            assertTrue(iter.hasNext());
+            Bus.BusConsumeItem second = iter.next();
+            assertInstanceOf(Bus.BusConsumeItem.Message.class, second);
+            Bus.BusConsumedMessage msg = ((Bus.BusConsumeItem.Message) second).message();
+            assertEquals("agents.demo.events", msg.topic());
+            assertEquals(5L, msg.offset());
+        }
+    }
+
+    @Test
+    void busSseIteratorSurfacesBusErrorEvent() throws Exception {
+        String sse = "event: bus.error\ndata: {\"error\":\"broker disconnected\"}\n\n";
+        try (BusSseIterator iter = new BusSseIterator(
+                new java.io.ByteArrayInputStream(sse.getBytes(StandardCharsets.UTF_8)))) {
+            assertTrue(iter.hasNext());
+            Bus.BusConsumeItem item = iter.next();
+            assertInstanceOf(Bus.BusConsumeItem.Error.class, item);
+            assertEquals("broker disconnected", ((Bus.BusConsumeItem.Error) item).message());
+        }
+    }
+
+    @Test
+    void busStreamSseIteratorClosesAfterEnd() throws Exception {
+        // Server emits a chunk, then end. The iterator must yield both
+        // and then report no more items (closes the stream).
+        String sse =
+            "event: bus.stream.chunk\nid: 0\n"
+            + "data: {\"stream_id\":\"s1\",\"chunk_seq\":3,\"body\":{\"token\":\"hi\"},\"created_at\":\"2026-05-02T12:00:00Z\"}\n\n"
+            + "event: bus.stream.end\nid: 1\n"
+            + "data: {\"stream_id\":\"s1\",\"chunk_seq\":4,\"status\":\"complete\",\"created_at\":\"2026-05-02T12:00:01Z\"}\n\n"
+            + "event: bus.stream.chunk\nid: 2\n"
+            + "data: {\"stream_id\":\"s1\",\"chunk_seq\":99,\"body\":{}}\n\n";
+        try (BusStreamSseIterator iter = new BusStreamSseIterator(
+                new java.io.ByteArrayInputStream(sse.getBytes(StandardCharsets.UTF_8)))) {
+            assertTrue(iter.hasNext());
+            assertInstanceOf(Bus.BusStreamItem.Chunk.class, iter.next());
+            assertTrue(iter.hasNext());
+            Bus.BusStreamItem end = iter.next();
+            assertInstanceOf(Bus.BusStreamItem.End.class, end);
+            assertEquals("complete", ((Bus.BusStreamItem.End) end).end().status());
+            // Stream should be closed; the trailing chunk after End is
+            // ignored even though the underlying bytes are still
+            // available.
+            assertFalse(iter.hasNext());
+        }
+    }
+
+    @Test
+    void busStreamSseErrorWithPlainStringBody() throws Exception {
+        // Defensive: future server emits an `error` event with a
+        // non-JSON body. The iterator should surface the raw text.
+        String sse = "event: bus.stream.error\ndata: broker disconnected\n\n";
+        try (BusStreamSseIterator iter = new BusStreamSseIterator(
+                new java.io.ByteArrayInputStream(sse.getBytes(StandardCharsets.UTF_8)))) {
+            assertTrue(iter.hasNext());
+            Bus.BusStreamItem item = iter.next();
+            assertInstanceOf(Bus.BusStreamItem.Error.class, item);
+            assertEquals("broker disconnected", ((Bus.BusStreamItem.Error) item).message());
+        }
+    }
 }


### PR DESCRIPTION
## Summary

PR 4 of 4 — closes the polyglot SSE-consumer parity work after #147 (Rust), #148 (Python), #149 (Node), and #150 (Go).

## API

```java
try (BusSseIterator iter = client.consumeBusSubscription(
        \"agent-A\", \"agents.demo.events\", \"earliest\")) {
    while (iter.hasNext()) {
        switch (iter.next()) {
            case Bus.BusConsumeItem.Message m -> System.out.println(m.message().offset());
            case Bus.BusConsumeItem.Error e   -> System.err.println(e.message());
            case Bus.BusConsumeItem.KeepAlive __ -> {}  // liveness ping
        }
    }
}

try (BusStreamSseIterator iter = client.consumeBusStream(\"agents\", \"demo\", \"thread-1\", \"stream-42\")) {
    while (iter.hasNext()) {
        if (iter.next() instanceof Bus.BusStreamItem.End) break;
    }
}
```

Both iterators implement `AutoCloseable` so try-with-resources cleans up the underlying HTTP stream. `BusStreamSseIterator` also closes itself once a terminal `End` lands so callers' loops drop out cleanly.

A new private `BusFrameReader` parses the SSE line protocol but surfaces SSE keep-alive comments as a typed `KeepAlive` variant — the existing `SseEventIterator` for the dispatch event stream silently drops them, which is fine for that use case but loses signal for bus consumers. Sealed-interface unions match the existing `PostBusToolCallOutcome` style.

## Test plan

- [ ] `gradle test` — 22 BusTest cases pass (4 new SSE consumer tests, including a post-`End` termination check)
- [ ] `gradle build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)