### PR TITLE
fix(node-sdk,go-sdk): defensive SSE consumer fixes

### DIFF
--- a/clients/go/acteon/bus.go
+++ b/clients/go/acteon/bus.go
@@ -641,18 +641,28 @@ func (c *Client) ConsumeBusStream(
 }
 
 // busSseEnvelope is the raw line-protocol output the bus consumers
-// post-process into typed items. Either a frame (event/id/data) or a
-// keep-alive comment.
+// post-process into typed items. Either a frame (event/id/data), a
+// keep-alive comment, or a synthesized scanner-side error (bumped
+// past `bufio.ErrTooLong` and similar transport faults so consumers
+// see a typed Error item instead of a silent channel close).
 type busSseEnvelope struct {
 	keepAlive bool
 	event     string
 	id        string
 	data      string
+	// Set when the underlying byte scanner failed mid-stream. The
+	// outer consumer parser maps this to its own Error variant
+	// (`BusConsumeKindError` or `BusStreamKindError`) so the caller
+	// gets a typed signal instead of an opaque close.
+	transportErr string
 }
 
 func parseBusConsumeEnvelope(env *busSseEnvelope) (*BusConsumeItem, error) {
 	if env.keepAlive {
 		return &BusConsumeItem{Kind: BusConsumeKindKeepAlive}, nil
+	}
+	if env.transportErr != "" {
+		return &BusConsumeItem{Kind: BusConsumeKindError, Error: env.transportErr}, nil
 	}
 	name := env.event
 	if name == "" {
@@ -675,6 +685,9 @@ func parseBusConsumeEnvelope(env *busSseEnvelope) (*BusConsumeItem, error) {
 func parseBusStreamEnvelope(env *busSseEnvelope) (*BusStreamItem, error) {
 	if env.keepAlive {
 		return &BusStreamItem{Kind: BusStreamKindKeepAlive}, nil
+	}
+	if env.transportErr != "" {
+		return &BusStreamItem{Kind: BusStreamKindError, Error: env.transportErr}, nil
 	}
 	name := env.event
 	if name == "" {
@@ -745,10 +758,13 @@ func (c *Client) openBusSSE(ctx context.Context, path string) (<-chan *busSseEnv
 		defer close(ch)
 		defer resp.Body.Close()
 		scanner := bufio.NewScanner(resp.Body)
-		// Bus messages may exceed the default 64 KiB scanner buffer
-		// when payloads carry large strings. Bump to 1 MiB to match
-		// the dispatch stream comfort margin.
-		const maxLine = 1 << 20
+		// Bus payloads can carry large LLM outputs or batched state.
+		// 8 MiB is the upper bound we'll tolerate per `data:` line —
+		// anything longer is almost certainly a bug or a hostile
+		// upstream, and we surface the failure as a typed Error item
+		// (rather than letting the channel close silently the way
+		// `bufio.ErrTooLong` would).
+		const maxLine = 8 << 20
 		scanner.Buffer(make([]byte, 0, 64*1024), maxLine)
 		var event, id string
 		var dataLines []string
@@ -790,6 +806,17 @@ func (c *Client) openBusSSE(ctx context.Context, path string) (<-chan *busSseEnv
 				event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
 			case strings.HasPrefix(line, "data:"):
 				dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+			}
+		}
+		// Surface scanner errors (most commonly `bufio.ErrTooLong`)
+		// as a synthesized envelope so both the subscription and
+		// stream parsers can lift it to their own Error item — the
+		// alternative is an opaque channel close that callers can't
+		// distinguish from the server cleanly ending the stream.
+		if err := scanner.Err(); err != nil {
+			select {
+			case ch <- &busSseEnvelope{transportErr: err.Error()}:
+			case <-ctx.Done():
 			}
 		}
 	}()

--- a/clients/go/acteon/bus_test.go
+++ b/clients/go/acteon/bus_test.go
@@ -529,6 +529,33 @@ func TestParseBusStreamEnvelope(t *testing.T) {
 	}
 }
 
+func TestParseBusEnvelopeSurfacesTransportError(t *testing.T) {
+	// Scanner-side faults (e.g. `bufio.ErrTooLong`) come through as a
+	// `transportErr`-flagged envelope. Both consumer parsers should
+	// lift it to their own Error variant so the caller's channel sees
+	// a typed signal instead of just closing.
+	consumeItem, err := parseBusConsumeEnvelope(&busSseEnvelope{
+		transportErr: "bufio.Scanner: token too long",
+	})
+	if err != nil {
+		t.Fatalf("consume parse: %v", err)
+	}
+	if consumeItem.Kind != BusConsumeKindError ||
+		consumeItem.Error != "bufio.Scanner: token too long" {
+		t.Errorf("unexpected consume item: %+v", consumeItem)
+	}
+
+	streamItem, err := parseBusStreamEnvelope(&busSseEnvelope{
+		transportErr: "unexpected EOF",
+	})
+	if err != nil {
+		t.Fatalf("stream parse: %v", err)
+	}
+	if streamItem.Kind != BusStreamKindError || streamItem.Error != "unexpected EOF" {
+		t.Errorf("unexpected stream item: %+v", streamItem)
+	}
+}
+
 func TestConsumeBusSubscriptionEndToEnd(t *testing.T) {
 	// Server emits one keep-alive (`:ping`), one message frame, and
 	// closes — the consumer should yield both items in order.

--- a/clients/nodejs/src/bus.test.ts
+++ b/clients/nodejs/src/bus.test.ts
@@ -550,3 +550,64 @@ describe("SSE consumer DTOs", () => {
     assert.equal(e.errorMessage, "broker disconnected");
   });
 });
+
+describe("SSE consumer line-protocol", () => {
+  // The bus SSE consumers split on `\n` for performance, so a trailing
+  // `\r` (from intermediaries that normalise to CRLF) needs to be
+  // stripped explicitly — otherwise the empty-line frame trigger
+  // misses entirely and frames stop dispatching.
+
+  it("consumeBusSubscription handles CRLF-terminated frames", async () => {
+    const http = await import("node:http");
+    const body =
+      ":keep-alive\r\n\r\n" +
+      "event: bus.message\r\nid: 5\r\n" +
+      'data: {"topic":"agents.demo.events","offset":5}\r\n\r\n';
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write(body);
+      res.end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as { port: number }).port;
+    try {
+      const c = new ActeonClient(`http://localhost:${port}`);
+      const items: string[] = [];
+      for await (const item of c.consumeBusSubscription("agent-A", {
+        topic: "agents.demo.events",
+      })) {
+        items.push(item.kind);
+        if (items.length >= 2) break;
+      }
+      assert.deepEqual(items, ["keepAlive", "message"]);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("consumeBusStream handles CRLF-terminated chunk + end", async () => {
+    const http = await import("node:http");
+    const body =
+      "event: bus.stream.chunk\r\nid: 0\r\n" +
+      'data: {"stream_id":"s1","chunk_seq":3,"body":{"t":"hi"},"created_at":"2026-05-02T12:00:00Z"}\r\n\r\n' +
+      "event: bus.stream.end\r\nid: 1\r\n" +
+      'data: {"stream_id":"s1","chunk_seq":4,"status":"complete","created_at":"2026-05-02T12:00:01Z"}\r\n\r\n';
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write(body);
+      res.end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as { port: number }).port;
+    try {
+      const c = new ActeonClient(`http://localhost:${port}`);
+      const items: string[] = [];
+      for await (const item of c.consumeBusStream("agents", "demo", "thread-1", "s1")) {
+        items.push(item.kind);
+      }
+      assert.deepEqual(items, ["chunk", "end"]);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/clients/nodejs/src/client.ts
+++ b/clients/nodejs/src/client.ts
@@ -2231,7 +2231,10 @@ export class ActeonClient {
         // Keep the last incomplete line in the buffer.
         buffer = lines.pop() ?? "";
 
-        for (const line of lines) {
+        for (const raw of lines) {
+          // Strip a trailing CR — splitting on `\n` alone leaves bare
+          // `\r` on every line when an intermediary normalises to CRLF.
+          const line = raw.endsWith("\r") ? raw.slice(0, -1) : raw;
           if (line === "") {
             // Empty line signals end of an event.
             if (currentData.length > 0) {
@@ -2301,7 +2304,12 @@ export class ActeonClient {
         buffer += decoder.decode(value, { stream: true });
         const lines = buffer.split("\n");
         buffer = lines.pop() ?? "";
-        for (const line of lines) {
+        for (const raw of lines) {
+          // Strip a trailing CR. The SSE spec accepts `\r\n`, `\r`, or
+          // `\n` as line terminators; splitting on `\n` alone leaves a
+          // bare `\r` on every line when an intermediary normalises to
+          // CRLF — and that breaks the empty-line frame trigger below.
+          const line = raw.endsWith("\r") ? raw.slice(0, -1) : raw;
           if (line.startsWith(":")) {
             yield { kind: "keepAlive" };
             continue;

--- a/clients/python/acteon_client/bus.py
+++ b/clients/python/acteon_client/bus.py
@@ -1130,6 +1130,13 @@ class _AsyncBusClientMixin:
 # comments. The bus consumers want to surface them as a liveness
 # signal, so we use a small private envelope type below and a
 # matching parser instead of layering on `_parse_sse_stream`.
+#
+# Sync vs async parser duplication: Python's sync and async generators
+# don't share an underlying state machine cleanly — `for line in lines`
+# and `async for line in aiter_lines` differ at the syntactic level,
+# and a unified class-based implementation would add more LOC and
+# indirection than two short copies. Any frame-level bug fix has to
+# touch both functions; keep them in lock-step.
 
 
 class _SseFrame:


### PR DESCRIPTION
## Summary

Three nits caught in adversarial review of the polyglot SSE consumer work (#147–#151).

### 1. Node CRLF handling (real bug)

`connectBusSse` and `connectSse` split on `\n` for streaming performance, but the SSE spec accepts \`\r\n\` too. A trailing \`\r\` left on each line breaks the empty-line frame trigger entirely — frames stop dispatching when any intermediary normalises to CRLF. Fix: strip a trailing \`\r\` per line before the empty-check. Two new vitest cases serve a \`\r\n\`-terminated SSE body via \`node:http\` and verify the consumers yield the expected items.

### 2. Go scanner buffer + error surfacing (real)

\`openBusSSE\` scanner buffer bumped 1 MiB → 8 MiB to accommodate large LLM tool outputs in \`data:\` lines. Scanner errors (\`bufio.ErrTooLong\`, mid-stream faults) now surface through a new \`transportErr\` field on the internal envelope, which both \`parseBusConsumeEnvelope\` and \`parseBusStreamEnvelope\` lift to their own typed Error item — so callers see a useful message instead of an opaque channel close.

### 3. Python sync/async parser duplication (doc)

Documented in \`bus.py\` why the two parsers are kept in lock-step rather than unified (Python's sync/async generators can't share a state machine cleanly).

### Recheck on CRLF scope

The review claimed CRLF was broken in 4 SDKs. On rechecking only Node uses raw \`split(\"\\\\n\")\`. Python (\`httpx.iter_lines\`), Go (\`bufio.ScanLines\`), Java (\`BufferedReader.readLine\`), and Rust (\`tokio::io::lines\`) all delegate to stdlib parsers that strip \`\\\\r?\\\\n\` cleanly.

### What's not in this PR

Auto-reconnection (Last-Event-ID + exponential backoff) is the remaining gap from the review. It touches the server-side bus subscribe handler plus all 5 SDKs and warrants its own design + PR.

## Test plan

- [ ] Node: \`npm test\` 87/87 pass (2 new CRLF end-to-end tests via \`node:http\`)
- [ ] Go: \`go test ./...\` and \`go vet ./...\` clean (1 new \`transportErr\` parser test)
- [ ] Python: \`pytest tests/test_bus.py\` 40/40 pass (doc-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)