### PR TITLE
feat(node-sdk): best-effort SSE reconnect for bus subscriptions

### DIFF
--- a/clients/nodejs/src/bus.test.ts
+++ b/clients/nodejs/src/bus.test.ts
@@ -611,3 +611,40 @@ describe("SSE consumer line-protocol", () => {
     }
   });
 });
+
+describe("consumeBusSubscription reconnect", () => {
+  it("yields a `reconnected` boundary item between attempts", async () => {
+    const http = await import("node:http");
+    let connectionCount = 0;
+    const server = http.createServer((_req, res) => {
+      connectionCount += 1;
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      const offset = connectionCount === 1 ? 1 : 2;
+      res.write(
+        `event: bus.message\nid: ${offset}\ndata: {"topic":"agents.demo.events","offset":${offset}}\n\n`,
+      );
+      res.end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as { port: number }).port;
+    try {
+      const c = new ActeonClient(`http://localhost:${port}`);
+      const seen: string[] = [];
+      let messageCount = 0;
+      for await (const item of c.consumeBusSubscription("agent-A", {
+        topic: "agents.demo.events",
+        reconnect: { initialBackoffMs: 5, maxBackoffMs: 5, maxAttempts: 1 },
+      })) {
+        seen.push(item.kind);
+        if (item.kind === "message") messageCount += 1;
+        if (messageCount >= 2) break;
+      }
+      // Expect: message → reconnected → message.
+      assert.ok(seen.includes("message"), `seen: ${seen.join(",")}`);
+      assert.ok(seen.includes("reconnected"), `seen: ${seen.join(",")}`);
+      assert.equal(connectionCount, 2);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/clients/nodejs/src/bus_models.ts
+++ b/clients/nodejs/src/bus_models.ts
@@ -392,14 +392,34 @@ export interface BusConsumedMessage {
 }
 
 /**
+ * Best-effort reconnect policy for `consumeBusSubscription`.
+ *
+ * Defaults: 500ms initial backoff, 30s cap, infinite retries. The
+ * counter resets after a successful read so a long-stable connection
+ * isn't penalised for a single later blip.
+ *
+ * Reconnect always resumes from `latest` because Phase 1 has no
+ * per-partition offset seek; workloads that need lossless delivery
+ * should use Phase 2 durable subscriptions with manual ack.
+ */
+export interface ReconnectConfig {
+  initialBackoffMs?: number;
+  maxBackoffMs?: number;
+  /** Omit / `null` to retry forever. */
+  maxAttempts?: number;
+}
+
+/**
  * One item from `consumeBusSubscription`. The discriminator
- * (`kind`) tells you whether this is a record, an error, or
- * just a keep-alive used as a liveness signal.
+ * (`kind`) tells you whether this is a record, an error, a
+ * keep-alive (used as a liveness signal), or a successful
+ * reconnect (only when `reconnect` is configured).
  */
 export type BusConsumeItem =
   | { kind: "message"; message: BusConsumedMessage }
   | { kind: "error"; error: string }
-  | { kind: "keepAlive" };
+  | { kind: "keepAlive" }
+  | { kind: "reconnected"; backoffMs: number; attempt: number };
 
 /** `StreamChunk` envelope as it appears on the SSE feed. Mirrors `acteon_core::StreamChunk`. */
 export interface StreamChunkEnvelope {

--- a/clients/nodejs/src/client.ts
+++ b/clients/nodejs/src/client.ts
@@ -173,6 +173,7 @@ import {
   type BusApprovalStatus,
   type BusApprovalView,
   type BusConsumeItem,
+  type ReconnectConfig,
   type BusConversation,
   type BusLag,
   type BusReplayResponse,
@@ -281,6 +282,21 @@ function decodeJsonOrPassthrough(data: string): unknown {
   } catch {
     return data;
   }
+}
+
+/**
+ * Exponential backoff capped at `maxBackoffMs`. The shift is bounded
+ * at 20 so wild attempt counters can't overflow; matches the Rust
+ * client's `backoff_for`.
+ */
+function reconnectBackoffMs(
+  attempt: number,
+  initialBackoffMs: number,
+  maxBackoffMs: number,
+): number {
+  const shift = Math.min(attempt, 20);
+  const exp = initialBackoffMs * Math.pow(2, shift);
+  return Math.min(exp, maxBackoffMs);
 }
 
 function extractErrorMessage(data: string): string {
@@ -2848,26 +2864,83 @@ export class ActeonClient {
    * as `kind: "error"`; SSE keep-alive comments surface as
    * `kind: "keepAlive"` so callers can use them as a liveness signal.
    *
+   * When `reconnect` is set, a clean disconnect triggers exponential
+   * backoff and a fresh subscribe call from `latest` — yielding a
+   * `kind: "reconnected"` item so callers can resync state. Note that
+   * resume from `latest` means messages produced during the disconnect
+   * window are dropped; use Phase 2 durable subscriptions with manual
+   * ack for lossless delivery.
+   *
    * @example
    * ```typescript
    * for await (const item of client.consumeBusSubscription("agent-A", {
    *   topic: "agents.demo.events",
    *   from: "earliest",
+   *   reconnect: {},  // 500ms initial, 30s cap, infinite retries
    * })) {
    *   if (item.kind === "message") console.log(item.message.offset);
+   *   else if (item.kind === "reconnected") {
+   *     console.warn(`reconnected after ${item.backoffMs}ms (attempt ${item.attempt})`);
+   *   }
    * }
    * ```
    */
   async *consumeBusSubscription(
     subscriptionId: string,
-    options: { topic: string; from?: "earliest" | "latest" },
+    options: {
+      topic: string;
+      from?: "earliest" | "latest";
+      reconnect?: ReconnectConfig;
+    },
   ): AsyncGenerator<BusConsumeItem, void, undefined> {
-    const params = new URLSearchParams();
-    params.set("topic", options.topic);
-    if (options.from !== undefined) params.set("from", options.from);
     const path = `/v1/bus/subscribe/${this.busSeg(subscriptionId)}`;
-    for await (const env of this.connectBusSse(path, params)) {
-      yield this.envelopeToConsumeItem(env);
+    if (options.reconnect === undefined) {
+      const params = new URLSearchParams();
+      params.set("topic", options.topic);
+      if (options.from !== undefined) params.set("from", options.from);
+      for await (const env of this.connectBusSse(path, params)) {
+        yield this.envelopeToConsumeItem(env);
+      }
+      return;
+    }
+
+    // Reconnect path: open the first stream with the caller's `from`,
+    // resume from `latest` after every disconnect. Counter resets on
+    // successful read so a long-stable connection isn't penalised
+    // for a single later blip.
+    const cfg = options.reconnect;
+    const initialBackoffMs = cfg.initialBackoffMs ?? 500;
+    const maxBackoffMs = cfg.maxBackoffMs ?? 30_000;
+    const maxAttempts = cfg.maxAttempts;
+    let attempt = 0;
+    let firstOpen = true;
+    while (true) {
+      const params = new URLSearchParams();
+      params.set("topic", options.topic);
+      params.set("from", firstOpen ? options.from ?? "latest" : "latest");
+      try {
+        for await (const env of this.connectBusSse(path, params)) {
+          attempt = 0;
+          yield this.envelopeToConsumeItem(env);
+        }
+      } catch (err) {
+        // Connection-level errors are the disconnect signal we're
+        // meant to recover from; let them flow through to the sleep+
+        // retry path. Anything else (parse error etc.) re-throws.
+        if (err instanceof HttpError || err instanceof ConnectionError) {
+          // expected — fall through to backoff
+        } else {
+          throw err;
+        }
+      }
+      firstOpen = false;
+      if (maxAttempts !== undefined && attempt >= maxAttempts) {
+        return;
+      }
+      const backoffMs = reconnectBackoffMs(attempt, initialBackoffMs, maxBackoffMs);
+      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+      attempt += 1;
+      yield { kind: "reconnected", backoffMs, attempt };
     }
   }
 

--- a/clients/nodejs/src/index.ts
+++ b/clients/nodejs/src/index.ts
@@ -159,6 +159,7 @@ export {
   type PostBusToolResult,
   type PublishBusMessage,
   type PublishReceipt,
+  type ReconnectConfig,
   type RegisterBusAgent,
   type RegisterBusSchema,
   type StreamChunkEnvelope,


### PR DESCRIPTION
## Summary

Mirrors the Rust (#153) + Python (#154) reconnect API. The Node SDK \`consumeBusSubscription\` now accepts an opt-in \`reconnect: ReconnectConfig\` option that wraps the underlying SSE generator with exponential backoff + reconnect-from-latest.

## API

\`\`\`typescript
for await (const item of client.consumeBusSubscription(\"agent-A\", {
  topic: \"agents.demo.events\",
  from: \"earliest\",
  reconnect: {},  // 500ms initial, 30s cap, infinite retries
})) {
  switch (item.kind) {
    case \"message\":
      process(item.message);
      break;
    case \"reconnected\":
      console.warn(\`reconnected after \${item.backoffMs}ms (attempt \${item.attempt})\`);
      resyncState();
      break;
    case \"error\":
      console.error(item.error);
      break;
    case \"keepAlive\":
      break;
  }
}
\`\`\`

## Design notes (matching Rust + Python)

- **Best-effort, not lossless.** Reconnect always resumes from \`latest\`; workloads that need lossless delivery should use Phase 2 durable subscriptions with manual ack.
- **Counter resets on successful read** so a long-stable connection isn't penalised for a single later blip.
- **Bounded shift in backoff math** caps at attempt 20 — wild attempt counters can't overflow the multiplication.

## Test plan

- [ ] \`npm run build\` clean (tsc)
- [ ] \`npm test\` 88/88 pass (1 new test: a \`node:http\` server accepts two connections and the consumer yields message → reconnected → message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)