### PR TITLE
feat(go-sdk): best-effort SSE reconnect for bus subscriptions

### DIFF
--- a/clients/go/acteon/bus.go
+++ b/clients/go/acteon/bus.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Phase 8c: agentic bus surface (Phases 1-6c).
@@ -546,16 +547,28 @@ type ConsumeBusSubscriptionOptions struct {
 	Topic string
 	// From is "earliest" or "latest" (server defaults to latest if empty).
 	From string
+	// Reconnect, when non-nil, wraps the underlying SSE pump with
+	// best-effort exponential backoff + reconnect-from-latest. A
+	// successful reconnect emits an item with Kind ==
+	// BusConsumeKindReconnected so callers can resync state.
+	Reconnect *ReconnectConfig
 }
 
 // ConsumeBusSubscription opens an SSE stream against
 // `/v1/bus/subscribe/{subscription_id}` and returns a channel of typed
 // items. The channel is closed when the context is cancelled or the
-// connection drops.
+// connection drops (and reconnect is not configured).
 //
 // Server-side `bus.error` events surface as items with Kind == Error;
 // SSE keep-alive comments surface as Kind == KeepAlive so callers can
 // use them as a liveness signal.
+//
+// When `opts.Reconnect` is non-nil, a clean disconnect triggers
+// exponential backoff and a fresh subscribe call from `latest` —
+// emitting Kind == BusConsumeKindReconnected so callers can resync
+// state. Note that resume from `latest` means messages produced
+// during the disconnect window are dropped; use Phase 2 durable
+// subscriptions with manual ack for lossless delivery.
 func (c *Client) ConsumeBusSubscription(
 	ctx context.Context,
 	subscriptionID string,
@@ -564,12 +577,20 @@ func (c *Client) ConsumeBusSubscription(
 	if opts == nil || opts.Topic == "" {
 		return nil, &ConnectionError{Message: "ConsumeBusSubscription: opts.Topic is required"}
 	}
-	q := url.Values{}
-	q.Set("topic", opts.Topic)
-	if opts.From != "" {
-		q.Set("from", opts.From)
+	if opts.Reconnect == nil {
+		path := fmt.Sprintf("/v1/bus/subscribe/%s?%s",
+			busSeg(subscriptionID), buildSubscribeQuery(opts.Topic, opts.From).Encode())
+		return c.consumeBusSubscriptionOnce(ctx, path)
 	}
-	path := fmt.Sprintf("/v1/bus/subscribe/%s?%s", busSeg(subscriptionID), q.Encode())
+	return c.consumeBusSubscriptionReconnecting(ctx, subscriptionID, opts), nil
+}
+
+// consumeBusSubscriptionOnce opens a single SSE stream — used for
+// the no-reconnect path and as the inner pump of the reconnect loop.
+func (c *Client) consumeBusSubscriptionOnce(
+	ctx context.Context,
+	path string,
+) (<-chan *BusConsumeItem, error) {
 	envCh, err := c.openBusSSE(ctx, path)
 	if err != nil {
 		return nil, err
@@ -595,6 +616,101 @@ func (c *Client) ConsumeBusSubscription(
 		}
 	}()
 	return out, nil
+}
+
+// consumeBusSubscriptionReconnecting wraps the once-pump with
+// exponential backoff + reconnect-from-latest. The first attempt uses
+// `opts.From`; subsequent attempts always use `latest`. Counter
+// resets on a successful read.
+func (c *Client) consumeBusSubscriptionReconnecting(
+	ctx context.Context,
+	subscriptionID string,
+	opts *ConsumeBusSubscriptionOptions,
+) <-chan *BusConsumeItem {
+	out := make(chan *BusConsumeItem, 64)
+	cfg := *opts.Reconnect
+	if cfg.InitialBackoffMs == 0 {
+		cfg.InitialBackoffMs = 500
+	}
+	if cfg.MaxBackoffMs == 0 {
+		cfg.MaxBackoffMs = 30_000
+	}
+	go func() {
+		defer close(out)
+		var attempt uint32
+		firstOpen := true
+		for {
+			from := opts.From
+			if !firstOpen {
+				from = "latest"
+			}
+			path := fmt.Sprintf("/v1/bus/subscribe/%s?%s",
+				busSeg(subscriptionID), buildSubscribeQuery(opts.Topic, from).Encode())
+			inner, err := c.consumeBusSubscriptionOnce(ctx, path)
+			if err != nil {
+				select {
+				case out <- &BusConsumeItem{Kind: BusConsumeKindError, Error: err.Error()}:
+				case <-ctx.Done():
+					return
+				}
+			} else {
+				for item := range inner {
+					attempt = 0
+					select {
+					case out <- item:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+			firstOpen = false
+			if cfg.MaxAttempts != 0 && attempt >= cfg.MaxAttempts {
+				return
+			}
+			backoff := reconnectBackoffMs(attempt, &cfg)
+			timer := time.NewTimer(time.Duration(backoff) * time.Millisecond)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			}
+			attempt++
+			select {
+			case out <- &BusConsumeItem{
+				Kind:      BusConsumeKindReconnected,
+				BackoffMs: backoff,
+				Attempt:   attempt,
+			}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out
+}
+
+func buildSubscribeQuery(topic, from string) url.Values {
+	q := url.Values{}
+	q.Set("topic", topic)
+	if from != "" {
+		q.Set("from", from)
+	}
+	return q
+}
+
+// reconnectBackoffMs is exponential, capped at cfg.MaxBackoffMs. The
+// shift is bounded at 20 so wild attempt counters can't overflow.
+func reconnectBackoffMs(attempt uint32, cfg *ReconnectConfig) int64 {
+	shift := attempt
+	if shift > 20 {
+		shift = 20
+	}
+	exp := cfg.InitialBackoffMs * (1 << shift)
+	if exp > cfg.MaxBackoffMs {
+		return cfg.MaxBackoffMs
+	}
+	return exp
 }
 
 // ConsumeBusStream opens an SSE stream against

--- a/clients/go/acteon/bus_models.go
+++ b/clients/go/acteon/bus_models.go
@@ -467,19 +467,40 @@ type BusConsumedMessage struct {
 type BusConsumeItemKind string
 
 const (
-	BusConsumeKindMessage   BusConsumeItemKind = "message"
-	BusConsumeKindError     BusConsumeItemKind = "error"
-	BusConsumeKindKeepAlive BusConsumeItemKind = "keepalive"
+	BusConsumeKindMessage     BusConsumeItemKind = "message"
+	BusConsumeKindError       BusConsumeItemKind = "error"
+	BusConsumeKindKeepAlive   BusConsumeItemKind = "keepalive"
+	BusConsumeKindReconnected BusConsumeItemKind = "reconnected"
 )
 
 // BusConsumeItem is the per-record yield from ConsumeBusSubscription.
 // Inspect Kind, then the matching field. KeepAlive carries no extra
 // data and lets callers use the SSE comment frame as a liveness
-// signal.
+// signal. Reconnected is only emitted when the consumer is configured
+// with a ReconnectConfig and a reconnect succeeded — subsequent
+// messages may have gaps versus the pre-disconnect cursor.
 type BusConsumeItem struct {
-	Kind    BusConsumeItemKind
-	Message *BusConsumedMessage
-	Error   string
+	Kind      BusConsumeItemKind
+	Message   *BusConsumedMessage
+	Error     string
+	BackoffMs int64
+	Attempt   uint32
+}
+
+// ReconnectConfig configures the best-effort reconnect wrapper around
+// ConsumeBusSubscription. Reconnect always resumes from `latest`
+// because Phase 1 has no per-partition offset seek; workloads that
+// need lossless delivery should use Phase 2 durable subscriptions
+// with manual ack instead.
+//
+// Zero-value defaults: 500ms initial backoff, 30s cap, infinite
+// retries. The attempt counter resets after a successful read so a
+// long-stable connection isn't penalised for a single later blip.
+type ReconnectConfig struct {
+	InitialBackoffMs int64
+	MaxBackoffMs     int64
+	// MaxAttempts of 0 means "retry forever".
+	MaxAttempts uint32
 }
 
 // StreamChunkEnvelope mirrors `acteon_core::StreamChunk`.

--- a/clients/go/acteon/bus_test.go
+++ b/clients/go/acteon/bus_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -599,6 +600,85 @@ func TestConsumeBusSubscriptionEndToEnd(t *testing.T) {
 	}
 	if got[1].Kind != BusConsumeKindMessage || *got[1].Message.Offset != 5 {
 		t.Errorf("second item: %+v", got[1])
+	}
+}
+
+func TestReconnectBackoffCapsAtMax(t *testing.T) {
+	cfg := &ReconnectConfig{InitialBackoffMs: 100, MaxBackoffMs: 5_000}
+	if got := reconnectBackoffMs(0, cfg); got != 100 {
+		t.Errorf("attempt 0: %d", got)
+	}
+	if got := reconnectBackoffMs(1, cfg); got != 200 {
+		t.Errorf("attempt 1: %d", got)
+	}
+	if got := reconnectBackoffMs(20, cfg); got != 5_000 {
+		t.Errorf("attempt 20 (cap): %d", got)
+	}
+	if got := reconnectBackoffMs(64, cfg); got != 5_000 {
+		// Bounded shift handles wild attempt counters cleanly.
+		t.Errorf("attempt 64 (bounded shift): %d", got)
+	}
+}
+
+func TestConsumeBusSubscriptionReconnects(t *testing.T) {
+	// Server accepts two connections; each emits one frame and
+	// closes. With a Reconnect config set, the consumer should
+	// yield: message → reconnected → message.
+	var connectionCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		connectionCount++
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		offset := connectionCount
+		_, _ = w.Write([]byte(
+			"event: bus.message\nid: " + strconv.Itoa(offset) +
+				"\ndata: {\"topic\":\"agents.demo.events\",\"offset\":" +
+				strconv.Itoa(offset) + "}\n\n"))
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch, err := client.ConsumeBusSubscription(ctx, "agent-A", &ConsumeBusSubscriptionOptions{
+		Topic: "agents.demo.events",
+		Reconnect: &ReconnectConfig{
+			InitialBackoffMs: 5,
+			MaxBackoffMs:     5,
+			MaxAttempts:      1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	var seen []BusConsumeItemKind
+	messageCount := 0
+	for item := range ch {
+		seen = append(seen, item.Kind)
+		if item.Kind == BusConsumeKindMessage {
+			messageCount++
+			if messageCount >= 2 {
+				cancel()
+			}
+		}
+	}
+	if messageCount < 2 {
+		t.Fatalf("expected 2 messages; got %d (seen %v)", messageCount, seen)
+	}
+	gotReconnected := false
+	for _, k := range seen {
+		if k == BusConsumeKindReconnected {
+			gotReconnected = true
+		}
+	}
+	if !gotReconnected {
+		t.Errorf("expected a Reconnected item between messages; got %v", seen)
+	}
+	if connectionCount < 2 {
+		t.Errorf("expected >=2 connections; got %d", connectionCount)
 	}
 }
 


### PR DESCRIPTION
## Summary

Mirrors the Rust (#153), Python (#154), and Node (#155) reconnect API. The Go SDK \`ConsumeBusSubscription\` now accepts an opt-in \`Reconnect *ReconnectConfig\` option that wraps the underlying SSE channel with exponential backoff + reconnect-from-latest.

## API

\`\`\`go
ctx, cancel := context.WithCancel(context.Background())
defer cancel()

ch, _ := client.ConsumeBusSubscription(ctx, \"agent-A\", &acteon.ConsumeBusSubscriptionOptions{
    Topic: \"agents.demo.events\",
    From:  \"earliest\",
    Reconnect: &acteon.ReconnectConfig{},  // 500ms initial, 30s cap, infinite retries
})
for item := range ch {
    switch item.Kind {
    case acteon.BusConsumeKindMessage:
        process(item.Message)
    case acteon.BusConsumeKindReconnected:
        log.Printf(\"reconnected after %dms (attempt %d)\", item.BackoffMs, item.Attempt)
        resyncState()
    case acteon.BusConsumeKindError:
        log.Printf(\"server error: %s\", item.Error)
    case acteon.BusConsumeKindKeepAlive:
        // liveness ping
    }
}
\`\`\`

## Design notes

Same as the prior PRs:

- **Best-effort, not lossless.** Reconnect always resumes from \`latest\`; workloads that need lossless delivery should use Phase 2 durable subscriptions with manual ack.
- **Counter resets on successful read** so a long-stable connection isn't penalised for a single later blip.
- **Bounded shift** in the backoff math caps at attempt 20.
- **Context cancellation propagates** through every \`select\` (including the backoff sleep) so callers cancelling the parent context get a clean channel close.

## Test plan

- [ ] \`go build ./...\` clean
- [ ] \`go vet ./...\` clean
- [ ] \`go test ./...\` green (2 new tests: backoff math + end-to-end reconnect through \`httptest.Server\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)