### PR TITLE
feat(java-sdk): best-effort SSE reconnect for bus subscriptions

### DIFF
--- a/clients/java/src/main/java/com/acteon/client/ActeonClient.java
+++ b/clients/java/src/main/java/com/acteon/client/ActeonClient.java
@@ -3546,6 +3546,36 @@ public class ActeonClient implements AutoCloseable {
     }
 
     /**
+     * Consume a bus subscription with best-effort reconnect on
+     * disconnect. The caller iterates a single
+     * {@link ReconnectingBusSseIterator} that transparently opens
+     * fresh SSE streams from {@code latest} between connections,
+     * yielding a {@link Bus.BusConsumeItem.Reconnected} boundary
+     * item so callers can resync state.
+     *
+     * <p>Resume from {@code latest} means messages produced during
+     * the disconnect window are dropped — workloads that need
+     * lossless delivery should use Phase 2 durable subscriptions
+     * with manual ack instead.
+     *
+     * @param subscriptionId Subscription id (Kafka consumer group).
+     * @param topic Full Kafka topic name ({@code namespace.tenant.name}).
+     * @param from {@code "earliest"} or {@code "latest"} for the first
+     *     attempt; subsequent attempts always use {@code "latest"}.
+     * @param reconnect Reconnect policy. Use {@link Bus.ReconnectConfig#defaults()}
+     *     for the standard 500ms / 30s / forever shape.
+     */
+    public ReconnectingBusSseIterator consumeBusSubscription(
+        String subscriptionId, String topic, String from, Bus.ReconnectConfig reconnect
+    ) throws ActeonException {
+        ReconnectingBusSseIterator.InnerOpener opener = (firstAttempt) -> {
+            String effectiveFrom = firstAttempt ? from : "latest";
+            return consumeBusSubscription(subscriptionId, topic, effectiveFrom);
+        };
+        return new ReconnectingBusSseIterator(opener, reconnect);
+    }
+
+    /**
      * Consume a typed stream via SSE
      * ({@code GET /v1/bus/streams/{ns}/{tenant}/{conversationId}/{streamId}}).
      * The server filters records by

--- a/clients/java/src/main/java/com/acteon/client/Bus.java
+++ b/clients/java/src/main/java/com/acteon/client/Bus.java
@@ -516,7 +516,10 @@ public final class Bus {
      * but lets callers use the SSE comment frame as a liveness signal.
      */
     public sealed interface BusConsumeItem
-        permits BusConsumeItem.Message, BusConsumeItem.Error, BusConsumeItem.KeepAlive {
+        permits BusConsumeItem.Message,
+            BusConsumeItem.Error,
+            BusConsumeItem.KeepAlive,
+            BusConsumeItem.Reconnected {
 
         /** A consumed Kafka record. */
         record Message(BusConsumedMessage message) implements BusConsumeItem {}
@@ -526,6 +529,39 @@ public final class Bus {
 
         /** SSE comment frame from the server. */
         record KeepAlive() implements BusConsumeItem {}
+
+        /**
+         * Best-effort reconnect succeeded after a disconnect. Only
+         * emitted when {@link ActeonClient#consumeBusSubscription} is
+         * called with a non-null {@link ReconnectConfig}; subsequent
+         * messages may have gaps versus the pre-disconnect cursor.
+         */
+        record Reconnected(long backoffMs, int attempt) implements BusConsumeItem {}
+    }
+
+    /**
+     * Best-effort reconnect policy for {@link ActeonClient#consumeBusSubscription}.
+     *
+     * <p>Defaults: 500ms initial backoff, 30s cap, infinite retries.
+     * The attempt counter resets after a successful read so a long-
+     * stable connection isn't penalised for a single later blip.
+     *
+     * <p>Reconnect always resumes from {@code latest} because Phase 1
+     * has no per-partition offset seek; workloads that need lossless
+     * delivery should use Phase 2 durable subscriptions with manual
+     * ack instead.
+     *
+     * @param maxAttempts {@code 0} means "retry forever".
+     */
+    public record ReconnectConfig(
+        long initialBackoffMs,
+        long maxBackoffMs,
+        int maxAttempts
+    ) {
+        /** Default policy: 500ms initial, 30s cap, retry forever. */
+        public static ReconnectConfig defaults() {
+            return new ReconnectConfig(500L, 30_000L, 0);
+        }
     }
 
     /** {@code StreamChunk} envelope as it appears on the SSE feed. Mirrors {@code acteon_core::StreamChunk}. */

--- a/clients/java/src/main/java/com/acteon/client/ReconnectingBusSseIterator.java
+++ b/clients/java/src/main/java/com/acteon/client/ReconnectingBusSseIterator.java
@@ -1,0 +1,152 @@
+package com.acteon.client;
+
+import com.acteon.client.exceptions.ActeonException;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Wraps a sequence of {@link BusSseIterator}s with best-effort
+ * exponential backoff. When the inner iterator drains (the server
+ * closed the SSE stream), this wrapper sleeps according to the
+ * {@link Bus.ReconnectConfig}, opens a fresh subscription from
+ * {@code latest}, and yields a {@link Bus.BusConsumeItem.Reconnected}
+ * boundary item before the next live record.
+ *
+ * <p>Resume is always from {@code latest} because the Phase 1 bus
+ * subscribe handler has no per-partition offset seek. Workloads
+ * that need lossless delivery should use Phase 2 durable
+ * subscriptions with manual ack instead.</p>
+ *
+ * <p>The attempt counter resets after a successful read so a long-
+ * stable connection isn't penalised for a single later blip.</p>
+ */
+public final class ReconnectingBusSseIterator
+    implements Iterator<Bus.BusConsumeItem>, AutoCloseable {
+
+    /** Opens a fresh inner iterator. */
+    @FunctionalInterface
+    public interface InnerOpener {
+        BusSseIterator open(boolean firstAttempt) throws ActeonException;
+    }
+
+    private final InnerOpener opener;
+    private final Bus.ReconnectConfig config;
+    private BusSseIterator current;
+    private Bus.BusConsumeItem nextItem;
+    private boolean closed;
+    private int attempt;
+    /** When set, emitted before pulling the next live item. */
+    private Bus.BusConsumeItem.Reconnected pendingReconnected;
+
+    public ReconnectingBusSseIterator(InnerOpener opener, Bus.ReconnectConfig config)
+        throws ActeonException {
+        this.opener = opener;
+        this.config = config;
+        this.current = opener.open(true);
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (closed) return false;
+        if (nextItem != null) return true;
+        nextItem = readNext();
+        return nextItem != null;
+    }
+
+    @Override
+    public Bus.BusConsumeItem next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException("No more bus SSE items");
+        }
+        Bus.BusConsumeItem item = nextItem;
+        nextItem = null;
+        return item;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+        if (current != null) {
+            current.close();
+            current = null;
+        }
+    }
+
+    private Bus.BusConsumeItem readNext() {
+        while (!closed) {
+            if (pendingReconnected != null) {
+                Bus.BusConsumeItem item = pendingReconnected;
+                pendingReconnected = null;
+                return item;
+            }
+            if (current == null) {
+                // Last reconnect attempt didn't open a stream; sleep
+                // again and try once more. `attemptReconnect` returns
+                // false only when we've hit `maxAttempts` or been
+                // interrupted.
+                if (!attemptReconnect()) return null;
+                continue;
+            }
+            try {
+                if (current.hasNext()) {
+                    Bus.BusConsumeItem item = current.next();
+                    attempt = 0;
+                    return item;
+                }
+            } catch (RuntimeException e) {
+                // Mid-stream parse failure — surface as a typed
+                // error and trigger a reconnect on the next call.
+                current.close();
+                current = null;
+                return new Bus.BusConsumeItem.Error(e.getMessage());
+            }
+            // Inner iterator drained cleanly. Tear it down and let
+            // the loop top take care of opening a fresh one.
+            current.close();
+            current = null;
+        }
+        return null;
+    }
+
+    /**
+     * Sleep for the current backoff, bump the attempt counter, then
+     * try to open a new inner iterator. Always queues a
+     * {@link Bus.BusConsumeItem.Reconnected} boundary so callers
+     * observe the attempt even if the open call fails.
+     *
+     * @return false when {@code maxAttempts} is exhausted or the
+     *     thread was interrupted; true otherwise.
+     */
+    private boolean attemptReconnect() {
+        if (config.maxAttempts() > 0 && attempt >= config.maxAttempts()) {
+            close();
+            return false;
+        }
+        long backoffMs = backoffFor(attempt, config);
+        try {
+            Thread.sleep(backoffMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            close();
+            return false;
+        }
+        attempt++;
+        pendingReconnected = new Bus.BusConsumeItem.Reconnected(backoffMs, attempt);
+        try {
+            current = opener.open(false);
+        } catch (ActeonException e) {
+            // Open failed; we still emit the Reconnected boundary so
+            // callers see the attempt counter, then loop back and
+            // retry on the next call (with another sleep).
+            current = null;
+        }
+        return true;
+    }
+
+    static long backoffFor(int attempt, Bus.ReconnectConfig config) {
+        int shift = Math.min(attempt, 20);
+        long exp = config.initialBackoffMs() * (1L << shift);
+        return Math.min(exp, config.maxBackoffMs());
+    }
+}

--- a/clients/java/src/test/java/com/acteon/client/BusTest.java
+++ b/clients/java/src/test/java/com/acteon/client/BusTest.java
@@ -481,4 +481,57 @@ class BusTest {
             assertEquals("broker disconnected", ((Bus.BusStreamItem.Error) item).message());
         }
     }
+
+    // -------------------------------------------------------------------------
+    // Reconnect behaviour
+    // -------------------------------------------------------------------------
+
+    @Test
+    void reconnectBackoffCapsAtMax() {
+        Bus.ReconnectConfig cfg = new Bus.ReconnectConfig(100L, 5_000L, 0);
+        assertEquals(100L, ReconnectingBusSseIterator.backoffFor(0, cfg));
+        assertEquals(200L, ReconnectingBusSseIterator.backoffFor(1, cfg));
+        assertEquals(400L, ReconnectingBusSseIterator.backoffFor(2, cfg));
+        assertEquals(5_000L, ReconnectingBusSseIterator.backoffFor(20, cfg));
+        // Bounded shift handles wild attempt counters cleanly.
+        assertEquals(5_000L, ReconnectingBusSseIterator.backoffFor(64, cfg));
+    }
+
+    @Test
+    void reconnectingIteratorYieldsReconnectedBoundary() throws Exception {
+        // Opener returns a fresh in-memory SSE stream on each call;
+        // we drain the first one, then the iterator should sleep,
+        // reopen, and emit a Reconnected boundary before the next
+        // live record.
+        java.util.concurrent.atomic.AtomicInteger opens =
+            new java.util.concurrent.atomic.AtomicInteger(0);
+        ReconnectingBusSseIterator.InnerOpener opener = (firstAttempt) -> {
+            int n = opens.incrementAndGet();
+            String body =
+                "event: bus.message\nid: " + n
+                    + "\ndata: {\"topic\":\"agents.demo.events\",\"offset\":" + n + "}\n\n";
+            return new BusSseIterator(
+                new java.io.ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+        };
+        Bus.ReconnectConfig cfg = new Bus.ReconnectConfig(1L, 1L, 1);
+        java.util.List<Class<?>> kinds = new java.util.ArrayList<>();
+        try (ReconnectingBusSseIterator iter =
+                new ReconnectingBusSseIterator(opener, cfg)) {
+            int seenMessages = 0;
+            while (seenMessages < 2 && iter.hasNext()) {
+                Bus.BusConsumeItem item = iter.next();
+                kinds.add(item.getClass());
+                if (item instanceof Bus.BusConsumeItem.Message) {
+                    seenMessages += 1;
+                }
+            }
+        }
+        // The attempt counter resets after each successful read, so
+        // any number of opens >= 2 is correct here. The contract we
+        // care about: callers see *both* a Message and a Reconnected
+        // boundary in the resulting kind sequence.
+        assertTrue(kinds.contains(Bus.BusConsumeItem.Message.class), kinds.toString());
+        assertTrue(kinds.contains(Bus.BusConsumeItem.Reconnected.class), kinds.toString());
+        assertTrue(opens.get() >= 2, "opens=" + opens.get());
+    }
 }


### PR DESCRIPTION
## Summary

Closes the polyglot reconnect series after #153 (Rust), #154 (Python), #155 (Node), #156 (Go).

## API

\`\`\`java
try (ReconnectingBusSseIterator iter = client.consumeBusSubscription(
        \"agent-A\", \"agents.demo.events\", \"earliest\",
        Bus.ReconnectConfig.defaults())) {
    while (iter.hasNext()) {
        switch (iter.next()) {
            case Bus.BusConsumeItem.Message m -> process(m.message());
            case Bus.BusConsumeItem.Reconnected r ->
                log.warn(\"reconnected after {}ms (attempt {})\", r.backoffMs(), r.attempt());
            case Bus.BusConsumeItem.Error e -> log.error(e.message());
            case Bus.BusConsumeItem.KeepAlive __ -> {}
        }
    }
}
\`\`\`

## Design notes (matching the prior PRs)

- **Best-effort, not lossless.** Reconnect always resumes from \`latest\`; workloads that need lossless delivery should use Phase 2 durable subscriptions with manual ack.
- **Counter resets on successful read** so a long-stable connection isn't penalised for a single later blip.
- **Bounded shift** in the backoff math caps at attempt 20.
- **Interrupt-aware sleep**: \`Thread.sleep\` interrupts close the iterator cleanly so callers can shut down with \`Thread.currentThread().interrupt()\`.
- **Failed reconnect opens still emit the \`Reconnected\` boundary** so callers see attempt counters even on intermittent failures; the next loop iteration retries.

## Test plan

- [ ] \`gradle build\` clean
- [ ] \`gradle test\` 24/24 BusTest cases pass (2 new: backoff math + end-to-end reconnect through an in-memory opener)

🤖 Generated with [Claude Code](https://claude.com/claude-code)