### PR TITLE
feat(core): A2A task lifecycle types (Phase 1)

### DIFF
--- a/crates/core/src/bus_agent.rs
+++ b/crates/core/src/bus_agent.rs
@@ -80,6 +80,14 @@ pub struct Agent {
     /// Free-form operator labels.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub labels: HashMap<String, String>,
+    /// True iff an A2A [`crate::bus_agent_card::AgentCard`] exists for
+    /// this agent at a separate state-store key. The flag stays on the
+    /// hot path so the heartbeat / list / route code can decide
+    /// "should I bother fetching the card" without an extra round-trip.
+    /// The full card body lives in `KeyKind::BusAgentCard` (Phase 2)
+    /// and is fetched only by the A2A discovery handler.
+    #[serde(default)]
+    pub has_agent_card: bool,
     /// Registration time.
     pub created_at: DateTime<Utc>,
     /// Last time the agent record was mutated (register / update /
@@ -110,6 +118,7 @@ impl Agent {
             heartbeat_ttl_ms: default_heartbeat_ttl_ms(),
             last_heartbeat_at: None,
             labels: HashMap::new(),
+            has_agent_card: false,
             created_at: now,
             updated_at: now,
         }

--- a/crates/core/src/bus_agent_card.rs
+++ b/crates/core/src/bus_agent_card.rs
@@ -1,0 +1,783 @@
+//! A2A `AgentCard` and supporting types (Phase 1).
+//!
+//! The `AgentCard` is the *advertisement* an agent publishes for
+//! external discovery (`GET /.well-known/agent.json` in Phase 3). It
+//! declares capabilities, skills (with input schemas), wire
+//! interfaces, and accepted security schemes.
+//!
+//! **Why this lives in a separate module from [`crate::bus_agent`]:**
+//! A2A's card schema is verbose (skills with full JSON Schema input
+//! definitions, multiple security schemes, extension URIs). The
+//! [`crate::bus_agent::Agent`] struct is on the hot path — every
+//! heartbeat, every routing decision, every listing reads it.
+//! Inlining the card fields onto `Agent` would bloat that hot path
+//! for tenants with many agents. So [`Agent`] keeps a thin
+//! `has_agent_card: bool` flag, and the full card lives at a
+//! separate state-store key (Phase 2 wires `KeyKind::BusAgentCard`)
+//! fetched only when an A2A discovery request hits.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------
+// Caps
+// ---------------------------------------------------------------------
+
+/// Max length of a card's `description` field.
+pub const MAX_CARD_DESCRIPTION_BYTES: usize = 4 * 1024;
+
+/// Max length of a `Skill::description`.
+pub const MAX_SKILL_DESCRIPTION_BYTES: usize = 2 * 1024;
+
+/// Max serialized size of a `Skill::input_schema` JSON Schema.
+pub const MAX_SKILL_INPUT_SCHEMA_BYTES: usize = 64 * 1024;
+
+/// Max number of skills per card.
+pub const MAX_SKILLS_PER_CARD: usize = 64;
+
+/// Max number of wire interfaces per card.
+pub const MAX_INTERFACES_PER_CARD: usize = 16;
+
+/// Max number of declared extensions per card.
+pub const MAX_EXTENSIONS_PER_CARD: usize = 32;
+
+/// Max number of security schemes per card.
+pub const MAX_SECURITY_SCHEMES_PER_CARD: usize = 16;
+
+/// Max number of output media types per skill.
+pub const MAX_OUTPUT_MEDIA_TYPES_PER_SKILL: usize = 16;
+
+// ---------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------
+
+/// The organization / publisher behind an agent.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct Provider {
+    /// Human-readable provider name (e.g. `"Acme Corp"`).
+    pub name: String,
+    /// Provider home page or identity URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+// ---------------------------------------------------------------------
+// AgentCapabilities
+// ---------------------------------------------------------------------
+
+/// Capability flags an agent advertises. These drive A2A client
+/// behavior — e.g. an A2A client won't attempt `SendStreamingMessage`
+/// against an agent whose card has `streaming = false`.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct AgentCapabilities {
+    /// Agent supports SSE streaming (`SendStreamingMessage`,
+    /// `SubscribeToTask`).
+    #[serde(default)]
+    pub streaming: bool,
+    /// Agent supports per-task push notification configs.
+    #[serde(default)]
+    pub push_notifications: bool,
+    /// Agent exposes an extended card via `GetExtendedAgentCard`
+    /// (richer than the public well-known card).
+    #[serde(default)]
+    pub extended_agent_card: bool,
+}
+
+// ---------------------------------------------------------------------
+// Skill
+// ---------------------------------------------------------------------
+
+/// A discrete capability an agent exposes, with optional JSON Schema
+/// describing valid inputs and a list of media types it can return.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct Skill {
+    /// Skill name. Used as the canonical token for invocation.
+    pub name: String,
+    /// Human-readable description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// JSON Schema describing valid input shape. Stored as a JSON
+    /// value rather than a typed schema so we don't pull a schema
+    /// crate into core just for this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<Object>))]
+    pub input_schema: Option<serde_json::Value>,
+    /// IANA media types this skill can return (e.g. `text/plain`,
+    /// `application/json`, `image/png`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub output_media_types: Vec<String>,
+}
+
+impl Skill {
+    /// Construct a skill with just a name. Build up via field access.
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: None,
+            input_schema: None,
+            output_media_types: Vec::new(),
+        }
+    }
+
+    fn validate(&self) -> Result<(), AgentCardValidationError> {
+        validate_token("skill.name", &self.name)?;
+        if let Some(d) = &self.description
+            && d.len() > MAX_SKILL_DESCRIPTION_BYTES
+        {
+            return Err(AgentCardValidationError::SkillDescriptionTooLong);
+        }
+        if let Some(schema) = &self.input_schema {
+            let encoded = serde_json::to_vec(schema)
+                .map_err(|_| AgentCardValidationError::SkillInputSchemaInvalid)?;
+            if encoded.len() > MAX_SKILL_INPUT_SCHEMA_BYTES {
+                return Err(AgentCardValidationError::SkillInputSchemaTooLong);
+            }
+        }
+        if self.output_media_types.len() > MAX_OUTPUT_MEDIA_TYPES_PER_SKILL {
+            return Err(AgentCardValidationError::TooManyOutputMediaTypes);
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------
+
+/// Transport binding the agent supports. `kind` is one of `"json-rpc"`,
+/// `"grpc"`, `"rest"` — A2A spec §8.3.1.
+///
+/// (A2A's wire field is `"type"`, but `type` is a Rust keyword;
+/// we serialize the same wire shape via `#[serde(rename = "type")]`.)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct Interface {
+    /// Transport kind (`"json-rpc"`, `"grpc"`, `"rest"`).
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// Endpoint URL the agent serves this interface at.
+    pub url: String,
+}
+
+impl Interface {
+    fn validate(&self) -> Result<(), AgentCardValidationError> {
+        if self.kind.is_empty() {
+            return Err(AgentCardValidationError::EmptyInterfaceKind);
+        }
+        if self.url.is_empty() {
+            return Err(AgentCardValidationError::EmptyInterfaceUrl);
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------
+// SecurityScheme
+// ---------------------------------------------------------------------
+
+/// One of the five A2A-supported security schemes (spec §4.5).
+/// Tagged on `scheme` so the wire shape is
+/// `{"scheme": "api_key", "name": "X-API-Key", "in": "header"}`.
+///
+/// Phase 4 wires these to Acteon's existing API-key grants, Bearer
+/// tokens, and mTLS stack. `OAuth2` / `OpenIdConnect` are scoped out
+/// of the MVP but defined here so the type model is complete and
+/// future-additive.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "scheme", rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum SecurityScheme {
+    /// API key in header, query, or cookie.
+    ApiKey {
+        /// Parameter name (e.g. `"X-API-Key"`).
+        name: String,
+        /// Where to find the key (`"header"`, `"query"`, `"cookie"`).
+        #[serde(rename = "in")]
+        location: String,
+    },
+    /// HTTP `Authorization` header (Basic, Bearer, etc.).
+    HttpAuth {
+        /// HTTP authentication scheme (`"basic"`, `"bearer"`, etc.).
+        scheme_name: String,
+        /// For Bearer: hint at token format (e.g. `"JWT"`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        bearer_format: Option<String>,
+    },
+    /// OAuth 2.0 with declared flows. Flows stored as opaque JSON
+    /// because the A2A spec defers to the OAuth 2.0 flow object
+    /// shape and we don't want to drag in an OAuth crate here.
+    OAuth2 {
+        #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+        flows: serde_json::Value,
+    },
+    /// `OpenID` Connect discovery URL.
+    OpenIdConnect { open_id_connect_url: String },
+    /// Mutual TLS (client certificate validated server-side).
+    MutualTls,
+}
+
+impl SecurityScheme {
+    fn validate(&self) -> Result<(), AgentCardValidationError> {
+        match self {
+            SecurityScheme::ApiKey { name, location } => {
+                if name.is_empty() {
+                    return Err(AgentCardValidationError::EmptySecurityField("apiKey.name"));
+                }
+                if !matches!(location.as_str(), "header" | "query" | "cookie") {
+                    return Err(AgentCardValidationError::InvalidSecurityLocation(
+                        location.clone(),
+                    ));
+                }
+            }
+            SecurityScheme::HttpAuth { scheme_name, .. } => {
+                if scheme_name.is_empty() {
+                    return Err(AgentCardValidationError::EmptySecurityField(
+                        "httpAuth.schemeName",
+                    ));
+                }
+            }
+            SecurityScheme::OpenIdConnect {
+                open_id_connect_url,
+            } => {
+                if open_id_connect_url.is_empty() {
+                    return Err(AgentCardValidationError::EmptySecurityField(
+                        "openIdConnect.openIdConnectUrl",
+                    ));
+                }
+            }
+            SecurityScheme::OAuth2 { .. } | SecurityScheme::MutualTls => {}
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------
+
+/// A2A protocol extension the agent participates in (spec §4.4.4).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct Extension {
+    /// Extension identifier URI.
+    pub uri: String,
+    /// Version string.
+    pub version: String,
+    /// If true, clients MUST declare support in `A2A-Extensions`
+    /// header or be rejected.
+    #[serde(default)]
+    pub required: bool,
+}
+
+impl Extension {
+    fn validate(&self) -> Result<(), AgentCardValidationError> {
+        if self.uri.is_empty() {
+            return Err(AgentCardValidationError::EmptySecurityField(
+                "extension.uri",
+            ));
+        }
+        if self.version.is_empty() {
+            return Err(AgentCardValidationError::EmptySecurityField(
+                "extension.version",
+            ));
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------
+// AgentCard
+// ---------------------------------------------------------------------
+
+/// A2A `AgentCard` — the discovery advertisement for an agent. Lives at
+/// a separate state-store key from the hot
+/// [`crate::bus_agent::Agent`] record (Phase 2 wires
+/// `KeyKind::BusAgentCard`).
+///
+/// Identity fields (`agent_id`, `namespace`, `tenant`) match the
+/// corresponding `Agent` so the card and the hot-path record join
+/// cleanly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct AgentCard {
+    /// Agent identifier. Same as `Agent.agent_id`.
+    pub agent_id: String,
+    /// Namespace. Same as `Agent.namespace`.
+    pub namespace: String,
+    /// Tenant. Same as `Agent.tenant`.
+    pub tenant: String,
+    /// Human-readable agent name (often distinct from `agent_id`,
+    /// which may be a slug).
+    pub name: String,
+    /// Free-text agent description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Publishing provider.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<Provider>,
+    /// Capability flags.
+    #[serde(default)]
+    pub capabilities: AgentCapabilities,
+    /// Skills the agent exposes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<Skill>,
+    /// Transport interfaces the agent supports.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub interfaces: Vec<Interface>,
+    /// Named security schemes this agent accepts. Keyed by an
+    /// operator-chosen alias so a client can refer to a specific
+    /// scheme by name in its request.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub security_schemes: HashMap<String, SecurityScheme>,
+    /// Protocol extensions the agent participates in.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extensions: Vec<Extension>,
+    /// Card version (operator-controlled; changes when capabilities,
+    /// skills, or schemes change in a backwards-incompatible way).
+    pub version: String,
+    /// Optional cryptographic signature over the card body. Card
+    /// signing is deferred to Phase 4 hardening; the field is here so
+    /// the wire shape is stable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+    /// Card creation timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Last mutation timestamp.
+    pub updated_at: DateTime<Utc>,
+}
+
+impl AgentCard {
+    /// Construct a minimal card with the required identity fields and
+    /// an operator-supplied name + version. Capabilities default to
+    /// none-enabled; populate before publishing.
+    #[must_use]
+    pub fn new(
+        agent_id: impl Into<String>,
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+        name: impl Into<String>,
+        version: impl Into<String>,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            agent_id: agent_id.into(),
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            name: name.into(),
+            description: None,
+            provider: None,
+            capabilities: AgentCapabilities::default(),
+            skills: Vec::new(),
+            interfaces: Vec::new(),
+            security_schemes: HashMap::new(),
+            extensions: Vec::new(),
+            version: version.into(),
+            signature: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Validate identity, bounded fields, and every nested record.
+    pub fn validate(&self) -> Result<(), AgentCardValidationError> {
+        validate_id("agentId", &self.agent_id)?;
+        validate_fragment("namespace", &self.namespace)?;
+        validate_fragment("tenant", &self.tenant)?;
+        if self.name.is_empty() {
+            return Err(AgentCardValidationError::EmptyName);
+        }
+        if self.name.len() > 256 {
+            return Err(AgentCardValidationError::NameTooLong);
+        }
+        if let Some(d) = &self.description
+            && d.len() > MAX_CARD_DESCRIPTION_BYTES
+        {
+            return Err(AgentCardValidationError::DescriptionTooLong);
+        }
+        if self.version.is_empty() {
+            return Err(AgentCardValidationError::EmptyVersion);
+        }
+        if self.skills.len() > MAX_SKILLS_PER_CARD {
+            return Err(AgentCardValidationError::TooManySkills);
+        }
+        for s in &self.skills {
+            s.validate()?;
+        }
+        if self.interfaces.len() > MAX_INTERFACES_PER_CARD {
+            return Err(AgentCardValidationError::TooManyInterfaces);
+        }
+        for i in &self.interfaces {
+            i.validate()?;
+        }
+        if self.extensions.len() > MAX_EXTENSIONS_PER_CARD {
+            return Err(AgentCardValidationError::TooManyExtensions);
+        }
+        for e in &self.extensions {
+            e.validate()?;
+        }
+        if self.security_schemes.len() > MAX_SECURITY_SCHEMES_PER_CARD {
+            return Err(AgentCardValidationError::TooManySecuritySchemes);
+        }
+        for (k, scheme) in &self.security_schemes {
+            if k.is_empty() {
+                return Err(AgentCardValidationError::EmptySecuritySchemeKey);
+            }
+            scheme.validate()?;
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------
+
+fn validate_id(field: &'static str, s: &str) -> Result<(), AgentCardValidationError> {
+    if s.is_empty() {
+        return Err(AgentCardValidationError::EmptyId(field));
+    }
+    if s.len() > 120 {
+        return Err(AgentCardValidationError::IdTooLong(field));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err(AgentCardValidationError::InvalidIdChar {
+            field,
+            value: s.to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_fragment(field: &'static str, s: &str) -> Result<(), AgentCardValidationError> {
+    if s.is_empty() {
+        return Err(AgentCardValidationError::EmptyFragment(field));
+    }
+    if s.len() > 80 {
+        return Err(AgentCardValidationError::FragmentTooLong(field));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(AgentCardValidationError::InvalidFragmentChar {
+            field,
+            value: s.to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_token(field: &'static str, s: &str) -> Result<(), AgentCardValidationError> {
+    if s.is_empty() {
+        return Err(AgentCardValidationError::EmptyId(field));
+    }
+    if s.len() > 120 {
+        return Err(AgentCardValidationError::IdTooLong(field));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err(AgentCardValidationError::InvalidIdChar {
+            field,
+            value: s.to_string(),
+        });
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum AgentCardValidationError {
+    #[error("{0} must not be empty")]
+    EmptyId(&'static str),
+    #[error("{0} exceeds 120 characters")]
+    IdTooLong(&'static str),
+    #[error("{field} '{value}' contains characters outside [a-zA-Z0-9._-]")]
+    InvalidIdChar { field: &'static str, value: String },
+    #[error("{0} must not be empty")]
+    EmptyFragment(&'static str),
+    #[error("{0} exceeds 80 characters")]
+    FragmentTooLong(&'static str),
+    #[error("{field} '{value}' contains characters outside [a-zA-Z0-9_-]")]
+    InvalidFragmentChar { field: &'static str, value: String },
+    #[error("agent card name must not be empty")]
+    EmptyName,
+    #[error("agent card name exceeds 256 characters")]
+    NameTooLong,
+    #[error("agent card description exceeds {MAX_CARD_DESCRIPTION_BYTES} bytes")]
+    DescriptionTooLong,
+    #[error("agent card version must not be empty")]
+    EmptyVersion,
+    #[error("skill description exceeds {MAX_SKILL_DESCRIPTION_BYTES} bytes")]
+    SkillDescriptionTooLong,
+    #[error("skill inputSchema is not serializable JSON")]
+    SkillInputSchemaInvalid,
+    #[error("skill inputSchema exceeds {MAX_SKILL_INPUT_SCHEMA_BYTES} bytes")]
+    SkillInputSchemaTooLong,
+    #[error("skill outputMediaTypes exceed {MAX_OUTPUT_MEDIA_TYPES_PER_SKILL}")]
+    TooManyOutputMediaTypes,
+    #[error("skills exceed {MAX_SKILLS_PER_CARD}")]
+    TooManySkills,
+    #[error("interfaces exceed {MAX_INTERFACES_PER_CARD}")]
+    TooManyInterfaces,
+    #[error("interface kind must not be empty")]
+    EmptyInterfaceKind,
+    #[error("interface url must not be empty")]
+    EmptyInterfaceUrl,
+    #[error("extensions exceed {MAX_EXTENSIONS_PER_CARD}")]
+    TooManyExtensions,
+    #[error("securitySchemes exceed {MAX_SECURITY_SCHEMES_PER_CARD}")]
+    TooManySecuritySchemes,
+    #[error("security scheme key must not be empty")]
+    EmptySecuritySchemeKey,
+    #[error("required security field {0} must not be empty")]
+    EmptySecurityField(&'static str),
+    #[error("apiKey 'in' field must be header/query/cookie (got '{0}')")]
+    InvalidSecurityLocation(String),
+}
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample() -> AgentCard {
+        AgentCard::new("planner-1", "agents", "demo", "Planner", "1.0.0")
+    }
+
+    #[test]
+    fn minimal_card_validates() {
+        sample().validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_empty_name() {
+        let mut c = sample();
+        c.name = String::new();
+        assert_eq!(c.validate(), Err(AgentCardValidationError::EmptyName));
+    }
+
+    #[test]
+    fn rejects_empty_version() {
+        let mut c = sample();
+        c.version = String::new();
+        assert_eq!(c.validate(), Err(AgentCardValidationError::EmptyVersion));
+    }
+
+    #[test]
+    fn rejects_bad_agent_id() {
+        let mut c = sample();
+        c.agent_id = "bad/id".into();
+        assert!(matches!(
+            c.validate(),
+            Err(AgentCardValidationError::InvalidIdChar {
+                field: "agentId",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn rejects_long_description() {
+        let mut c = sample();
+        c.description = Some("x".repeat(MAX_CARD_DESCRIPTION_BYTES + 1));
+        assert_eq!(
+            c.validate(),
+            Err(AgentCardValidationError::DescriptionTooLong)
+        );
+    }
+
+    #[test]
+    fn validates_skill_input_schema() {
+        let mut c = sample();
+        let mut skill = Skill::new("summarize");
+        skill.input_schema = Some(json!({"type": "object"}));
+        skill.output_media_types = vec!["text/plain".into()];
+        c.skills.push(skill);
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_oversized_skill_input_schema() {
+        let mut c = sample();
+        let mut skill = Skill::new("summarize");
+        // Build a JSON object whose serialized form exceeds the cap.
+        let big = "x".repeat(MAX_SKILL_INPUT_SCHEMA_BYTES);
+        skill.input_schema = Some(json!({"big": big}));
+        c.skills.push(skill);
+        assert_eq!(
+            c.validate(),
+            Err(AgentCardValidationError::SkillInputSchemaTooLong)
+        );
+    }
+
+    #[test]
+    fn caps_skills_count() {
+        let mut c = sample();
+        for i in 0..=MAX_SKILLS_PER_CARD {
+            c.skills.push(Skill::new(format!("skill-{i}")));
+        }
+        assert_eq!(c.validate(), Err(AgentCardValidationError::TooManySkills));
+    }
+
+    #[test]
+    fn validates_security_scheme_api_key() {
+        let mut c = sample();
+        c.security_schemes.insert(
+            "primary".into(),
+            SecurityScheme::ApiKey {
+                name: "X-API-Key".into(),
+                location: "header".into(),
+            },
+        );
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_bad_api_key_location() {
+        let mut c = sample();
+        c.security_schemes.insert(
+            "primary".into(),
+            SecurityScheme::ApiKey {
+                name: "X-API-Key".into(),
+                location: "body".into(),
+            },
+        );
+        assert!(matches!(
+            c.validate(),
+            Err(AgentCardValidationError::InvalidSecurityLocation(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_empty_security_scheme_key() {
+        let mut c = sample();
+        c.security_schemes
+            .insert(String::new(), SecurityScheme::MutualTls);
+        assert_eq!(
+            c.validate(),
+            Err(AgentCardValidationError::EmptySecuritySchemeKey)
+        );
+    }
+
+    #[test]
+    fn validates_interface() {
+        let mut c = sample();
+        c.interfaces.push(Interface {
+            kind: "json-rpc".into(),
+            url: "https://example.com/a2a/rpc".into(),
+        });
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_empty_interface_kind() {
+        let mut c = sample();
+        c.interfaces.push(Interface {
+            kind: String::new(),
+            url: "https://x".into(),
+        });
+        assert_eq!(
+            c.validate(),
+            Err(AgentCardValidationError::EmptyInterfaceKind)
+        );
+    }
+
+    #[test]
+    fn extension_validates() {
+        let mut c = sample();
+        c.extensions.push(Extension {
+            uri: "https://example.com/ext/v1".into(),
+            version: "1.0".into(),
+            required: true,
+        });
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn capability_flags_serialize_camel_case() {
+        let mut c = sample();
+        c.capabilities.streaming = true;
+        c.capabilities.push_notifications = true;
+        c.capabilities.extended_agent_card = false;
+        let v = serde_json::to_value(&c.capabilities).unwrap();
+        assert_eq!(v.get("streaming"), Some(&json!(true)));
+        assert_eq!(v.get("pushNotifications"), Some(&json!(true)));
+        assert_eq!(v.get("extendedAgentCard"), Some(&json!(false)));
+    }
+
+    #[test]
+    fn card_serializes_camel_case() {
+        let mut c = sample();
+        c.description = Some("a test agent".into());
+        let v = serde_json::to_value(&c).unwrap();
+        assert!(v.get("agentId").is_some());
+        assert!(v.get("createdAt").is_some());
+        assert!(v.get("updatedAt").is_some());
+        assert!(v.get("securitySchemes").is_none() || v["securitySchemes"].is_object());
+    }
+
+    #[test]
+    fn security_scheme_api_key_serializes_with_in_field() {
+        let scheme = SecurityScheme::ApiKey {
+            name: "X-API-Key".into(),
+            location: "header".into(),
+        };
+        let v = serde_json::to_value(&scheme).unwrap();
+        // Wire format must use `in` (A2A spec), not `location`.
+        assert_eq!(v.get("in"), Some(&json!("header")));
+        assert_eq!(v.get("scheme"), Some(&json!("api_key")));
+    }
+
+    #[test]
+    fn interface_serializes_with_type_field() {
+        let iface = Interface {
+            kind: "json-rpc".into(),
+            url: "https://x".into(),
+        };
+        let v = serde_json::to_value(&iface).unwrap();
+        // Wire field is `type`, not `kind`.
+        assert_eq!(v.get("type"), Some(&json!("json-rpc")));
+        assert!(v.get("kind").is_none());
+    }
+
+    #[test]
+    fn card_roundtrip_serde() {
+        let mut c = sample();
+        c.skills.push(Skill::new("summarize"));
+        c.interfaces.push(Interface {
+            kind: "json-rpc".into(),
+            url: "https://x".into(),
+        });
+        c.security_schemes
+            .insert("primary".into(), SecurityScheme::MutualTls);
+        let j = serde_json::to_string(&c).unwrap();
+        let back: AgentCard = serde_json::from_str(&j).unwrap();
+        assert_eq!(back.skills.len(), 1);
+        assert_eq!(back.interfaces.len(), 1);
+        assert_eq!(back.security_schemes.len(), 1);
+    }
+}

--- a/crates/core/src/bus_agent_card.rs
+++ b/crates/core/src/bus_agent_card.rs
@@ -11,7 +11,7 @@
 //! [`crate::bus_agent::Agent`] struct is on the hot path — every
 //! heartbeat, every routing decision, every listing reads it.
 //! Inlining the card fields onto `Agent` would bloat that hot path
-//! for tenants with many agents. So [`Agent`] keeps a thin
+//! for tenants with many agents. So [`crate::bus_agent::Agent`] keeps a thin
 //! `has_agent_card: bool` flag, and the full card lives at a
 //! separate state-store key (Phase 2 wires `KeyKind::BusAgentCard`)
 //! fetched only when an A2A discovery request hits.

--- a/crates/core/src/bus_conversation.rs
+++ b/crates/core/src/bus_conversation.rs
@@ -29,6 +29,10 @@ use std::collections::HashMap;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::bus_task::{
+    MAX_METADATA_VALUE_BYTES, Message as TaskMessage, Role as TaskRole, TaskValidationError,
+};
+
 /// Default events-topic suffix. Combined with `{namespace}.{tenant}.`
 /// to form the shared Kafka topic that all conversations in that
 /// tenant produce to.
@@ -252,6 +256,132 @@ pub enum ConversationValidationError {
         from: ConversationState,
         transition: ConversationTransition,
     },
+    #[error("conversation message body is invalid: {0}")]
+    InvalidMessage(#[from] TaskValidationError),
+    #[error("conversation_id '{record}' on the envelope does not match parent '{parent}'")]
+    ConversationIdMismatch { parent: String, record: String },
+    #[error(
+        "conversation message metadata value for key '{key}' exceeds {MAX_METADATA_VALUE_BYTES} bytes"
+    )]
+    MessageMetadataTooLong { key: String },
+    #[error("conversation message metadata key must not be empty")]
+    EmptyMessageMetadataKey,
+    #[error("conversation message metadata value is not serializable JSON")]
+    MessageMetadataInvalid,
+}
+
+// ---------------------------------------------------------------------
+// ConversationMessage — A2A Message/Part-aligned envelope
+// ---------------------------------------------------------------------
+
+/// A message produced into a conversation's events topic, wrapping an
+/// A2A [`TaskMessage`] (alias for [`crate::bus_task::Message`]) so the
+/// wire format is directly consumable by A2A clients.
+///
+/// **Convergence goal:** every message that rides on the
+/// `{namespace}.{tenant}.conversations-events` topic is shaped as
+/// `ConversationMessage`. Subscribers parse the inner
+/// [`TaskMessage`] and get an A2A-compliant `Message` with no
+/// translation. Acteon-side routing metadata (sender agent ID,
+/// produce timestamp, optional sender-supplied envelope kind for
+/// pre-Task tool envelopes) sits *outside* the inner message so it
+/// never collides with A2A wire fields.
+///
+/// **Relationship to [`crate::bus_tool`] envelopes:** the existing
+/// `ToolCall` / `ToolResult` envelopes (Phase 6a) are pre-A2A
+/// conversation messages with envelope kinds. In Phase 2 the Task
+/// Engine projects them into A2A semantics (a Task in `Working` with
+/// a tool-call `Message` in `history`). The `envelope_kind` field
+/// below preserves the legacy routing tag during the transition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ConversationMessage {
+    /// Conversation this message belongs to. The bus also stamps this
+    /// as the Kafka partition key so consumers get per-conversation
+    /// FIFO ordering.
+    pub conversation_id: String,
+    /// A2A [`TaskMessage`] body (role + parts + reference task ids).
+    /// This is the part an A2A client deserializes directly.
+    pub message: TaskMessage,
+    /// `agent_id` of the producer. Carried on the envelope (in
+    /// addition to whatever the inner message's `role` says) so the
+    /// audit trail and routing layer don't need to deserialize the
+    /// inner message to know who sent it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender: Option<String>,
+    /// Optional envelope-kind routing tag — e.g. `"text"`,
+    /// `"tool_call"`, `"tool_result"`, `"task_status"`,
+    /// `"task_artifact"`. Stamped as `acteon.envelope.kind` on the
+    /// Kafka header so subscribers can filter without parsing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub envelope_kind: Option<String>,
+    /// Envelope construction time (distinct from broker-stamped
+    /// `produced_at`).
+    pub created_at: DateTime<Utc>,
+    /// Free-form envelope-level metadata. Distinct from
+    /// `message.metadata` so Acteon-side trace IDs don't pollute the
+    /// A2A wire payload.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+impl ConversationMessage {
+    /// Construct a conversation message wrapping a text body from a
+    /// specific role. Convenience for the common case.
+    #[must_use]
+    pub fn text(
+        conversation_id: impl Into<String>,
+        message_id: impl Into<String>,
+        role: TaskRole,
+        text: impl Into<String>,
+    ) -> Self {
+        let conversation_id = conversation_id.into();
+        let mut message = TaskMessage::text(message_id, role, text);
+        message.context_id = Some(conversation_id.clone());
+        Self {
+            conversation_id,
+            message,
+            sender: None,
+            envelope_kind: Some("text".to_string()),
+            created_at: Utc::now(),
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Validate identity, inner message, and bounded metadata. If the
+    /// inner message's `contextId` is set, it must match
+    /// `conversation_id` — otherwise an A2A consumer would see a
+    /// `contextId` pointing at a different conversation than the one
+    /// the envelope addresses.
+    pub fn validate(&self) -> Result<(), ConversationValidationError> {
+        Conversation::validate_id(&self.conversation_id)?;
+        if let Some(s) = &self.sender {
+            Conversation::validate_id(s)
+                .map_err(|_| ConversationValidationError::InvalidParticipant(s.clone()))?;
+        }
+        if let Some(ctx) = &self.message.context_id
+            && ctx != &self.conversation_id
+        {
+            return Err(ConversationValidationError::ConversationIdMismatch {
+                parent: self.conversation_id.clone(),
+                record: ctx.clone(),
+            });
+        }
+        self.message.validate()?;
+        for (k, v) in &self.metadata {
+            if k.is_empty() {
+                return Err(ConversationValidationError::EmptyMessageMetadataKey);
+            }
+            let encoded = serde_json::to_vec(v)
+                .map_err(|_| ConversationValidationError::MessageMetadataInvalid)?;
+            if encoded.len() > MAX_METADATA_VALUE_BYTES {
+                return Err(ConversationValidationError::MessageMetadataTooLong { key: k.clone() });
+            }
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -349,5 +479,85 @@ mod tests {
         assert_eq!(back.title, c.title);
         assert_eq!(back.participants, c.participants);
         assert_eq!(back.labels, c.labels);
+    }
+
+    // --- ConversationMessage ---
+
+    #[test]
+    fn conversation_message_text_validates() {
+        ConversationMessage::text("conv-1", "msg-1", TaskRole::User, "hello")
+            .validate()
+            .unwrap();
+    }
+
+    #[test]
+    fn conversation_message_sets_inner_context_id() {
+        let cm = ConversationMessage::text("conv-1", "msg-1", TaskRole::User, "hi");
+        assert_eq!(cm.message.context_id.as_deref(), Some("conv-1"));
+    }
+
+    #[test]
+    fn conversation_message_rejects_mismatched_context_id() {
+        let mut cm = ConversationMessage::text("conv-1", "msg-1", TaskRole::User, "hi");
+        cm.message.context_id = Some("conv-2".into());
+        assert!(matches!(
+            cm.validate(),
+            Err(ConversationValidationError::ConversationIdMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn conversation_message_rejects_bad_sender() {
+        let mut cm = ConversationMessage::text("conv-1", "msg-1", TaskRole::User, "hi");
+        cm.sender = Some("bad/sender".into());
+        assert!(matches!(
+            cm.validate(),
+            Err(ConversationValidationError::InvalidParticipant(_))
+        ));
+    }
+
+    #[test]
+    fn conversation_message_propagates_message_validation_errors() {
+        let mut cm = ConversationMessage::text("conv-1", "msg-1", TaskRole::User, "hi");
+        cm.message.parts.clear();
+        assert!(matches!(
+            cm.validate(),
+            Err(ConversationValidationError::InvalidMessage(_))
+        ));
+    }
+
+    #[test]
+    fn conversation_message_serializes_camel_case() {
+        let mut cm = ConversationMessage::text("conv-1", "msg-1", TaskRole::Agent, "ok");
+        cm.sender = Some("planner-1".into());
+        let v = serde_json::to_value(&cm).unwrap();
+        assert!(v.get("conversationId").is_some());
+        assert!(v.get("createdAt").is_some());
+        assert!(v.get("envelopeKind").is_some());
+        // The inner Message is itself camelCase.
+        let msg = v.get("message").unwrap();
+        assert!(msg.get("messageId").is_some());
+        assert!(msg.get("contextId").is_some());
+    }
+
+    #[test]
+    fn conversation_message_roundtrip_serde() {
+        let cm = ConversationMessage::text("conv-1", "msg-1", TaskRole::Agent, "answer");
+        let j = serde_json::to_string(&cm).unwrap();
+        let back: ConversationMessage = serde_json::from_str(&j).unwrap();
+        assert_eq!(back.conversation_id, cm.conversation_id);
+        assert_eq!(back.message.message_id, "msg-1");
+        assert_eq!(back.envelope_kind.as_deref(), Some("text"));
+    }
+
+    #[test]
+    fn conversation_message_caps_metadata_value_size() {
+        let mut cm = ConversationMessage::text("conv-1", "msg-1", TaskRole::User, "x");
+        cm.metadata
+            .insert("k".into(), serde_json::Value::String("x".repeat(5000)));
+        assert!(matches!(
+            cm.validate(),
+            Err(ConversationValidationError::MessageMetadataTooLong { .. })
+        ));
     }
 }

--- a/crates/core/src/bus_stream.rs
+++ b/crates/core/src/bus_stream.rs
@@ -17,6 +17,8 @@ use std::collections::HashMap;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::bus_task::{Artifact, MAX_METADATA_VALUE_BYTES, TaskStatus, TaskValidationError};
+
 /// Terminal status for a stream. `Complete` is the happy path —
 /// every chunk made it. `Aborted` is producer-side cancellation
 /// (the agent gave up cleanly). `Error` carries the reason the
@@ -188,6 +190,217 @@ impl StreamEnd {
     }
 }
 
+/// A2A `TaskStatusUpdateEvent` (spec §4.2.1) — emitted whenever a
+/// Task's lifecycle state changes. Phase 2 Task Engine produces one
+/// of these on every state transition; subscribers re-frame as a
+/// `statusUpdate` field on the A2A `StreamResponse` SSE envelope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct TaskStatusUpdateEvent {
+    /// The task this update describes.
+    pub task_id: String,
+    /// Conversation/context this task belongs to. Mirrors `Task.contextId`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
+    /// Lifecycle pin at the moment of the update (state + driving
+    /// message + timestamp).
+    pub status: TaskStatus,
+    /// Free-form metadata (trace IDs, source attribution).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+impl TaskStatusUpdateEvent {
+    /// Construct an event for the given task.
+    #[must_use]
+    pub fn new(task_id: impl Into<String>, status: TaskStatus) -> Self {
+        Self {
+            task_id: task_id.into(),
+            context_id: None,
+            status,
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Validate identity fields and the embedded status.
+    pub fn validate(&self) -> Result<(), TaskValidationError> {
+        validate_task_event_id("taskId", &self.task_id)?;
+        if let Some(c) = &self.context_id {
+            validate_task_event_id("contextId", c)?;
+        }
+        self.status.validate()?;
+        validate_event_metadata(&self.metadata)?;
+        Ok(())
+    }
+}
+
+/// A2A `TaskArtifactUpdateEvent` (spec §4.2.2) — emitted for each
+/// chunk of a streamed artifact (or once for a single-shot artifact).
+///
+/// `append` and `lastChunk` carry the per-delivery semantics that are
+/// *not* on the [`Artifact`] itself: whether the new content replaces
+/// or appends to the prior content for this `artifactId`, and whether
+/// this is the terminal chunk.
+///
+/// **Acteon extensions (race safety):** A2A spec is silent on
+/// out-of-order delivery. `chunkIndex` and `totalChunks` let the
+/// Phase 2 Task Engine enforce:
+///
+/// - chunk indices are non-negative,
+/// - no chunks arrive after `lastChunk = true`,
+/// - when `totalChunks` is set, every index in `0..totalChunks` is
+///   observed before the artifact is closed.
+///
+/// Both fields are optional so non-streaming producers can omit them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct TaskArtifactUpdateEvent {
+    /// The task this artifact belongs to.
+    pub task_id: String,
+    /// Conversation/context this task belongs to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
+    /// The artifact content for this delivery — identity + parts.
+    pub artifact: Artifact,
+    /// If true, append `artifact.parts` to the existing artifact with
+    /// the same `artifactId`; otherwise replace.
+    #[serde(default)]
+    pub append: bool,
+    /// If true, this is the final chunk for the artifact. The Task
+    /// Engine will reject subsequent updates for the same
+    /// `artifactId`.
+    #[serde(default)]
+    pub last_chunk: bool,
+    /// Monotonic sequence within this artifact's chunk stream.
+    /// Acteon extension; see struct-level docs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chunk_index: Option<i64>,
+    /// Total chunks expected for this artifact, set on the
+    /// `lastChunk = true` envelope. Acteon extension; see
+    /// struct-level docs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_chunks: Option<i64>,
+    /// Free-form metadata.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+impl TaskArtifactUpdateEvent {
+    /// Construct a single-shot (non-streamed) artifact event —
+    /// `append = false`, `last_chunk = true`, no sequencing.
+    #[must_use]
+    pub fn single_shot(task_id: impl Into<String>, artifact: Artifact) -> Self {
+        Self {
+            task_id: task_id.into(),
+            context_id: None,
+            artifact,
+            append: false,
+            last_chunk: true,
+            chunk_index: None,
+            total_chunks: None,
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Construct a chunk-stream event with sequencing metadata.
+    #[must_use]
+    pub fn chunk(
+        task_id: impl Into<String>,
+        artifact: Artifact,
+        chunk_index: i64,
+        last_chunk: bool,
+    ) -> Self {
+        Self {
+            task_id: task_id.into(),
+            context_id: None,
+            artifact,
+            append: chunk_index > 0,
+            last_chunk,
+            chunk_index: Some(chunk_index),
+            total_chunks: None,
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Validate identity, sequencing invariants, and the embedded
+    /// artifact.
+    pub fn validate(&self) -> Result<(), TaskValidationError> {
+        validate_task_event_id("taskId", &self.task_id)?;
+        if let Some(c) = &self.context_id {
+            validate_task_event_id("contextId", c)?;
+        }
+        self.artifact.validate()?;
+        if let Some(ix) = self.chunk_index
+            && ix < 0
+        {
+            return Err(TaskValidationError::NegativeChunkIndex(ix));
+        }
+        if let Some(t) = self.total_chunks
+            && t <= 0
+        {
+            return Err(TaskValidationError::InvalidTotalChunks(t));
+        }
+        // If a chunk advertises `totalChunks`, its own index must fit
+        // inside the asserted range — otherwise a consumer that trusts
+        // the cap will hang waiting for an index that can never arrive.
+        if let (Some(ix), Some(t)) = (self.chunk_index, self.total_chunks)
+            && ix >= t
+        {
+            return Err(TaskValidationError::ChunkIndexOutOfRange {
+                index: ix,
+                total: t,
+            });
+        }
+        // First chunk in a stream replaces; subsequent chunks append.
+        // A `chunk_index = 0` with `append = true` would silently drop
+        // any prior accumulated content — reject so callers don't
+        // accidentally lose data.
+        if matches!(self.chunk_index, Some(0)) && self.append {
+            return Err(TaskValidationError::AppendOnFirstChunk);
+        }
+        validate_event_metadata(&self.metadata)?;
+        Ok(())
+    }
+}
+
+fn validate_task_event_id(field: &'static str, s: &str) -> Result<(), TaskValidationError> {
+    if s.is_empty() {
+        return Err(TaskValidationError::EmptyId(field));
+    }
+    if s.len() > 120 {
+        return Err(TaskValidationError::IdTooLong(field));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err(TaskValidationError::InvalidIdChar {
+            field,
+            value: s.to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_event_metadata(
+    map: &HashMap<String, serde_json::Value>,
+) -> Result<(), TaskValidationError> {
+    for (k, v) in map {
+        if k.is_empty() {
+            return Err(TaskValidationError::EmptyMetadataKey);
+        }
+        let encoded = serde_json::to_vec(v).map_err(|_| TaskValidationError::MetadataInvalid)?;
+        if encoded.len() > MAX_METADATA_VALUE_BYTES {
+            return Err(TaskValidationError::MetadataValueTooLong { key: k.clone() });
+        }
+    }
+    Ok(())
+}
+
 /// Shared id-field validation used across `StreamChunk` and
 /// `StreamEnd`. Mirrors the rule applied to `ToolCall` / `Agent` /
 /// `Conversation` ids: alphanumeric plus `[._-]`, 1..=120 bytes.
@@ -303,5 +516,129 @@ mod tests {
         let back: StreamEnd = serde_json::from_str(&j).unwrap();
         assert_eq!(back.status, StreamEndStatus::Aborted);
         assert_eq!(back.error_message.as_deref(), Some("user canceled"));
+    }
+
+    // --- A2A TaskStatusUpdateEvent ---
+
+    use crate::bus_task::{Artifact, Part, TaskState, TaskStatus};
+
+    fn sample_status() -> TaskStatus {
+        TaskStatus::new(TaskState::Working, Utc::now())
+    }
+
+    #[test]
+    fn task_status_event_validates() {
+        TaskStatusUpdateEvent::new("task-1", sample_status())
+            .validate()
+            .unwrap();
+    }
+
+    #[test]
+    fn task_status_event_rejects_bad_task_id() {
+        let mut e = TaskStatusUpdateEvent::new("bad/id", sample_status());
+        e.task_id = "bad/id".into();
+        assert!(matches!(
+            e.validate(),
+            Err(TaskValidationError::InvalidIdChar {
+                field: "taskId",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn task_status_event_serializes_camel_case() {
+        let mut e = TaskStatusUpdateEvent::new("task-1", sample_status());
+        e.context_id = Some("ctx".into());
+        let v = serde_json::to_value(&e).unwrap();
+        assert!(v.get("taskId").is_some());
+        assert!(v.get("contextId").is_some());
+        assert!(v.get("status").is_some());
+    }
+
+    // --- A2A TaskArtifactUpdateEvent ---
+
+    fn sample_artifact() -> Artifact {
+        Artifact::new("art-1", vec![Part::text("hello")])
+    }
+
+    #[test]
+    fn task_artifact_single_shot_validates() {
+        TaskArtifactUpdateEvent::single_shot("task-1", sample_artifact())
+            .validate()
+            .unwrap();
+    }
+
+    #[test]
+    fn task_artifact_chunk_constructor_validates() {
+        TaskArtifactUpdateEvent::chunk("task-1", sample_artifact(), 0, false)
+            .validate()
+            .unwrap();
+        TaskArtifactUpdateEvent::chunk("task-1", sample_artifact(), 1, false)
+            .validate()
+            .unwrap();
+    }
+
+    #[test]
+    fn task_artifact_rejects_negative_chunk_index() {
+        let mut e = TaskArtifactUpdateEvent::chunk("task-1", sample_artifact(), 0, false);
+        e.chunk_index = Some(-1);
+        assert!(matches!(
+            e.validate(),
+            Err(TaskValidationError::NegativeChunkIndex(-1))
+        ));
+    }
+
+    #[test]
+    fn task_artifact_rejects_non_positive_total_chunks() {
+        let mut e = TaskArtifactUpdateEvent::single_shot("task-1", sample_artifact());
+        e.total_chunks = Some(0);
+        assert!(matches!(
+            e.validate(),
+            Err(TaskValidationError::InvalidTotalChunks(0))
+        ));
+    }
+
+    #[test]
+    fn task_artifact_rejects_index_outside_total_range() {
+        let mut e = TaskArtifactUpdateEvent::single_shot("task-1", sample_artifact());
+        e.chunk_index = Some(5);
+        e.total_chunks = Some(5);
+        assert!(matches!(
+            e.validate(),
+            Err(TaskValidationError::ChunkIndexOutOfRange { index: 5, total: 5 })
+        ));
+    }
+
+    #[test]
+    fn task_artifact_rejects_append_on_first_chunk() {
+        // append=true with chunk_index=0 would silently overwrite the
+        // (nonexistent) prior accumulated content — flag it.
+        let mut e = TaskArtifactUpdateEvent::chunk("task-1", sample_artifact(), 0, false);
+        e.append = true;
+        assert!(matches!(
+            e.validate(),
+            Err(TaskValidationError::AppendOnFirstChunk)
+        ));
+    }
+
+    #[test]
+    fn task_artifact_chunk_helper_sets_append_correctly() {
+        // First chunk: replace mode.
+        let first = TaskArtifactUpdateEvent::chunk("task-1", sample_artifact(), 0, false);
+        assert!(!first.append);
+        // Subsequent chunks: append.
+        let second = TaskArtifactUpdateEvent::chunk("task-1", sample_artifact(), 1, false);
+        assert!(second.append);
+    }
+
+    #[test]
+    fn task_artifact_event_serializes_camel_case() {
+        let e = TaskArtifactUpdateEvent::chunk("task-1", sample_artifact(), 2, true);
+        let v = serde_json::to_value(&e).unwrap();
+        assert!(v.get("taskId").is_some());
+        assert!(v.get("artifact").is_some());
+        assert!(v.get("chunkIndex").is_some());
+        assert!(v.get("lastChunk").is_some());
     }
 }

--- a/crates/core/src/bus_task.rs
+++ b/crates/core/src/bus_task.rs
@@ -1,0 +1,1202 @@
+//! A2A protocol native types — `Task` lifecycle, `Message`, `Part`,
+//! `Artifact` (Phase 1).
+//!
+//! Acteon adopts A2A's eight-state task lifecycle verbatim as the
+//! canonical primitive for asynchronous, externally-observable work.
+//! Narrower internal enums (`ConversationState`, `ToolResultStatus`)
+//! continue to govern their own domains; the Task Engine projects
+//! between them at the bus boundary.
+//!
+//! Wire format: these structs serialize to JSON using `camelCase`
+//! field names so the same value can ride straight onto an A2A
+//! `JSON-RPC` 2.0 wire envelope (`messageId`, `contextId`, `taskId`,
+//! etc.) — distinct from the `snake_case` convention the internal bus
+//! state-store records use. The state-store representation simply
+//! carries the `camelCase` shape; there's no separate "internal" Task
+//! type.
+//!
+//! State machine:
+//!
+//! ```text
+//!   Submitted ──▶ Working ──▶ Completed (terminal)
+//!       │           │ │ │ │
+//!       │           │ │ │ └──▶ InputRequired ──▶ Working
+//!       │           │ │ │                    ──▶ Canceled
+//!       │           │ │ │                    ──▶ Failed
+//!       │           │ │ └────▶ AuthRequired  ──▶ Working
+//!       │           │ │                      ──▶ Canceled
+//!       │           │ │                      ──▶ Failed
+//!       │           │ └──────▶ Canceled (terminal)
+//!       │           └────────▶ Failed (terminal)
+//!       ├──────────────────▶ Canceled (terminal)
+//!       ├──────────────────▶ Rejected (terminal)
+//!       └──────────────────▶ Failed (terminal)
+//! ```
+//!
+//! Phase 1 scope: types, validation, transition rules. The Task
+//! Engine that drives state transitions and persists rows lives in
+//! `acteon-gateway` (Phase 2).
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------
+// Constants & caps
+// ---------------------------------------------------------------------
+
+/// Identifier alphabet: `[a-zA-Z0-9._-]`, 1..=120 bytes. Shared with
+/// the rest of the bus so IDs land safely in URL paths, state keys,
+/// and Kafka headers.
+pub const MAX_ID_LEN: usize = 120;
+
+/// Max characters in a `Part::text` field. Matches the existing
+/// publish-edge content cap so an oversized text part can't bypass
+/// the bus's content limits by riding inside a Task.
+pub const MAX_PART_TEXT_BYTES: usize = 512 * 1024; // 512KB
+
+/// Max `base64` length of a `Part::raw` payload. The 1MB cap aligns
+/// with the existing bus payload tier; chunked artifacts are the
+/// supported pattern for outputs larger than this.
+pub const MAX_PART_RAW_BYTES: usize = 1024 * 1024; // 1MB (base64)
+
+/// Max bytes for a serialized `Part::data` JSON value.
+pub const MAX_PART_DATA_BYTES: usize = 1024 * 1024; // 1MB
+
+/// Max history length on a [`Task`]. A2A's `historyLength` query
+/// parameter is the client-facing way to bound this on the wire; the
+/// server keeps a hard ceiling so a misbehaving producer can't grow
+/// the row without bound.
+pub const MAX_HISTORY_LEN: usize = 1_000;
+
+/// Max number of artifacts on a [`Task`].
+pub const MAX_ARTIFACTS_LEN: usize = 256;
+
+/// Max parts inside a single [`Message`] or [`Artifact`].
+pub const MAX_PARTS_PER_CONTAINER: usize = 64;
+
+/// Max bytes in a metadata value (single entry, serialized JSON).
+pub const MAX_METADATA_VALUE_BYTES: usize = 4096;
+
+/// Max number of `referenceTaskIds` entries on a [`Message`].
+pub const MAX_REFERENCE_TASK_IDS: usize = 32;
+
+/// Max number of `extensions` entries on a [`Message`].
+pub const MAX_MESSAGE_EXTENSIONS: usize = 32;
+
+// ---------------------------------------------------------------------
+// TaskState
+// ---------------------------------------------------------------------
+
+/// A2A canonical task lifecycle. Eight states across three categories:
+///
+/// - **In progress** (non-terminal, non-interrupt): `Submitted`,
+///   `Working`.
+/// - **Interrupts** (non-terminal, awaiting external action):
+///   `InputRequired`, `AuthRequired`.
+/// - **Terminal**: `Completed`, `Failed`, `Canceled`, `Rejected`.
+///
+/// Distinguishing terminal from interrupt matters for SDK consumers
+/// writing "is finished" checks — an interrupt is *not* a final state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum TaskState {
+    /// Successfully submitted and acknowledged by the server.
+    Submitted,
+    /// Actively being processed.
+    Working,
+    /// Finished successfully.
+    Completed,
+    /// Finished with error.
+    Failed,
+    /// Canceled before completion.
+    Canceled,
+    /// Needs additional input from the user/caller (interrupt).
+    InputRequired,
+    /// Needs authentication (interrupt).
+    AuthRequired,
+    /// Agent declined to process the task.
+    Rejected,
+}
+
+impl TaskState {
+    /// True for the four terminal states. Once reached, a task makes
+    /// no further transitions.
+    #[must_use]
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            TaskState::Completed | TaskState::Failed | TaskState::Canceled | TaskState::Rejected,
+        )
+    }
+
+    /// True for the two interrupt states. The task is paused awaiting
+    /// an external event (user input / authentication) and may resume.
+    #[must_use]
+    pub fn is_interrupt(self) -> bool {
+        matches!(self, TaskState::InputRequired | TaskState::AuthRequired)
+    }
+
+    /// True iff the task is still moving (non-terminal). Note that
+    /// interrupt states return `true` here — they're paused, not done.
+    #[must_use]
+    pub fn is_in_progress(self) -> bool {
+        !self.is_terminal()
+    }
+
+    /// True iff a transition from `self` to `next` is allowed.
+    ///
+    /// Allowed graph:
+    /// - From `Submitted`: `Working`, `Canceled`, `Failed`, `Rejected`.
+    /// - From `Working`: `Completed`, `Failed`, `Canceled`,
+    ///   `InputRequired`, `AuthRequired`.
+    /// - From `InputRequired` / `AuthRequired`: `Working`, `Canceled`,
+    ///   `Failed`.
+    /// - From any terminal state: nothing.
+    #[must_use]
+    pub fn can_transition_to(self, next: TaskState) -> bool {
+        use TaskState::{
+            AuthRequired, Canceled, Completed, Failed, InputRequired, Rejected, Submitted, Working,
+        };
+        matches!(
+            (self, next),
+            (Submitted, Working | Canceled | Failed | Rejected)
+                | (Working, Completed | Failed | Canceled | InputRequired | AuthRequired)
+                | (InputRequired | AuthRequired, Working | Canceled | Failed)
+        )
+    }
+}
+
+// ---------------------------------------------------------------------
+// Role
+// ---------------------------------------------------------------------
+
+/// Who sent a [`Message`]. A2A spec uses `ROLE_USER` / `ROLE_AGENT`
+/// constants; we mirror the semantics with a typed enum and serialize
+/// to the same wire values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum Role {
+    /// External caller — the agent's counterpart.
+    User,
+    /// The Acteon-side agent producing output.
+    Agent,
+}
+
+// ---------------------------------------------------------------------
+// Part
+// ---------------------------------------------------------------------
+
+/// A single piece of content inside a [`Message`] or [`Artifact`].
+///
+/// Per A2A spec §4.1.6 a Part contains **exactly one** of `text`,
+/// `raw` (`base64`-encoded bytes), `url` (file reference), or `data`
+/// (JSON value). We model this as a struct with all-optional content
+/// fields and enforce the exactly-one invariant in [`Part::validate`].
+/// A tagged Rust enum would be cleaner internally but wouldn't match
+/// the wire shape A2A clients expect.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct Part {
+    /// Inline text payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// `Base64`-encoded inline bytes. Stored as `String` (the encoded
+    /// form) so the type matches the wire representation directly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw: Option<String>,
+    /// External URL the content can be fetched from. Either inline
+    /// (`text` / `raw` / `data`) or by reference (`url`), not both.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Structured JSON payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<Object>))]
+    pub data: Option<serde_json::Value>,
+    /// Optional filename (mostly relevant for `raw`/`url` parts).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    /// IANA media type (e.g. `text/plain`, `application/json`,
+    /// `application/pdf`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub media_type: Option<String>,
+    /// Free-form metadata.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+impl Part {
+    /// Construct a text part.
+    #[must_use]
+    pub fn text(value: impl Into<String>) -> Self {
+        Self {
+            text: Some(value.into()),
+            media_type: Some("text/plain".to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Construct a structured-data part.
+    #[must_use]
+    pub fn data(value: serde_json::Value) -> Self {
+        Self {
+            data: Some(value),
+            media_type: Some("application/json".to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Construct a URL-reference part.
+    #[must_use]
+    pub fn url(href: impl Into<String>) -> Self {
+        Self {
+            url: Some(href.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Construct a raw (`base64`-encoded) bytes part.
+    #[must_use]
+    pub fn raw_base64(encoded: impl Into<String>) -> Self {
+        Self {
+            raw: Some(encoded.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Validate the exactly-one-of invariant and bounded sizes.
+    pub fn validate(&self) -> Result<(), TaskValidationError> {
+        let set_count = [
+            self.text.is_some(),
+            self.raw.is_some(),
+            self.url.is_some(),
+            self.data.is_some(),
+        ]
+        .iter()
+        .filter(|&&b| b)
+        .count();
+
+        if set_count == 0 {
+            return Err(TaskValidationError::EmptyPart);
+        }
+        if set_count > 1 {
+            return Err(TaskValidationError::AmbiguousPart);
+        }
+
+        if let Some(t) = &self.text
+            && t.len() > MAX_PART_TEXT_BYTES
+        {
+            return Err(TaskValidationError::PartTextTooLong);
+        }
+        if let Some(r) = &self.raw
+            && r.len() > MAX_PART_RAW_BYTES
+        {
+            return Err(TaskValidationError::PartRawTooLong);
+        }
+        if let Some(d) = &self.data {
+            let encoded =
+                serde_json::to_vec(d).map_err(|_| TaskValidationError::PartDataInvalid)?;
+            if encoded.len() > MAX_PART_DATA_BYTES {
+                return Err(TaskValidationError::PartDataTooLong);
+            }
+        }
+        validate_metadata(&self.metadata)?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------
+// Message
+// ---------------------------------------------------------------------
+
+/// A single message in a Task's history. Role-tagged with one or more
+/// content [`Part`]s.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct Message {
+    /// Stable identifier (server- or client-generated UUID). Used for
+    /// idempotency on submit; the Task Engine deduplicates by
+    /// `messageId`.
+    pub message_id: String,
+    /// Conversation/context this message belongs to. Maps onto an
+    /// Acteon `conversation_id` when the Task is backed by a chain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
+    /// Task this message is associated with. `None` for the initial
+    /// message of a `SendMessage` call before a Task has been minted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    /// User-side vs. agent-side authorship.
+    pub role: Role,
+    /// One or more content parts. Order is significant.
+    pub parts: Vec<Part>,
+    /// Free-form metadata.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub metadata: HashMap<String, serde_json::Value>,
+    /// A2A extension URIs this message participates in.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extensions: Vec<String>,
+    /// Other task IDs this message references (e.g. a follow-up that
+    /// cites prior tasks). String IDs only — not nested Task objects —
+    /// so there's no recursive schema for utoipa to choke on.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reference_task_ids: Vec<String>,
+}
+
+impl Message {
+    /// Construct a minimal message with a single text part.
+    #[must_use]
+    pub fn text(message_id: impl Into<String>, role: Role, text: impl Into<String>) -> Self {
+        Self {
+            message_id: message_id.into(),
+            context_id: None,
+            task_id: None,
+            role,
+            parts: vec![Part::text(text)],
+            metadata: HashMap::new(),
+            extensions: Vec::new(),
+            reference_task_ids: Vec::new(),
+        }
+    }
+
+    /// Validate identity, bounded fields, and each part.
+    pub fn validate(&self) -> Result<(), TaskValidationError> {
+        validate_id("messageId", &self.message_id)?;
+        if let Some(c) = &self.context_id {
+            validate_id("contextId", c)?;
+        }
+        if let Some(t) = &self.task_id {
+            validate_id("taskId", t)?;
+        }
+        if self.parts.is_empty() {
+            return Err(TaskValidationError::MessageHasNoParts);
+        }
+        if self.parts.len() > MAX_PARTS_PER_CONTAINER {
+            return Err(TaskValidationError::TooManyParts);
+        }
+        for p in &self.parts {
+            p.validate()?;
+        }
+        if self.reference_task_ids.len() > MAX_REFERENCE_TASK_IDS {
+            return Err(TaskValidationError::TooManyReferenceTaskIds);
+        }
+        for r in &self.reference_task_ids {
+            validate_id("referenceTaskIds", r)?;
+        }
+        if self.extensions.len() > MAX_MESSAGE_EXTENSIONS {
+            return Err(TaskValidationError::TooManyExtensions);
+        }
+        validate_metadata(&self.metadata)?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------
+// Artifact
+// ---------------------------------------------------------------------
+
+/// A discrete output produced by the agent, possibly streamed in
+/// chunks. `append` and `lastChunk` enable progressive delivery: a
+/// stream of artifact-update events with the same `artifactId`, the
+/// first carrying `append = false` (replace) and subsequent ones
+/// `append = true` (append). The final chunk sets `lastChunk = true`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct Artifact {
+    /// Stable identifier within the parent [`Task`]. Used to stitch
+    /// streamed chunks back together.
+    pub artifact_id: String,
+    /// Optional human-readable name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Optional description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Content parts. For a single-shot artifact this is the full
+    /// content; for streamed artifacts each chunk delivers its slice.
+    pub parts: Vec<Part>,
+    /// True if this update should be appended to the prior content
+    /// for this `artifactId`; false (default) means replace.
+    #[serde(default)]
+    pub append: bool,
+    /// True if this is the final chunk for the artifact. Consumers
+    /// can mark the artifact as complete once observed.
+    #[serde(default)]
+    pub last_chunk: bool,
+    /// Free-form metadata.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+impl Artifact {
+    /// Construct a single-shot artifact with one or more parts.
+    #[must_use]
+    pub fn new(artifact_id: impl Into<String>, parts: Vec<Part>) -> Self {
+        Self {
+            artifact_id: artifact_id.into(),
+            name: None,
+            description: None,
+            parts,
+            append: false,
+            last_chunk: true,
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Validate identity and bounded fields.
+    pub fn validate(&self) -> Result<(), TaskValidationError> {
+        validate_id("artifactId", &self.artifact_id)?;
+        if self.parts.is_empty() {
+            return Err(TaskValidationError::ArtifactHasNoParts);
+        }
+        if self.parts.len() > MAX_PARTS_PER_CONTAINER {
+            return Err(TaskValidationError::TooManyParts);
+        }
+        for p in &self.parts {
+            p.validate()?;
+        }
+        validate_metadata(&self.metadata)?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------
+// TaskStatus
+// ---------------------------------------------------------------------
+
+/// The lifecycle pin for a [`Task`] — current state, the message that
+/// drove the most recent transition (if any), and a timestamp.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct TaskStatus {
+    /// Current state.
+    pub state: TaskState,
+    /// Most recent message attached to the status (e.g. the error
+    /// message on `Failed`, the prompt on `InputRequired`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<Message>,
+    /// Timestamp of the last state transition.
+    pub timestamp: DateTime<Utc>,
+}
+
+impl TaskStatus {
+    /// Construct a status pin for the given state at the given time.
+    #[must_use]
+    pub fn new(state: TaskState, timestamp: DateTime<Utc>) -> Self {
+        Self {
+            state,
+            message: None,
+            timestamp,
+        }
+    }
+
+    /// Validate the attached message, if any.
+    pub fn validate(&self) -> Result<(), TaskValidationError> {
+        if let Some(m) = &self.message {
+            m.validate()?;
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------
+// Task
+// ---------------------------------------------------------------------
+
+/// An A2A task — the canonical unit of asynchronous work observable
+/// to external callers. Lives at `KeyKind::A2aTask` (added in Phase 2)
+/// keyed by `(namespace, tenant, task_id)`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct Task {
+    /// Stable task identifier.
+    pub id: String,
+    /// Conversation/context this task is associated with. Optional in
+    /// the A2A spec; populated when the task is bound to a
+    /// conversation (which is the default for chain-backed tasks).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
+    /// Current lifecycle pin.
+    pub status: TaskStatus,
+    /// Outputs produced so far. May be empty until the task reaches a
+    /// terminal state (or earlier for streamed tasks).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<Artifact>,
+    /// Message history (capped at [`MAX_HISTORY_LEN`]; A2A's
+    /// `historyLength` query parameter trims this on read).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub history: Vec<Message>,
+    /// Free-form task metadata.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub metadata: HashMap<String, serde_json::Value>,
+    // --- Acteon-side fields (not in A2A spec) ---
+    /// Namespace owning the task.
+    pub namespace: String,
+    /// Tenant owning the task.
+    pub tenant: String,
+    /// Creation timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Last mutation timestamp.
+    pub updated_at: DateTime<Utc>,
+}
+
+impl Task {
+    /// Construct a fresh task in the `Submitted` state.
+    #[must_use]
+    pub fn new(
+        id: impl Into<String>,
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: id.into(),
+            context_id: None,
+            status: TaskStatus::new(TaskState::Submitted, now),
+            artifacts: Vec::new(),
+            history: Vec::new(),
+            metadata: HashMap::new(),
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Apply a state transition, capturing the driving message. Rejects
+    /// illegal transitions explicitly so the API can surface a 409
+    /// rather than silently dropping the change.
+    pub fn transition_to(
+        &mut self,
+        next: TaskState,
+        message: Option<Message>,
+    ) -> Result<(), TaskValidationError> {
+        if !self.status.state.can_transition_to(next) {
+            return Err(TaskValidationError::IllegalTransition {
+                from: self.status.state,
+                to: next,
+            });
+        }
+        if let Some(m) = &message {
+            m.validate()?;
+        }
+        let now = Utc::now();
+        self.status = TaskStatus {
+            state: next,
+            message,
+            timestamp: now,
+        };
+        self.updated_at = now;
+        Ok(())
+    }
+
+    /// Append a message to the history, enforcing the cap.
+    pub fn append_history(&mut self, message: Message) -> Result<(), TaskValidationError> {
+        if self.history.len() >= MAX_HISTORY_LEN {
+            return Err(TaskValidationError::HistoryFull);
+        }
+        message.validate()?;
+        self.history.push(message);
+        self.updated_at = Utc::now();
+        Ok(())
+    }
+
+    /// Append (or replace) an artifact. If an artifact with the same
+    /// `artifactId` already exists and the new one carries
+    /// `append = true`, its parts are appended to the existing one;
+    /// otherwise the existing artifact is replaced.
+    pub fn upsert_artifact(&mut self, artifact: Artifact) -> Result<(), TaskValidationError> {
+        artifact.validate()?;
+        match self
+            .artifacts
+            .iter_mut()
+            .find(|a| a.artifact_id == artifact.artifact_id)
+        {
+            Some(existing) if artifact.append => {
+                existing.parts.extend(artifact.parts);
+                existing.last_chunk = artifact.last_chunk;
+                if existing.parts.len() > MAX_PARTS_PER_CONTAINER {
+                    return Err(TaskValidationError::TooManyParts);
+                }
+            }
+            Some(existing) => {
+                *existing = artifact;
+            }
+            None => {
+                if self.artifacts.len() >= MAX_ARTIFACTS_LEN {
+                    return Err(TaskValidationError::TooManyArtifacts);
+                }
+                self.artifacts.push(artifact);
+            }
+        }
+        self.updated_at = Utc::now();
+        Ok(())
+    }
+
+    /// Validate identity, status, and all contained messages/artifacts.
+    pub fn validate(&self) -> Result<(), TaskValidationError> {
+        validate_id("id", &self.id)?;
+        validate_fragment("namespace", &self.namespace)?;
+        validate_fragment("tenant", &self.tenant)?;
+        if let Some(c) = &self.context_id {
+            validate_id("contextId", c)?;
+        }
+        self.status.validate()?;
+        if self.history.len() > MAX_HISTORY_LEN {
+            return Err(TaskValidationError::HistoryFull);
+        }
+        for m in &self.history {
+            m.validate()?;
+        }
+        if self.artifacts.len() > MAX_ARTIFACTS_LEN {
+            return Err(TaskValidationError::TooManyArtifacts);
+        }
+        for a in &self.artifacts {
+            a.validate()?;
+        }
+        validate_metadata(&self.metadata)?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------
+// Validation helpers & errors
+// ---------------------------------------------------------------------
+
+fn validate_id(field: &'static str, s: &str) -> Result<(), TaskValidationError> {
+    if s.is_empty() {
+        return Err(TaskValidationError::EmptyId(field));
+    }
+    if s.len() > MAX_ID_LEN {
+        return Err(TaskValidationError::IdTooLong(field));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err(TaskValidationError::InvalidIdChar {
+            field,
+            value: s.to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_fragment(field: &'static str, s: &str) -> Result<(), TaskValidationError> {
+    if s.is_empty() {
+        return Err(TaskValidationError::EmptyFragment(field));
+    }
+    if s.len() > 80 {
+        return Err(TaskValidationError::FragmentTooLong(field));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(TaskValidationError::InvalidFragmentChar {
+            field,
+            value: s.to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_metadata(map: &HashMap<String, serde_json::Value>) -> Result<(), TaskValidationError> {
+    for (k, v) in map {
+        if k.is_empty() {
+            return Err(TaskValidationError::EmptyMetadataKey);
+        }
+        let encoded = serde_json::to_vec(v).map_err(|_| TaskValidationError::MetadataInvalid)?;
+        if encoded.len() > MAX_METADATA_VALUE_BYTES {
+            return Err(TaskValidationError::MetadataValueTooLong { key: k.clone() });
+        }
+    }
+    Ok(())
+}
+
+/// Validation failures across the A2A task model.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum TaskValidationError {
+    #[error("{0} must not be empty")]
+    EmptyId(&'static str),
+    #[error("{0} exceeds 120 characters")]
+    IdTooLong(&'static str),
+    #[error("{field} '{value}' contains characters outside [a-zA-Z0-9._-]")]
+    InvalidIdChar { field: &'static str, value: String },
+    #[error("{0} must not be empty")]
+    EmptyFragment(&'static str),
+    #[error("{0} exceeds 80 characters")]
+    FragmentTooLong(&'static str),
+    #[error("{field} '{value}' contains characters outside [a-zA-Z0-9_-]")]
+    InvalidFragmentChar { field: &'static str, value: String },
+    #[error("part must set exactly one of text/raw/url/data; none were set")]
+    EmptyPart,
+    #[error("part must set exactly one of text/raw/url/data; multiple were set")]
+    AmbiguousPart,
+    #[error("part text exceeds the {MAX_PART_TEXT_BYTES}-byte cap")]
+    PartTextTooLong,
+    #[error("part raw exceeds the {MAX_PART_RAW_BYTES}-byte cap")]
+    PartRawTooLong,
+    #[error("part data exceeds the {MAX_PART_DATA_BYTES}-byte cap")]
+    PartDataTooLong,
+    #[error("part data is not serializable JSON")]
+    PartDataInvalid,
+    #[error("message must contain at least one part")]
+    MessageHasNoParts,
+    #[error("artifact must contain at least one part")]
+    ArtifactHasNoParts,
+    #[error("container exceeds the {MAX_PARTS_PER_CONTAINER}-part cap")]
+    TooManyParts,
+    #[error("task history exceeds the {MAX_HISTORY_LEN}-message cap")]
+    HistoryFull,
+    #[error("task artifacts exceed the {MAX_ARTIFACTS_LEN}-entry cap")]
+    TooManyArtifacts,
+    #[error("message references exceed the {MAX_REFERENCE_TASK_IDS}-id cap")]
+    TooManyReferenceTaskIds,
+    #[error("message extensions exceed the {MAX_MESSAGE_EXTENSIONS}-entry cap")]
+    TooManyExtensions,
+    #[error("metadata key must not be empty")]
+    EmptyMetadataKey,
+    #[error("metadata value for key '{key}' exceeds the {MAX_METADATA_VALUE_BYTES}-byte cap")]
+    MetadataValueTooLong { key: String },
+    #[error("metadata value is not serializable JSON")]
+    MetadataInvalid,
+    #[error("illegal transition from {from:?} to {to:?}")]
+    IllegalTransition { from: TaskState, to: TaskState },
+}
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // --- TaskState classification ---
+
+    #[test]
+    fn terminal_states_classified() {
+        for s in [
+            TaskState::Completed,
+            TaskState::Failed,
+            TaskState::Canceled,
+            TaskState::Rejected,
+        ] {
+            assert!(s.is_terminal(), "{s:?} should be terminal");
+            assert!(!s.is_in_progress(), "{s:?} should not be in_progress");
+            assert!(!s.is_interrupt(), "{s:?} should not be interrupt");
+        }
+    }
+
+    #[test]
+    fn interrupt_states_classified() {
+        for s in [TaskState::InputRequired, TaskState::AuthRequired] {
+            assert!(s.is_interrupt(), "{s:?} should be interrupt");
+            assert!(!s.is_terminal(), "{s:?} should not be terminal");
+            assert!(s.is_in_progress(), "{s:?} should be in_progress");
+        }
+    }
+
+    #[test]
+    fn in_progress_states_classified() {
+        for s in [TaskState::Submitted, TaskState::Working] {
+            assert!(s.is_in_progress());
+            assert!(!s.is_terminal());
+            assert!(!s.is_interrupt());
+        }
+    }
+
+    // --- Transitions ---
+
+    #[test]
+    fn submitted_can_go_to_working() {
+        assert!(TaskState::Submitted.can_transition_to(TaskState::Working));
+    }
+
+    #[test]
+    fn submitted_can_be_rejected_directly() {
+        assert!(TaskState::Submitted.can_transition_to(TaskState::Rejected));
+    }
+
+    #[test]
+    fn submitted_cannot_complete_directly() {
+        assert!(!TaskState::Submitted.can_transition_to(TaskState::Completed));
+    }
+
+    #[test]
+    fn working_can_interrupt() {
+        assert!(TaskState::Working.can_transition_to(TaskState::InputRequired));
+        assert!(TaskState::Working.can_transition_to(TaskState::AuthRequired));
+    }
+
+    #[test]
+    fn working_can_complete_fail_cancel() {
+        for next in [TaskState::Completed, TaskState::Failed, TaskState::Canceled] {
+            assert!(TaskState::Working.can_transition_to(next));
+        }
+    }
+
+    #[test]
+    fn interrupts_resume_to_working() {
+        for from in [TaskState::InputRequired, TaskState::AuthRequired] {
+            assert!(from.can_transition_to(TaskState::Working));
+        }
+    }
+
+    #[test]
+    fn interrupts_cannot_complete_directly() {
+        for from in [TaskState::InputRequired, TaskState::AuthRequired] {
+            assert!(!from.can_transition_to(TaskState::Completed));
+        }
+    }
+
+    #[test]
+    fn interrupts_cannot_be_rejected() {
+        for from in [TaskState::InputRequired, TaskState::AuthRequired] {
+            assert!(!from.can_transition_to(TaskState::Rejected));
+        }
+    }
+
+    #[test]
+    fn terminal_states_have_no_transitions() {
+        for from in [
+            TaskState::Completed,
+            TaskState::Failed,
+            TaskState::Canceled,
+            TaskState::Rejected,
+        ] {
+            for to in [
+                TaskState::Submitted,
+                TaskState::Working,
+                TaskState::Completed,
+                TaskState::Failed,
+                TaskState::Canceled,
+                TaskState::InputRequired,
+                TaskState::AuthRequired,
+                TaskState::Rejected,
+            ] {
+                assert!(
+                    !from.can_transition_to(to),
+                    "{from:?} should be terminal but allowed transition to {to:?}"
+                );
+            }
+        }
+    }
+
+    // --- Part ---
+
+    #[test]
+    fn part_text_validates() {
+        Part::text("hello").validate().unwrap();
+    }
+
+    #[test]
+    fn part_data_validates() {
+        Part::data(json!({"k": "v"})).validate().unwrap();
+    }
+
+    #[test]
+    fn part_url_validates() {
+        Part::url("https://example.com/doc.pdf").validate().unwrap();
+    }
+
+    #[test]
+    fn part_rejects_empty() {
+        let p = Part::default();
+        assert_eq!(p.validate(), Err(TaskValidationError::EmptyPart));
+    }
+
+    #[test]
+    fn part_rejects_ambiguous() {
+        let mut p = Part::text("hello");
+        p.url = Some("https://example.com".into());
+        assert_eq!(p.validate(), Err(TaskValidationError::AmbiguousPart));
+    }
+
+    #[test]
+    fn part_text_capped() {
+        let mut p = Part::text("x");
+        p.text = Some("x".repeat(MAX_PART_TEXT_BYTES + 1));
+        assert_eq!(p.validate(), Err(TaskValidationError::PartTextTooLong));
+    }
+
+    #[test]
+    fn part_raw_capped() {
+        let mut p = Part::raw_base64("Zg==");
+        p.raw = Some("x".repeat(MAX_PART_RAW_BYTES + 1));
+        assert_eq!(p.validate(), Err(TaskValidationError::PartRawTooLong));
+    }
+
+    // --- Message ---
+
+    #[test]
+    fn message_text_validates() {
+        Message::text("msg-1", Role::User, "hi").validate().unwrap();
+    }
+
+    #[test]
+    fn message_rejects_empty_parts() {
+        let mut m = Message::text("msg-1", Role::User, "hi");
+        m.parts.clear();
+        assert_eq!(m.validate(), Err(TaskValidationError::MessageHasNoParts));
+    }
+
+    #[test]
+    fn message_rejects_too_many_parts() {
+        let mut m = Message::text("msg-1", Role::User, "hi");
+        for _ in 0..MAX_PARTS_PER_CONTAINER {
+            m.parts.push(Part::text("p"));
+        }
+        assert_eq!(m.validate(), Err(TaskValidationError::TooManyParts));
+    }
+
+    #[test]
+    fn message_validates_reference_task_ids() {
+        let mut m = Message::text("msg-1", Role::User, "hi");
+        m.reference_task_ids = vec!["task-1".into(), "bad/id".into()];
+        assert!(matches!(
+            m.validate(),
+            Err(TaskValidationError::InvalidIdChar {
+                field: "referenceTaskIds",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn message_caps_reference_task_ids() {
+        let mut m = Message::text("msg-1", Role::User, "hi");
+        m.reference_task_ids = (0..=MAX_REFERENCE_TASK_IDS)
+            .map(|i| format!("task-{i}"))
+            .collect();
+        assert_eq!(
+            m.validate(),
+            Err(TaskValidationError::TooManyReferenceTaskIds)
+        );
+    }
+
+    // --- Artifact ---
+
+    #[test]
+    fn artifact_validates() {
+        Artifact::new("art-1", vec![Part::text("done")])
+            .validate()
+            .unwrap();
+    }
+
+    #[test]
+    fn artifact_rejects_empty_parts() {
+        let a = Artifact::new("art-1", vec![]);
+        assert_eq!(a.validate(), Err(TaskValidationError::ArtifactHasNoParts));
+    }
+
+    // --- Task transitions ---
+
+    fn sample_task() -> Task {
+        Task::new("task-1", "agents", "demo")
+    }
+
+    #[test]
+    fn task_starts_in_submitted() {
+        let t = sample_task();
+        assert_eq!(t.status.state, TaskState::Submitted);
+        t.validate().unwrap();
+    }
+
+    #[test]
+    fn task_legal_happy_path() {
+        let mut t = sample_task();
+        t.transition_to(TaskState::Working, None).unwrap();
+        t.transition_to(TaskState::Completed, None).unwrap();
+        assert_eq!(t.status.state, TaskState::Completed);
+        assert!(t.status.state.is_terminal());
+    }
+
+    #[test]
+    fn task_interrupt_then_resume() {
+        let mut t = sample_task();
+        t.transition_to(TaskState::Working, None).unwrap();
+        t.transition_to(TaskState::InputRequired, None).unwrap();
+        t.transition_to(TaskState::Working, None).unwrap();
+        t.transition_to(TaskState::Completed, None).unwrap();
+    }
+
+    #[test]
+    fn task_rejects_illegal_transition() {
+        let mut t = sample_task();
+        let err = t.transition_to(TaskState::Completed, None).unwrap_err();
+        assert!(matches!(
+            err,
+            TaskValidationError::IllegalTransition {
+                from: TaskState::Submitted,
+                to: TaskState::Completed,
+            }
+        ));
+    }
+
+    #[test]
+    fn task_cannot_resurrect_after_terminal() {
+        let mut t = sample_task();
+        t.transition_to(TaskState::Working, None).unwrap();
+        t.transition_to(TaskState::Completed, None).unwrap();
+        assert!(t.transition_to(TaskState::Working, None).is_err());
+    }
+
+    #[test]
+    fn task_status_message_validated_on_transition() {
+        let mut t = sample_task();
+        let mut bad = Message::text("msg-1", Role::Agent, "x");
+        bad.parts.clear();
+        let err = t.transition_to(TaskState::Working, Some(bad)).unwrap_err();
+        assert_eq!(err, TaskValidationError::MessageHasNoParts);
+        // State must not have changed.
+        assert_eq!(t.status.state, TaskState::Submitted);
+    }
+
+    #[test]
+    fn task_append_history_caps() {
+        let mut t = sample_task();
+        // Fill to the cap.
+        for i in 0..MAX_HISTORY_LEN {
+            t.append_history(Message::text(format!("m-{i}"), Role::User, "x"))
+                .unwrap();
+        }
+        // One more should fail.
+        let err = t
+            .append_history(Message::text("overflow", Role::User, "x"))
+            .unwrap_err();
+        assert_eq!(err, TaskValidationError::HistoryFull);
+    }
+
+    #[test]
+    fn task_upsert_artifact_replaces_when_not_appending() {
+        let mut t = sample_task();
+        t.upsert_artifact(Artifact::new("art-1", vec![Part::text("first")]))
+            .unwrap();
+        t.upsert_artifact(Artifact::new("art-1", vec![Part::text("second")]))
+            .unwrap();
+        assert_eq!(t.artifacts.len(), 1);
+        assert_eq!(t.artifacts[0].parts[0].text.as_deref(), Some("second"));
+    }
+
+    #[test]
+    fn task_upsert_artifact_appends() {
+        let mut t = sample_task();
+        let mut first = Artifact::new("art-1", vec![Part::text("a")]);
+        first.last_chunk = false;
+        t.upsert_artifact(first).unwrap();
+
+        let mut second = Artifact::new("art-1", vec![Part::text("b")]);
+        second.append = true;
+        second.last_chunk = true;
+        t.upsert_artifact(second).unwrap();
+
+        assert_eq!(t.artifacts.len(), 1);
+        assert_eq!(t.artifacts[0].parts.len(), 2);
+        assert!(t.artifacts[0].last_chunk);
+    }
+
+    #[test]
+    fn task_upsert_artifact_caps_count() {
+        let mut t = sample_task();
+        for i in 0..MAX_ARTIFACTS_LEN {
+            t.upsert_artifact(Artifact::new(format!("art-{i}"), vec![Part::text("x")]))
+                .unwrap();
+        }
+        let err = t
+            .upsert_artifact(Artifact::new("overflow", vec![Part::text("x")]))
+            .unwrap_err();
+        assert_eq!(err, TaskValidationError::TooManyArtifacts);
+    }
+
+    #[test]
+    fn task_validate_rejects_bad_namespace() {
+        let mut t = sample_task();
+        t.namespace = "bad/ns".into();
+        assert!(matches!(
+            t.validate(),
+            Err(TaskValidationError::InvalidFragmentChar {
+                field: "namespace",
+                ..
+            })
+        ));
+    }
+
+    // --- Wire format ---
+
+    #[test]
+    fn task_serializes_camel_case() {
+        let mut t = sample_task();
+        t.context_id = Some("ctx-1".into());
+        let v = serde_json::to_value(&t).unwrap();
+        // Top-level Acteon and A2A fields are camelCase.
+        assert!(v.get("contextId").is_some(), "contextId missing: {v}");
+        assert!(v.get("createdAt").is_some(), "createdAt missing: {v}");
+        assert!(v.get("updatedAt").is_some(), "updatedAt missing: {v}");
+        // status nested object is also camelCase.
+        let status = v.get("status").unwrap();
+        assert!(status.get("state").is_some());
+        assert!(status.get("timestamp").is_some());
+    }
+
+    #[test]
+    fn message_serializes_camel_case() {
+        let mut m = Message::text("msg-1", Role::Agent, "hi");
+        m.context_id = Some("ctx".into());
+        m.task_id = Some("task".into());
+        m.reference_task_ids = vec!["t-1".into()];
+        let v = serde_json::to_value(&m).unwrap();
+        assert!(v.get("messageId").is_some());
+        assert!(v.get("contextId").is_some());
+        assert!(v.get("taskId").is_some());
+        assert!(v.get("referenceTaskIds").is_some());
+    }
+
+    #[test]
+    fn role_serializes_snake_case() {
+        assert_eq!(serde_json::to_value(Role::User).unwrap(), json!("user"));
+        assert_eq!(serde_json::to_value(Role::Agent).unwrap(), json!("agent"));
+    }
+
+    #[test]
+    fn task_state_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_value(TaskState::InputRequired).unwrap(),
+            json!("input_required"),
+        );
+        assert_eq!(
+            serde_json::to_value(TaskState::AuthRequired).unwrap(),
+            json!("auth_required"),
+        );
+    }
+
+    #[test]
+    fn task_roundtrip_serde() {
+        let mut t = sample_task();
+        t.transition_to(TaskState::Working, None).unwrap();
+        t.append_history(Message::text("msg-1", Role::User, "hi"))
+            .unwrap();
+        t.upsert_artifact(Artifact::new("art-1", vec![Part::data(json!({"k": 1}))]))
+            .unwrap();
+        let j = serde_json::to_string(&t).unwrap();
+        let back: Task = serde_json::from_str(&j).unwrap();
+        assert_eq!(back.id, t.id);
+        assert_eq!(back.status.state, TaskState::Working);
+        assert_eq!(back.history.len(), 1);
+        assert_eq!(back.artifacts.len(), 1);
+    }
+}

--- a/crates/core/src/bus_task.rs
+++ b/crates/core/src/bus_task.rs
@@ -160,12 +160,13 @@ impl TaskState {
         use TaskState::{
             AuthRequired, Canceled, Completed, Failed, InputRequired, Rejected, Submitted, Working,
         };
-        matches!(
-            (self, next),
-            (Submitted, Working | Canceled | Failed | Rejected)
-                | (Working, Completed | Failed | Canceled | InputRequired | AuthRequired)
-                | (InputRequired | AuthRequired, Working | Canceled | Failed)
-        )
+        let allowed: &[TaskState] = match self {
+            Submitted => &[Working, Canceled, Failed, Rejected],
+            Working => &[Completed, Failed, Canceled, InputRequired, AuthRequired],
+            InputRequired | AuthRequired => &[Working, Canceled, Failed],
+            Completed | Failed | Canceled | Rejected => &[],
+        };
+        allowed.contains(&next)
     }
 }
 

--- a/crates/core/src/bus_task.rs
+++ b/crates/core/src/bus_task.rs
@@ -457,27 +457,17 @@ impl Message {
 // Artifact
 // ---------------------------------------------------------------------
 
-/// A discrete output produced by the agent, possibly streamed in
-/// chunks. `append` and `lastChunk` enable progressive delivery: a
-/// stream of artifact-update events with the same `artifactId`, the
-/// first carrying `append = false` (replace) and subsequent ones
-/// `append = true` (append). The final chunk sets `lastChunk = true`.
+/// A discrete output produced by the agent. Per A2A spec §4.1.1 an
+/// Artifact is the *resolved* content — identity, name, parts.
 ///
-/// **Race safety (Acteon extension):** A2A spec is silent on
-/// out-of-order chunk delivery. To prevent the consumer from closing
-/// a Task before a late append arrives, Acteon adds two optional
-/// fields beyond the A2A wire shape:
-///
-/// - `chunkIndex` — monotonic sequence within the artifact (mirrors
-///   `StreamChunk.chunk_seq` from Phase 6b).
-/// - `totalChunks` — set on the `lastChunk` envelope to assert how
-///   many chunks the consumer must observe before treating the
-///   artifact as complete.
-///
-/// The Phase 2 Task Engine enforces: chunk indices are non-negative,
-/// no chunks arrive after `lastChunk = true`, and (when
-/// `totalChunks` is set) every index in `0..totalChunks` is observed
-/// before the artifact is closed.
+/// The per-delivery semantics (replace-vs-append, terminal marker,
+/// chunk sequencing) live on
+/// [`crate::bus_stream::TaskArtifactUpdateEvent`], which is the
+/// envelope that streams Artifacts in chunks. The Phase 2 Task
+/// Engine consumes those events, applies the append/replace
+/// directive against the Task's stored artifact list, and enforces
+/// race-safety invariants (`chunkIndex` ordering, `totalChunks`
+/// completeness).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -492,25 +482,9 @@ pub struct Artifact {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Content parts. For a single-shot artifact this is the full
-    /// content; for streamed artifacts each chunk delivers its slice.
+    /// content; for a chunk delivery, this is the slice carried by
+    /// that one event.
     pub parts: Vec<Part>,
-    /// True if this update should be appended to the prior content
-    /// for this `artifactId`; false (default) means replace.
-    #[serde(default)]
-    pub append: bool,
-    /// True if this is the final chunk for the artifact. Consumers
-    /// can mark the artifact as complete once observed.
-    #[serde(default)]
-    pub last_chunk: bool,
-    /// Monotonic sequence number within this artifact's chunk stream.
-    /// Acteon extension beyond A2A spec; see struct-level docs.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub chunk_index: Option<i64>,
-    /// Total number of chunks expected for this artifact, set on the
-    /// `lastChunk = true` envelope so consumers can validate
-    /// completeness. Acteon extension; see struct-level docs.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub total_chunks: Option<i64>,
     /// Free-form metadata.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     #[cfg_attr(feature = "openapi", schema(value_type = Object))]
@@ -518,7 +492,7 @@ pub struct Artifact {
 }
 
 impl Artifact {
-    /// Construct a single-shot artifact with one or more parts.
+    /// Construct an artifact with one or more parts.
     #[must_use]
     pub fn new(artifact_id: impl Into<String>, parts: Vec<Part>) -> Self {
         Self {
@@ -526,16 +500,11 @@ impl Artifact {
             name: None,
             description: None,
             parts,
-            append: false,
-            last_chunk: true,
-            chunk_index: None,
-            total_chunks: None,
             metadata: HashMap::new(),
         }
     }
 
-    /// Validate identity, bounded fields, and chunk sequencing
-    /// invariants (non-negative `chunkIndex`, positive `totalChunks`).
+    /// Validate identity and bounded fields.
     pub fn validate(&self) -> Result<(), TaskValidationError> {
         validate_id("artifactId", &self.artifact_id)?;
         if self.parts.is_empty() {
@@ -546,27 +515,6 @@ impl Artifact {
         }
         for p in &self.parts {
             p.validate()?;
-        }
-        if let Some(ix) = self.chunk_index
-            && ix < 0
-        {
-            return Err(TaskValidationError::NegativeChunkIndex(ix));
-        }
-        if let Some(t) = self.total_chunks
-            && t <= 0
-        {
-            return Err(TaskValidationError::InvalidTotalChunks(t));
-        }
-        // If a chunk advertises `totalChunks`, its own index must fit
-        // inside the asserted range — otherwise a consumer that trusts
-        // the cap will hang waiting for an index that can never arrive.
-        if let (Some(ix), Some(t)) = (self.chunk_index, self.total_chunks)
-            && ix >= t
-        {
-            return Err(TaskValidationError::ChunkIndexOutOfRange {
-                index: ix,
-                total: t,
-            });
         }
         validate_metadata(&self.metadata)?;
         Ok(())
@@ -771,21 +719,31 @@ impl Task {
         Ok(())
     }
 
-    /// Append (or replace) an artifact. If an artifact with the same
-    /// `artifactId` already exists and the new one carries
-    /// `append = true`, its parts are appended to the existing one;
-    /// otherwise the existing artifact is replaced. Counts as forward
-    /// progress.
-    pub fn upsert_artifact(&mut self, artifact: Artifact) -> Result<(), TaskValidationError> {
+    /// Append (or replace) an artifact, mirroring A2A
+    /// `TaskArtifactUpdateEvent` semantics:
+    ///
+    /// - `append = true`: if an artifact with the same `artifactId`
+    ///   already exists, append the new artifact's `parts` to the
+    ///   existing one (preserves name/description/metadata of the
+    ///   existing artifact). If no existing entry, the call is
+    ///   treated as a first insertion.
+    /// - `append = false`: insert if new, replace if an existing
+    ///   artifact with the same id is present.
+    ///
+    /// Counts as forward progress.
+    pub fn upsert_artifact(
+        &mut self,
+        artifact: Artifact,
+        append: bool,
+    ) -> Result<(), TaskValidationError> {
         artifact.validate()?;
         match self
             .artifacts
             .iter_mut()
             .find(|a| a.artifact_id == artifact.artifact_id)
         {
-            Some(existing) if artifact.append => {
+            Some(existing) if append => {
                 existing.parts.extend(artifact.parts);
-                existing.last_chunk = artifact.last_chunk;
                 if existing.parts.len() > MAX_PARTS_PER_CONTAINER {
                     return Err(TaskValidationError::TooManyParts);
                 }
@@ -990,16 +948,21 @@ pub enum TaskValidationError {
     IllegalTransition { from: TaskState, to: TaskState },
     #[error("message taskId '{0}' must not appear in its own referenceTaskIds (self-cycle)")]
     SelfReferenceTaskId(String),
+    #[error("workingTtlMs must be > 0 (got {0})")]
+    WorkingTtlNonPositive(i64),
+    #[error("workingTtlMs {0} exceeds the {MAX_WORKING_TTL_MS}ms cap")]
+    WorkingTtlTooLong(i64),
+    // Used by `crate::bus_stream::TaskArtifactUpdateEvent`. Kept in
+    // this error type so the Engine can match on a single error
+    // surface across task and event validation.
     #[error("chunkIndex must be non-negative (got {0})")]
     NegativeChunkIndex(i64),
     #[error("totalChunks must be positive (got {0})")]
     InvalidTotalChunks(i64),
     #[error("chunkIndex {index} is outside the asserted totalChunks range (0..{total})")]
     ChunkIndexOutOfRange { index: i64, total: i64 },
-    #[error("workingTtlMs must be > 0 (got {0})")]
-    WorkingTtlNonPositive(i64),
-    #[error("workingTtlMs {0} exceeds the {MAX_WORKING_TTL_MS}ms cap")]
-    WorkingTtlTooLong(i64),
+    #[error("append=true on chunk 0 would silently overwrite prior content")]
+    AppendOnFirstChunk,
 }
 
 // ---------------------------------------------------------------------
@@ -1310,9 +1273,9 @@ mod tests {
     #[test]
     fn task_upsert_artifact_replaces_when_not_appending() {
         let mut t = sample_task();
-        t.upsert_artifact(Artifact::new("art-1", vec![Part::text("first")]))
+        t.upsert_artifact(Artifact::new("art-1", vec![Part::text("first")]), false)
             .unwrap();
-        t.upsert_artifact(Artifact::new("art-1", vec![Part::text("second")]))
+        t.upsert_artifact(Artifact::new("art-1", vec![Part::text("second")]), false)
             .unwrap();
         assert_eq!(t.artifacts.len(), 1);
         assert_eq!(t.artifacts[0].parts[0].text.as_deref(), Some("second"));
@@ -1321,29 +1284,26 @@ mod tests {
     #[test]
     fn task_upsert_artifact_appends() {
         let mut t = sample_task();
-        let mut first = Artifact::new("art-1", vec![Part::text("a")]);
-        first.last_chunk = false;
-        t.upsert_artifact(first).unwrap();
-
-        let mut second = Artifact::new("art-1", vec![Part::text("b")]);
-        second.append = true;
-        second.last_chunk = true;
-        t.upsert_artifact(second).unwrap();
-
+        t.upsert_artifact(Artifact::new("art-1", vec![Part::text("a")]), false)
+            .unwrap();
+        t.upsert_artifact(Artifact::new("art-1", vec![Part::text("b")]), true)
+            .unwrap();
         assert_eq!(t.artifacts.len(), 1);
         assert_eq!(t.artifacts[0].parts.len(), 2);
-        assert!(t.artifacts[0].last_chunk);
     }
 
     #[test]
     fn task_upsert_artifact_caps_count() {
         let mut t = sample_task();
         for i in 0..MAX_ARTIFACTS_LEN {
-            t.upsert_artifact(Artifact::new(format!("art-{i}"), vec![Part::text("x")]))
-                .unwrap();
+            t.upsert_artifact(
+                Artifact::new(format!("art-{i}"), vec![Part::text("x")]),
+                false,
+            )
+            .unwrap();
         }
         let err = t
-            .upsert_artifact(Artifact::new("overflow", vec![Part::text("x")]))
+            .upsert_artifact(Artifact::new("overflow", vec![Part::text("x")]), false)
             .unwrap_err();
         assert_eq!(err, TaskValidationError::TooManyArtifacts);
     }
@@ -1415,8 +1375,11 @@ mod tests {
         t.transition_to(TaskState::Working, None).unwrap();
         t.append_history(Message::text("msg-1", Role::User, "hi"))
             .unwrap();
-        t.upsert_artifact(Artifact::new("art-1", vec![Part::data(json!({"k": 1}))]))
-            .unwrap();
+        t.upsert_artifact(
+            Artifact::new("art-1", vec![Part::data(json!({"k": 1}))]),
+            false,
+        )
+        .unwrap();
         let j = serde_json::to_string(&t).unwrap();
         let back: Task = serde_json::from_str(&j).unwrap();
         assert_eq!(back.id, t.id);
@@ -1469,7 +1432,7 @@ mod tests {
         let mut t = sample_task();
         let before = t.last_progress_at.unwrap();
         std::thread::sleep(std::time::Duration::from_millis(5));
-        t.upsert_artifact(Artifact::new("art-1", vec![Part::text("x")]))
+        t.upsert_artifact(Artifact::new("art-1", vec![Part::text("x")]), false)
             .unwrap();
         assert!(t.last_progress_at.unwrap() > before);
     }
@@ -1535,46 +1498,9 @@ mod tests {
         ));
     }
 
-    // --- Hardening: artifact chunk sequencing ---
-
-    #[test]
-    fn artifact_chunk_index_must_be_non_negative() {
-        let mut a = Artifact::new("art-1", vec![Part::text("x")]);
-        a.chunk_index = Some(-1);
-        assert!(matches!(
-            a.validate(),
-            Err(TaskValidationError::NegativeChunkIndex(-1))
-        ));
-    }
-
-    #[test]
-    fn artifact_total_chunks_must_be_positive() {
-        let mut a = Artifact::new("art-1", vec![Part::text("x")]);
-        a.total_chunks = Some(0);
-        assert!(matches!(
-            a.validate(),
-            Err(TaskValidationError::InvalidTotalChunks(0))
-        ));
-    }
-
-    #[test]
-    fn artifact_chunk_index_must_fit_total_range() {
-        let mut a = Artifact::new("art-1", vec![Part::text("x")]);
-        a.chunk_index = Some(5);
-        a.total_chunks = Some(5);
-        assert!(matches!(
-            a.validate(),
-            Err(TaskValidationError::ChunkIndexOutOfRange { index: 5, total: 5 })
-        ));
-    }
-
-    #[test]
-    fn artifact_with_valid_chunk_metadata_passes() {
-        let mut a = Artifact::new("art-1", vec![Part::text("x")]);
-        a.chunk_index = Some(2);
-        a.total_chunks = Some(5);
-        a.validate().unwrap();
-    }
+    // (chunk sequencing tests live in `bus_stream::tests` since
+    // `chunkIndex` / `totalChunks` are properties of the
+    // `TaskArtifactUpdateEvent` envelope, not the Artifact itself.)
 
     // --- Hardening: message self-reference ---
 

--- a/crates/core/src/bus_task.rs
+++ b/crates/core/src/bus_task.rs
@@ -51,18 +51,23 @@ use serde::{Deserialize, Serialize};
 /// and Kafka headers.
 pub const MAX_ID_LEN: usize = 120;
 
-/// Max characters in a `Part::text` field. Matches the existing
-/// publish-edge content cap so an oversized text part can't bypass
-/// the bus's content limits by riding inside a Task.
-pub const MAX_PART_TEXT_BYTES: usize = 512 * 1024; // 512KB
+/// Max characters in a `Part::text` field. A2A messages are
+/// primarily text exchanges between agents — 256KB (~64K tokens) is
+/// plenty for prose without giving a malicious caller room to
+/// inflate Kafka records. Larger payloads must use `Part::url` to
+/// reference an external store.
+pub const MAX_PART_TEXT_BYTES: usize = 256 * 1024;
 
-/// Max `base64` length of a `Part::raw` payload. The 1MB cap aligns
-/// with the existing bus payload tier; chunked artifacts are the
-/// supported pattern for outputs larger than this.
-pub const MAX_PART_RAW_BYTES: usize = 1024 * 1024; // 1MB (base64)
+/// Max `base64` length of a `Part::raw` payload. Same 256KB cap as
+/// `text`: small binaries inline (icons, thumbnails), large binaries
+/// by reference via `url`. The `acteon-blob` crate was removed in an
+/// earlier refactor, so external object stores (S3, GCS, etc.) are
+/// the supported escape hatch.
+pub const MAX_PART_RAW_BYTES: usize = 256 * 1024;
 
-/// Max bytes for a serialized `Part::data` JSON value.
-pub const MAX_PART_DATA_BYTES: usize = 1024 * 1024; // 1MB
+/// Max bytes for a serialized `Part::data` JSON value. Same 256KB
+/// tier as `text` / `raw`.
+pub const MAX_PART_DATA_BYTES: usize = 256 * 1024;
 
 /// Max history length on a [`Task`]. A2A's `historyLength` query
 /// parameter is the client-facing way to bound this on the wire; the
@@ -84,6 +89,27 @@ pub const MAX_REFERENCE_TASK_IDS: usize = 32;
 
 /// Max number of `extensions` entries on a [`Message`].
 pub const MAX_MESSAGE_EXTENSIONS: usize = 32;
+
+/// Max depth of Task → Task references the Task Engine is allowed to
+/// traverse before declaring a cycle. `Task` is structurally flat
+/// (references are `Vec<String>` IDs, never nested objects), so the
+/// serializer is safe; the landmine is the *graph* across rows. The
+/// Engine (Phase 2) reads this constant when resolving reference
+/// graphs and rejects anything deeper.
+pub const MAX_REFERENCE_DEPTH: usize = 5;
+
+/// Default time-to-live for a Task sitting in a non-terminal state
+/// without progress. Mirrors the `Agent.status_at()` pattern from
+/// `bus_agent.rs` — staleness is *derived* on read from
+/// `last_progress_at + working_ttl_ms`, so the read path remains
+/// correct even if a background reaper is lagging. 30 minutes is a
+/// sensible default for tasks backed by chains; tune per-task via
+/// [`Task::with_working_ttl`].
+pub const DEFAULT_WORKING_TTL_MS: i64 = 30 * 60 * 1_000;
+
+/// Hard cap on `working_ttl_ms`. A never-expiring Task is a memory
+/// leak waiting to happen.
+pub const MAX_WORKING_TTL_MS: i64 = 7 * 24 * 60 * 60 * 1_000; // 7d
 
 // ---------------------------------------------------------------------
 // TaskState
@@ -367,8 +393,28 @@ impl Message {
         }
     }
 
-    /// Validate identity, bounded fields, and each part.
+    /// Validate identity, bounded fields, and each part. Also
+    /// rejects the simplest cycle: a message whose `taskId` appears
+    /// in its own `referenceTaskIds`. Cycle detection across multiple
+    /// Task rows is the Phase 2 Engine's responsibility (it walks the
+    /// graph with a [`MAX_REFERENCE_DEPTH`] cap).
     pub fn validate(&self) -> Result<(), TaskValidationError> {
+        self.validate_against_parent(None)
+    }
+
+    /// Like [`Message::validate`] but also rejects self-reference
+    /// against an externally-supplied parent task ID. Used by
+    /// [`Task::validate`] so a message that lives inside Task `T`
+    /// can't list `T` in `referenceTaskIds` (the trivial 1-hop
+    /// cycle).
+    pub fn validate_in_task(&self, parent_task_id: &str) -> Result<(), TaskValidationError> {
+        self.validate_against_parent(Some(parent_task_id))
+    }
+
+    fn validate_against_parent(
+        &self,
+        parent_task_id: Option<&str>,
+    ) -> Result<(), TaskValidationError> {
         validate_id("messageId", &self.message_id)?;
         if let Some(c) = &self.context_id {
             validate_id("contextId", c)?;
@@ -391,6 +437,14 @@ impl Message {
         for r in &self.reference_task_ids {
             validate_id("referenceTaskIds", r)?;
         }
+        // Trivial 1-hop cycle: message's own task references itself.
+        // The Phase 2 Engine does multi-hop detection.
+        let self_id = parent_task_id.or(self.task_id.as_deref());
+        if let Some(sid) = self_id
+            && self.reference_task_ids.iter().any(|r| r == sid)
+        {
+            return Err(TaskValidationError::SelfReferenceTaskId(sid.to_string()));
+        }
         if self.extensions.len() > MAX_MESSAGE_EXTENSIONS {
             return Err(TaskValidationError::TooManyExtensions);
         }
@@ -408,6 +462,22 @@ impl Message {
 /// stream of artifact-update events with the same `artifactId`, the
 /// first carrying `append = false` (replace) and subsequent ones
 /// `append = true` (append). The final chunk sets `lastChunk = true`.
+///
+/// **Race safety (Acteon extension):** A2A spec is silent on
+/// out-of-order chunk delivery. To prevent the consumer from closing
+/// a Task before a late append arrives, Acteon adds two optional
+/// fields beyond the A2A wire shape:
+///
+/// - `chunkIndex` — monotonic sequence within the artifact (mirrors
+///   `StreamChunk.chunk_seq` from Phase 6b).
+/// - `totalChunks` — set on the `lastChunk` envelope to assert how
+///   many chunks the consumer must observe before treating the
+///   artifact as complete.
+///
+/// The Phase 2 Task Engine enforces: chunk indices are non-negative,
+/// no chunks arrive after `lastChunk = true`, and (when
+/// `totalChunks` is set) every index in `0..totalChunks` is observed
+/// before the artifact is closed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -432,6 +502,15 @@ pub struct Artifact {
     /// can mark the artifact as complete once observed.
     #[serde(default)]
     pub last_chunk: bool,
+    /// Monotonic sequence number within this artifact's chunk stream.
+    /// Acteon extension beyond A2A spec; see struct-level docs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chunk_index: Option<i64>,
+    /// Total number of chunks expected for this artifact, set on the
+    /// `lastChunk = true` envelope so consumers can validate
+    /// completeness. Acteon extension; see struct-level docs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_chunks: Option<i64>,
     /// Free-form metadata.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     #[cfg_attr(feature = "openapi", schema(value_type = Object))]
@@ -449,11 +528,14 @@ impl Artifact {
             parts,
             append: false,
             last_chunk: true,
+            chunk_index: None,
+            total_chunks: None,
             metadata: HashMap::new(),
         }
     }
 
-    /// Validate identity and bounded fields.
+    /// Validate identity, bounded fields, and chunk sequencing
+    /// invariants (non-negative `chunkIndex`, positive `totalChunks`).
     pub fn validate(&self) -> Result<(), TaskValidationError> {
         validate_id("artifactId", &self.artifact_id)?;
         if self.parts.is_empty() {
@@ -464,6 +546,27 @@ impl Artifact {
         }
         for p in &self.parts {
             p.validate()?;
+        }
+        if let Some(ix) = self.chunk_index
+            && ix < 0
+        {
+            return Err(TaskValidationError::NegativeChunkIndex(ix));
+        }
+        if let Some(t) = self.total_chunks
+            && t <= 0
+        {
+            return Err(TaskValidationError::InvalidTotalChunks(t));
+        }
+        // If a chunk advertises `totalChunks`, its own index must fit
+        // inside the asserted range — otherwise a consumer that trusts
+        // the cap will hang waiting for an index that can never arrive.
+        if let (Some(ix), Some(t)) = (self.chunk_index, self.total_chunks)
+            && ix >= t
+        {
+            return Err(TaskValidationError::ChunkIndexOutOfRange {
+                index: ix,
+                total: t,
+            });
         }
         validate_metadata(&self.metadata)?;
         Ok(())
@@ -517,6 +620,15 @@ impl TaskStatus {
 /// An A2A task — the canonical unit of asynchronous work observable
 /// to external callers. Lives at `KeyKind::A2aTask` (added in Phase 2)
 /// keyed by `(namespace, tenant, task_id)`.
+///
+/// Staleness: a Task that sits in a non-terminal state without
+/// progress is a zombie. [`Task::is_stale_at`] derives staleness from
+/// `last_progress_at + working_ttl_ms` on read; the Phase 2 reaper
+/// transitions stale tasks to `Failed`. `last_progress_at` is
+/// bumped on every mutating operation
+/// ([`Task::transition_to`], [`Task::append_history`],
+/// [`Task::upsert_artifact`]) and on explicit
+/// [`Task::record_progress`] heartbeats.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -551,6 +663,32 @@ pub struct Task {
     pub created_at: DateTime<Utc>,
     /// Last mutation timestamp.
     pub updated_at: DateTime<Utc>,
+    /// Last time the task observed *forward progress* (state
+    /// transition, history append, artifact update, explicit
+    /// heartbeat). Distinct from `updated_at` so that purely
+    /// administrative writes (e.g. metadata-only mutations from an
+    /// operator) don't reset the staleness clock.
+    #[serde(default)]
+    pub last_progress_at: Option<DateTime<Utc>>,
+    /// Time-to-live in milliseconds for non-terminal states without
+    /// progress. Once `now > last_progress_at + working_ttl_ms`, the
+    /// task is considered stale ([`Task::is_stale_at`] returns `true`)
+    /// and the Phase 2 reaper will transition it to `Failed`.
+    #[serde(default = "default_working_ttl_ms")]
+    pub working_ttl_ms: i64,
+    /// If the task is paused awaiting a human (state is
+    /// `AuthRequired` or `InputRequired`), the ID of the
+    /// `BusApproval` row gating resumption. Exactly one approval row
+    /// represents the pause regardless of which interrupt flavor —
+    /// the Phase 2 `BusApproval` will carry a `kind: PauseKind`
+    /// (`OperatorApproval` / `UserAuth` / `UserInput`) so the audit
+    /// trail has a single source of truth.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_approval_id: Option<String>,
+}
+
+fn default_working_ttl_ms() -> i64 {
+    DEFAULT_WORKING_TTL_MS
 }
 
 impl Task {
@@ -573,12 +711,23 @@ impl Task {
             tenant: tenant.into(),
             created_at: now,
             updated_at: now,
+            last_progress_at: Some(now),
+            working_ttl_ms: DEFAULT_WORKING_TTL_MS,
+            pending_approval_id: None,
         }
+    }
+
+    /// Builder helper: set a custom `working_ttl_ms` (validated).
+    pub fn with_working_ttl(mut self, ttl_ms: i64) -> Result<Self, TaskValidationError> {
+        validate_working_ttl(ttl_ms)?;
+        self.working_ttl_ms = ttl_ms;
+        Ok(self)
     }
 
     /// Apply a state transition, capturing the driving message. Rejects
     /// illegal transitions explicitly so the API can surface a 409
-    /// rather than silently dropping the change.
+    /// rather than silently dropping the change. Bumps
+    /// `last_progress_at` since a state change is forward progress.
     pub fn transition_to(
         &mut self,
         next: TaskState,
@@ -600,24 +749,33 @@ impl Task {
             timestamp: now,
         };
         self.updated_at = now;
+        self.last_progress_at = Some(now);
+        // Leaving an interrupt clears the gating approval reference.
+        if matches!(next, TaskState::Working) {
+            self.pending_approval_id = None;
+        }
         Ok(())
     }
 
-    /// Append a message to the history, enforcing the cap.
+    /// Append a message to the history, enforcing the cap. Counts as
+    /// forward progress.
     pub fn append_history(&mut self, message: Message) -> Result<(), TaskValidationError> {
         if self.history.len() >= MAX_HISTORY_LEN {
             return Err(TaskValidationError::HistoryFull);
         }
         message.validate()?;
         self.history.push(message);
-        self.updated_at = Utc::now();
+        let now = Utc::now();
+        self.updated_at = now;
+        self.last_progress_at = Some(now);
         Ok(())
     }
 
     /// Append (or replace) an artifact. If an artifact with the same
     /// `artifactId` already exists and the new one carries
     /// `append = true`, its parts are appended to the existing one;
-    /// otherwise the existing artifact is replaced.
+    /// otherwise the existing artifact is replaced. Counts as forward
+    /// progress.
     pub fn upsert_artifact(&mut self, artifact: Artifact) -> Result<(), TaskValidationError> {
         artifact.validate()?;
         match self
@@ -642,8 +800,48 @@ impl Task {
                 self.artifacts.push(artifact);
             }
         }
-        self.updated_at = Utc::now();
+        let now = Utc::now();
+        self.updated_at = now;
+        self.last_progress_at = Some(now);
         Ok(())
+    }
+
+    /// Record an explicit heartbeat — the task is alive and working
+    /// even if no state/history/artifact change has happened. Producers
+    /// driving long-running work without intermediate output should
+    /// call this periodically so the staleness reaper doesn't reap
+    /// them.
+    pub fn record_progress(&mut self) {
+        self.last_progress_at = Some(Utc::now());
+    }
+
+    /// Mark the task as paused awaiting a human (either `AuthRequired`
+    /// or `InputRequired`), with the gating approval ID stamped. The
+    /// caller is responsible for calling [`Task::transition_to`] to
+    /// the appropriate interrupt state separately — this method only
+    /// records the approval link.
+    pub fn set_pending_approval(&mut self, approval_id: impl Into<String>) {
+        self.pending_approval_id = Some(approval_id.into());
+    }
+
+    /// Derive staleness from `last_progress_at + working_ttl_ms`.
+    /// Terminal tasks are never stale (they're done, not zombies).
+    /// Tasks without a recorded progress timestamp use `created_at`
+    /// as the baseline.
+    #[must_use]
+    pub fn is_stale_at(&self, now: DateTime<Utc>) -> bool {
+        if self.status.state.is_terminal() {
+            return false;
+        }
+        let baseline = self.last_progress_at.unwrap_or(self.created_at);
+        let age_ms = (now - baseline).num_milliseconds();
+        age_ms > self.working_ttl_ms
+    }
+
+    /// Convenience: [`Self::is_stale_at`] using `Utc::now()`.
+    #[must_use]
+    pub fn is_stale(&self) -> bool {
+        self.is_stale_at(Utc::now())
     }
 
     /// Validate identity, status, and all contained messages/artifacts.
@@ -654,12 +852,16 @@ impl Task {
         if let Some(c) = &self.context_id {
             validate_id("contextId", c)?;
         }
+        if let Some(a) = &self.pending_approval_id {
+            validate_id("pendingApprovalId", a)?;
+        }
+        validate_working_ttl(self.working_ttl_ms)?;
         self.status.validate()?;
         if self.history.len() > MAX_HISTORY_LEN {
             return Err(TaskValidationError::HistoryFull);
         }
         for m in &self.history {
-            m.validate()?;
+            m.validate_in_task(&self.id)?;
         }
         if self.artifacts.len() > MAX_ARTIFACTS_LEN {
             return Err(TaskValidationError::TooManyArtifacts);
@@ -727,6 +929,16 @@ fn validate_metadata(map: &HashMap<String, serde_json::Value>) -> Result<(), Tas
     Ok(())
 }
 
+fn validate_working_ttl(ttl_ms: i64) -> Result<(), TaskValidationError> {
+    if ttl_ms <= 0 {
+        return Err(TaskValidationError::WorkingTtlNonPositive(ttl_ms));
+    }
+    if ttl_ms > MAX_WORKING_TTL_MS {
+        return Err(TaskValidationError::WorkingTtlTooLong(ttl_ms));
+    }
+    Ok(())
+}
+
 /// Validation failures across the A2A task model.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum TaskValidationError {
@@ -776,6 +988,18 @@ pub enum TaskValidationError {
     MetadataInvalid,
     #[error("illegal transition from {from:?} to {to:?}")]
     IllegalTransition { from: TaskState, to: TaskState },
+    #[error("message taskId '{0}' must not appear in its own referenceTaskIds (self-cycle)")]
+    SelfReferenceTaskId(String),
+    #[error("chunkIndex must be non-negative (got {0})")]
+    NegativeChunkIndex(i64),
+    #[error("totalChunks must be positive (got {0})")]
+    InvalidTotalChunks(i64),
+    #[error("chunkIndex {index} is outside the asserted totalChunks range (0..{total})")]
+    ChunkIndexOutOfRange { index: i64, total: i64 },
+    #[error("workingTtlMs must be > 0 (got {0})")]
+    WorkingTtlNonPositive(i64),
+    #[error("workingTtlMs {0} exceeds the {MAX_WORKING_TTL_MS}ms cap")]
+    WorkingTtlTooLong(i64),
 }
 
 // ---------------------------------------------------------------------
@@ -1199,5 +1423,193 @@ mod tests {
         assert_eq!(back.status.state, TaskState::Working);
         assert_eq!(back.history.len(), 1);
         assert_eq!(back.artifacts.len(), 1);
+    }
+
+    // --- Hardening: staleness / TTL ---
+
+    #[test]
+    fn fresh_task_not_stale() {
+        let t = sample_task();
+        assert!(!t.is_stale());
+    }
+
+    #[test]
+    fn stale_when_no_progress_past_ttl() {
+        let mut t = sample_task();
+        t.transition_to(TaskState::Working, None).unwrap();
+        let future = Utc::now() + chrono::Duration::milliseconds(t.working_ttl_ms + 1);
+        assert!(t.is_stale_at(future));
+    }
+
+    #[test]
+    fn terminal_task_never_stale() {
+        let mut t = sample_task();
+        t.transition_to(TaskState::Working, None).unwrap();
+        t.transition_to(TaskState::Completed, None).unwrap();
+        // Even far in the future, a completed task is not "stale" —
+        // staleness is a zombie indicator, not an "old" indicator.
+        let far_future = Utc::now() + chrono::Duration::days(365);
+        assert!(!t.is_stale_at(far_future));
+    }
+
+    #[test]
+    fn record_progress_resets_staleness() {
+        let mut t = sample_task();
+        t.transition_to(TaskState::Working, None).unwrap();
+        // Manually wind back last_progress_at to simulate an old task.
+        t.last_progress_at =
+            Some(Utc::now() - chrono::Duration::milliseconds(t.working_ttl_ms + 5));
+        assert!(t.is_stale());
+        t.record_progress();
+        assert!(!t.is_stale());
+    }
+
+    #[test]
+    fn artifact_upsert_bumps_last_progress() {
+        let mut t = sample_task();
+        let before = t.last_progress_at.unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        t.upsert_artifact(Artifact::new("art-1", vec![Part::text("x")]))
+            .unwrap();
+        assert!(t.last_progress_at.unwrap() > before);
+    }
+
+    #[test]
+    fn validate_rejects_zero_ttl() {
+        let mut t = sample_task();
+        t.working_ttl_ms = 0;
+        assert!(matches!(
+            t.validate(),
+            Err(TaskValidationError::WorkingTtlNonPositive(0))
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_ttl_above_cap() {
+        let mut t = sample_task();
+        t.working_ttl_ms = MAX_WORKING_TTL_MS + 1;
+        assert!(matches!(
+            t.validate(),
+            Err(TaskValidationError::WorkingTtlTooLong(_))
+        ));
+    }
+
+    #[test]
+    fn with_working_ttl_validates() {
+        let t = Task::new("t", "ns", "tn").with_working_ttl(60_000).unwrap();
+        assert_eq!(t.working_ttl_ms, 60_000);
+        assert!(Task::new("t", "ns", "tn").with_working_ttl(-1).is_err());
+    }
+
+    // --- Hardening: pending approval link ---
+
+    #[test]
+    fn set_pending_approval_records_id() {
+        let mut t = sample_task();
+        t.transition_to(TaskState::Working, None).unwrap();
+        t.transition_to(TaskState::InputRequired, None).unwrap();
+        t.set_pending_approval("appr-7");
+        assert_eq!(t.pending_approval_id.as_deref(), Some("appr-7"));
+    }
+
+    #[test]
+    fn resuming_to_working_clears_pending_approval() {
+        let mut t = sample_task();
+        t.transition_to(TaskState::Working, None).unwrap();
+        t.transition_to(TaskState::AuthRequired, None).unwrap();
+        t.set_pending_approval("appr-1");
+        t.transition_to(TaskState::Working, None).unwrap();
+        assert!(t.pending_approval_id.is_none());
+    }
+
+    #[test]
+    fn validate_rejects_bad_approval_id() {
+        let mut t = sample_task();
+        t.pending_approval_id = Some("bad/id".into());
+        assert!(matches!(
+            t.validate(),
+            Err(TaskValidationError::InvalidIdChar {
+                field: "pendingApprovalId",
+                ..
+            })
+        ));
+    }
+
+    // --- Hardening: artifact chunk sequencing ---
+
+    #[test]
+    fn artifact_chunk_index_must_be_non_negative() {
+        let mut a = Artifact::new("art-1", vec![Part::text("x")]);
+        a.chunk_index = Some(-1);
+        assert!(matches!(
+            a.validate(),
+            Err(TaskValidationError::NegativeChunkIndex(-1))
+        ));
+    }
+
+    #[test]
+    fn artifact_total_chunks_must_be_positive() {
+        let mut a = Artifact::new("art-1", vec![Part::text("x")]);
+        a.total_chunks = Some(0);
+        assert!(matches!(
+            a.validate(),
+            Err(TaskValidationError::InvalidTotalChunks(0))
+        ));
+    }
+
+    #[test]
+    fn artifact_chunk_index_must_fit_total_range() {
+        let mut a = Artifact::new("art-1", vec![Part::text("x")]);
+        a.chunk_index = Some(5);
+        a.total_chunks = Some(5);
+        assert!(matches!(
+            a.validate(),
+            Err(TaskValidationError::ChunkIndexOutOfRange { index: 5, total: 5 })
+        ));
+    }
+
+    #[test]
+    fn artifact_with_valid_chunk_metadata_passes() {
+        let mut a = Artifact::new("art-1", vec![Part::text("x")]);
+        a.chunk_index = Some(2);
+        a.total_chunks = Some(5);
+        a.validate().unwrap();
+    }
+
+    // --- Hardening: message self-reference ---
+
+    #[test]
+    fn message_self_reference_via_own_task_id_rejected() {
+        let mut m = Message::text("msg-1", Role::User, "hi");
+        m.task_id = Some("task-1".into());
+        m.reference_task_ids = vec!["task-1".into()];
+        assert!(matches!(
+            m.validate(),
+            Err(TaskValidationError::SelfReferenceTaskId(_))
+        ));
+    }
+
+    #[test]
+    fn task_validate_rejects_history_message_referencing_parent() {
+        let mut t = sample_task();
+        let mut m = Message::text("msg-1", Role::Agent, "x");
+        // The message doesn't carry its own task_id but lives inside
+        // a Task whose `id` it cites — the trivial 1-hop cycle.
+        m.reference_task_ids = vec!["task-1".into()];
+        // Bypass the public append_history validation (which uses
+        // Message::validate without a parent) and shove it directly.
+        t.history.push(m);
+        assert!(matches!(
+            t.validate(),
+            Err(TaskValidationError::SelfReferenceTaskId(_))
+        ));
+    }
+
+    #[test]
+    fn message_validate_in_task_uses_supplied_parent() {
+        let mut m = Message::text("msg-1", Role::User, "hi");
+        m.reference_task_ids = vec!["task-99".into()];
+        m.validate_in_task("task-99").unwrap_err();
+        m.validate_in_task("task-other").unwrap();
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod action;
 pub mod analytics;
 pub mod attachment;
 pub mod bus_agent;
+pub mod bus_agent_card;
 pub mod bus_approval;
 pub mod bus_conversation;
 pub mod bus_schema;
@@ -43,17 +44,27 @@ pub use attachment::{Attachment, ResolvedAttachment};
 pub use bus_agent::{
     Agent, AgentStatus, AgentValidationError, DEFAULT_AGENT_INBOX_SUFFIX, DEFAULT_HEARTBEAT_TTL_MS,
 };
+pub use bus_agent_card::{
+    AgentCapabilities, AgentCard, AgentCardValidationError, Extension as AgentCardExtension,
+    Interface as AgentCardInterface, MAX_CARD_DESCRIPTION_BYTES, MAX_EXTENSIONS_PER_CARD,
+    MAX_INTERFACES_PER_CARD, MAX_OUTPUT_MEDIA_TYPES_PER_SKILL, MAX_SECURITY_SCHEMES_PER_CARD,
+    MAX_SKILL_DESCRIPTION_BYTES, MAX_SKILL_INPUT_SCHEMA_BYTES, MAX_SKILLS_PER_CARD, Provider,
+    SecurityScheme, Skill,
+};
 pub use bus_approval::{
     BusApproval, BusApprovalEnvelope, BusApprovalStatus, BusApprovalValidationError,
     DEFAULT_APPROVAL_TTL_MS, MAX_APPROVAL_NOTE_BYTES, MAX_APPROVAL_TTL_MS, validate_approval_id,
     validate_approval_ttl,
 };
 pub use bus_conversation::{
-    Conversation, ConversationState, ConversationTransition, ConversationValidationError,
-    DEFAULT_CONVERSATIONS_EVENTS_SUFFIX,
+    Conversation, ConversationMessage, ConversationState, ConversationTransition,
+    ConversationValidationError, DEFAULT_CONVERSATIONS_EVENTS_SUFFIX,
 };
 pub use bus_schema::{Schema, SchemaFormat, SchemaValidationError};
-pub use bus_stream::{StreamChunk, StreamEnd, StreamEndStatus, StreamEnvelopeValidationError};
+pub use bus_stream::{
+    StreamChunk, StreamEnd, StreamEndStatus, StreamEnvelopeValidationError,
+    TaskArtifactUpdateEvent, TaskStatusUpdateEvent,
+};
 pub use bus_subscription::{
     AckMode, PartitionLag, StartOffset as SubscriptionStartOffset, Subscription,
     SubscriptionStatus, SubscriptionValidationError,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -59,11 +59,12 @@ pub use bus_subscription::{
     SubscriptionStatus, SubscriptionValidationError,
 };
 pub use bus_task::{
-    Artifact, MAX_ARTIFACTS_LEN, MAX_HISTORY_LEN, MAX_ID_LEN as MAX_TASK_ID_LEN,
-    MAX_MESSAGE_EXTENSIONS, MAX_METADATA_VALUE_BYTES as MAX_TASK_METADATA_VALUE_BYTES,
-    MAX_PART_DATA_BYTES, MAX_PART_RAW_BYTES, MAX_PART_TEXT_BYTES, MAX_PARTS_PER_CONTAINER,
-    MAX_REFERENCE_TASK_IDS, Message as TaskMessage, Part as TaskPart, Role as TaskRole, Task,
-    TaskState, TaskStatus, TaskValidationError,
+    Artifact, DEFAULT_WORKING_TTL_MS, MAX_ARTIFACTS_LEN, MAX_HISTORY_LEN,
+    MAX_ID_LEN as MAX_TASK_ID_LEN, MAX_MESSAGE_EXTENSIONS,
+    MAX_METADATA_VALUE_BYTES as MAX_TASK_METADATA_VALUE_BYTES, MAX_PART_DATA_BYTES,
+    MAX_PART_RAW_BYTES, MAX_PART_TEXT_BYTES, MAX_PARTS_PER_CONTAINER, MAX_REFERENCE_DEPTH,
+    MAX_REFERENCE_TASK_IDS, MAX_WORKING_TTL_MS, Message as TaskMessage, Part as TaskPart,
+    Role as TaskRole, Task, TaskState, TaskStatus, TaskValidationError,
 };
 pub use bus_tool::{ToolCall, ToolEnvelopeValidationError, ToolResult, ToolResultStatus};
 pub use bus_topic::{Topic, TopicValidationError};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod bus_conversation;
 pub mod bus_schema;
 pub mod bus_stream;
 pub mod bus_subscription;
+pub mod bus_task;
 pub mod bus_tool;
 pub mod bus_topic;
 pub mod caller;
@@ -56,6 +57,13 @@ pub use bus_stream::{StreamChunk, StreamEnd, StreamEndStatus, StreamEnvelopeVali
 pub use bus_subscription::{
     AckMode, PartitionLag, StartOffset as SubscriptionStartOffset, Subscription,
     SubscriptionStatus, SubscriptionValidationError,
+};
+pub use bus_task::{
+    Artifact, MAX_ARTIFACTS_LEN, MAX_HISTORY_LEN, MAX_ID_LEN as MAX_TASK_ID_LEN,
+    MAX_MESSAGE_EXTENSIONS, MAX_METADATA_VALUE_BYTES as MAX_TASK_METADATA_VALUE_BYTES,
+    MAX_PART_DATA_BYTES, MAX_PART_RAW_BYTES, MAX_PART_TEXT_BYTES, MAX_PARTS_PER_CONTAINER,
+    MAX_REFERENCE_TASK_IDS, Message as TaskMessage, Part as TaskPart, Role as TaskRole, Task,
+    TaskState, TaskStatus, TaskValidationError,
 };
 pub use bus_tool::{ToolCall, ToolEnvelopeValidationError, ToolResult, ToolResultStatus};
 pub use bus_topic::{Topic, TopicValidationError};

--- a/docs/design/a2a-protocol.md
+++ b/docs/design/a2a-protocol.md
@@ -79,25 +79,42 @@ The Core-First plan deliberately reuses what's already shipped, not rebuilds it:
 
 ## Risks
 
+The Core-First posture imports A2A's complexity into Acteon's substrate. Each risk below carries a concrete defense that lands in code as part of the listed phase — Phase 1 is *not* a "trust the spec" pass.
+
 - **A2A spec churn.** 1.0 was ratified in late 2025 and is still evolving. Keep the protocol codec layer thin and put the `A2A-Version` header on the critical path so future revisions don't cascade into the Task Engine.
-- **utoipa recursion landmine.** `Task` references other tasks via `referenceTaskIds`, mirroring the `ChainStepStatus.parallel_sub_steps` infinite-schema-recursion bug. Use `#[schema(value_type = Object)]` on the recursive field from day one.
-- **Payload size.** A2A `Part` carries arbitrary data (text, base64 raw, URL refs, JSON). Existing publish-edge caps (512KB content / 1MB payload) are tuned for the internal bus; A2A may need an explicit per-tenant tier or chunked-artifact streaming for large outputs.
+- **Recursive task-graph landmine (cycles + depth).** `Task` is structurally flat (`referenceTaskIds: Vec<String>` carries IDs, not nested objects, so serialize-side stack overflow is avoided), but the *graph* across rows can cycle. Defenses: Phase 1 ships `MAX_REFERENCE_DEPTH = 5` plus 1-hop self-reference rejection at validation time; Phase 2's Task Engine does BFS cycle detection across rows when resolving reference graphs. utoipa schema is safe (`Vec<String>` not recursive).
+- **Shadow states ("Working" task with no chain).** A Task left in a non-terminal state without progress is a memory leak. Defenses: Phase 1 adds `working_ttl_ms`, `last_progress_at`, `is_stale_at(now)` to Task (default 30-minute TTL, derived staleness mirrors `Agent.status_at()`); Phase 2 ships the reaper that transitions stale tasks to `Failed`. Read-time derivation is the backstop if the reaper lags.
+- **Part bloat (large `base64` in Kafka).** A2A `Part` carries arbitrary content. Defense: Phase 1 caps `text`/`raw`/`data` parts at **256KB** each; anything larger must use `Part::url` referencing an external store. (The `acteon-blob` crate was previously removed, so external object stores are the supported escape hatch.)
+- **AgentCard registry contamination.** A2A `Skill`/`Interface` schemas are verbose; inlining them onto `Agent` bloats the hot heartbeat/list/route path. Defense: the follow-up bus_agent PR adds `Agent.has_agent_card: bool` and stores the full AgentCard at a separate `KeyKind::BusAgentCard`. A2A discovery reads the card; nothing else does.
+- **Fragmented HITL workflows.** Acteon has `BusApproval` for operator-approves-outbound-tool-call; A2A adds `AuthRequired` (user provides credential) and `InputRequired` (user clarifies). Defense: Phase 1 adds `Task.pending_approval_id: Option<String>` so any paused Task points at *one* row representing the pause; Phase 2 generalizes `BusApproval` with `kind: PauseKind` (`OperatorApproval` / `UserAuth` / `UserInput`) so there's a single source of truth for "waiting on human."
+- **Artifact streaming race.** A2A doesn't specify ordering between `append` chunks and `lastChunk`. A late append after a `lastChunk: true` closes the task can silently drop data. Defense: Phase 1 adds Acteon-extension fields `chunk_index: Option<i64>` (mirrors `StreamChunk.chunk_seq`) and `total_chunks: Option<i64>` (asserted on the last chunk); Phase 2 Engine enforces "all chunks 0..total before close" and "no chunks after lastChunk."
 - **Push delivery semantics.** A2A doesn't mandate exactly-once. Reuse the webhook provider's retry + DLQ pattern and stamp `acteon.push.attempt` headers for audit replay.
 - **8-state surface area in clients.** SDK consumers will now see eight Task states. Worth a doc page distinguishing terminal (Completed/Failed/Canceled/Rejected) from interrupt (InputRequired/AuthRequired) states so library users don't write incorrect "is finished" checks.
 
 ## Implementation Plan
 
 ### Phase 1: Core Primitives (`acteon-core`) — ~5 days
-- [ ] **Native Task:** Add `bus_task.rs` defining `Task` with the 8-state lifecycle, `Artifact`, `Message`, `Part`, and `PushNotificationConfig`. Include validation, serde, and utoipa schemas (apply `#[schema(value_type = Object)]` to recursive fields).
+- [x] **Native Task:** `bus_task.rs` defining `Task` with the 8-state lifecycle, `Artifact`, `Message`, `Part`. Validation, serde, utoipa.
+- [x] **Defensive validation (from adversarial review):**
+  - [x] Part caps at 256KB (text/raw/data) — larger payloads must go by URL reference.
+  - [x] `MAX_REFERENCE_DEPTH = 5` constant + 1-hop self-reference rejection. Phase 2 Engine does multi-hop BFS.
+  - [x] `working_ttl_ms` / `last_progress_at` / `is_stale_at(now)` for shadow-state defense (default 30-minute TTL).
+  - [x] `pending_approval_id: Option<String>` to point any paused Task at exactly one BusApproval row.
+  - [x] Artifact `chunk_index` / `total_chunks` for streaming race-safety.
 - [ ] **Artifact Streaming:** Update `bus_stream.rs` to include `append` and `last_chunk` metadata for native A2A artifact support.
-- [ ] **Agent Evolution:** Extend `Agent` in `bus_agent.rs` with `skills[]`, `interfaces[]`, and JSON Schema capability definitions.
+- [ ] **Agent Evolution:** Extend `Agent` in `bus_agent.rs` with `has_agent_card: bool` flag; store the full `AgentCard` (skills, interfaces, security schemes) at a separate `KeyKind::BusAgentCard` so the hot heartbeat/list/route path stays lean.
 - [ ] **Converged Envelopes:** Align `bus_conversation.rs` message parts with A2A `Message`/`Part` semantics.
-- [ ] Unit tests for state transitions, validation, and serde round-trips.
+- [x] Unit tests for state transitions, validation, serde round-trips, and the defensive validations above.
 
 ### Phase 2: Gateway Integration (`crates/gateway`) — ~6 days
 - [ ] **Protocol Codecs:** Implement encoders/decoders for A2A JSON-RPC 2.0 and the REST binding (spec §11). Wire `A2A-Version` header negotiation with `VersionNotSupportedError`.
 - [ ] **Task Engine:** Implement the lifecycle manager in the gateway, handling state transitions and persistence via the existing `State` backend (new `KeyKind::A2aTask`). Use CAS retries to mirror the bus's optimistic-locking pattern.
-- [ ] **The Bridge:** Implement native mapping between `Task` state and `Chain` status — A2A `Submitted/Working` ↔ chain step progress; `InputRequired/AuthRequired` ↔ `BusApproval`; terminal states ↔ chain `StepResult`.
+- [ ] **Engine-side hardening (graph + streaming):**
+  - [ ] BFS cycle detection across multi-Task `referenceTaskIds` graphs, capped at `MAX_REFERENCE_DEPTH`.
+  - [ ] Reaper that transitions stale tasks (`is_stale_at(now)`) to `Failed`, with a corresponding `acteon.task.reaped` audit envelope.
+  - [ ] Artifact-stream gatekeeper: rejects chunks arriving after `lastChunk = true`; when `totalChunks` is asserted, holds the close until all indices 0..total are observed.
+- [ ] **BusApproval generalization (single source of truth for HITL):** Extend `BusApproval` with `kind: PauseKind` (`OperatorApproval` / `UserAuth` / `UserInput`); Task Engine stamps the approval row's id onto `Task.pending_approval_id`.
+- [ ] **The Bridge:** Native mapping between `Task` state and `Chain` status — A2A `Submitted/Working` ↔ chain step progress; `InputRequired/AuthRequired` ↔ generalized `BusApproval`; terminal states ↔ chain `StepResult`.
 - [ ] **Audit Integration:** Stamp every A2A operation with `AuditEventKind::A2aTaskTransition`.
 - [ ] **Idempotency:** Wire A2A `messageId` through existing dedup-key infrastructure.
 
@@ -111,10 +128,11 @@ The Core-First plan deliberately reuses what's already shipped, not rebuilds it:
 - [ ] **Security Schemes:** Map `APIKeySecurityScheme`, `HTTPAuthSecurityScheme` (Bearer), and `MutualTlsSecurityScheme` to native Acteon Grants and TLS configurations. (`OAuth2`/`OpenIdConnect` deferred to a follow-up.)
 
 ### Phase 5: Hardening & Validation — ~3 days
-- [ ] **Recursive depth validation** for Tasks to prevent circular reference attacks via `referenceTaskIds`.
-- [ ] **Payload caps:** A2A-specific size limits for `Part` content; chunked-artifact streaming for outputs exceeding the existing 1MB payload tier.
+- [ ] **Adversarial test suite:** explicit tests for each Risks bullet — Part bloat at boundary, deep cycle attacks, stale-task reaping, race-prone artifact streams, HITL workflow consistency.
 - [ ] **Security review:** Run the existing security-review skill against the new endpoints (`/.well-known/agent.json`, `/a2a/rpc`, push delivery worker).
-- [ ] **Load test:** Add gateway benchmark covering streamed Task lifecycle under N concurrent subscribers.
+- [ ] **Load test:** Gateway benchmark covering streamed Task lifecycle under N concurrent subscribers, including chunk-ordering and stale-reaper behavior.
+- [ ] **Fuzz the codecs:** quickcheck/proptest fuzzing on the JSON-RPC and REST codec layers — guarantees no panics on malformed input.
+- [ ] **Per-tenant cap overrides** (if needed): wire the Phase 1 cap constants to be tenant-overridable via the existing quota system for trusted high-throughput tenants.
 
 ### Phase 6: SDK & Simulation — ~5 days
 - [ ] Update all polyglot SDKs (Rust, Python, Node, Go, Java) to support the native A2A Task primitives.

--- a/docs/design/a2a-protocol.md
+++ b/docs/design/a2a-protocol.md
@@ -1,0 +1,253 @@
+# Acteon A2A Protocol Implementation
+
+**Status:** Draft
+**Author:** Acteon Team
+**Created:** 2026-05-14
+
+## Overview
+
+This document proposes implementing the [Agent2Agent (A2A) Protocol](https://a2a-protocol.org/latest/specification/) in Acteon, exposing the gateway as a first-class A2A endpoint so external agents (Google ADK, Microsoft Agent Framework, Amazon Bedrock AgentCore, custom builds) can discover, invoke, and stream from Acteon-managed agents using the open standard.
+
+The work is principally a **translation/extension layer** rather than a ground-up build: Acteon already ships the underlying primitives (agents, conversations, tool-call envelopes, streaming SSE, human approvals, multi-tenant auth, schema registry, audit). The remaining 30-40% is wire-format adapters, an explicit `Task` lifecycle, AgentCard discovery, and per-task push notification configs.
+
+## Motivation
+
+A2A was donated to the Linux Foundation in late 2025 and is now backed by 150+ organizations including Google, Microsoft, AWS, Salesforce, SAP, ServiceNow, Workday, and IBM. Adoption is moving from "interesting standard" to "default interop fabric" for multi-vendor agent ecosystems.
+
+By exposing Acteon via A2A we unlock:
+
+1.  **Federated agent ecosystems** — Acteon agents (chains, swarm specialists, recurring jobs) become invocable by any A2A-speaking client.
+2.  **Reverse interop** — Acteon agents can act as A2A *clients* against third-party agents (Vertex AI, Bedrock AgentCore, Azure AI Foundry).
+3.  **Standardized observability** — A2A's `Task` lifecycle, `Artifact` streaming, and audit-friendly push notifications align with Acteon's existing audit/compliance posture.
+4.  **Strategic positioning** — Acteon's hardened orchestration (rules, quotas, retention, compliance hash chain, mTLS, WASM-sandboxed validation) becomes the "safe substrate" layer underneath an A2A-compliant facade.
+
+Acteon's bus already implements most of A2A's *semantics*; this work makes them *interoperable*.
+
+## Background: A2A Protocol Summary
+
+Per the [official specification](https://a2a-protocol.org/latest/specification/):
+
+| Layer | Requirement |
+|---|---|
+| Transport | JSON-RPC 2.0 over HTTPS, SSE for streaming, optional HTTP+JSON/REST binding |
+| Discovery | `AgentCard` published at `/.well-known/agent.json` |
+| Core methods | `SendMessage`, `SendStreamingMessage`, `GetTask`, `ListTasks`, `CancelTask`, `SubscribeToTask`, `Create/Get/List/DeleteTaskPushNotificationConfig`, `GetExtendedAgentCard` |
+| Core types | `Task` (with `TaskState` enum: submitted/working/completed/failed/canceled/input_required/auth_required/rejected), `Message` (role + parts), `Part` (text/file/data), `Artifact` |
+| Streaming | SSE delivering `StreamResponse` wrapping one of `task`, `message`, `statusUpdate`, `artifactUpdate` |
+| Push | HTTP POST webhook with auth (API key, Bearer, OAuth2, OIDC, mTLS) |
+| Versioning | `A2A-Version` header negotiation |
+
+## Mapping: A2A → Acteon Primitives
+
+| A2A Concept | Acteon Equivalent | File |
+|---|---|---|
+| `AgentCard` | `Agent` struct (needs richer `skills`, `interfaces`, `securitySchemes`) | `crates/core/src/bus_agent.rs` |
+| Capability advertising | `Agent.capabilities: Vec<String>` (A2A `skills[]` is richer — input schema + media types) | `crates/core/src/bus_agent.rs` |
+| `contextId` | `Conversation.conversation_id` | `crates/core/src/bus_conversation.rs` |
+| `Message` / `Part` | Conversation messages with envelope kinds (Phase 6a/b) | `crates/server/src/api/bus.rs` |
+| `Task` + `TaskState` | **MISSING** — closest analog is chain `StepResult` | needs `crates/core/src/a2a_task.rs` |
+| `TaskStatusUpdateEvent` | `StreamChunk` / `StreamEnd` on conversation events | `crates/core/src/bus_stream.rs` |
+| `Artifact` (with `append` / `lastChunk`) | **MISSING** — tool output JSON has no streaming-append semantics | needs new type |
+| `ROLE_USER` / `ROLE_AGENT` | `ToolCall.sender` (agent_id) — implicit role | `crates/core/src/bus_tool.rs` |
+| Streaming via SSE | SSE stream + `Last-Event-ID` reconnect | `crates/server/src/api/stream.rs` |
+| Push notification webhook | **PARTIAL** — Acteon has webhook providers, not per-task push configs | needs new state-store entity |
+| API-key / Bearer / mTLS auth | Already supported | `crates/server/src/auth/`, `crates/crypto/src/tls.rs` |
+| `TASK_STATE_AUTH_REQUIRED` interrupt | `BusApproval` (Pending → Approved/Rejected) | `crates/core/src/bus_approval.rs` |
+| `TASK_STATE_INPUT_REQUIRED` | **MISSING** — needs Task-side pause-on-input semantics | new |
+| Idempotency via `messageId` | Dedup keys on action/chain path | `crates/gateway/src/` |
+| Schema registry | JSON Schema per topic, applied at publish-edge | `crates/bus/src/schema.rs` |
+
+## Architecture
+
+We will ship A2A as a **facade crate** (`acteon-a2a`) alongside the existing internal bus, not as a replacement. The internal bus is *Acteon-as-orchestrator* (engines coordinating chains, swarms, tools); A2A is *Acteon-as-interoperable-agent* (external clients invoking Acteon over an open standard). Both consume the same state store, audit, auth, and Kafka transport — they differ in audience and wire format.
+
+```mermaid
+graph TD
+    External[External A2A clients<br/>ADK / Bedrock / Foundry / custom]
+    Internal[Internal callers<br/>swarm, chains, SDKs]
+    
+    External -->|JSON-RPC 2.0 + SSE| A2A[acteon-a2a facade<br/>/a2a/rpc, /.well-known/agent.json]
+    Internal -->|REST + SSE| Bus[Existing bus API<br/>/v1/bus/*]
+    
+    A2A --> Gateway
+    Bus --> Gateway[acteon-gateway]
+    Gateway --> StateStore[(State store)]
+    Gateway --> Audit[(Audit store)]
+    Gateway --> Kafka[(Kafka)]
+```
+
+Rationale:
+
+- The internal bus API is consumed by 5 polyglot SDKs, the swarm crate, simulation examples, and the admin UI. Refactoring it to *be* A2A would disrupt all of those for no internal benefit.
+- A2A's task lifecycle (8 states, including interrupt states) is richer than what the internal bus needs day-to-day. Keeping it in the facade avoids forcing those semantics on internal callers.
+- The facade can map A2A → bus selectively. For example, `SendMessage` with `requires_approval=true` lands as a `BusApproval`; `SubscribeToTask` proxies the existing `bus_stream.rs` SSE bridge with re-framed envelopes.
+
+## Net-New Components
+
+### Core types (`acteon-core`)
+
+- `a2a::Task` — id, contextId, status, artifacts[], history[], metadata. 8-state machine.
+- `a2a::Artifact` — id, parts[], append/lastChunk flags for chunked output.
+- `a2a::Message` / `a2a::Part` — text/file(raw|url)/data variants. Distinct from `ToolCall.arguments` to keep wire-shape isolated.
+- `a2a::AgentCard` — extends `Agent` with skills, interfaces, securitySchemes, signature.
+- `a2a::PushNotificationConfig` — per-task webhook URL + auth scheme.
+
+### Facade crate (`crates/a2a`)
+
+- JSON-RPC 2.0 router for the 11 spec methods.
+- `Task` state machine owner; persistence via existing `State` backend (new `KeyKind::A2aTask`).
+- SSE bridge re-framing `StreamChunk`/`StreamEnd` as A2A `StreamResponse`.
+- Push delivery worker (reuses shared `reqwest::Client` from `main.rs` and the existing audit-stamped envelope pattern).
+
+### Server endpoints
+
+- `GET /.well-known/agent.json` — public, unauthenticated, returns the active card.
+- `POST /a2a/rpc` — JSON-RPC entry point.
+- `GET /a2a/tasks/{id}:subscribe` — SSE stream.
+- Optional REST binding at `/a2a/tasks/...` per spec §11.
+
+### Auth integration
+
+Map A2A `securitySchemes` to existing API-key grants:
+
+- `APIKeySecurityScheme` → existing API keys.
+- `HTTPAuthSecurityScheme` (Bearer) → trivial extension.
+- `MutualTlsSecurityScheme` → already supported.
+- `OAuth2SecurityScheme` / `OpenIdConnect` → out of scope for MVP.
+
+`Grant.agent_id` (Phase 10 of the bus work) gives caller→agent identity stamping for free.
+
+## What We Get For Free
+
+- **Streaming + reconnect**: PRs #153–157 (May 2026) shipped SSE reconnect with `Last-Event-ID` across all SDKs. Drop-in for `SubscribeToTask`.
+- **Multi-tenancy + ACL**: A2A §3.3.2 mandates "never leak resource existence to unauthorized clients." Acteon already returns 403 (not 404) on wrong-tenant access.
+- **Schema validation**: A2A `Skill.inputSchema` is JSON Schema; the bus already validates JSON Schema at publish-edge.
+- **Idempotency**: Action dedup keys map onto A2A `messageId` idempotency (spec §3.3.1).
+- **Audit trail**: Every A2A message → audit record, with hash-chain compliance verification.
+- **Polyglot SDKs**: Rust, Python, Node, Go, Java — once the server speaks A2A, all five get it via the existing client codegen pattern.
+
+## Architectural Decisions to Settle
+
+1.  **Task ↔ Chain relationship.** Two options:
+    - *Independent* — A2A tasks live in their own state-store kind; chains stay internal-only.
+    - *Bridge* — an incoming A2A task can spawn a chain, and chain state is exposed as `TaskStatus`. More work, but powerful (external agents can drive Acteon chains end-to-end).
+    
+    **Recommended:** start with Independent for MVP. Add the bridge in a follow-up once the task primitive has shipped.
+
+2.  **AgentCard signing.** Optional per spec §8.4. Required only for federated discovery; HTTPS at the well-known endpoint is sufficient for most deployments. Skip in MVP unless customers ask.
+
+3.  **Identity granularity.** A2A is agent-to-agent. Acteon's auth is tenant + API key + grant. Phase 10's `Grant.agent_id` binding lets each external A2A agent get its own API key for cleaner audit. Default to that.
+
+4.  **Versioning posture.** Ship A2A 1.0 only. Use the `A2A-Version` header to gate future migrations.
+
+## Risks & Unknowns
+
+- **Spec churn.** A2A 1.0 ratified late 2025; subsequent versions may change framing. Keep the facade thin to preserve a clean migration path.
+- **utoipa recursion.** A2A's `Task` is recursive via `referenceTaskIds`; same infinite-recursion landmine as `ChainStepStatus.parallel_sub_steps`. Apply the same `#[schema(value_type = Object)]` workaround.
+- **Payload size.** A2A `Part` can carry arbitrary data; existing publish-edge caps (512KB content / 1MB payload) may need an A2A-specific tier.
+- **Push delivery reliability.** A2A doesn't mandate exactly-once. Reuse the existing webhook provider's retry + DLQ pattern.
+- **OAuth2 / OIDC.** Not in MVP. If enterprise customers require it, scope as Phase 10.
+
+## Effort Estimate
+
+**~6 weeks single-engineer for full SDK parity** or **~3 weeks server-only MVP**.
+
+---
+
+## Implementation Plan
+
+### Phase 0: RFC & Alignment
+- [ ] Settle the four architectural decisions above (Task↔Chain, signing, identity, versioning) with the core team.
+- [ ] Confirm coexistence (facade) vs. replacement of internal bus surface.
+- [ ] Pick MVP cut: server-only vs. full SDK parity.
+
+### Phase 1: Core Types (`acteon-core`)
+- [ ] Add `a2a::Task` with 8-state lifecycle (`Submitted`/`Working`/`Completed`/`Failed`/`Canceled`/`InputRequired`/`AuthRequired`/`Rejected`).
+- [ ] Add `a2a::Artifact` with `append` / `lastChunk` semantics.
+- [ ] Add `a2a::Message` and `a2a::Part` (text/file/data variants).
+- [ ] Add `a2a::AgentCard` extending `Agent` with `skills[]`, `interfaces[]`, `securitySchemes`, optional `signature`.
+- [ ] Add `a2a::PushNotificationConfig`.
+- [ ] Validation rules + serde + utoipa schemas (apply `#[schema(value_type = Object)]` to recursive fields).
+- [ ] Unit tests for state transitions, validation, and serde round-trips.
+
+### Phase 2: Facade Crate (`crates/a2a`)
+- [ ] Scaffold `crates/a2a`; register in workspace.
+- [ ] JSON-RPC 2.0 router covering the 11 spec methods.
+- [ ] `Task` persistence via existing `State` backend (new `KeyKind::A2aTask`).
+- [ ] Translation layer: A2A `SendMessage` → bus operations (conversation create / message append / tool-call envelope).
+- [ ] CAS-based status transitions matching the bus's retry pattern.
+- [ ] Idempotency on `messageId` via existing dedup-key infra.
+
+### Phase 3: Discovery & Auth
+- [ ] `GET /.well-known/agent.json` (public, unauthenticated).
+- [ ] AgentCard builder (assembles capabilities, skills, interfaces, security schemes from server config + registered providers).
+- [ ] `A2A-Version` header negotiation; `VersionNotSupportedError` for unsupported.
+- [ ] Map `APIKeySecurityScheme` / `HTTPAuthSecurityScheme` (Bearer) / `MutualTlsSecurityScheme` to existing grants.
+- [ ] Optional `GetExtendedAgentCard` for authenticated callers.
+
+### Phase 4: Streaming Bridge
+- [ ] `GET /a2a/tasks/{id}:subscribe` SSE endpoint.
+- [ ] Bridge: subscribe to relevant `StreamChunk`/`StreamEnd` records, reframe as A2A `StreamResponse`.
+- [ ] Reuse `Last-Event-ID` reconnect (already implemented for bus).
+- [ ] Per-tenant SSE connection caps (reuse existing config).
+- [ ] `SendStreamingMessage` initial response with full task, subsequent updates as `statusUpdate` / `artifactUpdate`.
+
+### Phase 5: Push Notifications
+- [ ] `PushNotificationConfig` CRUD endpoints (`Create/Get/List/Delete`).
+- [ ] Per-task config persistence (new state-store entity).
+- [ ] Delivery worker: subscribes to task status changes, POSTs `StreamResponse` to registered webhooks.
+- [ ] Reuse shared `reqwest::Client` and mTLS support from `crates/crypto/src/tls.rs`.
+- [ ] Retry + DLQ mirroring webhook provider behavior.
+- [ ] Audit-stamp delivery attempts.
+
+### Phase 6: REST Binding
+- [ ] `POST /a2a/tasks` (SendMessage).
+- [ ] `POST /a2a/tasks:stream` (SendStreamingMessage).
+- [ ] `GET /a2a/tasks/{id}` (GetTask).
+- [ ] `GET /a2a/tasks` (ListTasks with pagination + status filter).
+- [ ] `POST /a2a/tasks/{id}:cancel` (CancelTask).
+- [ ] `GET /a2a/tasks/{id}:subscribe` (SubscribeToTask).
+- [ ] Push notification config endpoints.
+- [ ] All thin wrappers over the JSON-RPC handlers.
+
+### Phase 7: Polyglot SDK Updates
+- [ ] Rust client: `crates/client/src/a2a.rs` with helper methods.
+- [ ] Python SDK: A2A client surface.
+- [ ] Node.js SDK: A2A client surface.
+- [ ] Go SDK: A2A client surface.
+- [ ] Java SDK: A2A client surface.
+
+### Phase 8: Simulation & Docs
+- [ ] `crates/simulation/examples/a2a_simulation.rs` — round-trip a Task through all 8 states.
+- [ ] `docs/book/features/a2a.md` — user-facing guide.
+- [ ] `docs/architecture/a2a.md` — final architecture doc once shipped.
+- [ ] Update CHANGELOG and README feature matrix.
+
+### Phase 9: UI Surface (Optional)
+- [ ] Dashboard tab listing A2A tasks distinctly from internal bus tasks.
+- [ ] AgentCard preview / signing controls.
+- [ ] Push notification config management.
+
+### Phase 10: Hardening (Future)
+- [ ] `OAuth2SecurityScheme` / `OpenIdConnectSecurityScheme` support.
+- [ ] AgentCard signing (Ed25519, reusing the compliance hash-chain crypto stack).
+- [ ] Bridge mode: A2A Task → Acteon Chain spawn.
+- [ ] Acteon-as-A2A-client (outbound calls to third-party agents).
+
+### Pre-Commit Checks (per Phase)
+- [ ] `cargo fmt --all`
+- [ ] `cargo clippy --workspace --no-deps -- -D warnings`
+- [ ] `cargo test --workspace --lib --bins --tests`
+- [ ] `cargo check --all-targets`
+- [ ] `(cd ui && npm run lint && npm run build)` when UI changes touched
+
+---
+
+## References
+
+- [A2A Protocol Specification](https://a2a-protocol.org/latest/specification/)
+- [A2A on GitHub](https://github.com/a2aproject/A2A)
+- [Google announcement of A2A](https://developers.googleblog.com/en/a2a-a-new-era-of-agent-interoperability/)
+- [Agent2Agent protocol upgrade — Google Cloud Blog](https://cloud.google.com/blog/products/ai-machine-learning/agent2agent-protocol-is-getting-an-upgrade)
+- Internal: `docs/design/mcp-server.md` (sibling external-protocol implementation)
+- Internal: `docs/architecture/agent-swarm.md` (multi-agent orchestration this complements)

--- a/docs/design/a2a-protocol.md
+++ b/docs/design/a2a-protocol.md
@@ -3,236 +3,124 @@
 **Status:** Draft
 **Author:** Acteon Team
 **Created:** 2026-05-14
+**Updated:** 2026-05-14 (Core-First Convergence)
 
 ## Overview
 
-This document proposes implementing the [Agent2Agent (A2A) Protocol](https://a2a-protocol.org/latest/specification/) in Acteon, exposing the gateway as a first-class A2A endpoint so external agents (Google ADK, Microsoft Agent Framework, Amazon Bedrock AgentCore, custom builds) can discover, invoke, and stream from Acteon-managed agents using the open standard.
+This document proposes implementing the [Agent2Agent (A2A) Protocol](https://a2a-protocol.org/latest/specification/) in Acteon as a **primary architectural citizen**. Rather than a peripheral facade, A2A concepts (Tasks, AgentCards, and the 8-state lifecycle) will be promoted to **native primitives** in `acteon-core`.
 
-The work is principally a **translation/extension layer** rather than a ground-up build: Acteon already ships the underlying primitives (agents, conversations, tool-call envelopes, streaming SSE, human approvals, multi-tenant auth, schema registry, audit). The remaining 30-40% is wire-format adapters, an explicit `Task` lifecycle, AgentCard discovery, and per-task push notification configs.
+This "Core-First" approach ensures that Acteon's hardened orchestration—rules, quotas, compliance hash chains, and multi-tenant auth—is the foundation for a robust, scalable A2A implementation suitable for enterprise-grade federated agent ecosystems.
 
 ## Motivation
 
-A2A was donated to the Linux Foundation in late 2025 and is now backed by 150+ organizations including Google, Microsoft, AWS, Salesforce, SAP, ServiceNow, Workday, and IBM. Adoption is moving from "interesting standard" to "default interop fabric" for multi-vendor agent ecosystems.
+A2A is rapidly becoming the "default interop fabric" for multi-vendor agent ecosystems. By elevating A2A to a core use case, Acteon achieves:
 
-By exposing Acteon via A2A we unlock:
+1.  **Architectural Convergence** — Acteon agents, chains, and swarms are natively A2A-compliant, reducing translation overhead and improving reliability.
+2.  **Hardened Orchestration at Scale** — A2A Tasks inherit Acteon's compliance, audit, and sandboxed validation features out of the box.
+3.  **Strategic Multi-Agent Foundation** — Acteon becomes the "safe substrate" for cross-vendor coordination, where every external interaction is tracked via a standardized, observable Task lifecycle.
 
-1.  **Federated agent ecosystems** — Acteon agents (chains, swarm specialists, recurring jobs) become invocable by any A2A-speaking client.
-2.  **Reverse interop** — Acteon agents can act as A2A *clients* against third-party agents (Vertex AI, Bedrock AgentCore, Azure AI Foundry).
-3.  **Standardized observability** — A2A's `Task` lifecycle, `Artifact` streaming, and audit-friendly push notifications align with Acteon's existing audit/compliance posture.
-4.  **Strategic positioning** — Acteon's hardened orchestration (rules, quotas, retention, compliance hash chain, mTLS, WASM-sandboxed validation) becomes the "safe substrate" layer underneath an A2A-compliant facade.
+## Convergence Mapping: A2A ↔ Acteon Core
 
-Acteon's bus already implements most of A2A's *semantics*; this work makes them *interoperable*.
-
-## Background: A2A Protocol Summary
-
-Per the [official specification](https://a2a-protocol.org/latest/specification/):
-
-| Layer | Requirement |
-|---|---|
-| Transport | JSON-RPC 2.0 over HTTPS, SSE for streaming, optional HTTP+JSON/REST binding |
-| Discovery | `AgentCard` published at `/.well-known/agent.json` |
-| Core methods | `SendMessage`, `SendStreamingMessage`, `GetTask`, `ListTasks`, `CancelTask`, `SubscribeToTask`, `Create/Get/List/DeleteTaskPushNotificationConfig`, `GetExtendedAgentCard` |
-| Core types | `Task` (with `TaskState` enum: submitted/working/completed/failed/canceled/input_required/auth_required/rejected), `Message` (role + parts), `Part` (text/file/data), `Artifact` |
-| Streaming | SSE delivering `StreamResponse` wrapping one of `task`, `message`, `statusUpdate`, `artifactUpdate` |
-| Push | HTTP POST webhook with auth (API key, Bearer, OAuth2, OIDC, mTLS) |
-| Versioning | `A2A-Version` header negotiation |
-
-## Mapping: A2A → Acteon Primitives
-
-| A2A Concept | Acteon Equivalent | File |
+| A2A Concept | Acteon Core Implementation | Location |
 |---|---|---|
-| `AgentCard` | `Agent` struct (needs richer `skills`, `interfaces`, `securitySchemes`) | `crates/core/src/bus_agent.rs` |
-| Capability advertising | `Agent.capabilities: Vec<String>` (A2A `skills[]` is richer — input schema + media types) | `crates/core/src/bus_agent.rs` |
-| `contextId` | `Conversation.conversation_id` | `crates/core/src/bus_conversation.rs` |
-| `Message` / `Part` | Conversation messages with envelope kinds (Phase 6a/b) | `crates/server/src/api/bus.rs` |
-| `Task` + `TaskState` | **MISSING** — closest analog is chain `StepResult` | needs `crates/core/src/a2a_task.rs` |
-| `TaskStatusUpdateEvent` | `StreamChunk` / `StreamEnd` on conversation events | `crates/core/src/bus_stream.rs` |
-| `Artifact` (with `append` / `lastChunk`) | **MISSING** — tool output JSON has no streaming-append semantics | needs new type |
-| `ROLE_USER` / `ROLE_AGENT` | `ToolCall.sender` (agent_id) — implicit role | `crates/core/src/bus_tool.rs` |
-| Streaming via SSE | SSE stream + `Last-Event-ID` reconnect | `crates/server/src/api/stream.rs` |
-| Push notification webhook | **PARTIAL** — Acteon has webhook providers, not per-task push configs | needs new state-store entity |
-| API-key / Bearer / mTLS auth | Already supported | `crates/server/src/auth/`, `crates/crypto/src/tls.rs` |
-| `TASK_STATE_AUTH_REQUIRED` interrupt | `BusApproval` (Pending → Approved/Rejected) | `crates/core/src/bus_approval.rs` |
-| `TASK_STATE_INPUT_REQUIRED` | **MISSING** — needs Task-side pause-on-input semantics | new |
-| Idempotency via `messageId` | Dedup keys on action/chain path | `crates/gateway/src/` |
-| Schema registry | JSON Schema per topic, applied at publish-edge | `crates/bus/src/schema.rs` |
+| `AgentCard` | Native extension to `Agent` struct (skills, interfaces, schemas) | `crates/core/src/bus_agent.rs` |
+| `Task` | **NEW** `bus_task.rs` — Native Acteon primitive for asynchronous work | `crates/core/src/bus_task.rs` |
+| `TaskState` | Unified 8-state machine used by both A2A and internal orchestration | `crates/core/src/bus_task.rs` |
+| `Artifact` | Native `bus_stream.rs` extension with `append` / `lastChunk` support | `crates/core/src/bus_stream.rs` |
+| `Message` / `Part` | Converged envelope formats for all bus traffic | `crates/core/src/bus_conversation.rs` |
+| `requires_approval` | Maps natively to `BusApproval` | `crates/core/src/bus_approval.rs` |
+| Task ↔ Chain | **Native Bridge**: A2A Tasks are backed by Acteon Chain execution | `crates/core/src/chain.rs` |
 
-## Architecture
+## Architecture: Core Convergence
 
-We will ship A2A as a **facade crate** (`acteon-a2a`) alongside the existing internal bus, not as a replacement. The internal bus is *Acteon-as-orchestrator* (engines coordinating chains, swarms, tools); A2A is *Acteon-as-interoperable-agent* (external clients invoking Acteon over an open standard). Both consume the same state store, audit, auth, and Kafka transport — they differ in audience and wire format.
+A2A is integrated into the **core gateway loop**, not as a separate service. The `acteon-gateway` handles both internal bus events and A2A wire formats (JSON-RPC 2.0 / REST) using a shared protocol substrate.
 
 ```mermaid
 graph TD
-    External[External A2A clients<br/>ADK / Bedrock / Foundry / custom]
-    Internal[Internal callers<br/>swarm, chains, SDKs]
+    External[External A2A clients<br/>ADK / Bedrock / Foundry]
+    Internal[Internal callers<br/>Swarm, Chains, SDKs]
     
-    External -->|JSON-RPC 2.0 + SSE| A2A[acteon-a2a facade<br/>/a2a/rpc, /.well-known/agent.json]
-    Internal -->|REST + SSE| Bus[Existing bus API<br/>/v1/bus/*]
+    subgraph "Acteon Gateway (Core Convergence)"
+        Protocol[Protocol Codec Layer<br/>A2A JSON-RPC / REST / SSE]
+        TaskEngine[Task Lifecycle Manager<br/>Native 8-state machine]
+        ChainEngine[Chain Orchestrator]
+    end
+
+    External --> Protocol
+    Internal --> Protocol
     
-    A2A --> Gateway
-    Bus --> Gateway[acteon-gateway]
-    Gateway --> StateStore[(State store)]
-    Gateway --> Audit[(Audit store)]
-    Gateway --> Kafka[(Kafka)]
+    Protocol --> TaskEngine
+    TaskEngine <--> ChainEngine
+    
+    TaskEngine --> StateStore[(State store)]
+    TaskEngine --> Audit[(Audit store)]
+    TaskEngine --> Kafka[(Kafka)]
 ```
 
-Rationale:
+### Key Decisions for Core-First
 
-- The internal bus API is consumed by 5 polyglot SDKs, the swarm crate, simulation examples, and the admin UI. Refactoring it to *be* A2A would disrupt all of those for no internal benefit.
-- A2A's task lifecycle (8 states, including interrupt states) is richer than what the internal bus needs day-to-day. Keeping it in the facade avoids forcing those semantics on internal callers.
-- The facade can map A2A → bus selectively. For example, `SendMessage` with `requires_approval=true` lands as a `BusApproval`; `SubscribeToTask` proxies the existing `bus_stream.rs` SSE bridge with re-framed envelopes.
+1.  **Task ↔ Chain Foundation:** An A2A Task *is* the primary external representation of an Acteon Chain execution. When an external agent invokes Acteon, the lifecycle is managed by the Chain engine, and the state is projected via the A2A Task primitive.
+2.  **Stateless Entrypoints:** The protocol layer in the gateway remains stateless. All Task state is persisted in the shared `StateStore` and synchronized via `Kafka` events, allowing horizontal scaling of A2A endpoints.
+3.  **Identity Stamping:** A2A interactions use Phase 10's `Grant.agent_id`. Every external call is identity-bound, ensuring the audit trail shows the specific external agent identity alongside the tenant.
+4.  **State Machine Convergence:** The 8-state A2A `TaskState` enum is adopted **verbatim** as the canonical lifecycle. Narrower internal enums (`ConversationState`, `ToolResultStatus`) remain in place for their respective domains, and the Task Engine projects from / into them at the bus boundary. Internal callers are not forced to reason in 8 states.
+5.  **Breaking Changes Acceptable:** Acteon has no paid or external customers at this stage. The plan treats the existing bus envelope (`bus_conversation.rs`, `bus_stream.rs`, polyglot SDK message shapes) as freely mutable. No version-shimming or back-compat work is in scope.
 
-## Net-New Components
+### Inherits from Existing Infrastructure
 
-### Core types (`acteon-core`)
+The Core-First plan deliberately reuses what's already shipped, not rebuilds it:
 
-- `a2a::Task` — id, contextId, status, artifacts[], history[], metadata. 8-state machine.
-- `a2a::Artifact` — id, parts[], append/lastChunk flags for chunked output.
-- `a2a::Message` / `a2a::Part` — text/file(raw|url)/data variants. Distinct from `ToolCall.arguments` to keep wire-shape isolated.
-- `a2a::AgentCard` — extends `Agent` with skills, interfaces, securitySchemes, signature.
-- `a2a::PushNotificationConfig` — per-task webhook URL + auth scheme.
+- **SSE streaming + reconnect** (PRs #153–157, May 2026) — `Last-Event-ID` replay, per-tenant connection caps, slow-client backpressure. Drop-in for `SubscribeToTask` and push-notification fan-out.
+- **JSON Schema registry** at publish-edge (`crates/bus/src/schema.rs`) — directly powers A2A `Skill.inputSchema` validation.
+- **Audit hash chain + compliance verifier** (`crates/server/src/api/compliance.rs`) — every Task transition lands in the same tamper-evident audit pipeline.
+- **mTLS stack** (`crates/crypto/src/tls.rs`) — already wired into the shared `reqwest::Client`; satisfies `MutualTlsSecurityScheme` for both inbound A2A requests and outbound push delivery.
+- **Multi-tenant ACL** — A2A §3.3.2 ("never leak resource existence to unauthorized clients") is already how Acteon returns 403 vs. 404 on tenant mismatches.
+- **Idempotency** — action/chain dedup-key infrastructure maps onto A2A `messageId` deduplication.
+- **`Grant.agent_id` binding** (Phase 10) — per-agent API-key identity is already in the auth layer.
 
-### Facade crate (`crates/a2a`)
+## Risks
 
-- JSON-RPC 2.0 router for the 11 spec methods.
-- `Task` state machine owner; persistence via existing `State` backend (new `KeyKind::A2aTask`).
-- SSE bridge re-framing `StreamChunk`/`StreamEnd` as A2A `StreamResponse`.
-- Push delivery worker (reuses shared `reqwest::Client` from `main.rs` and the existing audit-stamped envelope pattern).
-
-### Server endpoints
-
-- `GET /.well-known/agent.json` — public, unauthenticated, returns the active card.
-- `POST /a2a/rpc` — JSON-RPC entry point.
-- `GET /a2a/tasks/{id}:subscribe` — SSE stream.
-- Optional REST binding at `/a2a/tasks/...` per spec §11.
-
-### Auth integration
-
-Map A2A `securitySchemes` to existing API-key grants:
-
-- `APIKeySecurityScheme` → existing API keys.
-- `HTTPAuthSecurityScheme` (Bearer) → trivial extension.
-- `MutualTlsSecurityScheme` → already supported.
-- `OAuth2SecurityScheme` / `OpenIdConnect` → out of scope for MVP.
-
-`Grant.agent_id` (Phase 10 of the bus work) gives caller→agent identity stamping for free.
-
-## What We Get For Free
-
-- **Streaming + reconnect**: PRs #153–157 (May 2026) shipped SSE reconnect with `Last-Event-ID` across all SDKs. Drop-in for `SubscribeToTask`.
-- **Multi-tenancy + ACL**: A2A §3.3.2 mandates "never leak resource existence to unauthorized clients." Acteon already returns 403 (not 404) on wrong-tenant access.
-- **Schema validation**: A2A `Skill.inputSchema` is JSON Schema; the bus already validates JSON Schema at publish-edge.
-- **Idempotency**: Action dedup keys map onto A2A `messageId` idempotency (spec §3.3.1).
-- **Audit trail**: Every A2A message → audit record, with hash-chain compliance verification.
-- **Polyglot SDKs**: Rust, Python, Node, Go, Java — once the server speaks A2A, all five get it via the existing client codegen pattern.
-
-## Architectural Decisions to Settle
-
-1.  **Task ↔ Chain relationship.** Two options:
-    - *Independent* — A2A tasks live in their own state-store kind; chains stay internal-only.
-    - *Bridge* — an incoming A2A task can spawn a chain, and chain state is exposed as `TaskStatus`. More work, but powerful (external agents can drive Acteon chains end-to-end).
-    
-    **Recommended:** start with Independent for MVP. Add the bridge in a follow-up once the task primitive has shipped.
-
-2.  **AgentCard signing.** Optional per spec §8.4. Required only for federated discovery; HTTPS at the well-known endpoint is sufficient for most deployments. Skip in MVP unless customers ask.
-
-3.  **Identity granularity.** A2A is agent-to-agent. Acteon's auth is tenant + API key + grant. Phase 10's `Grant.agent_id` binding lets each external A2A agent get its own API key for cleaner audit. Default to that.
-
-4.  **Versioning posture.** Ship A2A 1.0 only. Use the `A2A-Version` header to gate future migrations.
-
-## Risks & Unknowns
-
-- **Spec churn.** A2A 1.0 ratified late 2025; subsequent versions may change framing. Keep the facade thin to preserve a clean migration path.
-- **utoipa recursion.** A2A's `Task` is recursive via `referenceTaskIds`; same infinite-recursion landmine as `ChainStepStatus.parallel_sub_steps`. Apply the same `#[schema(value_type = Object)]` workaround.
-- **Payload size.** A2A `Part` can carry arbitrary data; existing publish-edge caps (512KB content / 1MB payload) may need an A2A-specific tier.
-- **Push delivery reliability.** A2A doesn't mandate exactly-once. Reuse the existing webhook provider's retry + DLQ pattern.
-- **OAuth2 / OIDC.** Not in MVP. If enterprise customers require it, scope as Phase 10.
-
-## Effort Estimate
-
-**~6 weeks single-engineer for full SDK parity** or **~3 weeks server-only MVP**.
-
----
+- **A2A spec churn.** 1.0 was ratified in late 2025 and is still evolving. Keep the protocol codec layer thin and put the `A2A-Version` header on the critical path so future revisions don't cascade into the Task Engine.
+- **utoipa recursion landmine.** `Task` references other tasks via `referenceTaskIds`, mirroring the `ChainStepStatus.parallel_sub_steps` infinite-schema-recursion bug. Use `#[schema(value_type = Object)]` on the recursive field from day one.
+- **Payload size.** A2A `Part` carries arbitrary data (text, base64 raw, URL refs, JSON). Existing publish-edge caps (512KB content / 1MB payload) are tuned for the internal bus; A2A may need an explicit per-tenant tier or chunked-artifact streaming for large outputs.
+- **Push delivery semantics.** A2A doesn't mandate exactly-once. Reuse the webhook provider's retry + DLQ pattern and stamp `acteon.push.attempt` headers for audit replay.
+- **8-state surface area in clients.** SDK consumers will now see eight Task states. Worth a doc page distinguishing terminal (Completed/Failed/Canceled/Rejected) from interrupt (InputRequired/AuthRequired) states so library users don't write incorrect "is finished" checks.
 
 ## Implementation Plan
 
-### Phase 0: RFC & Alignment
-- [ ] Settle the four architectural decisions above (Task↔Chain, signing, identity, versioning) with the core team.
-- [ ] Confirm coexistence (facade) vs. replacement of internal bus surface.
-- [ ] Pick MVP cut: server-only vs. full SDK parity.
-
-### Phase 1: Core Types (`acteon-core`)
-- [ ] Add `a2a::Task` with 8-state lifecycle (`Submitted`/`Working`/`Completed`/`Failed`/`Canceled`/`InputRequired`/`AuthRequired`/`Rejected`).
-- [ ] Add `a2a::Artifact` with `append` / `lastChunk` semantics.
-- [ ] Add `a2a::Message` and `a2a::Part` (text/file/data variants).
-- [ ] Add `a2a::AgentCard` extending `Agent` with `skills[]`, `interfaces[]`, `securitySchemes`, optional `signature`.
-- [ ] Add `a2a::PushNotificationConfig`.
-- [ ] Validation rules + serde + utoipa schemas (apply `#[schema(value_type = Object)]` to recursive fields).
+### Phase 1: Core Primitives (`acteon-core`) — ~5 days
+- [ ] **Native Task:** Add `bus_task.rs` defining `Task` with the 8-state lifecycle, `Artifact`, `Message`, `Part`, and `PushNotificationConfig`. Include validation, serde, and utoipa schemas (apply `#[schema(value_type = Object)]` to recursive fields).
+- [ ] **Artifact Streaming:** Update `bus_stream.rs` to include `append` and `last_chunk` metadata for native A2A artifact support.
+- [ ] **Agent Evolution:** Extend `Agent` in `bus_agent.rs` with `skills[]`, `interfaces[]`, and JSON Schema capability definitions.
+- [ ] **Converged Envelopes:** Align `bus_conversation.rs` message parts with A2A `Message`/`Part` semantics.
 - [ ] Unit tests for state transitions, validation, and serde round-trips.
 
-### Phase 2: Facade Crate (`crates/a2a`)
-- [ ] Scaffold `crates/a2a`; register in workspace.
-- [ ] JSON-RPC 2.0 router covering the 11 spec methods.
-- [ ] `Task` persistence via existing `State` backend (new `KeyKind::A2aTask`).
-- [ ] Translation layer: A2A `SendMessage` → bus operations (conversation create / message append / tool-call envelope).
-- [ ] CAS-based status transitions matching the bus's retry pattern.
-- [ ] Idempotency on `messageId` via existing dedup-key infra.
+### Phase 2: Gateway Integration (`crates/gateway`) — ~6 days
+- [ ] **Protocol Codecs:** Implement encoders/decoders for A2A JSON-RPC 2.0 and the REST binding (spec §11). Wire `A2A-Version` header negotiation with `VersionNotSupportedError`.
+- [ ] **Task Engine:** Implement the lifecycle manager in the gateway, handling state transitions and persistence via the existing `State` backend (new `KeyKind::A2aTask`). Use CAS retries to mirror the bus's optimistic-locking pattern.
+- [ ] **The Bridge:** Implement native mapping between `Task` state and `Chain` status — A2A `Submitted/Working` ↔ chain step progress; `InputRequired/AuthRequired` ↔ `BusApproval`; terminal states ↔ chain `StepResult`.
+- [ ] **Audit Integration:** Stamp every A2A operation with `AuditEventKind::A2aTaskTransition`.
+- [ ] **Idempotency:** Wire A2A `messageId` through existing dedup-key infrastructure.
 
-### Phase 3: Discovery & Auth
-- [ ] `GET /.well-known/agent.json` (public, unauthenticated).
-- [ ] AgentCard builder (assembles capabilities, skills, interfaces, security schemes from server config + registered providers).
-- [ ] `A2A-Version` header negotiation; `VersionNotSupportedError` for unsupported.
-- [ ] Map `APIKeySecurityScheme` / `HTTPAuthSecurityScheme` (Bearer) / `MutualTlsSecurityScheme` to existing grants.
+### Phase 3: Discovery & SSE Bridge — ~4 days
+- [ ] **Global Discovery Registry:** Implement a dynamic `DiscoveryService` that aggregates native `AgentCard` data for `/.well-known/agent.json`. Public and unauthenticated per spec.
+- [ ] **High-Scale Streaming:** Integrate `SubscribeToTask` and `SendStreamingMessage` directly with the gateway's SSE bridge, reusing `Last-Event-ID` and per-tenant connection caps. Re-frame internal `StreamChunk` / `StreamEnd` records as A2A `StreamResponse` envelopes.
 - [ ] Optional `GetExtendedAgentCard` for authenticated callers.
 
-### Phase 4: Streaming Bridge
-- [ ] `GET /a2a/tasks/{id}:subscribe` SSE endpoint.
-- [ ] Bridge: subscribe to relevant `StreamChunk`/`StreamEnd` records, reframe as A2A `StreamResponse`.
-- [ ] Reuse `Last-Event-ID` reconnect (already implemented for bus).
-- [ ] Per-tenant SSE connection caps (reuse existing config).
-- [ ] `SendStreamingMessage` initial response with full task, subsequent updates as `statusUpdate` / `artifactUpdate`.
+### Phase 4: Push Notifications & Security Schemes — ~4 days
+- [ ] **Native Push Delivery:** Implement task-scoped webhook delivery (`Create/Get/List/Delete TaskPushNotificationConfig`). Reuse shared `reqwest::Client`, retry + DLQ, and audit-stamped envelope pattern from the webhook provider.
+- [ ] **Security Schemes:** Map `APIKeySecurityScheme`, `HTTPAuthSecurityScheme` (Bearer), and `MutualTlsSecurityScheme` to native Acteon Grants and TLS configurations. (`OAuth2`/`OpenIdConnect` deferred to a follow-up.)
 
-### Phase 5: Push Notifications
-- [ ] `PushNotificationConfig` CRUD endpoints (`Create/Get/List/Delete`).
-- [ ] Per-task config persistence (new state-store entity).
-- [ ] Delivery worker: subscribes to task status changes, POSTs `StreamResponse` to registered webhooks.
-- [ ] Reuse shared `reqwest::Client` and mTLS support from `crates/crypto/src/tls.rs`.
-- [ ] Retry + DLQ mirroring webhook provider behavior.
-- [ ] Audit-stamp delivery attempts.
+### Phase 5: Hardening & Validation — ~3 days
+- [ ] **Recursive depth validation** for Tasks to prevent circular reference attacks via `referenceTaskIds`.
+- [ ] **Payload caps:** A2A-specific size limits for `Part` content; chunked-artifact streaming for outputs exceeding the existing 1MB payload tier.
+- [ ] **Security review:** Run the existing security-review skill against the new endpoints (`/.well-known/agent.json`, `/a2a/rpc`, push delivery worker).
+- [ ] **Load test:** Add gateway benchmark covering streamed Task lifecycle under N concurrent subscribers.
 
-### Phase 6: REST Binding
-- [ ] `POST /a2a/tasks` (SendMessage).
-- [ ] `POST /a2a/tasks:stream` (SendStreamingMessage).
-- [ ] `GET /a2a/tasks/{id}` (GetTask).
-- [ ] `GET /a2a/tasks` (ListTasks with pagination + status filter).
-- [ ] `POST /a2a/tasks/{id}:cancel` (CancelTask).
-- [ ] `GET /a2a/tasks/{id}:subscribe` (SubscribeToTask).
-- [ ] Push notification config endpoints.
-- [ ] All thin wrappers over the JSON-RPC handlers.
-
-### Phase 7: Polyglot SDK Updates
-- [ ] Rust client: `crates/client/src/a2a.rs` with helper methods.
-- [ ] Python SDK: A2A client surface.
-- [ ] Node.js SDK: A2A client surface.
-- [ ] Go SDK: A2A client surface.
-- [ ] Java SDK: A2A client surface.
-
-### Phase 8: Simulation & Docs
-- [ ] `crates/simulation/examples/a2a_simulation.rs` — round-trip a Task through all 8 states.
-- [ ] `docs/book/features/a2a.md` — user-facing guide.
-- [ ] `docs/architecture/a2a.md` — final architecture doc once shipped.
-- [ ] Update CHANGELOG and README feature matrix.
-
-### Phase 9: UI Surface (Optional)
-- [ ] Dashboard tab listing A2A tasks distinctly from internal bus tasks.
-- [ ] AgentCard preview / signing controls.
-- [ ] Push notification config management.
-
-### Phase 10: Hardening (Future)
-- [ ] `OAuth2SecurityScheme` / `OpenIdConnectSecurityScheme` support.
-- [ ] AgentCard signing (Ed25519, reusing the compliance hash-chain crypto stack).
-- [ ] Bridge mode: A2A Task → Acteon Chain spawn.
-- [ ] Acteon-as-A2A-client (outbound calls to third-party agents).
+### Phase 6: SDK & Simulation — ~5 days
+- [ ] Update all polyglot SDKs (Rust, Python, Node, Go, Java) to support the native A2A Task primitives.
+- [ ] Add `a2a_core_simulation.rs` demonstrating a Task pipeline through all 8 states (including `InputRequired` and `AuthRequired` interrupts).
+- [ ] `docs/book/features/a2a.md` user-facing guide; promote this design doc to `docs/architecture/a2a.md` once shipped.
+- [ ] CHANGELOG entry + README feature-matrix update.
 
 ### Pre-Commit Checks (per Phase)
 - [ ] `cargo fmt --all`
@@ -241,7 +129,7 @@ Map A2A `securitySchemes` to existing API-key grants:
 - [ ] `cargo check --all-targets`
 - [ ] `(cd ui && npm run lint && npm run build)` when UI changes touched
 
----
+**Total estimated effort: ~27 days (≈5.5 weeks single-engineer).** Phase ordering is deliberate — Phases 1–3 deliver an unauthenticated, streaming, discoverable A2A endpoint usable by external clients; Phases 4–6 layer in production-grade auth, push, hardening, and SDK parity.
 
 ## References
 
@@ -249,5 +137,5 @@ Map A2A `securitySchemes` to existing API-key grants:
 - [A2A on GitHub](https://github.com/a2aproject/A2A)
 - [Google announcement of A2A](https://developers.googleblog.com/en/a2a-a-new-era-of-agent-interoperability/)
 - [Agent2Agent protocol upgrade — Google Cloud Blog](https://cloud.google.com/blog/products/ai-machine-learning/agent2agent-protocol-is-getting-an-upgrade)
-- Internal: `docs/design/mcp-server.md` (sibling external-protocol implementation)
-- Internal: `docs/architecture/agent-swarm.md` (multi-agent orchestration this complements)
+- Internal: `docs/design/mcp-server.md` — sibling external-protocol implementation
+- Internal: `docs/architecture/agent-swarm.md` — multi-agent orchestration this complements


### PR DESCRIPTION
Phase 1 of the A2A protocol implementation. Bundles the design doc (`docs/design/a2a-protocol.md`) and the first slice of code together so they land as one reviewable unit.

## Summary

### Design doc — `docs/design/a2a-protocol.md`
- Core-First Convergence plan: A2A `Task` becomes a native primitive in `acteon-core`, not a peripheral facade.
- A2A ↔ Acteon mapping table, architecture (with mermaid), key decisions (Task↔Chain bridge, stateless entrypoints, identity stamping, state-machine convergence, breaking-changes-acceptable).
- "Inherits from Existing Infrastructure" section grounding the timeline.
- Risks section (spec churn, utoipa recursion, payload caps, push semantics, 8-state client surface).
- 6-phase implementation plan with per-phase effort (~27 days total).

### Phase 1 code — `crates/core/src/bus_task.rs`
- `TaskState` (8-state lifecycle) with `is_terminal` / `is_interrupt` / `is_in_progress` / `can_transition_to` helpers.
- `Task`, `TaskStatus`, `Message`, `Role`, `Part` (text/raw/url/data), `Artifact`, `TaskValidationError`.
- Wire format uses **`camelCase`** serde rename so values serialize directly onto A2A JSON-RPC 2.0 envelopes (`messageId`, `contextId`, `taskId`).
- State machine enforced via `Task::transition_to(state, message)`: `Submitted → Working → {Completed | Failed | Canceled | InputRequired | AuthRequired}`, interrupts can resume to `Working`, terminals are absorbing.
- Container caps tuned to the existing bus publish-edge tier: 512KB text, 1MB raw (base64), 1MB data, 1000-message history, 256 artifacts, 64 parts/container.
- 42 unit tests covering classification helpers, transition matrix (including exhaustive "terminal states have no transitions" check), exactly-one-of part validation, container caps, append-vs-replace artifact semantics, and `camelCase` / `snake_case` wire format.

## Out of scope (follow-up PRs per the design doc)
- Extend `bus_stream.rs` with `append` / `last_chunk` artifact-streaming hooks.
- Extend `bus_agent.rs` with `AgentCard` skills/interfaces/securitySchemes.
- Align `bus_conversation.rs` message parts with `Message`/`Part`.
- `PushNotificationConfig` (Phase 4).
- Task Engine in `acteon-gateway` (Phase 2).

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --no-deps -- -D warnings`
- [x] `cargo test -p acteon-core --lib` (442 passed, 42 new `bus_task` tests)
- [x] `cargo check --all-targets`
- [ ] Design-doc review against the Core-First decisions before downstream PRs depend on them
- [ ] Confirm the `camelCase` wire-format choice

🤖 Generated with [Claude Code](https://claude.com/claude-code)