### PR TITLE
feat(gateway): A2A stale-task reaper — Phase 2.3

### DIFF
--- a/crates/gateway/src/background/mod.rs
+++ b/crates/gateway/src/background/mod.rs
@@ -56,6 +56,10 @@ pub struct BackgroundConfig {
     pub enable_retention_reaper: bool,
     /// How often to run the data retention reaper (default: 3600 seconds).
     pub retention_check_interval: Duration,
+    /// Whether the stale-task reaper is enabled (default: false).
+    pub enable_stale_task_reaper: bool,
+    /// How often to run the stale-task reaper (default: 60 seconds).
+    pub stale_task_check_interval: Duration,
     /// Whether periodic template sync from state store is enabled (default: false).
     pub enable_template_sync: bool,
     /// How often to sync templates from the state store (default: 30 seconds).
@@ -109,6 +113,8 @@ impl Default for BackgroundConfig {
             recurring_check_interval: Duration::from_secs(60),
             enable_retention_reaper: false,
             retention_check_interval: Duration::from_secs(3600),
+            enable_stale_task_reaper: false,
+            stale_task_check_interval: Duration::from_secs(60),
             enable_template_sync: false,
             template_sync_interval: Duration::from_secs(30),
             enable_silence_sync: true,
@@ -367,6 +373,7 @@ impl BackgroundProcessor {
         let mut scheduled_interval = interval(self.config.scheduled_check_interval);
         let mut recurring_interval = interval(self.config.recurring_check_interval);
         let mut retention_interval = interval(self.config.retention_check_interval);
+        let mut stale_task_interval = interval(self.config.stale_task_check_interval);
         let mut template_sync_interval = interval(self.config.template_sync_interval);
         let mut silence_sync_interval = interval(self.config.silence_sync_interval);
         let mut time_interval_sync_interval = interval(self.config.time_interval_sync_interval);
@@ -406,6 +413,11 @@ impl BackgroundProcessor {
                 _ = retention_interval.tick(), if self.config.enable_retention_reaper => {
                     if let Err(e) = self.run_retention_reaper().await {
                         error!(error = %e, "error running retention reaper");
+                    }
+                }
+                _ = stale_task_interval.tick(), if self.config.enable_stale_task_reaper => {
+                    if let Err(e) = self.run_stale_task_reaper().await {
+                        error!(error = %e, "error running stale-task reaper");
                     }
                 }
                 // TODO(template-sync): Replace with reactive invalidation
@@ -711,6 +723,8 @@ mod tests {
                 recurring_check_interval: Duration::from_secs(60),
                 enable_retention_reaper: false,
                 retention_check_interval: Duration::from_secs(3600),
+                enable_stale_task_reaper: false,
+                stale_task_check_interval: Duration::from_secs(60),
                 enable_template_sync: false,
                 template_sync_interval: Duration::from_secs(30),
                 enable_silence_sync: false,
@@ -837,6 +851,8 @@ mod tests {
                 recurring_check_interval: Duration::from_secs(60),
                 enable_retention_reaper: false,
                 retention_check_interval: Duration::from_secs(3600),
+                enable_stale_task_reaper: false,
+                stale_task_check_interval: Duration::from_secs(60),
                 enable_template_sync: false,
                 template_sync_interval: Duration::from_secs(30),
                 enable_silence_sync: false,
@@ -954,6 +970,8 @@ mod tests {
                 recurring_check_interval: Duration::from_secs(60),
                 enable_retention_reaper: false,
                 retention_check_interval: Duration::from_secs(3600),
+                enable_stale_task_reaper: false,
+                stale_task_check_interval: Duration::from_secs(60),
                 enable_template_sync: false,
                 template_sync_interval: Duration::from_secs(30),
                 enable_silence_sync: false,
@@ -1062,6 +1080,8 @@ mod tests {
                 recurring_check_interval: Duration::from_secs(60),
                 enable_retention_reaper: false,
                 retention_check_interval: Duration::from_secs(3600),
+                enable_stale_task_reaper: false,
+                stale_task_check_interval: Duration::from_secs(60),
                 enable_template_sync: false,
                 template_sync_interval: Duration::from_secs(30),
                 enable_silence_sync: false,
@@ -1596,6 +1616,60 @@ mod tests {
         let snap = metrics.snapshot();
         assert_eq!(snap.retention_deleted_state, 0);
         assert_eq!(snap.retention_skipped_compliance, 1);
+    }
+
+    #[tokio::test]
+    async fn stale_task_reaper_fails_zombie_tasks() {
+        let group_manager = Arc::new(GroupManager::new());
+        let state: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+        let metrics = Arc::new(GatewayMetrics::default());
+
+        // A zombie: non-terminal, last progress two hours ago, 60s TTL.
+        let mut zombie = acteon_core::Task::new("zombie", "ns", "tn");
+        zombie.last_progress_at = Some(Utc::now() - chrono::Duration::hours(2));
+        zombie.working_ttl_ms = 60_000;
+        let zombie_key = StateKey::new("ns", "tn", KeyKind::A2aTask, "zombie");
+        state
+            .set(&zombie_key, &serde_json::to_string(&zombie).unwrap(), None)
+            .await
+            .unwrap();
+
+        // A fresh task: progress just now, well within its TTL.
+        let fresh = acteon_core::Task::new("fresh", "ns", "tn");
+        let fresh_key = StateKey::new("ns", "tn", KeyKind::A2aTask, "fresh");
+        state
+            .set(&fresh_key, &serde_json::to_string(&fresh).unwrap(), None)
+            .await
+            .unwrap();
+
+        let processor = BackgroundProcessor::new(
+            BackgroundConfig {
+                enable_stale_task_reaper: true,
+                stale_task_check_interval: Duration::from_secs(60),
+                ..BackgroundConfig::default()
+            },
+            group_manager,
+            Arc::clone(&state),
+            Arc::clone(&metrics),
+            Vec::new(),
+            mpsc::channel(1).1,
+        );
+
+        processor.run_stale_task_reaper().await.unwrap();
+
+        // The zombie was transitioned to Failed.
+        let raw = state.get(&zombie_key).await.unwrap().unwrap();
+        let reaped: acteon_core::Task = serde_json::from_str(&raw).unwrap();
+        assert_eq!(reaped.status.state, acteon_core::TaskState::Failed);
+
+        // The fresh task was left untouched.
+        let raw = state.get(&fresh_key).await.unwrap().unwrap();
+        let kept: acteon_core::Task = serde_json::from_str(&raw).unwrap();
+        assert_eq!(kept.status.state, acteon_core::TaskState::Submitted);
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.stale_tasks_reaped, 1);
+        assert_eq!(snap.stale_task_reaper_errors, 0);
     }
 
     #[tokio::test]

--- a/crates/gateway/src/background/workers/mod.rs
+++ b/crates/gateway/src/background/workers/mod.rs
@@ -4,4 +4,5 @@ mod group_flush;
 mod recurring;
 mod retention;
 mod scheduled;
+mod stale_task;
 mod timeout;

--- a/crates/gateway/src/background/workers/stale_task.rs
+++ b/crates/gateway/src/background/workers/stale_task.rs
@@ -1,0 +1,85 @@
+use chrono::Utc;
+use tracing::{info, warn};
+
+use acteon_core::Task;
+use acteon_state::KeyKind;
+
+use super::super::BackgroundProcessor;
+use crate::task_engine::{TaskEngine, TaskScope};
+
+impl BackgroundProcessor {
+    /// Run the stale-task reaper.
+    ///
+    /// Scans every A2A task row and transitions each **stale** task —
+    /// one sitting in a non-terminal state past its `working_ttl_ms`
+    /// without recorded progress — to `Failed`. A zombie task that no
+    /// producer is advancing would otherwise stay non-terminal
+    /// forever; `Task::is_stale_at` already reports it as stale on
+    /// read, and this worker makes that verdict durable.
+    ///
+    /// Each candidate is re-checked for staleness inside the task
+    /// engine's compare-and-swap (see `TaskEngine::fail_if_stale`), so
+    /// a task that recorded progress between the scan and the write is
+    /// left untouched.
+    pub(crate) async fn run_stale_task_reaper(
+        &self,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let now = Utc::now();
+        let engine = TaskEngine::new(self.state.clone());
+        let entries = self.state.scan_keys_by_kind(KeyKind::A2aTask).await?;
+
+        let mut reaped = 0u64;
+        let mut errors = 0u64;
+
+        for (key, raw_value) in entries {
+            // Task rows are stored as plain JSON — the TaskEngine does
+            // not encrypt them — so no decryption step is needed.
+            let task: Task = match serde_json::from_str(&raw_value) {
+                Ok(t) => t,
+                Err(e) => {
+                    warn!(key = %key, error = %e, "stale-task reaper: skipping malformed task row");
+                    continue;
+                }
+            };
+            // Cheap pre-filter on the scanned snapshot; the engine
+            // re-checks against the fresh row before it commits.
+            if !task.is_stale_at(now) {
+                continue;
+            }
+            let scope = TaskScope::new(&task.namespace, &task.tenant);
+            match engine.fail_if_stale(&scope, &task.id, now).await {
+                Ok(Some(t)) => {
+                    reaped += 1;
+                    self.metrics.increment_stale_tasks_reaped();
+                    info!(
+                        namespace = %t.namespace,
+                        tenant = %t.tenant,
+                        task_id = %t.id,
+                        "stale-task reaper: task failed (exceeded working TTL)"
+                    );
+                }
+                Ok(None) => {
+                    // Recorded progress or reached a terminal state
+                    // between the scan and the commit — leave it.
+                }
+                Err(e) => {
+                    warn!(
+                        namespace = %task.namespace,
+                        tenant = %task.tenant,
+                        task_id = %task.id,
+                        error = %e,
+                        "stale-task reaper: error failing stale task"
+                    );
+                    errors += 1;
+                    self.metrics.increment_stale_task_reaper_errors();
+                }
+            }
+        }
+
+        if reaped > 0 || errors > 0 {
+            info!(reaped, errors, "stale-task reaper cycle complete");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/gateway/src/metrics.rs
+++ b/crates/gateway/src/metrics.rs
@@ -79,6 +79,10 @@ pub struct GatewayMetrics {
     pub retention_skipped_compliance: AtomicU64,
     /// Retention reaper errors.
     pub retention_errors: AtomicU64,
+    /// A2A tasks transitioned to `Failed` by the stale-task reaper.
+    pub stale_tasks_reaped: AtomicU64,
+    /// Stale-task reaper errors.
+    pub stale_task_reaper_errors: AtomicU64,
     /// WASM plugin invocations.
     pub wasm_invocations: AtomicU64,
     /// WASM plugin invocation errors.
@@ -273,6 +277,17 @@ impl GatewayMetrics {
         self.retention_errors.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Increment the stale-tasks-reaped counter.
+    pub fn increment_stale_tasks_reaped(&self) {
+        self.stale_tasks_reaped.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the stale-task reaper errors counter.
+    pub fn increment_stale_task_reaper_errors(&self) {
+        self.stale_task_reaper_errors
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
     /// Increment the WASM invocations counter.
     pub fn increment_wasm_invocations(&self) {
         self.wasm_invocations.fetch_add(1, Ordering::Relaxed);
@@ -372,6 +387,8 @@ impl GatewayMetrics {
             retention_deleted_state: self.retention_deleted_state.load(Ordering::Relaxed),
             retention_skipped_compliance: self.retention_skipped_compliance.load(Ordering::Relaxed),
             retention_errors: self.retention_errors.load(Ordering::Relaxed),
+            stale_tasks_reaped: self.stale_tasks_reaped.load(Ordering::Relaxed),
+            stale_task_reaper_errors: self.stale_task_reaper_errors.load(Ordering::Relaxed),
             wasm_invocations: self.wasm_invocations.load(Ordering::Relaxed),
             wasm_errors: self.wasm_errors.load(Ordering::Relaxed),
             signing_verified: self.signing_verified.load(Ordering::Relaxed),
@@ -452,6 +469,10 @@ pub struct MetricsSnapshot {
     pub retention_skipped_compliance: u64,
     /// Retention reaper errors.
     pub retention_errors: u64,
+    /// A2A tasks transitioned to `Failed` by the stale-task reaper.
+    pub stale_tasks_reaped: u64,
+    /// Stale-task reaper errors.
+    pub stale_task_reaper_errors: u64,
     /// WASM plugin invocations.
     pub wasm_invocations: u64,
     /// WASM plugin invocation errors.

--- a/crates/gateway/src/task_engine.rs
+++ b/crates/gateway/src/task_engine.rs
@@ -35,9 +35,6 @@
 //! - **Audit integration**: stamping `AuditEventKind::A2aTaskTransition`
 //!   on every transition. Deferred to a follow-up that touches
 //!   `acteon-audit` simultaneously.
-//! - **Stale-task reaper**: background job that transitions stale
-//!   tasks to `Failed` via [`Task::is_stale_at`]. Lives in
-//!   `crates/gateway/src/background/` (next PR).
 //! - **Artifact-stream gatekeeper**: enforces "no chunks after
 //!   `lastChunk`" and `totalChunks` completeness across multiple
 //!   `TaskArtifactUpdateEvent` deliveries. Stateful per-artifact;
@@ -53,12 +50,12 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use tracing::{debug, warn};
 
 use acteon_core::{
-    Artifact, MAX_REFERENCE_DEPTH, Task, TaskArtifactUpdateEvent, TaskMessage, TaskState,
+    Artifact, MAX_REFERENCE_DEPTH, Task, TaskArtifactUpdateEvent, TaskMessage, TaskRole, TaskState,
     TaskValidationError,
 };
 use acteon_state::{CasResult, KeyKind, StateError, StateKey, StateStore};
@@ -235,6 +232,66 @@ impl TaskEngine {
             Ok(())
         })
         .await
+    }
+
+    /// Transition a task to [`TaskState::Failed`] **iff** it is still
+    /// stale at `now` when the fresh row is loaded under CAS.
+    ///
+    /// This is the stale-task reaper's mutation entry point. A task
+    /// that sits in a non-terminal state past its `working_ttl_ms`
+    /// without recorded progress is a zombie; failing it makes that
+    /// verdict durable rather than only derived on read by
+    /// [`Task::is_stale_at`].
+    ///
+    /// Returns the updated task if it was reaped, or `None` if —
+    /// between the reaper's scan and this write — the task recorded
+    /// progress or reached a terminal state and is no longer stale.
+    /// The staleness re-check runs against the *fresh* CAS-loaded
+    /// row, so a task a producer just heartbeated is never failed out
+    /// from under it. [`Task::is_stale_at`] already excludes terminal
+    /// tasks, and `Failed` is a legal transition from every
+    /// non-terminal state, so the transition itself cannot be
+    /// rejected.
+    pub async fn fail_if_stale(
+        &self,
+        scope: &TaskScope,
+        task_id: &str,
+        now: DateTime<Utc>,
+    ) -> Result<Option<Task>, TaskEngineError> {
+        let key = scope.task_key(task_id);
+        let reason = TaskMessage::text(
+            format!("stale-reaper-{}", now.timestamp_millis()),
+            TaskRole::Agent,
+            "Task failed by the stale-task reaper: no recorded progress within its working TTL.",
+        );
+        for _ in 0..MAX_CAS_RETRY_ATTEMPTS {
+            let Some((raw, version)) = self.state.get_versioned(&key).await? else {
+                // Task was deleted between the reaper's scan and now.
+                return Ok(None);
+            };
+            let mut task: Task = serde_json::from_str(&raw)?;
+            if !task.is_stale_at(now) {
+                // Recorded progress or reached a terminal state since
+                // the scan — no longer a zombie, leave it untouched.
+                return Ok(None);
+            }
+            task.transition_to(TaskState::Failed, Some(reason.clone()))?;
+            let payload = serde_json::to_string(&task)?;
+            match self
+                .state
+                .compare_and_swap(&key, version, &payload, None)
+                .await?
+            {
+                CasResult::Ok => {
+                    debug!(task_id = %task_id, "stale task reaped to Failed");
+                    return Ok(Some(task));
+                }
+                CasResult::Conflict { .. } => {
+                    // Lost the race; re-read and re-evaluate staleness.
+                }
+            }
+        }
+        Err(TaskEngineError::CasExhausted(task_id.to_string()))
     }
 
     /// Append a history message to a task. Idempotent on
@@ -1139,5 +1196,92 @@ mod tests {
         }
         e.create_task(root).await.unwrap();
         assert!(e.get_task(&scope(), "wide-root").await.unwrap().is_some());
+    }
+
+    // --- Stale-task reaper (fail_if_stale) ---
+
+    /// A task whose last progress is `age_secs` in the past with a
+    /// `ttl_ms` working TTL — stale once `age > ttl`.
+    fn aged_task(id: &str, age_secs: i64, ttl_ms: i64) -> Task {
+        let mut t = sample_task(id);
+        t.last_progress_at = Some(Utc::now() - chrono::Duration::seconds(age_secs));
+        t.working_ttl_ms = ttl_ms;
+        t
+    }
+
+    #[tokio::test]
+    async fn fail_if_stale_reaps_a_stale_task() {
+        let e = engine();
+        // Submitted, last progress an hour ago, 60s TTL → stale.
+        e.create_task(aged_task("zombie", 3600, 60_000))
+            .await
+            .unwrap();
+        let reaped = e
+            .fail_if_stale(&scope(), "zombie", Utc::now())
+            .await
+            .unwrap();
+        assert!(reaped.is_some());
+        let t = e.get_task(&scope(), "zombie").await.unwrap().unwrap();
+        assert_eq!(t.status.state, TaskState::Failed);
+        // The failure carries an explanatory status message.
+        assert!(t.status.message.is_some());
+    }
+
+    #[tokio::test]
+    async fn fail_if_stale_leaves_a_fresh_task() {
+        let e = engine();
+        // Fresh task: last progress is now, well within its TTL.
+        e.create_task(sample_task("alive")).await.unwrap();
+        let reaped = e
+            .fail_if_stale(&scope(), "alive", Utc::now())
+            .await
+            .unwrap();
+        assert!(reaped.is_none());
+        let t = e.get_task(&scope(), "alive").await.unwrap().unwrap();
+        assert_eq!(t.status.state, TaskState::Submitted);
+    }
+
+    #[tokio::test]
+    async fn fail_if_stale_leaves_a_terminal_task() {
+        // A terminal task is never stale; fail_if_stale must no-op
+        // rather than re-transition it.
+        let e = engine();
+        e.create_task(sample_task("done")).await.unwrap();
+        e.transition_task(&scope(), "done", TaskState::Working, None)
+            .await
+            .unwrap();
+        e.transition_task(&scope(), "done", TaskState::Completed, None)
+            .await
+            .unwrap();
+        let reaped = e.fail_if_stale(&scope(), "done", Utc::now()).await.unwrap();
+        assert!(reaped.is_none());
+        let t = e.get_task(&scope(), "done").await.unwrap().unwrap();
+        assert_eq!(t.status.state, TaskState::Completed);
+    }
+
+    #[tokio::test]
+    async fn fail_if_stale_reaps_a_stale_working_task() {
+        // Staleness applies to any non-terminal state. Reap a Working
+        // task by evaluating against a `now` far past its TTL.
+        let e = engine();
+        e.create_task(sample_task("busy")).await.unwrap();
+        e.transition_task(&scope(), "busy", TaskState::Working, None)
+            .await
+            .unwrap();
+        let far_future = Utc::now() + chrono::Duration::days(1);
+        let reaped = e.fail_if_stale(&scope(), "busy", far_future).await.unwrap();
+        assert!(reaped.is_some());
+        let t = e.get_task(&scope(), "busy").await.unwrap().unwrap();
+        assert_eq!(t.status.state, TaskState::Failed);
+    }
+
+    #[tokio::test]
+    async fn fail_if_stale_on_missing_task_is_noop() {
+        let e = engine();
+        let reaped = e
+            .fail_if_stale(&scope(), "ghost", Utc::now())
+            .await
+            .unwrap();
+        assert!(reaped.is_none());
     }
 }

--- a/crates/server/src/api/health.rs
+++ b/crates/server/src/api/health.rs
@@ -55,6 +55,8 @@ fn build_metrics_response(
         retention_deleted_state: snap.retention_deleted_state,
         retention_skipped_compliance: snap.retention_skipped_compliance,
         retention_errors: snap.retention_errors,
+        stale_tasks_reaped: snap.stale_tasks_reaped,
+        stale_task_reaper_errors: snap.stale_task_reaper_errors,
         wasm_invocations: snap.wasm_invocations,
         wasm_errors: snap.wasm_errors,
         signing_verified: snap.signing_verified,

--- a/crates/server/src/api/prometheus.rs
+++ b/crates/server/src/api/prometheus.rs
@@ -327,6 +327,20 @@ fn render_snapshot(snap: &MetricsSnapshot) -> String {
         "Retention reaper processing errors.",
         snap.retention_errors,
     );
+
+    // -- Stale-task reaper counters --
+    write_counter(
+        &mut buf,
+        "acteon_stale_tasks_reaped_total",
+        "A2A tasks transitioned to Failed by the stale-task reaper.",
+        snap.stale_tasks_reaped,
+    );
+    write_counter(
+        &mut buf,
+        "acteon_stale_task_reaper_errors_total",
+        "Stale-task reaper processing errors.",
+        snap.stale_task_reaper_errors,
+    );
     write_counter(
         &mut buf,
         "acteon_wasm_invocations_total",
@@ -608,6 +622,8 @@ mod tests {
             retention_deleted_state: 0,
             retention_skipped_compliance: 0,
             retention_errors: 0,
+            stale_tasks_reaped: 0,
+            stale_task_reaper_errors: 0,
             wasm_invocations: 0,
             wasm_errors: 0,
             signing_verified: 0,
@@ -654,6 +670,8 @@ mod tests {
             retention_deleted_state: 10,
             retention_skipped_compliance: 2,
             retention_errors: 1,
+            stale_tasks_reaped: 4,
+            stale_task_reaper_errors: 1,
             wasm_invocations: 6,
             wasm_errors: 2,
             signing_verified: 42,
@@ -864,6 +882,8 @@ mod tests {
         "acteon_retention_deleted_state_total",
         "acteon_retention_skipped_compliance_total",
         "acteon_retention_errors_total",
+        "acteon_stale_tasks_reaped_total",
+        "acteon_stale_task_reaper_errors_total",
         "acteon_wasm_invocations_total",
         "acteon_wasm_errors_total",
         "acteon_signing_verified_total",
@@ -876,7 +896,7 @@ mod tests {
     ];
 
     #[test]
-    fn render_snapshot_contains_all_40_counter_metrics() {
+    fn render_snapshot_contains_all_counter_metrics() {
         let snap = zero_snapshot();
         let output = render_snapshot(&snap);
 
@@ -956,6 +976,8 @@ mod tests {
         assert!(output.contains("acteon_retention_deleted_state_total 10"));
         assert!(output.contains("acteon_retention_skipped_compliance_total 2"));
         assert!(output.contains("acteon_retention_errors_total 1"));
+        assert!(output.contains("acteon_stale_tasks_reaped_total 4"));
+        assert!(output.contains("acteon_stale_task_reaper_errors_total 1"));
         assert!(output.contains("acteon_wasm_invocations_total 6"));
         assert!(output.contains("acteon_wasm_errors_total 2"));
         assert!(output.contains("acteon_signing_verified_total 42"));
@@ -1190,7 +1212,7 @@ mod tests {
         providers.insert("email".to_string(), sample_provider_stats());
         render_provider_metrics(&mut output, &providers);
 
-        // 40 counter metrics from the snapshot
+        // 42 counter metrics from the snapshot
         for metric in EXPECTED_COUNTER_METRICS {
             assert!(output.contains(metric), "Missing snapshot metric: {metric}");
         }
@@ -1200,16 +1222,16 @@ mod tests {
             assert!(output.contains(name), "Missing provider metric: {name}");
         }
 
-        // 40 counters + 1 gauge from the snapshot + 8 provider families = 49.
+        // 42 counters + 1 gauge from the snapshot + 8 provider families = 51.
         let type_lines: Vec<&str> = output
             .lines()
             .filter(|l| l.starts_with("# TYPE "))
             .collect();
-        assert_eq!(type_lines.len(), 49, "Expected 49 TYPE declarations");
+        assert_eq!(type_lines.len(), 51, "Expected 51 TYPE declarations");
     }
 
     #[test]
-    fn full_render_no_providers_has_40_type_lines() {
+    fn full_render_no_providers_type_lines() {
         let snap = zero_snapshot();
         let mut output = render_snapshot(&snap);
         let empty: HashMap<String, ProviderStatsSnapshot> = HashMap::new();
@@ -1221,8 +1243,8 @@ mod tests {
             .collect();
         assert_eq!(
             type_lines.len(),
-            41,
-            "Expected 41 TYPE declarations without providers (40 counters + 1 gauge)"
+            43,
+            "Expected 43 TYPE declarations without providers (42 counters + 1 gauge)"
         );
     }
 

--- a/crates/server/src/api/schemas.rs
+++ b/crates/server/src/api/schemas.rs
@@ -116,6 +116,12 @@ pub struct MetricsResponse {
     /// Retention reaper errors.
     #[schema(example = 0)]
     pub retention_errors: u64,
+    /// A2A tasks transitioned to `Failed` by the stale-task reaper.
+    #[schema(example = 0)]
+    pub stale_tasks_reaped: u64,
+    /// Stale-task reaper errors.
+    #[schema(example = 0)]
+    pub stale_task_reaper_errors: u64,
     /// WASM plugin invocations.
     #[schema(example = 0)]
     pub wasm_invocations: u64,

--- a/crates/server/src/config/background.rs
+++ b/crates/server/src/config/background.rs
@@ -46,6 +46,12 @@ pub struct BackgroundProcessingConfig {
     /// How often to run the data retention reaper (seconds).
     #[serde(default = "default_retention_check_interval")]
     pub retention_check_interval_seconds: u64,
+    /// Whether to run the stale-task reaper.
+    #[serde(default)]
+    pub enable_stale_task_reaper: bool,
+    /// How often to run the stale-task reaper (seconds).
+    #[serde(default = "default_stale_task_check_interval")]
+    pub stale_task_check_interval_seconds: u64,
     /// Whether to periodically sync templates from the state store.
     #[serde(default = "default_enable_template_sync")]
     pub enable_template_sync: bool,
@@ -108,6 +114,8 @@ impl Default for BackgroundProcessingConfig {
             max_recurring_actions_per_tenant: default_max_recurring_actions_per_tenant(),
             enable_retention_reaper: false,
             retention_check_interval_seconds: default_retention_check_interval(),
+            enable_stale_task_reaper: false,
+            stale_task_check_interval_seconds: default_stale_task_check_interval(),
             enable_template_sync: default_enable_template_sync(),
             template_sync_interval_seconds: default_template_sync_interval(),
             enable_silence_sync: default_enable_silence_sync(),
@@ -148,6 +156,10 @@ fn default_group_sync_interval() -> u64 {
 
 fn default_retention_check_interval() -> u64 {
     3600
+}
+
+fn default_stale_task_check_interval() -> u64 {
+    60
 }
 
 fn default_enable_template_sync() -> bool {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1653,6 +1653,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             retention_check_interval: Duration::from_secs(
                 config.background.retention_check_interval_seconds,
             ),
+            enable_stale_task_reaper: config.background.enable_stale_task_reaper,
+            stale_task_check_interval: Duration::from_secs(
+                config.background.stale_task_check_interval_seconds,
+            ),
             enable_template_sync: config.background.enable_template_sync,
             template_sync_interval: Duration::from_secs(
                 config.background.template_sync_interval_seconds,

--- a/docs/design/a2a-protocol.md
+++ b/docs/design/a2a-protocol.md
@@ -112,7 +112,7 @@ The Core-First posture imports A2A's complexity into Acteon's substrate. Each ri
 - [x] **Idempotency (2.1):** A2A `messageId` deduplication via `KeyKind::A2aMessageDedup` markers, bounded by a 24h TTL.
 - [ ] **Engine-side hardening (graph + streaming):**
   - [x] **BFS cycle detection (2.2):** reference-graph walk at *write time* (in `create_task` / `append_history`), capped at `MAX_REFERENCE_DEPTH` (cycle) and `MAX_REFERENCE_GRAPH_NODES` (fan-out). Graph bombs refused before they persist.
-  - [ ] Reaper that transitions stale tasks (`is_stale_at(now)`) to `Failed`, with a corresponding `acteon.task.reaped` audit envelope.
+  - [x] **Stale-task reaper (2.3):** background worker scans `KeyKind::A2aTask` and transitions tasks stale per `is_stale_at(now)` to `Failed` via `TaskEngine::fail_if_stale` (staleness re-checked under CAS, so a just-heartbeated task is spared). The `acteon.task.reaped` audit envelope rides along with the Audit Integration item below.
   - [ ] Artifact-stream gatekeeper: rejects chunks arriving after `lastChunk = true`; when `totalChunks` is asserted, holds the close until all indices 0..total are observed.
 - [ ] **BusApproval generalization (single source of truth for HITL):** Extend `BusApproval` with `kind: PauseKind` (`OperatorApproval` / `UserAuth` / `UserInput`); Task Engine stamps the approval row's id onto `Task.pending_approval_id`.
 - [ ] **The Bridge:** Native mapping between `Task` state and `Chain` status — A2A `Submitted/Working` ↔ chain step progress; `InputRequired/AuthRequired` ↔ generalized `BusApproval`; terminal states ↔ chain `StepResult`.


### PR DESCRIPTION
## Summary

Phase 2.3 of the A2A protocol work (follows #160 Task Engine, #161
reference-graph validation). Adds the **stale-task reaper** — the
background worker the A2A design doc deferred from Phase 2.

An A2A `Task` left in a non-terminal state without progress is a
zombie that leaks memory. `Task::is_stale_at` already derives
staleness on read; this makes the verdict durable.

## What's included

- **`TaskEngine::fail_if_stale`** — transitions a task to `Failed`
  only if it is *still* stale when the fresh row is loaded under
  CAS. A task a producer heartbeated between the reaper's scan and
  the write is left untouched (the scan-to-write race is closed).
- **`run_stale_task_reaper`** (`background/workers/stale_task.rs`) —
  scans every `KeyKind::A2aTask` row each cycle, pre-filters on the
  scanned snapshot, and delegates the mutation to `fail_if_stale`.
- **Config** — `BackgroundConfig::enable_stale_task_reaper` (default
  off) + `stale_task_check_interval` (default 60s), wired through
  the server `[background]` TOML config and the processor run loop.
- **Metrics** — `stale_tasks_reaped` / `stale_task_reaper_errors`,
  surfaced through `MetricsSnapshot`, the `/health` metrics schema,
  and the Prometheus exporter (`acteon_stale_tasks_reaped_total`,
  `acteon_stale_task_reaper_errors_total`).

## Out of scope

Audit envelopes (`AuditEventKind::A2aTaskTransition`) for the
transition ride with the separate audit-integration follow-up — the
A2A design doc tracks them under the same Phase 2 item.

## Testing

- `cargo fmt`; `cargo clippy -p acteon-gateway` — clean
- 6 new tests: 5 `fail_if_stale` unit tests (stale / fresh /
  terminal / working / missing) + 1 reaper integration test;
  Prometheus metric fixtures updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
