### PR TITLE
feat(gateway): A2A Task audit integration — Phase 2.5

### DIFF
--- a/crates/audit/audit/src/lib.rs
+++ b/crates/audit/audit/src/lib.rs
@@ -12,6 +12,6 @@ pub use compliance::{ComplianceAuditStore, HashChainAuditStore};
 pub use cursor::{AuditCursor, CursorKind};
 pub use encrypt::EncryptingAuditStore;
 pub use error::AuditError;
-pub use record::{AuditPage, AuditQuery, AuditRecord};
+pub use record::{A2A_AUDIT_PROVIDER, AuditEventKind, AuditPage, AuditQuery, AuditRecord};
 pub use redact::{RedactConfig, RedactingAuditStore, Redactor};
 pub use store::AuditStore;

--- a/crates/audit/audit/src/record.rs
+++ b/crates/audit/audit/src/record.rs
@@ -1,6 +1,53 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// The kind of event an [`AuditRecord`] describes.
+///
+/// The audit pipeline was originally action-centric — every record was
+/// a dispatched action's lifecycle. A2A Task transitions reuse the same
+/// [`AuditRecord`] schema (and therefore the same hash-chain and
+/// compliance machinery) rather than a parallel table; this enum is the
+/// taxonomy that distinguishes them.
+///
+/// There is deliberately no dedicated `event_kind` column on
+/// [`AuditRecord`]: the discriminator rides in the existing
+/// `action_type` field via [`AuditEventKind::as_action_type`], so no
+/// cross-backend schema migration is needed. Audit queries filter A2A
+/// task events with `action_type = "a2a.task.transition"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum AuditEventKind {
+    /// A dispatched action's lifecycle — the original audit use case.
+    /// Real action records carry the action's own type (`send_email`,
+    /// …) in `action_type`, so this variant's discriminator string is
+    /// only a fallback label.
+    #[default]
+    ActionDispatch,
+    /// An A2A Task lifecycle event recorded by the gateway Task Engine
+    /// (creation, state transition, history append, artifact update,
+    /// stale-task reap, …).
+    A2aTaskTransition,
+}
+
+impl AuditEventKind {
+    /// The `action_type` discriminator string stamped on records of
+    /// this kind. For [`AuditEventKind::A2aTaskTransition`] this is the
+    /// stable value audit queries filter on.
+    #[must_use]
+    pub fn as_action_type(self) -> &'static str {
+        match self {
+            Self::ActionDispatch => "action_dispatch",
+            Self::A2aTaskTransition => "a2a.task.transition",
+        }
+    }
+}
+
+/// The `provider` value stamped on A2A Task audit records. Action
+/// records carry a real provider; Task transitions are not provider
+/// dispatches, so they share this synthetic marker.
+pub const A2A_AUDIT_PROVIDER: &str = "a2a";
+
 /// A single audit record capturing the full lifecycle of a dispatched action.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]

--- a/crates/core/src/bus_task.rs
+++ b/crates/core/src/bus_task.rs
@@ -172,6 +172,24 @@ impl TaskState {
         !self.is_terminal()
     }
 
+    /// Stable `snake_case` wire value for this state. Matches the
+    /// serde representation; useful for audit records and metrics
+    /// labels that need a `&'static str` without a serialization
+    /// round-trip.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TaskState::Submitted => "submitted",
+            TaskState::Working => "working",
+            TaskState::Completed => "completed",
+            TaskState::Failed => "failed",
+            TaskState::Canceled => "canceled",
+            TaskState::InputRequired => "input_required",
+            TaskState::AuthRequired => "auth_required",
+            TaskState::Rejected => "rejected",
+        }
+    }
+
     /// True iff a transition from `self` to `next` is allowed.
     ///
     /// Allowed graph:

--- a/crates/gateway/src/audit_helpers.rs
+++ b/crates/gateway/src/audit_helpers.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 
 use chrono::Utc;
 
-use acteon_audit::AuditRecord;
-use acteon_core::{Action, ActionOutcome, Caller};
+use acteon_audit::{A2A_AUDIT_PROVIDER, AuditEventKind, AuditRecord};
+use acteon_core::{Action, ActionOutcome, Caller, Task, TaskState};
 use acteon_rules::RuleVerdict;
 
 /// Extract the matched rule name from a `RuleVerdict`, if any.
@@ -102,6 +102,75 @@ pub(crate) fn enrich_audit_metadata(action: &Action) -> serde_json::Value {
         }
     }
     meta
+}
+
+/// Build an [`AuditRecord`] for an A2A Task lifecycle event.
+///
+/// A2A Task transitions are not rule-evaluated provider dispatches, so
+/// the action-centric fields are mapped onto the Task domain: `action_id`
+/// is the task id, `provider` is the synthetic [`A2A_AUDIT_PROVIDER`]
+/// marker, `action_type` is the [`AuditEventKind::A2aTaskTransition`]
+/// discriminator, and the lifecycle detail (operation, from/to state)
+/// lands in `outcome_details`. Routing it through [`AuditRecord`] means
+/// every Task event inherits the same hash-chain and compliance
+/// machinery as action records.
+///
+/// `caller` is `None` for system-driven events (e.g. the stale-task
+/// reaper); externally-driven transitions stamp the caller once the
+/// protocol-codec layer threads identity into the engine.
+pub(crate) fn build_task_audit_record(
+    task: &Task,
+    operation: &str,
+    from_state: Option<TaskState>,
+    occurred_at: chrono::DateTime<chrono::Utc>,
+    caller: Option<&Caller>,
+) -> AuditRecord {
+    let to_state = task.status.state;
+    let outcome_details = serde_json::json!({
+        "operation": operation,
+        "from_state": from_state.map(TaskState::as_str),
+        "to_state": to_state.as_str(),
+        "context_id": task.context_id,
+        "pending_approval_id": task.pending_approval_id,
+        "history_len": task.history.len(),
+        "artifact_count": task.artifacts.len(),
+    });
+
+    AuditRecord {
+        id: uuid::Uuid::now_v7().to_string(),
+        action_id: task.id.clone(),
+        chain_id: None,
+        namespace: task.namespace.clone(),
+        tenant: task.tenant.clone(),
+        provider: A2A_AUDIT_PROVIDER.to_owned(),
+        action_type: AuditEventKind::A2aTaskTransition
+            .as_action_type()
+            .to_owned(),
+        // Task transitions are not gated by rule evaluation; record a
+        // stable neutral verdict so analytics that group on it don't
+        // see an empty bucket.
+        verdict: "allow".to_owned(),
+        matched_rule: None,
+        outcome: to_state.as_str().to_owned(),
+        action_payload: None,
+        verdict_details: serde_json::json!({}),
+        outcome_details,
+        metadata: serde_json::to_value(&task.metadata).unwrap_or_default(),
+        dispatched_at: occurred_at,
+        completed_at: occurred_at,
+        duration_ms: 0,
+        expires_at: None,
+        caller_id: caller.map_or_else(String::new, |c| c.id.clone()),
+        auth_method: caller.map_or_else(String::new, |c| c.auth_method.clone()),
+        record_hash: None,
+        previous_hash: None,
+        sequence_number: None,
+        attachment_metadata: Vec::new(),
+        signature: None,
+        signer_id: None,
+        kid: None,
+        canonical_hash: None,
+    }
 }
 
 /// Build an `AuditRecord` from the dispatch context.

--- a/crates/gateway/src/background/mod.rs
+++ b/crates/gateway/src/background/mod.rs
@@ -16,6 +16,7 @@ use tokio::sync::mpsc;
 use tokio::time::interval;
 use tracing::{debug, error, info};
 
+use acteon_audit::store::AuditStore;
 use acteon_core::{EventGroup, StateMachineConfig};
 use acteon_state::StateStore;
 
@@ -244,6 +245,9 @@ pub struct BackgroundProcessor {
     pub(crate) retention_policies: HashMap<String, acteon_core::RetentionPolicy>,
     /// Optional gateway reference for template sync.
     pub(crate) gateway: Option<Arc<tokio::sync::RwLock<crate::gateway::Gateway>>>,
+    /// Optional audit sink. When set, the stale-task reaper records an
+    /// A2A task-transition audit entry for every task it reaps.
+    pub(crate) audit: Option<Arc<dyn AuditStore>>,
 }
 
 impl BackgroundProcessor {
@@ -272,7 +276,16 @@ impl BackgroundProcessor {
             payload_encryptor: None,
             retention_policies: HashMap::new(),
             gateway: None,
+            audit: None,
         }
+    }
+
+    /// Set the audit sink so the stale-task reaper records an audit
+    /// entry for every task it transitions to `Failed`.
+    #[must_use]
+    pub fn with_audit_store(mut self, audit: Arc<dyn AuditStore>) -> Self {
+        self.audit = Some(audit);
+        self
     }
 
     /// Set the retention policies for the reaper.
@@ -518,6 +531,7 @@ pub struct BackgroundProcessorBuilder {
     payload_encryptor: Option<Arc<PayloadEncryptor>>,
     metrics: Option<Arc<GatewayMetrics>>,
     gateway: Option<Arc<tokio::sync::RwLock<crate::gateway::Gateway>>>,
+    audit: Option<Arc<dyn AuditStore>>,
 }
 
 impl BackgroundProcessorBuilder {
@@ -538,7 +552,18 @@ impl BackgroundProcessorBuilder {
             payload_encryptor: None,
             metrics: None,
             gateway: None,
+            audit: None,
         }
+    }
+
+    /// Set the audit store. When set, the stale-task reaper records an
+    /// A2A task-transition audit entry for every task it reaps. Pass
+    /// the gateway's compliance-decorated store so reaped-task records
+    /// share the hash chain with action records.
+    #[must_use]
+    pub fn audit(mut self, audit: Arc<dyn AuditStore>) -> Self {
+        self.audit = Some(audit);
+        self
     }
 
     /// Set the metrics for the background processor.
@@ -681,6 +706,10 @@ impl BackgroundProcessorBuilder {
 
         if let Some(gw) = self.gateway {
             processor = processor.with_gateway(gw);
+        }
+
+        if let Some(audit) = self.audit {
+            processor = processor.with_audit_store(audit);
         }
 
         Ok((processor, shutdown_tx))

--- a/crates/gateway/src/background/workers/stale_task.rs
+++ b/crates/gateway/src/background/workers/stale_task.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chrono::Utc;
 use tracing::{info, warn};
 
@@ -25,7 +27,10 @@ impl BackgroundProcessor {
         &self,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let now = Utc::now();
-        let engine = TaskEngine::new(self.state.clone());
+        let mut engine = TaskEngine::new(self.state.clone());
+        if let Some(audit) = &self.audit {
+            engine = engine.with_audit(Arc::clone(audit));
+        }
         let entries = self.state.scan_keys_by_kind(KeyKind::A2aTask).await?;
 
         let mut reaped = 0u64;

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -5756,6 +5756,17 @@ impl Gateway {
         &self.state
     }
 
+    /// Get a clone of the audit store, if one is configured.
+    ///
+    /// This is the compliance-decorated store (hash chain / immutable
+    /// audit applied as configured), so callers that record their own
+    /// audit entries — e.g. the [`BackgroundProcessor`](crate::background::BackgroundProcessor)
+    /// stale-task reaper — share the same tamper-evident chain as
+    /// action records.
+    pub fn audit_store(&self) -> Option<Arc<dyn AuditStore>> {
+        self.audit.clone()
+    }
+
     /// Get a clone of the broadcast sender for SSE event streaming.
     ///
     /// Callers can use `subscribe()` on the returned sender to create

--- a/crates/gateway/src/task_engine.rs
+++ b/crates/gateway/src/task_engine.rs
@@ -30,11 +30,21 @@
 //! wider than [`MAX_REFERENCE_GRAPH_NODES`] distinct nodes is
 //! rejected. See the `check_reference_graph` method.
 //!
+//! ## Audit integration
+//!
+//! When an [`AuditStore`] is attached via [`TaskEngine::with_audit`],
+//! every successful mutation emits an
+//! [`AuditEventKind::A2aTaskTransition`](acteon_audit::AuditEventKind)
+//! record — creation, state transition, history append, artifact
+//! update, heartbeat, pending-approval stamp, and stale-task reap.
+//! The record rides the same [`AuditStore`] the gateway uses, so it
+//! inherits hash-chaining and compliance decorators automatically. An
+//! audit write failure is logged but never fails the mutation: the
+//! task transition is the source of truth, the audit record a
+//! best-effort projection of it.
+//!
 //! ## Out of scope for this PR (deferred to follow-ups)
 //!
-//! - **Audit integration**: stamping `AuditEventKind::A2aTaskTransition`
-//!   on every transition. Deferred to a follow-up that touches
-//!   `acteon-audit` simultaneously.
 //! - **`BusApproval.kind: PauseKind`** generalization. The engine
 //!   exposes [`TaskEngine::set_pending_approval`] today; the
 //!   semantic projection into the new `BusApproval` kind lands when
@@ -50,11 +60,14 @@ use chrono::{DateTime, Utc};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use tracing::{debug, warn};
 
+use acteon_audit::store::AuditStore;
 use acteon_core::{
     Artifact, MAX_REFERENCE_DEPTH, Task, TaskArtifactUpdateEvent, TaskMessage, TaskRole, TaskState,
     TaskValidationError,
 };
 use acteon_state::{CasResult, KeyKind, StateError, StateKey, StateStore};
+
+use crate::audit_helpers::build_task_audit_record;
 
 /// Max number of CAS retry attempts before declaring contention
 /// exhausted. Matches the bus's
@@ -140,6 +153,11 @@ impl TaskScope {
 #[derive(Clone)]
 pub struct TaskEngine {
     state: Arc<dyn StateStore>,
+    /// Optional audit sink. When set, every successful mutation emits
+    /// an A2A task-transition record. `None` disables audit emission
+    /// entirely (the engine still functions; transitions just aren't
+    /// projected into the audit trail).
+    audit: Option<Arc<dyn AuditStore>>,
 }
 
 impl std::fmt::Debug for TaskEngine {
@@ -149,10 +167,40 @@ impl std::fmt::Debug for TaskEngine {
 }
 
 impl TaskEngine {
-    /// Construct a Task Engine backed by the given state store.
+    /// Construct a Task Engine backed by the given state store, with
+    /// audit emission disabled. Use [`TaskEngine::with_audit`] to
+    /// attach an audit sink.
     #[must_use]
     pub fn new(state: Arc<dyn StateStore>) -> Self {
-        Self { state }
+        Self { state, audit: None }
+    }
+
+    /// Attach an audit sink so every successful mutation emits an A2A
+    /// task-transition record. Pass the same (compliance-decorated)
+    /// [`AuditStore`] the gateway uses so task records share the
+    /// hash chain with action records.
+    #[must_use]
+    pub fn with_audit(mut self, audit: Arc<dyn AuditStore>) -> Self {
+        self.audit = Some(audit);
+        self
+    }
+
+    /// Emit a best-effort A2A task-transition audit record. A write
+    /// failure is logged, never propagated — the persisted task is the
+    /// source of truth and must not be rolled back over an audit miss.
+    async fn emit_audit(&self, task: &Task, operation: &str, from_state: Option<TaskState>) {
+        let Some(audit) = &self.audit else {
+            return;
+        };
+        let record = build_task_audit_record(task, operation, from_state, Utc::now(), None);
+        if let Err(e) = audit.record(record).await {
+            warn!(
+                error = %e,
+                task_id = %task.id,
+                operation,
+                "A2A task audit write failed"
+            );
+        }
     }
 
     /// Create a new task. Fails with [`TaskEngineError::AlreadyExists`]
@@ -176,6 +224,7 @@ impl TaskEngine {
             return Err(TaskEngineError::AlreadyExists(task.id));
         }
         debug!(task_id = %task.id, namespace = %task.namespace, tenant = %task.tenant, "task created");
+        self.emit_audit(&task, "create", None).await;
         Ok(task)
     }
 
@@ -223,7 +272,7 @@ impl TaskEngine {
         message: Option<TaskMessage>,
     ) -> Result<Task, TaskEngineError> {
         let key = scope.task_key(task_id);
-        self.cas_mutate(&key, task_id, move |task: &mut Task| {
+        self.cas_mutate(&key, task_id, "transition", move |task: &mut Task| {
             task.transition_to(next, message.clone())?;
             Ok(())
         })
@@ -271,6 +320,7 @@ impl TaskEngine {
                 // the scan — no longer a zombie, leave it untouched.
                 return Ok(None);
             }
+            let from_state = task.status.state;
             task.transition_to(TaskState::Failed, Some(reason.clone()))?;
             let payload = serde_json::to_string(&task)?;
             match self
@@ -280,6 +330,7 @@ impl TaskEngine {
             {
                 CasResult::Ok => {
                     debug!(task_id = %task_id, "stale task reaped to Failed");
+                    self.emit_audit(&task, "reap", Some(from_state)).await;
                     return Ok(Some(task));
                 }
                 CasResult::Conflict { .. } => {
@@ -346,7 +397,7 @@ impl TaskEngine {
                 .ok_or_else(|| TaskEngineError::NotFound(task_id.to_string()));
         }
         let key = scope.task_key(task_id);
-        self.cas_mutate(&key, task_id, move |task: &mut Task| {
+        self.cas_mutate(&key, task_id, "append_history", move |task: &mut Task| {
             task.append_history(message.clone())?;
             Ok(())
         })
@@ -375,7 +426,7 @@ impl TaskEngine {
         // borrows it for error reporting while the closure moves the
         // whole `event` in to apply it.
         let task_id = event.task_id.clone();
-        self.cas_mutate(&key, &task_id, move |task: &mut Task| {
+        self.cas_mutate(&key, &task_id, "artifact_update", move |task: &mut Task| {
             task.apply_artifact_event(&event)?;
             Ok(())
         })
@@ -391,7 +442,7 @@ impl TaskEngine {
         task_id: &str,
     ) -> Result<Task, TaskEngineError> {
         let key = scope.task_key(task_id);
-        self.cas_mutate(&key, task_id, |task: &mut Task| {
+        self.cas_mutate(&key, task_id, "progress", |task: &mut Task| {
             task.record_progress();
             Ok(())
         })
@@ -409,7 +460,7 @@ impl TaskEngine {
         approval_id: String,
     ) -> Result<Task, TaskEngineError> {
         let key = scope.task_key(task_id);
-        self.cas_mutate(&key, task_id, move |task: &mut Task| {
+        self.cas_mutate(&key, task_id, "pending_approval", move |task: &mut Task| {
             task.set_pending_approval(approval_id.clone());
             Ok(())
         })
@@ -427,7 +478,7 @@ impl TaskEngine {
         append: bool,
     ) -> Result<Task, TaskEngineError> {
         let key = scope.task_key(task_id);
-        self.cas_mutate(&key, task_id, move |task: &mut Task| {
+        self.cas_mutate(&key, task_id, "artifact_upsert", move |task: &mut Task| {
             task.upsert_artifact(artifact.clone(), append)?;
             Ok(())
         })
@@ -436,10 +487,15 @@ impl TaskEngine {
 
     /// Atomically read-modify-write the task at `key` via CAS retry.
     /// The closure is reapplied on each retry against a fresh copy.
+    ///
+    /// On commit, emits an audit record tagged with `operation` and
+    /// the task's pre-mutation state, so the audit trail captures the
+    /// `from → to` transition rather than only the resulting state.
     async fn cas_mutate<F>(
         &self,
         key: &StateKey,
         task_id: &str,
+        operation: &str,
         mut mutate: F,
     ) -> Result<Task, TaskEngineError>
     where
@@ -450,6 +506,7 @@ impl TaskEngine {
                 return Err(TaskEngineError::NotFound(task_id.to_string()));
             };
             let mut task: Task = serde_json::from_str(&raw)?;
+            let from_state = task.status.state;
             mutate(&mut task)?;
             let payload = serde_json::to_string(&task)?;
             match self
@@ -459,6 +516,7 @@ impl TaskEngine {
             {
                 CasResult::Ok => {
                     debug!(task_id = %task_id, state = ?task.status.state, "task mutated");
+                    self.emit_audit(&task, operation, Some(from_state)).await;
                     return Ok(task);
                 }
                 CasResult::Conflict { .. } => {
@@ -1351,5 +1409,200 @@ mod tests {
             .await
             .unwrap();
         assert!(reaped.is_none());
+    }
+
+    // --- Audit integration ---
+
+    use acteon_audit::store::AuditStore;
+    use acteon_audit::{AuditError, AuditPage, AuditQuery, AuditRecord};
+
+    /// In-memory `AuditStore` that just collects every record it is
+    /// handed, so a test can assert on what the engine emitted.
+    #[derive(Default)]
+    struct CollectingAudit {
+        records: parking_lot::Mutex<Vec<AuditRecord>>,
+    }
+
+    impl CollectingAudit {
+        fn records(&self) -> Vec<AuditRecord> {
+            self.records.lock().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AuditStore for CollectingAudit {
+        async fn record(&self, entry: AuditRecord) -> Result<(), AuditError> {
+            self.records.lock().push(entry);
+            Ok(())
+        }
+        async fn get_by_action_id(&self, _: &str) -> Result<Option<AuditRecord>, AuditError> {
+            Ok(None)
+        }
+        async fn get_by_id(&self, _: &str) -> Result<Option<AuditRecord>, AuditError> {
+            Ok(None)
+        }
+        async fn query(&self, _: &AuditQuery) -> Result<AuditPage, AuditError> {
+            Ok(AuditPage {
+                records: Vec::new(),
+                total: Some(0),
+                limit: 0,
+                offset: 0,
+                next_cursor: None,
+            })
+        }
+        async fn cleanup_expired(&self) -> Result<u64, AuditError> {
+            Ok(0)
+        }
+    }
+
+    /// An audit store that always fails to record — proves an audit
+    /// write failure never fails the underlying mutation.
+    struct FailingAudit;
+
+    #[async_trait::async_trait]
+    impl AuditStore for FailingAudit {
+        async fn record(&self, _: AuditRecord) -> Result<(), AuditError> {
+            Err(AuditError::Storage("synthetic audit failure".into()))
+        }
+        async fn get_by_action_id(&self, _: &str) -> Result<Option<AuditRecord>, AuditError> {
+            Ok(None)
+        }
+        async fn get_by_id(&self, _: &str) -> Result<Option<AuditRecord>, AuditError> {
+            Ok(None)
+        }
+        async fn query(&self, _: &AuditQuery) -> Result<AuditPage, AuditError> {
+            Ok(AuditPage {
+                records: Vec::new(),
+                total: Some(0),
+                limit: 0,
+                offset: 0,
+                next_cursor: None,
+            })
+        }
+        async fn cleanup_expired(&self) -> Result<u64, AuditError> {
+            Ok(0)
+        }
+    }
+
+    fn audited_engine() -> (TaskEngine, Arc<CollectingAudit>) {
+        let audit = Arc::new(CollectingAudit::default());
+        let engine = TaskEngine::new(Arc::new(MemoryStateStore::new()))
+            .with_audit(Arc::clone(&audit) as Arc<dyn AuditStore>);
+        (engine, audit)
+    }
+
+    #[tokio::test]
+    async fn audit_records_task_creation() {
+        let (e, audit) = audited_engine();
+        e.create_task(sample_task("t1")).await.unwrap();
+        let records = audit.records();
+        assert_eq!(records.len(), 1);
+        let r = &records[0];
+        assert_eq!(r.action_id, "t1");
+        assert_eq!(r.provider, "a2a");
+        assert_eq!(r.action_type, "a2a.task.transition");
+        assert_eq!(r.outcome, "submitted");
+        assert_eq!(r.outcome_details["operation"], "create");
+        // A fresh task has no prior state.
+        assert!(r.outcome_details["from_state"].is_null());
+        assert_eq!(r.outcome_details["to_state"], "submitted");
+    }
+
+    #[tokio::test]
+    async fn audit_records_state_transition_with_from_state() {
+        let (e, audit) = audited_engine();
+        e.create_task(sample_task("t1")).await.unwrap();
+        e.transition_task(&scope(), "t1", TaskState::Working, None)
+            .await
+            .unwrap();
+        let records = audit.records();
+        assert_eq!(records.len(), 2);
+        let t = &records[1];
+        assert_eq!(t.outcome_details["operation"], "transition");
+        assert_eq!(t.outcome_details["from_state"], "submitted");
+        assert_eq!(t.outcome_details["to_state"], "working");
+        assert_eq!(t.outcome, "working");
+    }
+
+    #[tokio::test]
+    async fn audit_records_history_and_artifact_operations() {
+        let (e, audit) = audited_engine();
+        e.create_task(sample_task("t1")).await.unwrap();
+        e.append_history(&scope(), "t1", TaskMessage::text("m1", Role::User, "hi"))
+            .await
+            .unwrap();
+        e.apply_artifact_update(
+            &scope(),
+            TaskArtifactUpdateEvent::single_shot(
+                "t1",
+                Artifact::new("art-1", vec![Part::text("out")]),
+            ),
+        )
+        .await
+        .unwrap();
+        let ops: Vec<String> = audit
+            .records()
+            .iter()
+            .map(|r| r.outcome_details["operation"].as_str().unwrap().to_owned())
+            .collect();
+        assert_eq!(ops, vec!["create", "append_history", "artifact_update"]);
+    }
+
+    #[tokio::test]
+    async fn audit_records_stale_task_reap() {
+        let (e, audit) = audited_engine();
+        e.create_task(aged_task("zombie", 3600, 60_000))
+            .await
+            .unwrap();
+        e.fail_if_stale(&scope(), "zombie", Utc::now())
+            .await
+            .unwrap()
+            .expect("task should be reaped");
+        let records = audit.records();
+        // create + reap.
+        assert_eq!(records.len(), 2);
+        let reap = &records[1];
+        assert_eq!(reap.outcome_details["operation"], "reap");
+        assert_eq!(reap.outcome_details["from_state"], "submitted");
+        assert_eq!(reap.outcome, "failed");
+    }
+
+    #[tokio::test]
+    async fn audit_skips_rejected_transition() {
+        // An illegal transition errors before the CAS commit, so no
+        // audit record is emitted for it.
+        let (e, audit) = audited_engine();
+        e.create_task(sample_task("t1")).await.unwrap();
+        // Submitted -> Completed is illegal.
+        e.transition_task(&scope(), "t1", TaskState::Completed, None)
+            .await
+            .unwrap_err();
+        // Only the creation record exists.
+        assert_eq!(audit.records().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn audit_failure_does_not_fail_mutation() {
+        // An audit write failure is logged, never propagated — the
+        // task transition still succeeds and persists.
+        let engine = TaskEngine::new(Arc::new(MemoryStateStore::new()))
+            .with_audit(Arc::new(FailingAudit) as Arc<dyn AuditStore>);
+        engine.create_task(sample_task("t1")).await.unwrap();
+        let updated = engine
+            .transition_task(&scope(), "t1", TaskState::Working, None)
+            .await
+            .unwrap();
+        assert_eq!(updated.status.state, TaskState::Working);
+    }
+
+    #[tokio::test]
+    async fn engine_without_audit_emits_nothing() {
+        // The bare engine (no audit sink) still mutates correctly.
+        let e = engine();
+        e.create_task(sample_task("t1")).await.unwrap();
+        e.transition_task(&scope(), "t1", TaskState::Working, None)
+            .await
+            .unwrap();
+        assert!(e.audit.is_none());
     }
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1711,6 +1711,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             bg_builder = bg_builder.payload_encryptor(Arc::clone(enc));
         }
 
+        // Give the stale-task reaper the gateway's compliance-decorated
+        // audit store so reaped A2A tasks land on the same hash chain
+        // as action records.
+        if let Some(audit) = gateway.read().await.audit_store() {
+            bg_builder = bg_builder.audit(audit);
+        }
+
         if config.background.enable_template_sync {
             bg_builder = bg_builder.gateway(Arc::clone(&gateway));
         }

--- a/docs/design/a2a-protocol.md
+++ b/docs/design/a2a-protocol.md
@@ -116,7 +116,7 @@ The Core-First posture imports A2A's complexity into Acteon's substrate. Each ri
   - [x] **Artifact-stream gatekeeper (2.4):** `Task::apply_artifact_event` enforces, across deliveries, no updates after a `lastChunk`, strictly in-order `chunkIndex`, and `totalChunks` completeness on close. Per-artifact stream state lives on the Task and commits under the engine CAS.
 - [ ] **BusApproval generalization (single source of truth for HITL):** Extend `BusApproval` with `kind: PauseKind` (`OperatorApproval` / `UserAuth` / `UserInput`); Task Engine stamps the approval row's id onto `Task.pending_approval_id`.
 - [ ] **The Bridge:** Native mapping between `Task` state and `Chain` status — A2A `Submitted/Working` ↔ chain step progress; `InputRequired/AuthRequired` ↔ generalized `BusApproval`; terminal states ↔ chain `StepResult`.
-- [ ] **Audit Integration:** Stamp every A2A operation with `AuditEventKind::A2aTaskTransition`.
+- [x] **Audit Integration:** Stamp every A2A operation with `AuditEventKind::A2aTaskTransition`. The `TaskEngine` takes an optional `AuditStore` (`with_audit`); every successful mutation — create, transition, history append, artifact update, heartbeat, pending-approval stamp, stale-task reap — emits an `AuditRecord` carrying the `a2a.task.transition` discriminator and the `from → to` states. Records ride the gateway's compliance-decorated store, so they inherit hash-chaining automatically.
 
 ### Phase 3: Discovery & SSE Bridge — ~4 days
 - [ ] **Global Discovery Registry:** Implement a dynamic `DiscoveryService` that aggregates native `AgentCard` data for `/.well-known/agent.json`. Public and unauthenticated per spec.


### PR DESCRIPTION
## Summary

Phase 2.5 of the A2A protocol work (follows #160 Task Engine, #161/#162
reference-graph validation, #163 stale-task reaper, #164 artifact-stream
gatekeeper) — the **Audit Integration** item of Phase 2.

Every A2A Task lifecycle mutation now lands in the same tamper-evident
audit pipeline as action dispatches: task creation, state transitions,
history appends, artifact updates, heartbeats, pending-approval stamps,
and stale-task reaps.

## What's included

**`acteon-audit`** gains `AuditEventKind { ActionDispatch,
A2aTaskTransition }`. There is deliberately **no new `AuditRecord`
column** — the discriminator rides the existing `action_type` field via
`as_action_type()`, so no cross-backend schema migration is needed.
Audit queries filter A2A task events with `action_type =
"a2a.task.transition"` (the existing `AuditQuery.action_type` filter);
the synthetic `A2A_AUDIT_PROVIDER` (`"a2a"`) marker fills the `provider`
field.

**`TaskEngine`** takes an optional `AuditStore` via `with_audit()`:

- `cas_mutate` captures the pre-mutation state and, on commit, emits an
  `AuditRecord` tagged with the operation and the `from → to` states.
- `create_task` and `fail_if_stale` emit alongside their own writes.
- A **rejected** transition emits no record — the mutation closure
  errors before the CAS commit is reached.
- An audit write failure is **logged but never propagated**: the
  persisted task is the source of truth and is not rolled back over an
  audit miss.

**The stale-task reaper** is wired to the gateway's compliance-decorated
audit store (`Gateway::audit_store()`, threaded through
`BackgroundProcessor`), so reaped-task records share the hash chain with
action records rather than starting a divergent one.

`TaskState` gains `as_str()` for the snake_case wire value used in audit
outcome fields.

## Notes

- `build_task_audit_record` maps the action-centric `AuditRecord` onto
  the Task domain: `action_id` = task id, `provider` =
  `A2A_AUDIT_PROVIDER`, and the lifecycle detail (operation, from/to
  state, context id, history/artifact counts) lands in
  `outcome_details`.
- `caller` is `None` for now — system-driven events (the reaper) have no
  caller, and externally-driven transitions will stamp identity once the
  protocol-codec layer (Phase 2, still open) threads it into the engine.
  `build_task_audit_record` already accepts the `caller` argument for
  that.

## Testing

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --no-deps -- -D warnings` — clean
- `cargo test --workspace --lib --bins --tests` — 2707 pass, 0 fail
- `cargo check --all-targets` — clean
- 7 new `TaskEngine` tests: record shape, from/to capture across create /
  transition / history / artifact / reap, that a rejected transition
  emits no record, that an engine without an audit sink emits nothing,
  and that an audit-store failure does not fail the mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
