### PR TITLE
docs(a2a): user-facing guide at docs/book/features/a2a.md

### DIFF
--- a/docs/book/features/a2a.md
+++ b/docs/book/features/a2a.md
@@ -1,0 +1,368 @@
+# Agent2Agent (A2A) Protocol
+
+Acteon implements the [A2A Protocol v1.0](https://a2aprotocol.org) — the
+ratified standard for one agent to delegate work to another over a
+durable Task abstraction. Bringing A2A into Acteon means agents you
+own and agents your peers run can interoperate without per-counterparty
+glue.
+
+The whole protocol surface (JSON-RPC + REST + SSE) is scoped to one
+namespace and one tenant via the URL prefix `/a2a/{namespace}/{tenant}`,
+so the same multi-tenant model you use elsewhere in Acteon carries
+through unchanged.
+
+## When to reach for A2A
+
+| Reach for A2A when | Reach for the native Acteon API when |
+|---|---|
+| You need to interop with non-Acteon agents | You only call Acteon-from-Acteon |
+| The work is a long-running Task with intermediate state | The work is a single fire-and-forget dispatch |
+| External clients should be able to subscribe to progress | Only internal subscribers consume the stream |
+| You want to publish discovery metadata at `.well-known/agent.json` | Discovery is internal-only |
+
+A2A and the rest of the Acteon API coexist on the same server. Both
+share the same auth, the same audit trail, and the same gateway.
+
+## URL surface
+
+Every endpoint lives under `/a2a/{namespace}/{tenant}/…`. All endpoints
+require the standard `Dispatch` permission grant on `(namespace,
+tenant)` *except* the unauthenticated discovery endpoint.
+
+### JSON-RPC 2.0 (the primary transport)
+
+A single endpoint dispatches by method name in the envelope:
+
+```text
+POST /a2a/{namespace}/{tenant}
+Content-Type: application/json
+
+{ "jsonrpc": "2.0", "method": "tasks/get", "params": {…}, "id": 1 }
+```
+
+| Method | Purpose |
+|---|---|
+| `message/send` | Start a new Task or continue an existing one. |
+| `tasks/get` | Read a Task by id. |
+| `tasks/cancel` | Cancel a non-terminal Task. |
+| `tasks/pushNotificationConfig/set` | Register a webhook for Task events. |
+| `tasks/pushNotificationConfig/get` | Read one push config. |
+| `tasks/pushNotificationConfig/list` | List push configs for a Task. |
+| `tasks/pushNotificationConfig/delete` | Remove a push config. |
+| `agent/getAuthenticatedExtendedCard` | Discovery card variant for authenticated callers. |
+
+Batch arrays and notifications (requests with no `id`) follow the
+JSON-RPC 2.0 spec exactly.
+
+### REST binding (A2A spec §11)
+
+Mirrors the JSON-RPC methods on resource-shaped paths:
+
+```text
+POST   /a2a/{ns}/{tenant}/v1/message:send
+GET    /a2a/{ns}/{tenant}/v1/tasks/{id}
+POST   /a2a/{ns}/{tenant}/v1/tasks/{id}:cancel
+GET    /a2a/{ns}/{tenant}/v1/tasks/{id}/events            # SSE
+POST   /a2a/{ns}/{tenant}/v1/tasks/{id}/pushNotificationConfigs
+GET    /a2a/{ns}/{tenant}/v1/tasks/{id}/pushNotificationConfigs
+GET    /a2a/{ns}/{tenant}/v1/tasks/{id}/pushNotificationConfigs/{cfgId}
+DELETE /a2a/{ns}/{tenant}/v1/tasks/{id}/pushNotificationConfigs/{cfgId}
+```
+
+### Discovery (unauthenticated)
+
+```text
+GET    /a2a/{ns}/{tenant}/.well-known/agent.json
+```
+
+Returns the tenant's `AgentCard` — verbatim if exactly one agent has
+published, aggregated if several have. See [Discovery](#discovery)
+below.
+
+### Version negotiation
+
+Every request and response carries an `A2A-Version` header. A request
+that pins an unsupported version is rejected up front with JSON-RPC
+error `-32000`. The current server speaks `1.0`.
+
+## Tasks — the core abstraction
+
+An A2A Task is a row in Acteon's state store with an explicit state
+machine. The protocol defines eight states:
+
+```text
+              ┌─ Working ──┬─→ InputRequired ─┐
+              │            ├─→ AuthRequired ──┤
+   Submitted ─┘            │                  │
+                           └──────┐           │
+              ┌── Rejected ───────┤           │
+              │                   ▼           ▼
+              │             Completed | Canceled | Failed
+```
+
+| State | Meaning | Reachable from |
+|---|---|---|
+| `Submitted` | New Task; no work started yet. | (initial) |
+| `Working` | Agent is actively processing. | `Submitted`, `InputRequired`, `AuthRequired` |
+| `InputRequired` | Agent paused awaiting user input. | `Working` |
+| `AuthRequired` | Agent paused awaiting user auth. | `Working` |
+| `Completed` | Terminal, success. | `Working` |
+| `Canceled` | Terminal, explicit cancel. | any non-terminal |
+| `Failed` | Terminal, error or stale reap. | any non-terminal |
+| `Rejected` | Terminal, never accepted (validation fail). | (initial; no row written) |
+
+Acteon's Task Engine (`crates/gateway/src/task_engine.rs`) is the
+single source of truth for these transitions. Illegal transitions
+return a JSON-RPC `INVALID_PARAMS` error and leave the row unchanged.
+
+### Send your first message
+
+```bash
+curl -X POST https://acteon.example.com/a2a/agents/demo \
+  -H 'Authorization: Bearer YOUR_KEY' \
+  -H 'Content-Type: application/json' \
+  -H 'A2A-Version: 1.0' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "message/send",
+    "params": {
+      "message": {
+        "messageId": "01HPM-…",
+        "role": "user",
+        "parts": [{ "text": "Summarize the latest deploy log." }]
+      }
+    }
+  }'
+```
+
+The response is the freshly-minted Task with `status.state = "submitted"`
+and `history[0]` set to the inbound message.
+
+### Continue an existing Task
+
+Set `params.message.taskId` to thread the message into an existing
+Task's history. The Task's state machine governs whether the
+continuation is legal.
+
+```json
+{
+  "messageId": "01HPM-…-b",
+  "taskId": "task-alpha",
+  "role": "user",
+  "parts": [{ "text": "Yes, send it to ops@example.com." }]
+}
+```
+
+### Cancel a Task
+
+```bash
+curl -X POST https://acteon.example.com/a2a/agents/demo/v1/tasks/task-alpha:cancel
+```
+
+The cancel verb is split off in-handler (axum routes whole segments).
+Acteon also propagates the cancel to any linked Acteon Chain via the
+Task ↔ Chain bridge.
+
+## Pause for human (HITL)
+
+Two of the eight Task states represent agent-initiated pauses:
+
+- **`InputRequired`** — the agent needs the user to supply more
+  information.
+- **`AuthRequired`** — the agent needs the user to authenticate (e.g.
+  re-authorize an OAuth grant).
+
+A pause writes a `BusApproval` row alongside the Task transition in
+one atomic step, so a pause never leaves an orphan approval and a
+resolved approval is always paired with a Task move.
+
+Resume by sending a normal `message/send` that drives the state
+transition back to `Working`.
+
+## Artifact streaming
+
+Long-running Tasks emit results piecewise as `Artifact` rows. Each
+artifact can be streamed across multiple `TaskArtifactUpdateEvent`s:
+
+```text
+chunk_index=0  last_chunk=false   "Hello, "
+chunk_index=1  last_chunk=false   "world."
+chunk_index=2  last_chunk=true    "!"
+```
+
+The artifact-stream gatekeeper enforces three cross-delivery invariants:
+
+1. **No updates after `last_chunk=true`** — a "stream closed" attempt
+   to append more is rejected.
+2. **Strictly in-order `chunk_index`** — chunks must arrive 0, 1, 2, …
+3. **Completeness on `total_chunks`** — when set, the stream cannot
+   close with fewer chunks than promised.
+
+The cap on Part content (text/raw/data) is **256 KiB**. Larger payloads
+must use `Part::url` referencing an external store.
+
+## SSE event subscription
+
+Subscribe to per-Task lifecycle events:
+
+```text
+GET /a2a/{ns}/{tenant}/v1/tasks/{id}/events
+Accept: text/event-stream
+```
+
+The stream emits three event types:
+
+| Event | When |
+|---|---|
+| `task_transitioned` | After a successful `Submitted → Working`, `Working → Completed`, etc. |
+| `task_history_appended` | After a `message/send` adds a history entry. |
+| `task_artifact_updated` | After any `apply_artifact_update` commit. |
+
+Each event carries `task_id`, plus event-specific fields (`from`/`to`
+for transitions, `message_id` for history, `artifact_id`/`last_chunk`
+for artifacts). The endpoint reuses the same `ConnectionRegistry` as
+`/v1/stream` so per-tenant connection caps are unified.
+
+**Live-only** — task events aren't persisted to audit, so
+`Last-Event-ID` replay is intentionally not supported on this endpoint.
+
+## Push notifications
+
+For consumers that prefer push over pull, register a webhook with
+`tasks/pushNotificationConfig/set`:
+
+```bash
+curl -X POST .../a2a/agents/demo \
+  -d '{
+    "jsonrpc": "2.0", "id": 1,
+    "method": "tasks/pushNotificationConfig/set",
+    "params": {
+      "taskId": "task-alpha",
+      "pushNotificationConfig": {
+        "url": "https://my-service.example.com/a2a-hook",
+        "token": "shared-secret"
+      }
+    }
+  }'
+```
+
+The token (if set) is sent as `Authorization: Bearer <token>` on every
+POST. The delivery worker:
+
+- Subscribes to the same stream broadcast as the SSE endpoint.
+- Looks up registered configs by task id (short-TTL cache folds
+  bursts).
+- POSTs the event envelope verbatim to every registered URL,
+  concurrently across configs and across events.
+- Retries with capped exponential backoff (1s, 2s, …, capped at 30s)
+  for transient failures: HTTP 5xx, network/timeout errors, and **HTTP
+  408 / 425 / 429** (the codes a well-behaved server uses to ask for
+  backoff).
+- Treats other HTTP 4xx as terminal — the URL is permanently rejecting
+  the payload and the retry loop stops.
+- Bounds total in-flight HTTP deliveries at 64, so a misbehaving
+  destination cannot starve the rest of the fleet.
+
+**No DLQ in v1.** Terminal and exhausted failures are counted in
+`PushDeliveryMetrics` and emitted with `error!` logs.
+
+### URL validation
+
+Push URLs must be `http://` or `https://`. Other schemes (`file:`,
+`javascript:`, etc.) are denied at registration time — the same
+SSRF / information-disclosure surface that has bitten similar
+webhook products. URLs are capped at 2 KiB.
+
+## Discovery
+
+Each tenant can publish an `AgentCard` (per-agent) that the
+discovery endpoint exposes:
+
+```text
+GET /a2a/agents/demo/.well-known/agent.json
+```
+
+| Cards published | Card returned |
+|---|---|
+| 0 | 404 `not_found` |
+| 1 | the single card, verbatim |
+| ≥2 | a synthesized aggregate card (skills, interfaces, capabilities, schemes merged; colliding skill names suffixed `@agent_id`) |
+
+The unauthenticated REST endpoint serves the discovery card. The
+authenticated JSON-RPC method `agent/getAuthenticatedExtendedCard`
+returns the same shape with `capabilities.extendedAgentCard = true`
+set, so a client can confirm it is talking to the authenticated
+extension. Future revisions may differentiate the two further.
+
+### Security schemes on the card
+
+When Acteon's auth is enabled, the discovery card is enriched with
+the gateway's own intrinsic security schemes under reserved aliases:
+
+| Alias | Scheme | Use |
+|---|---|---|
+| `acteon.bearer` | `HttpAuth { scheme = "bearer" }` | `Authorization: Bearer …` (JWT or API key) |
+| `acteon.apiKey` | `ApiKey { name = "X-API-Key", in = "header" }` | Explicit API-key fallback header |
+
+The enrichment is `entry().or_insert(…)` — if a tenant explicitly
+publishes a scheme under either reserved alias, theirs is preserved
+verbatim. `MutualTls` is not added intrinsically; a tenant using
+mTLS publishes the scheme on its per-agent card.
+
+## Limits and caps
+
+| Limit | Value | Where |
+|---|---|---|
+| Request body | 2 MiB | `A2A_MAX_BODY_BYTES` |
+| Part text / raw / data | 256 KiB | `MAX_PART_TEXT_BYTES`, etc. |
+| Reference graph depth | 5 hops | `MAX_REFERENCE_DEPTH` |
+| Reference graph width | 32 ids per message | `MAX_REFERENCE_TASK_IDS` |
+| Working TTL (default) | 30 minutes | `DEFAULT_WORKING_TTL_MS` |
+| Push URL | 2 KiB | `MAX_PUSH_URL_BYTES` |
+| Push bearer token | 4 KiB | `MAX_PUSH_TOKEN_BYTES` |
+| In-flight push deliveries | 64 concurrent | `MAX_INFLIGHT_DELIVERIES` |
+| Push config cache TTL | 500 ms | `CONFIG_CACHE_TTL` |
+
+## Try it locally
+
+The simulation example exercises the entire surface in-process,
+in ~200 ms:
+
+```bash
+cargo run -p acteon-simulation --example a2a_core_simulation
+```
+
+The output reads as a linear log with each scenario bracketed by a
+banner. Engine actions and the `StreamEvent`s they emit line up by id.
+
+## Errors
+
+A2A error codes follow JSON-RPC 2.0 conventions plus the A2A-specific
+codes from spec §8:
+
+| Code | Name | When |
+|---|---|---|
+| `-32700` | `PARSE_ERROR` | The JSON-RPC body itself is malformed. |
+| `-32600` | `INVALID_REQUEST` | The envelope is structurally wrong. |
+| `-32601` | `METHOD_NOT_FOUND` | The method name is unknown. |
+| `-32602` | `INVALID_PARAMS` | The params fail validation, *including* illegal Task transitions. |
+| `-32603` | `INTERNAL_ERROR` | Server-internal failure (CAS exhaustion, state-store error). The message is intentionally opaque (CWE-209). |
+| `-32001` | `TaskNotFound` | The named Task or sub-resource does not exist for this caller. |
+| `-32002` | `TaskNotCancelable` | The Task is in a terminal state and cannot be canceled. |
+| `-32000` | `VersionNotSupported` | The `A2A-Version` header names a version this server does not implement. |
+
+REST responses translate these codes to HTTP statuses (`404`, `409`,
+`400`, `500`, etc.) and put the message in the body.
+
+## Architecture references
+
+- Design doc: `docs/design/a2a-protocol.md`
+- Task engine: `crates/gateway/src/task_engine.rs`
+- Protocol codec (JSON-RPC + REST): `crates/server/src/api/a2a.rs`
+- SSE consumer endpoint: `crates/server/src/api/a2a.rs::a2a_task_events`
+- Discovery: `crates/server/src/api/a2a_discovery.rs`
+- Push config CRUD: `crates/server/src/api/a2a_push.rs`
+- Push delivery worker: `crates/server/src/api/a2a_push_worker.rs`
+- Core types: `crates/core/src/bus_task.rs`, `bus_agent_card.rs`,
+  `task_push.rs`

--- a/docs/design/a2a-protocol.md
+++ b/docs/design/a2a-protocol.md
@@ -144,7 +144,7 @@ The Core-First posture imports A2A's complexity into Acteon's substrate. Each ri
 ### Phase 6: SDK & Simulation — ~5 days
 - [ ] Update all polyglot SDKs (Rust, Python, Node, Go, Java) to support the native A2A Task primitives.
 - [x] Add `a2a_core_simulation.rs` demonstrating a Task pipeline through all 8 states (including `InputRequired` and `AuthRequired` interrupts). In-process simulation runs in ~200ms with no external dependencies; eleven scenarios cover every reachable `TaskState`, both pause-for-human kinds, the artifact-stream gatekeeper across two chunks, and an end-to-end push-notification delivery to a mock HTTP receiver (with the worker's metrics snapshot printed). A background event tailer prints every emitted `StreamEvent` so engine actions and observer events line up by id.
-- [ ] `docs/book/features/a2a.md` user-facing guide; promote this design doc to `docs/architecture/a2a.md` once shipped.
+- [x] `docs/book/features/a2a.md` user-facing guide shipped — covers the URL surface (JSON-RPC + REST + SSE + discovery), the 8-state Task lifecycle with a state-machine diagram, pause-for-human, artifact streaming, SSE subscription, push-notification config + delivery semantics (retry classification + transient codes), discovery aggregation, intrinsic security schemes, the full limit table, and a run-it-locally pointer to the simulation example. Registered in `mkdocs.yml` between Approvals and Task Chains. Promoting this design doc to `docs/architecture/a2a.md` remains a follow-up.
 - [ ] CHANGELOG entry + README feature-matrix update.
 
 ### Pre-Commit Checks (per Phase)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ nav:
     - Event Grouping: features/event-grouping.md
     - State Machines: features/state-machines.md
     - Human Approvals: features/approvals.md
+    - Agent2Agent (A2A) Protocol: features/a2a.md
     - Task Chains: features/chains.md
     - Sub-Chains: features/sub-chains.md
     - LLM Guardrails: features/llm-guardrails.md


### PR DESCRIPTION
Shipped the A2A feature guide. Closes the
\`docs/book/features/a2a.md\` bullet of Phase 6 in the design doc.

## Coverage

- **URL surface table** for JSON-RPC, REST, SSE, and discovery.
- **8-state Task lifecycle** with a state-machine diagram and a
  transition-source table.
- \`message/send\` example for both minting a Task and continuing one.
- **Pause-for-human** flow (\`InputRequired\` + \`AuthRequired\`), with
  the atomic pairing of \`BusApproval\` row + Task transition explicit.
- **Artifact streaming** + the three cross-delivery invariants the
  gatekeeper enforces (no updates after \`last_chunk\`, strict
  \`chunk_index\` order, \`total_chunks\` completeness).
- **SSE event subscription** endpoint with the three event types it
  emits, plus the explicit \"no Last-Event-ID replay\" call-out.
- **Push notifications end-to-end**: config CRUD, the retry
  classification (4xx terminal *except* 408/425/429 which are
  transient), the in-flight delivery cap, the short-TTL config
  cache, and the \"no DLQ in v1\" disclosure.
- **URL scheme validation** (http/https only, denying SSRF surfaces).
- **Discovery** — single-card-verbatim vs. aggregated rules.
- **Intrinsic security schemes** (\`acteon.bearer\`, \`acteon.apiKey\`)
  and the \`entry().or_insert(…)\` precedence rule.
- **Full limit table** tying every cap constant back to its
  identifier in the codebase (verified against
  \`crates/core/src/bus_task.rs\` and the push-config module).
- **JSON-RPC error code table** mapping each code to its trigger
  and HTTP-status counterpart in the REST binding.
- **\"Try it locally\"** pointer to the Phase 6 simulation example
  (\`a2a_core_simulation.rs\`).
- **\"Architecture references\"** footer pointing back to every
  implementation module.

## Navigation

Registered in \`mkdocs.yml\` between **Approvals** and **Task Chains**
— the A2A guide reads as the natural extension of the Approvals page
(both are HITL surfaces) and as the natural precursor to Task Chains
(which A2A can drive end-to-end via the Task ↔ Chain bridge).

## Pre-commit

Docs-only PR — no code touched. The only Rust-touching change is the
mkdocs.yml entry, which doesn't go through the Rust toolchain. Gate
not re-run on this branch since the previous PR (#179) already passed
the full gate against this main tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)