### PR TITLE
feat(client/python): add A2A protocol module

### DIFF
--- a/clients/python/acteon_client/__init__.py
+++ b/clients/python/acteon_client/__init__.py
@@ -122,11 +122,25 @@ from .models import (
     CoverageQuery,
     CoverageReport,
 )
+from .a2a import (
+    A2A_PROTOCOL_VERSION,
+    make_message,
+    make_part_data,
+    make_part_text,
+    make_part_url,
+    make_push_config,
+)
 
 __version__ = "0.1.0"
 __all__ = [
     "ActeonClient",
     "AsyncActeonClient",
+    "A2A_PROTOCOL_VERSION",
+    "make_message",
+    "make_part_data",
+    "make_part_text",
+    "make_part_url",
+    "make_push_config",
     "ActeonError",
     "ConnectionError",
     "ApiError",

--- a/clients/python/acteon_client/a2a.py
+++ b/clients/python/acteon_client/a2a.py
@@ -1,0 +1,572 @@
+"""A2A protocol surface for the Python ActeonClient.
+
+Two mixins — ``_A2AClientMixin`` for sync and ``_AsyncA2AClientMixin``
+for async — bolt the A2A REST surface plus the one JSON-RPC-only
+method onto :class:`~acteon_client.client.ActeonClient` and
+:class:`~acteon_client.client.AsyncActeonClient`. Methods mirror the
+Rust client at ``crates/client/src/a2a.rs`` so cross-language code
+reads the same.
+
+Wire payloads are kept as ``dict[str, Any]`` matching the A2A JSON
+shapes verbatim. A2A spec evolves and the schema is JSON-native; the
+explicit dataclass route the bus module uses would force a translation
+layer for every field change. The factory helpers
+(:func:`make_message`, :func:`make_part_text`, etc.) cover the common
+construction cases without the dataclass boilerplate.
+
+Every authenticated call sends ``A2A-Version: 1.0`` so the server's
+version negotiation honours version-pinned callers. The discovery
+endpoint (``GET /.well-known/agent.json``) is issued *without* the
+API-key header — the A2A spec requires it to be unauthenticated.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+from urllib.parse import quote
+
+from .errors import ApiError, HttpError
+
+if TYPE_CHECKING:
+    import httpx
+
+# ---------------------------------------------------------------------
+# Wire constants
+# ---------------------------------------------------------------------
+
+#: A2A protocol version this client speaks. Matches
+#: ``A2A_PROTOCOL_VERSION`` in the Rust client and the server.
+A2A_PROTOCOL_VERSION = "1.0"
+
+_A2A_VERSION_HEADER = "A2A-Version"
+_A2A_HEADERS = {_A2A_VERSION_HEADER: A2A_PROTOCOL_VERSION}
+
+
+def _seg(s: str) -> str:
+    """Percent-encode a path segment opaquely (no ``/`` passthrough).
+
+    Mirrors ``_seg`` in ``bus.py``: a tenant or task id that happens
+    to contain a slash must be escaped, not silently split into
+    additional path components.
+    """
+    return quote(s, safe="")
+
+
+def _raise_for_status(resp: "httpx.Response") -> None:
+    """Translate a non-2xx response into either ``ApiError`` (with the
+    server's structured error envelope) or ``HttpError`` (raw body).
+
+    The A2A REST binding uses the same ``{"error": "..."}`` envelope
+    Acteon's other handlers use, so this helper covers both A2A and
+    cross-handler errors uniformly.
+    """
+    if 200 <= resp.status_code < 300:
+        return
+    try:
+        data = resp.json()
+        message = (
+            data.get("error")
+            or data.get("message")
+            or f"a2a error (status {resp.status_code})"
+        )
+        raise ApiError(
+            code=data.get("code", "A2A"),
+            message=message,
+            retryable=resp.status_code in (408, 425, 429) or resp.status_code >= 500,
+        )
+    except ValueError:
+        # Not JSON — fall back to a raw HTTP error with the body text.
+        raise HttpError(
+            status=resp.status_code,
+            message=resp.text or "a2a error",
+        ) from None
+
+
+# ---------------------------------------------------------------------
+# Factory helpers — the common construction shapes
+# ---------------------------------------------------------------------
+
+
+def make_part_text(text: str) -> dict[str, Any]:
+    """Build a text ``Part`` payload — the lightest A2A part shape.
+
+    Caps: the server rejects text > 256 KiB (``MAX_PART_TEXT_BYTES``)
+    at validation time.
+    """
+    return {"text": text}
+
+
+def make_part_url(href: str) -> dict[str, Any]:
+    """Build a URL-reference ``Part``. Use this for payloads that
+    exceed the 256 KiB inline cap — the URL points at an external
+    store the receiver fetches separately.
+    """
+    return {"url": href}
+
+
+def make_part_data(value: Any, media_type: str = "application/json") -> dict[str, Any]:
+    """Build a structured-data ``Part``. The server JSON-encodes the
+    value to measure against ``MAX_PART_DATA_BYTES = 256 KiB``.
+    """
+    return {"data": value, "mediaType": media_type}
+
+
+def make_message(
+    message_id: str,
+    role: str,
+    parts: list[dict[str, Any]],
+    *,
+    task_id: Optional[str] = None,
+    context_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a ``TaskMessage`` payload.
+
+    Set ``task_id`` to thread this message into an existing Task's
+    history; leave it ``None`` to mint a fresh Task on ``send_message``.
+
+    ``role`` must be ``"user"`` or ``"agent"`` — the server validates.
+    """
+    msg: dict[str, Any] = {
+        "messageId": message_id,
+        "role": role,
+        "parts": parts,
+    }
+    if task_id is not None:
+        msg["taskId"] = task_id
+    if context_id is not None:
+        msg["contextId"] = context_id
+    return msg
+
+
+def make_push_config(
+    url: str,
+    *,
+    id: Optional[str] = None,  # noqa: A002 - mirrors the spec field
+    token: Optional[str] = None,
+    authentication: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Build a ``PushNotificationConfig`` body.
+
+    ``url`` must be ``http://`` or ``https://`` — the server denies
+    other schemes at registration time. ``token`` (if set) is sent
+    as ``Authorization: Bearer <token>`` on every push POST and is
+    treated as a secret server-side.
+    """
+    body: dict[str, Any] = {"url": url}
+    if id is not None:
+        body["id"] = id
+    if token is not None:
+        body["token"] = token
+    if authentication is not None:
+        body["authentication"] = authentication
+    return body
+
+
+# ---------------------------------------------------------------------
+# Sync mixin
+# ---------------------------------------------------------------------
+
+
+class _A2AClientMixin:
+    """Mixin providing the A2A protocol surface (sync)."""
+
+    # The mixin doesn't define ``__init__``; these attributes are set
+    # by the concrete client class. Stubbed for type-checkers.
+    if TYPE_CHECKING:
+        def _request(  # noqa: D401
+            self,
+            method: str,
+            path: str,
+            *,
+            json: Optional[dict] = None,
+            params: Optional[dict] = None,
+            extra_headers: Optional[dict[str, str]] = None,
+            skip_auth: bool = False,
+        ) -> "httpx.Response": ...
+
+    # ---- Task lifecycle ----
+
+    def a2a_send_message(
+        self,
+        namespace: str,
+        tenant: str,
+        message: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``POST /a2a/{namespace}/{tenant}/v1/message:send``.
+
+        Start a new A2A Task or continue an existing one. Set
+        ``message["taskId"]`` to thread into an existing Task's
+        history.
+        """
+        resp = self._request(
+            "POST",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}/v1/message:send",
+            json={"message": message},
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+        return resp.json()
+
+    def a2a_get_task(
+        self,
+        namespace: str,
+        tenant: str,
+        task_id: str,
+    ) -> dict[str, Any]:
+        """``GET /a2a/{namespace}/{tenant}/v1/tasks/{id}`` — read a
+        Task by id. Raises ``ApiError`` with HTTP 404 when the task
+        does not exist for the caller.
+        """
+        resp = self._request(
+            "GET",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}/v1/tasks/{_seg(task_id)}",
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+        return resp.json()
+
+    def a2a_cancel_task(
+        self,
+        namespace: str,
+        tenant: str,
+        task_id: str,
+    ) -> dict[str, Any]:
+        """``POST /a2a/{namespace}/{tenant}/v1/tasks/{id}:cancel``.
+
+        The ``:cancel`` verb is part of the URL (spec §11) — the
+        server splits it off in-handler. Raises ``ApiError`` with
+        HTTP 409 ``TaskNotCancelable`` when the task is terminal.
+        """
+        resp = self._request(
+            "POST",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}/v1/tasks/{_seg(task_id)}:cancel",
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+        return resp.json()
+
+    # ---- Push-notification configs ----
+
+    def a2a_set_push_config(
+        self,
+        namespace: str,
+        tenant: str,
+        task_id: str,
+        config: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``POST .../v1/tasks/{id}/pushNotificationConfigs`` — register
+        or upsert a push-notification webhook for a Task.
+
+        Use :func:`make_push_config` to build ``config``.
+        """
+        resp = self._request(
+            "POST",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}"
+            f"/v1/tasks/{_seg(task_id)}/pushNotificationConfigs",
+            json=config,
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+        return resp.json()
+
+    def a2a_list_push_configs(
+        self,
+        namespace: str,
+        tenant: str,
+        task_id: str,
+    ) -> list[dict[str, Any]]:
+        """``GET .../v1/tasks/{id}/pushNotificationConfigs`` — list
+        every config registered for the task.
+        """
+        resp = self._request(
+            "GET",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}"
+            f"/v1/tasks/{_seg(task_id)}/pushNotificationConfigs",
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+        return resp.json()
+
+    def a2a_get_push_config(
+        self,
+        namespace: str,
+        tenant: str,
+        task_id: str,
+        config_id: str,
+    ) -> dict[str, Any]:
+        """``GET …/pushNotificationConfigs/{cfgId}`` — read one
+        config.
+        """
+        resp = self._request(
+            "GET",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}/v1/tasks/{_seg(task_id)}"
+            f"/pushNotificationConfigs/{_seg(config_id)}",
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+        return resp.json()
+
+    def a2a_delete_push_config(
+        self,
+        namespace: str,
+        tenant: str,
+        task_id: str,
+        config_id: str,
+    ) -> None:
+        """``DELETE …/pushNotificationConfigs/{cfgId}``. Raises
+        ``ApiError`` with HTTP 404 when the config doesn't exist —
+        the server never silently no-ops.
+        """
+        resp = self._request(
+            "DELETE",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}/v1/tasks/{_seg(task_id)}"
+            f"/pushNotificationConfigs/{_seg(config_id)}",
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+
+    # ---- Discovery ----
+
+    def a2a_discover_agent(
+        self,
+        namespace: str,
+        tenant: str,
+    ) -> dict[str, Any]:
+        """``GET /a2a/{namespace}/{tenant}/.well-known/agent.json`` —
+        unauthenticated discovery endpoint.
+
+        Sent **without** the API-key header per the A2A spec. Returns
+        the tenant's ``AgentCard`` (single-card verbatim or
+        aggregated across registered agents). Raises ``ApiError``
+        with HTTP 404 when no agent has published a card.
+        """
+        resp = self._request(
+            "GET",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}/.well-known/agent.json",
+            skip_auth=True,
+        )
+        _raise_for_status(resp)
+        return resp.json()
+
+    def a2a_get_authenticated_extended_card(
+        self,
+        namespace: str,
+        tenant: str,
+    ) -> dict[str, Any]:
+        """JSON-RPC ``agent/getAuthenticatedExtendedCard`` — the
+        authenticated discovery variant.
+
+        Issued through the JSON-RPC envelope against
+        ``POST /a2a/{ns}/{tenant}`` (the A2A spec defines no REST
+        counterpart for this method). The returned card has
+        ``capabilities.extendedAgentCard = True``.
+        """
+        envelope = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "agent/getAuthenticatedExtendedCard",
+        }
+        resp = self._request(
+            "POST",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}",
+            json=envelope,
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+        return _unwrap_jsonrpc(resp.json())
+
+
+# ---------------------------------------------------------------------
+# Async mixin (mirrors the sync one method-for-method)
+# ---------------------------------------------------------------------
+
+
+class _AsyncA2AClientMixin:
+    """Mixin providing the A2A protocol surface (async)."""
+
+    if TYPE_CHECKING:
+        async def _request(  # noqa: D401
+            self,
+            method: str,
+            path: str,
+            *,
+            json: Optional[dict] = None,
+            params: Optional[dict] = None,
+            extra_headers: Optional[dict[str, str]] = None,
+            skip_auth: bool = False,
+        ) -> "httpx.Response": ...
+
+    async def a2a_send_message(
+        self,
+        namespace: str,
+        tenant: str,
+        message: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Async counterpart of :meth:`_A2AClientMixin.a2a_send_message`."""
+        resp = await self._request(
+            "POST",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}/v1/message:send",
+            json={"message": message},
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+        return resp.json()
+
+    async def a2a_get_task(
+        self,
+        namespace: str,
+        tenant: str,
+        task_id: str,
+    ) -> dict[str, Any]:
+        """Async counterpart of :meth:`_A2AClientMixin.a2a_get_task`."""
+        resp = await self._request(
+            "GET",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}/v1/tasks/{_seg(task_id)}",
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+        return resp.json()
+
+    async def a2a_cancel_task(
+        self,
+        namespace: str,
+        tenant: str,
+        task_id: str,
+    ) -> dict[str, Any]:
+        """Async counterpart of :meth:`_A2AClientMixin.a2a_cancel_task`."""
+        resp = await self._request(
+            "POST",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}/v1/tasks/{_seg(task_id)}:cancel",
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+        return resp.json()
+
+    async def a2a_set_push_config(
+        self,
+        namespace: str,
+        tenant: str,
+        task_id: str,
+        config: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Async counterpart of :meth:`_A2AClientMixin.a2a_set_push_config`."""
+        resp = await self._request(
+            "POST",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}"
+            f"/v1/tasks/{_seg(task_id)}/pushNotificationConfigs",
+            json=config,
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+        return resp.json()
+
+    async def a2a_list_push_configs(
+        self,
+        namespace: str,
+        tenant: str,
+        task_id: str,
+    ) -> list[dict[str, Any]]:
+        """Async counterpart of :meth:`_A2AClientMixin.a2a_list_push_configs`."""
+        resp = await self._request(
+            "GET",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}"
+            f"/v1/tasks/{_seg(task_id)}/pushNotificationConfigs",
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+        return resp.json()
+
+    async def a2a_get_push_config(
+        self,
+        namespace: str,
+        tenant: str,
+        task_id: str,
+        config_id: str,
+    ) -> dict[str, Any]:
+        """Async counterpart of :meth:`_A2AClientMixin.a2a_get_push_config`."""
+        resp = await self._request(
+            "GET",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}/v1/tasks/{_seg(task_id)}"
+            f"/pushNotificationConfigs/{_seg(config_id)}",
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+        return resp.json()
+
+    async def a2a_delete_push_config(
+        self,
+        namespace: str,
+        tenant: str,
+        task_id: str,
+        config_id: str,
+    ) -> None:
+        """Async counterpart of :meth:`_A2AClientMixin.a2a_delete_push_config`."""
+        resp = await self._request(
+            "DELETE",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}/v1/tasks/{_seg(task_id)}"
+            f"/pushNotificationConfigs/{_seg(config_id)}",
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+
+    async def a2a_discover_agent(
+        self,
+        namespace: str,
+        tenant: str,
+    ) -> dict[str, Any]:
+        """Async counterpart of :meth:`_A2AClientMixin.a2a_discover_agent`."""
+        resp = await self._request(
+            "GET",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}/.well-known/agent.json",
+            skip_auth=True,
+        )
+        _raise_for_status(resp)
+        return resp.json()
+
+    async def a2a_get_authenticated_extended_card(
+        self,
+        namespace: str,
+        tenant: str,
+    ) -> dict[str, Any]:
+        """Async counterpart of
+        :meth:`_A2AClientMixin.a2a_get_authenticated_extended_card`.
+        """
+        envelope = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "agent/getAuthenticatedExtendedCard",
+        }
+        resp = await self._request(
+            "POST",
+            f"/a2a/{_seg(namespace)}/{_seg(tenant)}",
+            json=envelope,
+            extra_headers=_A2A_HEADERS,
+        )
+        _raise_for_status(resp)
+        return _unwrap_jsonrpc(resp.json())
+
+
+# ---------------------------------------------------------------------
+# JSON-RPC envelope helper (shared by sync + async paths)
+# ---------------------------------------------------------------------
+
+
+def _unwrap_jsonrpc(body: dict[str, Any]) -> dict[str, Any]:
+    """Unwrap a JSON-RPC 2.0 reply envelope. Raises ``ApiError`` when
+    the envelope carries an ``error`` member.
+    """
+    if "error" in body and body["error"] is not None:
+        err = body["error"]
+        raise ApiError(
+            code=str(err.get("code", "JSONRPC")),
+            message=err.get("message", "JSON-RPC error"),
+            retryable=False,
+        )
+    result = body.get("result")
+    if result is None:
+        raise ApiError(
+            code="JSONRPC",
+            message="JSON-RPC reply had neither result nor error",
+            retryable=False,
+        )
+    return result

--- a/clients/python/acteon_client/client.py
+++ b/clients/python/acteon_client/client.py
@@ -102,10 +102,11 @@ from .models import (
 )
 
 
+from .a2a import _A2AClientMixin, _AsyncA2AClientMixin
 from .bus import _AsyncBusClientMixin, _BusClientMixin
 
 
-class ActeonClient(_BusClientMixin):
+class ActeonClient(_A2AClientMixin, _BusClientMixin):
     """HTTP client for the Acteon action gateway.
 
     Example:
@@ -179,16 +180,27 @@ class ActeonClient(_BusClientMixin):
         *,
         json: Optional[dict] = None,
         params: Optional[dict] = None,
+        extra_headers: Optional[dict[str, str]] = None,
+        skip_auth: bool = False,
     ) -> httpx.Response:
-        """Make an HTTP request."""
+        """Make an HTTP request.
+
+        ``extra_headers`` are merged on top of the auth headers (caller
+        overrides win). ``skip_auth=True`` suppresses the
+        ``Authorization`` / API-key headers — used by A2A's unauthenticated
+        ``.well-known/agent.json`` discovery endpoint.
+        """
         url = f"{self.base_url}{path}"
+        headers = {"Content-Type": "application/json"} if skip_auth else self._headers()
+        if extra_headers:
+            headers.update(extra_headers)
         try:
             response = self._client.request(
                 method,
                 url,
                 json=json,
                 params=params,
-                headers=self._headers(),
+                headers=headers,
             )
             return response
         except httpx.ConnectError as e:
@@ -2596,7 +2608,7 @@ class ActeonClient(_BusClientMixin):
         raise HttpError(response.status_code, "Failed to cancel swarm run")
 
 
-class AsyncActeonClient(_AsyncBusClientMixin):
+class AsyncActeonClient(_AsyncA2AClientMixin, _AsyncBusClientMixin):
     """Async HTTP client for the Acteon action gateway.
 
     Example:
@@ -2661,15 +2673,25 @@ class AsyncActeonClient(_AsyncBusClientMixin):
         *,
         json: Optional[dict] = None,
         params: Optional[dict] = None,
+        extra_headers: Optional[dict[str, str]] = None,
+        skip_auth: bool = False,
     ) -> httpx.Response:
+        """Async counterpart of the sync ``_request``.
+
+        See the sync version's docstring for the ``extra_headers`` /
+        ``skip_auth`` semantics.
+        """
         url = f"{self.base_url}{path}"
+        headers = {"Content-Type": "application/json"} if skip_auth else self._headers()
+        if extra_headers:
+            headers.update(extra_headers)
         try:
             response = await self._client.request(
                 method,
                 url,
                 json=json,
                 params=params,
-                headers=self._headers(),
+                headers=headers,
             )
             return response
         except httpx.ConnectError as e:

--- a/clients/python/tests/test_a2a.py
+++ b/clients/python/tests/test_a2a.py
@@ -1,0 +1,243 @@
+"""A2A Python SDK — factory + URL/header smoke.
+
+Live HTTP tests would need a running Acteon server with A2A
+enabled; instead these tests pin the wire surface of the new
+``a2a.py`` module: the factory helpers produce the dict shapes the
+server expects, and the mixin's per-method URL + header behaviour
+is observable from a fake ``_request`` capture.
+"""
+
+import unittest
+from typing import Any, Optional
+
+from acteon_client import (
+    A2A_PROTOCOL_VERSION,
+    make_message,
+    make_part_data,
+    make_part_text,
+    make_part_url,
+    make_push_config,
+)
+from acteon_client.a2a import _A2AClientMixin
+
+
+class _Captured:
+    """One captured ``_request`` call."""
+
+    def __init__(
+        self,
+        method: str,
+        path: str,
+        json: Optional[dict],
+        params: Optional[dict],
+        extra_headers: Optional[dict],
+        skip_auth: bool,
+    ):
+        self.method = method
+        self.path = path
+        self.json = json
+        self.params = params
+        self.extra_headers = extra_headers
+        self.skip_auth = skip_auth
+
+
+class _FakeResponse:
+    """Minimal ``httpx.Response`` stand-in covering only the bits the
+    A2A mixin uses (``status_code``, ``json()``, ``text``)."""
+
+    def __init__(self, status_code: int = 200, body: Any = None):
+        self.status_code = status_code
+        self._body = body if body is not None else {}
+        self.text = ""
+
+    def json(self):
+        return self._body
+
+
+class _StubClient(_A2AClientMixin):
+    """Mixin host that records every ``_request`` call without
+    hitting the network. Returns a canned body so the mixin's
+    parsing code runs end-to-end.
+    """
+
+    def __init__(self, body: Any = None, status_code: int = 200):
+        self.calls: list[_Captured] = []
+        self._body = body if body is not None else {}
+        self._status_code = status_code
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: Optional[dict] = None,
+        params: Optional[dict] = None,
+        extra_headers: Optional[dict] = None,
+        skip_auth: bool = False,
+    ):
+        self.calls.append(
+            _Captured(method, path, json, params, extra_headers, skip_auth)
+        )
+        return _FakeResponse(status_code=self._status_code, body=self._body)
+
+
+# ---------------------------------------------------------------------
+# Factory helpers
+# ---------------------------------------------------------------------
+
+
+class TestFactories(unittest.TestCase):
+    def test_make_part_text(self):
+        self.assertEqual(make_part_text("hi"), {"text": "hi"})
+
+    def test_make_part_url(self):
+        self.assertEqual(
+            make_part_url("https://x/y"),
+            {"url": "https://x/y"},
+        )
+
+    def test_make_part_data_defaults_media_type_to_json(self):
+        p = make_part_data({"k": 1})
+        self.assertEqual(p["data"], {"k": 1})
+        self.assertEqual(p["mediaType"], "application/json")
+
+    def test_make_part_data_honors_custom_media_type(self):
+        p = make_part_data({"k": 1}, media_type="application/cloudevents+json")
+        self.assertEqual(p["mediaType"], "application/cloudevents+json")
+
+    def test_make_message_minimal(self):
+        msg = make_message("m-1", "user", [make_part_text("hi")])
+        self.assertEqual(msg["messageId"], "m-1")
+        self.assertEqual(msg["role"], "user")
+        self.assertEqual(msg["parts"], [{"text": "hi"}])
+        # Absent task_id / context_id must NOT appear in the dict —
+        # the server treats absent vs. empty differently.
+        self.assertNotIn("taskId", msg)
+        self.assertNotIn("contextId", msg)
+
+    def test_make_message_threads_taskid(self):
+        msg = make_message(
+            "m-2",
+            "user",
+            [make_part_text("yes")],
+            task_id="task-alpha",
+        )
+        self.assertEqual(msg["taskId"], "task-alpha")
+
+    def test_make_push_config_minimal(self):
+        cfg = make_push_config("https://hook/x")
+        self.assertEqual(cfg, {"url": "https://hook/x"})
+
+    def test_make_push_config_full(self):
+        cfg = make_push_config(
+            "https://hook/x",
+            id="cfg-1",
+            token="t",
+            authentication={"schemes": ["api-key"]},
+        )
+        self.assertEqual(cfg["id"], "cfg-1")
+        self.assertEqual(cfg["token"], "t")
+        self.assertEqual(cfg["authentication"], {"schemes": ["api-key"]})
+
+
+# ---------------------------------------------------------------------
+# Mixin URL + header behaviour
+# ---------------------------------------------------------------------
+
+
+class TestMixinUrlsAndHeaders(unittest.TestCase):
+    def test_send_message_url_and_a2a_version_header(self):
+        c = _StubClient(body={"id": "task-1", "status": {"state": "submitted"}})
+        c.a2a_send_message("ns", "tnt", make_message("m-1", "user", [make_part_text("hi")]))
+        self.assertEqual(len(c.calls), 1)
+        call = c.calls[0]
+        self.assertEqual(call.method, "POST")
+        self.assertEqual(call.path, "/a2a/ns/tnt/v1/message:send")
+        # The send is wrapped in {"message": ...} per spec.
+        self.assertIn("message", call.json)
+        self.assertEqual(call.json["message"]["messageId"], "m-1")
+        # A2A-Version header is set on every authenticated call.
+        self.assertEqual(call.extra_headers, {"A2A-Version": A2A_PROTOCOL_VERSION})
+        self.assertFalse(call.skip_auth)
+
+    def test_cancel_task_url_carries_cancel_verb_in_segment(self):
+        c = _StubClient(body={"id": "task-1", "status": {"state": "canceled"}})
+        c.a2a_cancel_task("ns", "tnt", "task-1")
+        self.assertEqual(c.calls[0].method, "POST")
+        # The :cancel verb must end up as part of the final segment,
+        # not a separate path component.
+        self.assertEqual(
+            c.calls[0].path,
+            "/a2a/ns/tnt/v1/tasks/task-1:cancel",
+        )
+
+    def test_delete_push_config_url(self):
+        c = _StubClient(body=None, status_code=204)
+        c.a2a_delete_push_config("ns", "tnt", "task-1", "cfg-a")
+        self.assertEqual(c.calls[0].method, "DELETE")
+        self.assertEqual(
+            c.calls[0].path,
+            "/a2a/ns/tnt/v1/tasks/task-1/pushNotificationConfigs/cfg-a",
+        )
+
+    def test_discover_agent_is_unauthenticated(self):
+        c = _StubClient(body={"agent_id": "tenant"})
+        c.a2a_discover_agent("ns", "tnt")
+        call = c.calls[0]
+        self.assertEqual(call.method, "GET")
+        self.assertEqual(call.path, "/a2a/ns/tnt/.well-known/agent.json")
+        # The discovery endpoint is unauthenticated per the A2A spec
+        # — the mixin must request without the API-key header.
+        self.assertTrue(
+            call.skip_auth,
+            "discovery must skip auth headers",
+        )
+
+    def test_extended_card_uses_jsonrpc_envelope(self):
+        c = _StubClient(
+            body={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"agent_id": "tenant", "capabilities": {}},
+            }
+        )
+        card = c.a2a_get_authenticated_extended_card("ns", "tnt")
+        call = c.calls[0]
+        self.assertEqual(call.path, "/a2a/ns/tnt")
+        self.assertEqual(call.json["jsonrpc"], "2.0")
+        self.assertEqual(call.json["method"], "agent/getAuthenticatedExtendedCard")
+        # The mixin unwraps the JSON-RPC envelope on the way out.
+        self.assertEqual(card, {"agent_id": "tenant", "capabilities": {}})
+
+    def test_path_segments_are_percent_encoded(self):
+        c = _StubClient(body={"id": "t"})
+        # A tenant name with a slash must be percent-encoded so it
+        # cannot leak into additional path components.
+        c.a2a_get_task("ns/escape", "tnt", "t")
+        self.assertIn("/a2a/ns%2Fescape/tnt/v1/tasks/t", c.calls[0].path)
+
+
+# ---------------------------------------------------------------------
+# JSON-RPC error unwrap surfaces ApiError
+# ---------------------------------------------------------------------
+
+
+class TestJsonRpcErrorUnwrap(unittest.TestCase):
+    def test_jsonrpc_error_body_raises_api_error(self):
+        from acteon_client import ApiError
+
+        c = _StubClient(
+            body={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"code": -32001, "message": "task not found"},
+            }
+        )
+        with self.assertRaises(ApiError) as ctx:
+            c.a2a_get_authenticated_extended_card("ns", "tnt")
+        self.assertIn("task not found", ctx.exception.message)
+        self.assertEqual(ctx.exception.code, "-32001")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Phase 6 SDK update — **Python slot**. Adds
\`clients/python/acteon_client/a2a.py\` with sync + async mixins
covering every A2A REST endpoint plus the one JSON-RPC-only
method. Mirrors the Rust client at #182 method-for-method so
cross-language code reads the same.

The three remaining polyglot SDKs (Node, Go, Java) follow as
separate per-language PRs using this same template.

## Public methods on \`ActeonClient\` / \`AsyncActeonClient\`

| Method | Endpoint |
|---|---|
| \`a2a_send_message\` | \`POST .../v1/message:send\` |
| \`a2a_get_task\` | \`GET .../v1/tasks/{id}\` |
| \`a2a_cancel_task\` | \`POST .../v1/tasks/{id}:cancel\` |
| \`a2a_set_push_config\` | \`POST .../v1/tasks/{id}/pushNotificationConfigs\` |
| \`a2a_list_push_configs\` | \`GET .../v1/tasks/{id}/pushNotificationConfigs\` |
| \`a2a_get_push_config\` | \`GET …/pushNotificationConfigs/{cfgId}\` |
| \`a2a_delete_push_config\` | \`DELETE …/pushNotificationConfigs/{cfgId}\` |
| \`a2a_discover_agent\` | \`GET .../.well-known/agent.json\` (no auth) |
| \`a2a_get_authenticated_extended_card\` | JSON-RPC \`agent/getAuthenticatedExtendedCard\` |

## Wire shape: dicts, not dataclasses

Wire payloads are kept as \`dict[str, Any]\` matching the A2A JSON
shapes verbatim. The A2A schema evolves and is JSON-native; the
explicit dataclass route the bus module uses would force a
translation layer for every field change. **Factory helpers** cover
the common construction cases without the dataclass boilerplate:

- \`make_part_text(text)\` / \`make_part_url(href)\` /
  \`make_part_data(value, media_type)\` — the three \`Part\` shapes.
- \`make_message(message_id, role, parts, *, task_id, context_id)\`
  — TaskMessage envelope; \`task_id\` threads into an existing
  Task's history.
- \`make_push_config(url, *, id, token, authentication)\` —
  PushNotificationConfig body.

## Plumbing changes in \`client.py\`

- \`_request\` (both sync and async) gains \`extra_headers\` and
  \`skip_auth\` kwargs. **Backward compatible** — both default to
  \`None\` / \`False\` — and used by the A2A mixin to attach
  \`A2A-Version: 1.0\` and to issue the unauthenticated discovery
  GET respectively.
- \`ActeonClient\` and \`AsyncActeonClient\` now inherit from the
  A2A mixin first, then the bus mixin, in the same pattern bus
  used for Phase 8a.

## Tests (\`tests/test_a2a.py\`, 15 cases)

- **8 factory-helper round-trips**, including absent-field handling
  (\`taskId\` / \`contextId\` MUST NOT appear when \`None\` — the
  server treats absent vs. empty differently).
- **7 mixin URL + header tests** via a fake \`_request\` capture:
  the \`:cancel\` verb stays in its segment, the delete URL is
  built end-to-end, the discovery call skips auth
  (\`skip_auth=True\`), the extended-card path uses the JSON-RPC
  envelope, JSON-RPC errors unwrap to \`ApiError\`, and path
  segments are percent-encoded so \`/\` in a tenant name cannot
  leak into the path.

Full local suite: **122 passed, 0 failed** (107 pre-existing + 15
new).

## Pre-commit

- Python: \`pytest\` ✅ (122/122)
- Rust gate not re-run — this PR touches Python only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)