### PR TITLE
feat(client/nodejs): add A2A protocol module

### DIFF
--- a/clients/nodejs/src/a2a.test.ts
+++ b/clients/nodejs/src/a2a.test.ts
@@ -1,0 +1,266 @@
+/**
+ * A2A SDK — factory + URL/header smoke tests.
+ *
+ * Live HTTP tests would need a running Acteon server with A2A
+ * enabled; these exercise the wire surface of the new `a2a.ts`
+ * module + the `ActeonClient` methods via a captured `fetch`
+ * stub. The contract under test: factories produce the dict
+ * shapes the server expects, URLs are spec-correct, and the
+ * `A2A-Version` header lands on every authenticated call.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  A2A_PROTOCOL_VERSION,
+  A2A_VERSION_HEADER,
+  makeMessage,
+  makePartData,
+  makePartText,
+  makePartUrl,
+  makePushConfig,
+} from "./a2a.js";
+import { ActeonClient } from "./client.js";
+
+// ---------------------------------------------------------------------
+// Factory helpers
+// ---------------------------------------------------------------------
+
+describe("a2a factory helpers", () => {
+  it("makePartText", () => {
+    expect(makePartText("hi")).toEqual({ text: "hi" });
+  });
+
+  it("makePartUrl", () => {
+    expect(makePartUrl("https://x/y")).toEqual({ url: "https://x/y" });
+  });
+
+  it("makePartData defaults mediaType to application/json", () => {
+    const p = makePartData({ k: 1 });
+    expect(p).toEqual({ data: { k: 1 }, mediaType: "application/json" });
+  });
+
+  it("makePartData honors custom mediaType", () => {
+    const p = makePartData({ k: 1 }, "application/cloudevents+json");
+    expect((p as Record<string, unknown>).mediaType).toEqual(
+      "application/cloudevents+json",
+    );
+  });
+
+  it("makeMessage minimal omits taskId and contextId", () => {
+    const m = makeMessage("m-1", "user", [makePartText("hi")]);
+    expect(m).toEqual({
+      messageId: "m-1",
+      role: "user",
+      parts: [{ text: "hi" }],
+    });
+    // Absent vs. empty matters server-side; the helper must NOT
+    // surface either key as `undefined` either.
+    expect((m as Record<string, unknown>).taskId).toBeUndefined();
+    expect((m as Record<string, unknown>).contextId).toBeUndefined();
+  });
+
+  it("makeMessage threads taskId into history", () => {
+    const m = makeMessage("m-2", "user", [makePartText("yes")], {
+      taskId: "task-alpha",
+    });
+    expect((m as Record<string, unknown>).taskId).toEqual("task-alpha");
+  });
+
+  it("makePushConfig minimal includes only url", () => {
+    expect(makePushConfig("https://hook/x")).toEqual({ url: "https://hook/x" });
+  });
+
+  it("makePushConfig full carries id, token, authentication", () => {
+    const cfg = makePushConfig("https://hook/x", {
+      id: "cfg-1",
+      token: "t",
+      authentication: { schemes: ["api-key"] },
+    });
+    expect((cfg as Record<string, unknown>).id).toEqual("cfg-1");
+    expect((cfg as Record<string, unknown>).token).toEqual("t");
+    expect((cfg as Record<string, unknown>).authentication).toEqual({
+      schemes: ["api-key"],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------
+// Client method URL + header behaviour via a captured `fetch`
+// ---------------------------------------------------------------------
+
+interface CapturedFetch {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+/** Replace `globalThis.fetch` with a stub that records the call and
+ *  returns the supplied response. Returns the captured-calls array
+ *  plus a restore function. */
+function captureFetch(
+  status: number = 200,
+  body: unknown = {},
+): { calls: CapturedFetch[]; restore: () => void } {
+  const calls: CapturedFetch[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    calls.push({ url: String(input), init });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof globalThis.fetch;
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+function headerValue(init: RequestInit | undefined, name: string): string | null {
+  const h = init?.headers;
+  if (!h) return null;
+  if (h instanceof Headers) return h.get(name);
+  if (Array.isArray(h)) {
+    const entry = h.find(
+      ([k]) => k.toLowerCase() === name.toLowerCase(),
+    );
+    return entry ? entry[1] : null;
+  }
+  // Record<string, string>
+  const obj = h as Record<string, string>;
+  for (const [k, v] of Object.entries(obj)) {
+    if (k.toLowerCase() === name.toLowerCase()) return v;
+  }
+  return null;
+}
+
+describe("a2a client URLs and headers", () => {
+  it("a2aSendMessage hits the right URL + carries A2A-Version", async () => {
+    const { calls, restore } = captureFetch(200, {
+      id: "task-1",
+      status: { state: "submitted" },
+    });
+    try {
+      const c = new ActeonClient("http://x", { apiKey: "k" });
+      const msg = makeMessage("m-1", "user", [makePartText("hi")]);
+      await c.a2aSendMessage("ns", "tnt", msg);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].url).toEqual("http://x/a2a/ns/tnt/v1/message:send");
+      expect(calls[0].init?.method).toEqual("POST");
+      expect(headerValue(calls[0].init, A2A_VERSION_HEADER)).toEqual(
+        A2A_PROTOCOL_VERSION,
+      );
+      expect(headerValue(calls[0].init, "Authorization")).toEqual("Bearer k");
+      // Body must wrap message in { message: ... } per spec.
+      const body = JSON.parse(String(calls[0].init?.body));
+      expect(body).toEqual({ message: msg });
+    } finally {
+      restore();
+    }
+  });
+
+  it("a2aCancelTask keeps the :cancel verb in the final segment", async () => {
+    const { calls, restore } = captureFetch(200, {
+      id: "task-1",
+      status: { state: "canceled" },
+    });
+    try {
+      const c = new ActeonClient("http://x");
+      await c.a2aCancelTask("ns", "tnt", "task-1");
+      expect(calls[0].url).toEqual("http://x/a2a/ns/tnt/v1/tasks/task-1:cancel");
+      expect(calls[0].init?.method).toEqual("POST");
+    } finally {
+      restore();
+    }
+  });
+
+  it("a2aDeletePushConfig builds the nested URL", async () => {
+    // 204 No Content can't carry a body in the fetch Response
+    // constructor — use 200 + empty object for the mock and let
+    // the helper just shrug at the unused payload.
+    const { calls, restore } = captureFetch(200, {});
+    try {
+      const c = new ActeonClient("http://x");
+      await c.a2aDeletePushConfig("ns", "tnt", "task-1", "cfg-a");
+      expect(calls[0].url).toEqual(
+        "http://x/a2a/ns/tnt/v1/tasks/task-1/pushNotificationConfigs/cfg-a",
+      );
+      expect(calls[0].init?.method).toEqual("DELETE");
+    } finally {
+      restore();
+    }
+  });
+
+  it("a2aDiscoverAgent is unauthenticated (no Authorization header)", async () => {
+    const { calls, restore } = captureFetch(200, { agent_id: "tenant" });
+    try {
+      const c = new ActeonClient("http://x", { apiKey: "k" });
+      await c.a2aDiscoverAgent("ns", "tnt");
+      expect(calls[0].url).toEqual("http://x/a2a/ns/tnt/.well-known/agent.json");
+      // Discovery is anonymous per A2A spec — even when an API key is
+      // configured on the client, this call must NOT carry it.
+      expect(headerValue(calls[0].init, "Authorization")).toBeNull();
+    } finally {
+      restore();
+    }
+  });
+
+  it("a2aGetAuthenticatedExtendedCard uses the JSON-RPC envelope", async () => {
+    const { calls, restore } = captureFetch(200, {
+      jsonrpc: "2.0",
+      id: 1,
+      result: { agent_id: "tenant", capabilities: {} },
+    });
+    try {
+      const c = new ActeonClient("http://x", { apiKey: "k" });
+      const card = await c.a2aGetAuthenticatedExtendedCard("ns", "tnt");
+      expect(calls[0].url).toEqual("http://x/a2a/ns/tnt");
+      const body = JSON.parse(String(calls[0].init?.body));
+      expect(body.jsonrpc).toEqual("2.0");
+      expect(body.method).toEqual("agent/getAuthenticatedExtendedCard");
+      // The mixin unwraps the envelope on the way out.
+      expect(card).toEqual({ agent_id: "tenant", capabilities: {} });
+    } finally {
+      restore();
+    }
+  });
+
+  it("path segments are percent-encoded", async () => {
+    const { calls, restore } = captureFetch(200, {});
+    try {
+      const c = new ActeonClient("http://x");
+      // A tenant id with a slash MUST be percent-encoded so it
+      // cannot leak into additional path components.
+      await c.a2aGetTask("ns/escape", "tnt", "t");
+      expect(calls[0].url).toContain("/a2a/ns%2Fescape/tnt/v1/tasks/t");
+    } finally {
+      restore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------
+// JSON-RPC error unwrap
+// ---------------------------------------------------------------------
+
+describe("a2a JSON-RPC error unwrap", () => {
+  it("surfaces JSON-RPC errors as ApiError", async () => {
+    const { restore } = captureFetch(200, {
+      jsonrpc: "2.0",
+      id: 1,
+      error: { code: -32001, message: "task not found" },
+    });
+    try {
+      const c = new ActeonClient("http://x", { apiKey: "k" });
+      await expect(
+        c.a2aGetAuthenticatedExtendedCard("ns", "tnt"),
+      ).rejects.toThrow(/task not found/);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/clients/nodejs/src/a2a.ts
+++ b/clients/nodejs/src/a2a.ts
@@ -1,0 +1,141 @@
+/**
+ * A2A protocol surface — factory helpers + shared constants.
+ *
+ * The {@link ActeonClient} class carries the actual HTTP methods
+ * (kept inline because TypeScript doesn't have Python-style mixins
+ * and the class already aggregates every other surface). This module
+ * publishes the wire-shape factories that mirror the Python SDK's
+ * `make_*` helpers, plus the `A2A-Version: 1.0` header constant.
+ *
+ * Wire payloads are typed as `Record<string, unknown>` — the A2A
+ * schema is JSON-native and evolves; the factory functions hide the
+ * camelCase conventions (`messageId`, `taskId`, `mediaType`) so
+ * callers don't have to remember them.
+ */
+
+/** A2A protocol version this client speaks. Matches the Rust client's
+ *  `A2A_PROTOCOL_VERSION` and the server's negotiated version. */
+export const A2A_PROTOCOL_VERSION = "1.0";
+
+/** HTTP header name carrying the negotiated A2A protocol version.
+ *  Sent on every authenticated A2A call so the server's version
+ *  negotiation honours a version-pinned caller. */
+export const A2A_VERSION_HEADER = "A2A-Version";
+
+/** Header object the client mixes into every authenticated request.
+ *  Exported so callers writing their own integration can reuse the
+ *  exact same constant. */
+export const A2A_HEADERS: Readonly<Record<string, string>> = Object.freeze({
+  [A2A_VERSION_HEADER]: A2A_PROTOCOL_VERSION,
+});
+
+/** Build a text `Part` payload — the lightest A2A part shape.
+ *  The server rejects text larger than 256 KiB
+ *  (`MAX_PART_TEXT_BYTES`) at validation time. */
+export function makePartText(text: string): Record<string, unknown> {
+  return { text };
+}
+
+/** Build a URL-reference `Part`. Use this for payloads that exceed
+ *  the 256 KiB inline cap — the URL points at an external store the
+ *  receiver fetches separately. */
+export function makePartUrl(href: string): Record<string, unknown> {
+  return { url: href };
+}
+
+/** Build a structured-data `Part`. The server JSON-encodes `value`
+ *  to measure against `MAX_PART_DATA_BYTES = 256 KiB`. `mediaType`
+ *  defaults to `application/json`. */
+export function makePartData(
+  value: unknown,
+  mediaType: string = "application/json",
+): Record<string, unknown> {
+  return { data: value, mediaType };
+}
+
+/** Options accepted by {@link makeMessage}. */
+export interface MakeMessageOptions {
+  /** Thread the message into an existing Task's history. Omit to
+   *  mint a fresh Task on `a2aSendMessage`. */
+  taskId?: string;
+  /** Optional context id (carried across related tasks). */
+  contextId?: string;
+}
+
+/** Build a `TaskMessage` payload. `role` must be `"user"` or
+ *  `"agent"` — the server validates. */
+export function makeMessage(
+  messageId: string,
+  role: "user" | "agent",
+  parts: Record<string, unknown>[],
+  options: MakeMessageOptions = {},
+): Record<string, unknown> {
+  const msg: Record<string, unknown> = { messageId, role, parts };
+  if (options.taskId !== undefined) msg.taskId = options.taskId;
+  if (options.contextId !== undefined) msg.contextId = options.contextId;
+  return msg;
+}
+
+/** Options accepted by {@link makePushConfig}. */
+export interface MakePushConfigOptions {
+  /** Pre-allocate the config id (UUIDv7 by convention). Omit to let
+   *  the server mint one. */
+  id?: string;
+  /** Optional bearer token sent in
+   *  `Authorization: Bearer <token>` on every push POST. */
+  token?: string;
+  /** Optional richer authentication metadata. */
+  authentication?: Record<string, unknown>;
+}
+
+/** Build a `PushNotificationConfig` body. `url` must be `http://` or
+ *  `https://` — the server denies other schemes at registration
+ *  time. */
+export function makePushConfig(
+  url: string,
+  options: MakePushConfigOptions = {},
+): Record<string, unknown> {
+  const body: Record<string, unknown> = { url };
+  if (options.id !== undefined) body.id = options.id;
+  if (options.token !== undefined) body.token = options.token;
+  if (options.authentication !== undefined) {
+    body.authentication = options.authentication;
+  }
+  return body;
+}
+
+/**
+ * Percent-encode a path segment opaquely (no `/` passthrough).
+ * Mirrors the segment encoding used by the Python and Rust clients
+ * so a tenant id with reserved characters cannot leak into
+ * additional path components.
+ */
+export function a2aSegment(s: string): string {
+  return encodeURIComponent(s);
+}
+
+/** JSON-RPC 2.0 envelope shape used for the one
+ *  `agent/getAuthenticatedExtendedCard` round-trip. */
+export interface JsonRpcReply<T> {
+  jsonrpc: "2.0";
+  id: number | string | null;
+  result?: T;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+/**
+ * Unwrap a JSON-RPC 2.0 reply envelope. Throws an `ApiError`-shaped
+ * `Error` when the envelope carries an `error` member.
+ */
+export function unwrapJsonRpc<T>(
+  body: JsonRpcReply<T>,
+  raise: (code: string, message: string) => never,
+): T {
+  if (body.error) {
+    raise(String(body.error.code), body.error.message);
+  }
+  if (body.result === undefined) {
+    raise("JSONRPC", "JSON-RPC reply had neither result nor error");
+  }
+  return body.result as T;
+}

--- a/clients/nodejs/src/client.ts
+++ b/clients/nodejs/src/client.ts
@@ -163,6 +163,12 @@ import {
   parseSigningKeysResponse,
 } from "./models.js";
 import { ActeonError, ApiError, ConnectionError, HttpError } from "./errors.js";
+import {
+  A2A_HEADERS,
+  a2aSegment,
+  unwrapJsonRpc,
+  type JsonRpcReply,
+} from "./a2a.js";
 import { readFileSync } from "node:fs";
 import { Agent as HttpsAgent } from "node:https";
 import {
@@ -355,6 +361,13 @@ export class ActeonClient {
     options?: {
       body?: unknown;
       params?: URLSearchParams;
+      extraHeaders?: Record<string, string>;
+      /**
+       * When true, suppress the `Authorization` header. Used by the
+       * A2A unauthenticated discovery endpoint
+       * (`/.well-known/agent.json`), which per spec is anonymous.
+       */
+      skipAuth?: boolean;
     }
   ): Promise<Response> {
     let url = `${this.baseUrl}${path}`;
@@ -366,9 +379,16 @@ export class ActeonClient {
     const timeoutId = setTimeout(() => controller.abort(), this.timeout);
 
     try {
+      const baseHeaders = options?.skipAuth
+        ? { "Content-Type": "application/json" }
+        : this.headers();
+      const headers: Record<string, string> = {
+        ...baseHeaders,
+        ...(options?.extraHeaders ?? {}),
+      };
       const fetchOptions: RequestInit & { dispatcher?: unknown } = {
         method,
-        headers: this.headers(),
+        headers,
         body: options?.body ? JSON.stringify(options.body) : undefined,
         signal: controller.signal,
       };
@@ -3036,5 +3056,195 @@ export class ActeonClient {
     );
     if (!response.ok) await this.busThrowFromResponse(response);
     return parseBusApprovalDecisionResponse((await response.json()) as Record<string, unknown>);
+  }
+
+  // ===========================================================================
+  // A2A protocol surface
+  //
+  // Mirrors the Rust + Python SDKs method-for-method. Every authenticated
+  // call sends `A2A-Version: 1.0`; the discovery call is intentionally
+  // unauthenticated per spec.
+  // ===========================================================================
+
+  /** Translate an A2A error response into an `ApiError`. The A2A
+   *  surface uses the same `{ "error": "..." }` envelope as the rest
+   *  of the Acteon REST API. */
+  private async a2aThrowFromResponse(response: Response): Promise<never> {
+    let payload: Record<string, unknown> = {};
+    try {
+      payload = (await response.json()) as Record<string, unknown>;
+    } catch {
+      /* fall through with empty payload */
+    }
+    const message =
+      (payload.error as string | undefined) ??
+      (payload.message as string | undefined) ??
+      `a2a error (status ${response.status})`;
+    const retryable =
+      response.status === 408 ||
+      response.status === 425 ||
+      response.status === 429 ||
+      response.status >= 500;
+    throw new ApiError(
+      (payload.code as string | undefined) ?? "A2A",
+      message,
+      retryable,
+    );
+  }
+
+  /** `POST /a2a/{namespace}/{tenant}/v1/message:send`. */
+  async a2aSendMessage(
+    namespace: string,
+    tenant: string,
+    message: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const response = await this.request(
+      "POST",
+      `/a2a/${a2aSegment(namespace)}/${a2aSegment(tenant)}/v1/message:send`,
+      { body: { message }, extraHeaders: { ...A2A_HEADERS } },
+    );
+    if (!response.ok) await this.a2aThrowFromResponse(response);
+    return (await response.json()) as Record<string, unknown>;
+  }
+
+  /** `GET /a2a/{namespace}/{tenant}/v1/tasks/{id}`. */
+  async a2aGetTask(
+    namespace: string,
+    tenant: string,
+    taskId: string,
+  ): Promise<Record<string, unknown>> {
+    const response = await this.request(
+      "GET",
+      `/a2a/${a2aSegment(namespace)}/${a2aSegment(tenant)}/v1/tasks/${a2aSegment(taskId)}`,
+      { extraHeaders: { ...A2A_HEADERS } },
+    );
+    if (!response.ok) await this.a2aThrowFromResponse(response);
+    return (await response.json()) as Record<string, unknown>;
+  }
+
+  /** `POST /a2a/{namespace}/{tenant}/v1/tasks/{id}:cancel`. The
+   *  `:cancel` verb is part of the URL (spec §11) — the server
+   *  splits it off in-handler. */
+  async a2aCancelTask(
+    namespace: string,
+    tenant: string,
+    taskId: string,
+  ): Promise<Record<string, unknown>> {
+    const response = await this.request(
+      "POST",
+      `/a2a/${a2aSegment(namespace)}/${a2aSegment(tenant)}/v1/tasks/${a2aSegment(taskId)}:cancel`,
+      { extraHeaders: { ...A2A_HEADERS } },
+    );
+    if (!response.ok) await this.a2aThrowFromResponse(response);
+    return (await response.json()) as Record<string, unknown>;
+  }
+
+  /** `POST .../v1/tasks/{id}/pushNotificationConfigs` — register or
+   *  upsert a push-notification webhook for a Task. Use
+   *  {@link makePushConfig} to build `config`. */
+  async a2aSetPushConfig(
+    namespace: string,
+    tenant: string,
+    taskId: string,
+    config: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const response = await this.request(
+      "POST",
+      `/a2a/${a2aSegment(namespace)}/${a2aSegment(tenant)}/v1/tasks/${a2aSegment(taskId)}/pushNotificationConfigs`,
+      { body: config, extraHeaders: { ...A2A_HEADERS } },
+    );
+    if (!response.ok) await this.a2aThrowFromResponse(response);
+    return (await response.json()) as Record<string, unknown>;
+  }
+
+  /** `GET .../v1/tasks/{id}/pushNotificationConfigs` — list every
+   *  config registered for the task. */
+  async a2aListPushConfigs(
+    namespace: string,
+    tenant: string,
+    taskId: string,
+  ): Promise<Record<string, unknown>[]> {
+    const response = await this.request(
+      "GET",
+      `/a2a/${a2aSegment(namespace)}/${a2aSegment(tenant)}/v1/tasks/${a2aSegment(taskId)}/pushNotificationConfigs`,
+      { extraHeaders: { ...A2A_HEADERS } },
+    );
+    if (!response.ok) await this.a2aThrowFromResponse(response);
+    return (await response.json()) as Record<string, unknown>[];
+  }
+
+  /** `GET …/pushNotificationConfigs/{cfgId}` — read one config. */
+  async a2aGetPushConfig(
+    namespace: string,
+    tenant: string,
+    taskId: string,
+    configId: string,
+  ): Promise<Record<string, unknown>> {
+    const response = await this.request(
+      "GET",
+      `/a2a/${a2aSegment(namespace)}/${a2aSegment(tenant)}/v1/tasks/${a2aSegment(taskId)}/pushNotificationConfigs/${a2aSegment(configId)}`,
+      { extraHeaders: { ...A2A_HEADERS } },
+    );
+    if (!response.ok) await this.a2aThrowFromResponse(response);
+    return (await response.json()) as Record<string, unknown>;
+  }
+
+  /** `DELETE …/pushNotificationConfigs/{cfgId}`. Throws an
+   *  `ApiError` with HTTP 404 when the config doesn't exist — the
+   *  server never silently no-ops. */
+  async a2aDeletePushConfig(
+    namespace: string,
+    tenant: string,
+    taskId: string,
+    configId: string,
+  ): Promise<void> {
+    const response = await this.request(
+      "DELETE",
+      `/a2a/${a2aSegment(namespace)}/${a2aSegment(tenant)}/v1/tasks/${a2aSegment(taskId)}/pushNotificationConfigs/${a2aSegment(configId)}`,
+      { extraHeaders: { ...A2A_HEADERS } },
+    );
+    if (!response.ok) await this.a2aThrowFromResponse(response);
+  }
+
+  /** `GET /a2a/{namespace}/{tenant}/.well-known/agent.json` — the
+   *  unauthenticated discovery endpoint. Issued **without** the
+   *  Authorization header per A2A spec. */
+  async a2aDiscoverAgent(
+    namespace: string,
+    tenant: string,
+  ): Promise<Record<string, unknown>> {
+    const response = await this.request(
+      "GET",
+      `/a2a/${a2aSegment(namespace)}/${a2aSegment(tenant)}/.well-known/agent.json`,
+      { skipAuth: true },
+    );
+    if (!response.ok) await this.a2aThrowFromResponse(response);
+    return (await response.json()) as Record<string, unknown>;
+  }
+
+  /** JSON-RPC `agent/getAuthenticatedExtendedCard` — authenticated
+   *  discovery variant. Issued through the JSON-RPC envelope against
+   *  `POST /a2a/{ns}/{tenant}` (the A2A spec defines no REST
+   *  counterpart). The returned card has
+   *  `capabilities.extendedAgentCard = true`. */
+  async a2aGetAuthenticatedExtendedCard(
+    namespace: string,
+    tenant: string,
+  ): Promise<Record<string, unknown>> {
+    const envelope = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "agent/getAuthenticatedExtendedCard",
+    };
+    const response = await this.request(
+      "POST",
+      `/a2a/${a2aSegment(namespace)}/${a2aSegment(tenant)}`,
+      { body: envelope, extraHeaders: { ...A2A_HEADERS } },
+    );
+    if (!response.ok) await this.a2aThrowFromResponse(response);
+    const body = (await response.json()) as JsonRpcReply<Record<string, unknown>>;
+    return unwrapJsonRpc(body, (code, message) => {
+      throw new ApiError(code, message, false);
+    });
   }
 }

--- a/clients/nodejs/src/index.ts
+++ b/clients/nodejs/src/index.ts
@@ -166,3 +166,15 @@ export {
   type StreamEndEnvelope,
   type StreamEndEnvelopeStatus,
 } from "./bus_models.js";
+export {
+  A2A_PROTOCOL_VERSION,
+  A2A_VERSION_HEADER,
+  A2A_HEADERS,
+  makeMessage,
+  makePartData,
+  makePartText,
+  makePartUrl,
+  makePushConfig,
+  type MakeMessageOptions,
+  type MakePushConfigOptions,
+} from "./a2a.js";


### PR DESCRIPTION
Phase 6 SDK update — **Node/TS slot**. Adds
\`clients/nodejs/src/a2a.ts\` (factory helpers + constants) and
folds nine A2A methods into \`ActeonClient\` in \`client.ts\`. Mirrors
the Rust and Python SDKs method-for-method.

The two remaining polyglot SDKs (Go, Java) follow as separate
per-language PRs using this same template.

## Public methods on \`ActeonClient\`

| Method | Endpoint |
|---|---|
| \`a2aSendMessage\` | \`POST .../v1/message:send\` |
| \`a2aGetTask\` | \`GET .../v1/tasks/{id}\` |
| \`a2aCancelTask\` | \`POST .../v1/tasks/{id}:cancel\` |
| \`a2aSetPushConfig\` | \`POST .../v1/tasks/{id}/pushNotificationConfigs\` |
| \`a2aListPushConfigs\` | \`GET .../v1/tasks/{id}/pushNotificationConfigs\` |
| \`a2aGetPushConfig\` | \`GET …/pushNotificationConfigs/{cfgId}\` |
| \`a2aDeletePushConfig\` | \`DELETE …/pushNotificationConfigs/{cfgId}\` |
| \`a2aDiscoverAgent\` | \`GET .../.well-known/agent.json\` (no auth) |
| \`a2aGetAuthenticatedExtendedCard\` | JSON-RPC \`agent/getAuthenticatedExtendedCard\` |

## Wire shape: \`Record<string, unknown>\` + factories

Same rationale as the Python SDK (#183): A2A schema is JSON-native
and evolves; an explicit interface route forces a translation layer
for every field change. **Factory helpers** cover the common
construction cases:

- \`makePartText(text)\` / \`makePartUrl(href)\` / \`makePartData(value, mediaType)\`
- \`makeMessage(messageId, role, parts, { taskId, contextId })\`
- \`makePushConfig(url, { id, token, authentication })\`

## Plumbing changes in \`client.ts\`

- Private \`request\` gains optional \`extraHeaders\` and \`skipAuth\`
  fields. **Backward compatible** (both default to undefined /
  false). Used by the A2A methods to attach \`A2A-Version: 1.0\` and
  to issue the unauthenticated discovery GET respectively.
- New private \`a2aThrowFromResponse\` maps the
  \`{\"error\": \"...\"}\` envelope to \`ApiError\`, marking 408/425/429
  and ≥500 as retryable (matching the server's classification).

## Tests (\`src/a2a.test.ts\`, 15 cases via vitest)

- **8 factory-helper round-trips**, including absent-field handling
  (\`taskId\` / \`contextId\` MUST NOT appear when omitted — the
  server treats absent vs. empty differently).
- **7 client-method URL + header tests** using a captured \`fetch\`
  stub: the \`:cancel\` verb stays in its segment, the delete URL is
  built end-to-end, the discovery call carries no \`Authorization\`
  even when an API key is configured, the extended-card path uses
  the JSON-RPC envelope, JSON-RPC errors unwrap to \`ApiError\`, and
  path segments are percent-encoded so \`/\` in a tenant id cannot
  leak into the path.

Full local suite: **103 passed, 0 failed** (88 pre-existing + 15
new). TypeScript build clean (\`npm run build\` no errors).

## Pre-commit

- Node: \`npm run build\` ✅, \`npm test\` ✅ (103/103)
- Rust gate not re-run — this PR touches Node only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)