### PR TITLE
feat(client/go): add A2A protocol module

### DIFF
--- a/clients/go/acteon/a2a.go
+++ b/clients/go/acteon/a2a.go
@@ -1,0 +1,374 @@
+// A2A protocol surface for the Go ActeonClient.
+//
+// Mirrors the Rust, Python, and Node SDKs method-for-method.
+// Wire payloads are typed as map[string]any matching the A2A JSON
+// shapes verbatim — the schema evolves and is JSON-native; pinned
+// Go structs would force a translation layer for every field
+// change. Factory helpers cover the common construction cases.
+//
+// Every authenticated call sends `A2A-Version: 1.0` so the server's
+// version negotiation honours version-pinned callers. The discovery
+// endpoint is intentionally unauthenticated per the A2A spec.
+
+package acteon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// A2AProtocolVersion is the A2A protocol version this client speaks.
+// Matches the Rust client's `A2A_PROTOCOL_VERSION` and the server's
+// negotiated version.
+const A2AProtocolVersion = "1.0"
+
+// A2AVersionHeader is the HTTP header name carrying the negotiated
+// A2A protocol version.
+const A2AVersionHeader = "A2A-Version"
+
+// a2aHeaders is the header set every authenticated A2A call sends.
+var a2aHeaders = map[string]string{A2AVersionHeader: A2AProtocolVersion}
+
+// ----------------------------------------------------------------------
+// Factory helpers
+// ----------------------------------------------------------------------
+
+// MakePartText builds a text `Part` payload — the lightest A2A part
+// shape. The server rejects text larger than 256 KiB
+// (`MAX_PART_TEXT_BYTES`) at validation time.
+func MakePartText(text string) map[string]any {
+	return map[string]any{"text": text}
+}
+
+// MakePartURL builds a URL-reference `Part`. Use this for payloads
+// that exceed the 256 KiB inline cap.
+func MakePartURL(href string) map[string]any {
+	return map[string]any{"url": href}
+}
+
+// MakePartData builds a structured-data `Part`. The server
+// JSON-encodes the value to measure against `MAX_PART_DATA_BYTES`
+// (256 KiB). `mediaType` defaults to `application/json` when empty.
+func MakePartData(value any, mediaType string) map[string]any {
+	if mediaType == "" {
+		mediaType = "application/json"
+	}
+	return map[string]any{"data": value, "mediaType": mediaType}
+}
+
+// MakeMessageOptions carries the optional fields for `MakeMessage`.
+type MakeMessageOptions struct {
+	// TaskID threads the message into an existing Task's history.
+	// Leave empty to mint a fresh Task on `A2ASendMessage`.
+	TaskID string
+	// ContextID is an optional context id carried across related
+	// tasks.
+	ContextID string
+}
+
+// MakeMessage builds a `TaskMessage` payload. `role` must be
+// `"user"` or `"agent"` — the server validates.
+func MakeMessage(messageID, role string, parts []map[string]any, opts MakeMessageOptions) map[string]any {
+	msg := map[string]any{
+		"messageId": messageID,
+		"role":      role,
+		"parts":     parts,
+	}
+	if opts.TaskID != "" {
+		msg["taskId"] = opts.TaskID
+	}
+	if opts.ContextID != "" {
+		msg["contextId"] = opts.ContextID
+	}
+	return msg
+}
+
+// MakePushConfigOptions carries the optional fields for
+// `MakePushConfig`.
+type MakePushConfigOptions struct {
+	// ID is the optional pre-allocated config id (UUIDv7 by
+	// convention). Empty string lets the server mint one.
+	ID string
+	// Token is the optional bearer token sent in
+	// `Authorization: Bearer <token>` on every push POST.
+	Token string
+	// Authentication is optional richer authentication metadata.
+	Authentication map[string]any
+}
+
+// MakePushConfig builds a `PushNotificationConfig` body. `url` must
+// be `http://` or `https://` — the server denies other schemes at
+// registration time.
+func MakePushConfig(targetURL string, opts MakePushConfigOptions) map[string]any {
+	body := map[string]any{"url": targetURL}
+	if opts.ID != "" {
+		body["id"] = opts.ID
+	}
+	if opts.Token != "" {
+		body["token"] = opts.Token
+	}
+	if opts.Authentication != nil {
+		body["authentication"] = opts.Authentication
+	}
+	return body
+}
+
+// ----------------------------------------------------------------------
+// Internal helpers
+// ----------------------------------------------------------------------
+
+// a2aSeg percent-encodes a single path segment opaquely. Mirrors
+// the Python/Node `_seg` / `a2aSegment` helpers — a tenant id or
+// task id with reserved characters must not leak into additional
+// path components.
+func a2aSeg(s string) string {
+	return url.PathEscape(s)
+}
+
+// a2aDoJSON wraps `doRequestExt` with body reading + structured
+// error decoding. Mirrors `busDoJSON`. On non-2xx surfaces an
+// `*APIError` (with the server's structured envelope) or
+// `*HTTPError` (raw body). On 2xx unmarshals into `out` when
+// non-nil.
+func (c *Client) a2aDoJSON(
+	ctx context.Context,
+	method, path string,
+	body, out any,
+	opts requestOpts,
+) error {
+	resp, err := c.doRequestExt(ctx, method, path, body, opts)
+	if err != nil {
+		return err
+	}
+	respBody, readErr := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if readErr != nil {
+		return &ConnectionError{Message: readErr.Error()}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var errResp struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+			Error   string `json:"error"`
+		}
+		if jsonErr := json.Unmarshal(respBody, &errResp); jsonErr == nil {
+			msg := errResp.Error
+			if msg == "" {
+				msg = errResp.Message
+			}
+			if msg == "" {
+				msg = fmt.Sprintf("a2a error (status %d)", resp.StatusCode)
+			}
+			code := errResp.Code
+			if code == "" {
+				code = "A2A"
+			}
+			retryable := resp.StatusCode == http.StatusRequestTimeout ||
+				resp.StatusCode == http.StatusTooEarly ||
+				resp.StatusCode == http.StatusTooManyRequests ||
+				resp.StatusCode >= 500
+			return &APIError{Code: code, Message: msg, Retryable: retryable}
+		}
+		return &HTTPError{Status: resp.StatusCode, Message: string(respBody)}
+	}
+	if out != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return &ConnectionError{Message: err.Error()}
+		}
+	}
+	return nil
+}
+
+// jsonRPCReply is the JSON-RPC 2.0 reply envelope used by the one
+// `agent/getAuthenticatedExtendedCard` round-trip.
+type jsonRPCReply struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      any             `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// ----------------------------------------------------------------------
+// Task lifecycle
+// ----------------------------------------------------------------------
+
+// A2ASendMessage calls `POST /a2a/{namespace}/{tenant}/v1/message:send`
+// to start a new A2A Task or continue an existing one.
+//
+// Set `message["taskId"]` (use `MakeMessage` with
+// `MakeMessageOptions{TaskID: ...}`) to thread the message into an
+// existing Task's history.
+func (c *Client) A2ASendMessage(
+	ctx context.Context,
+	namespace, tenant string,
+	message map[string]any,
+) (map[string]any, error) {
+	var out map[string]any
+	path := fmt.Sprintf("/a2a/%s/%s/v1/message:send", a2aSeg(namespace), a2aSeg(tenant))
+	err := c.a2aDoJSON(ctx, http.MethodPost, path, map[string]any{"message": message}, &out,
+		requestOpts{extraHeaders: a2aHeaders})
+	return out, err
+}
+
+// A2AGetTask calls `GET /a2a/{namespace}/{tenant}/v1/tasks/{id}`.
+// Returns an `*APIError` with HTTP 404 when the task does not exist
+// for the caller.
+func (c *Client) A2AGetTask(
+	ctx context.Context,
+	namespace, tenant, taskID string,
+) (map[string]any, error) {
+	var out map[string]any
+	path := fmt.Sprintf("/a2a/%s/%s/v1/tasks/%s",
+		a2aSeg(namespace), a2aSeg(tenant), a2aSeg(taskID))
+	err := c.a2aDoJSON(ctx, http.MethodGet, path, nil, &out,
+		requestOpts{extraHeaders: a2aHeaders})
+	return out, err
+}
+
+// A2ACancelTask calls `POST /a2a/{namespace}/{tenant}/v1/tasks/{id}:cancel`.
+// The `:cancel` verb is part of the URL (spec §11) — the server
+// splits it off in-handler.
+func (c *Client) A2ACancelTask(
+	ctx context.Context,
+	namespace, tenant, taskID string,
+) (map[string]any, error) {
+	var out map[string]any
+	path := fmt.Sprintf("/a2a/%s/%s/v1/tasks/%s:cancel",
+		a2aSeg(namespace), a2aSeg(tenant), a2aSeg(taskID))
+	err := c.a2aDoJSON(ctx, http.MethodPost, path, nil, &out,
+		requestOpts{extraHeaders: a2aHeaders})
+	return out, err
+}
+
+// ----------------------------------------------------------------------
+// Push-notification configs
+// ----------------------------------------------------------------------
+
+// A2ASetPushConfig calls
+// `POST .../v1/tasks/{id}/pushNotificationConfigs` to register or
+// upsert a push-notification webhook for a Task. Use
+// `MakePushConfig` to build `config`.
+func (c *Client) A2ASetPushConfig(
+	ctx context.Context,
+	namespace, tenant, taskID string,
+	config map[string]any,
+) (map[string]any, error) {
+	var out map[string]any
+	path := fmt.Sprintf("/a2a/%s/%s/v1/tasks/%s/pushNotificationConfigs",
+		a2aSeg(namespace), a2aSeg(tenant), a2aSeg(taskID))
+	err := c.a2aDoJSON(ctx, http.MethodPost, path, config, &out,
+		requestOpts{extraHeaders: a2aHeaders})
+	return out, err
+}
+
+// A2AListPushConfigs calls
+// `GET .../v1/tasks/{id}/pushNotificationConfigs` to list every
+// config registered for the task.
+func (c *Client) A2AListPushConfigs(
+	ctx context.Context,
+	namespace, tenant, taskID string,
+) ([]map[string]any, error) {
+	var out []map[string]any
+	path := fmt.Sprintf("/a2a/%s/%s/v1/tasks/%s/pushNotificationConfigs",
+		a2aSeg(namespace), a2aSeg(tenant), a2aSeg(taskID))
+	err := c.a2aDoJSON(ctx, http.MethodGet, path, nil, &out,
+		requestOpts{extraHeaders: a2aHeaders})
+	return out, err
+}
+
+// A2AGetPushConfig calls
+// `GET …/pushNotificationConfigs/{cfgId}` to read one config.
+func (c *Client) A2AGetPushConfig(
+	ctx context.Context,
+	namespace, tenant, taskID, configID string,
+) (map[string]any, error) {
+	var out map[string]any
+	path := fmt.Sprintf("/a2a/%s/%s/v1/tasks/%s/pushNotificationConfigs/%s",
+		a2aSeg(namespace), a2aSeg(tenant), a2aSeg(taskID), a2aSeg(configID))
+	err := c.a2aDoJSON(ctx, http.MethodGet, path, nil, &out,
+		requestOpts{extraHeaders: a2aHeaders})
+	return out, err
+}
+
+// A2ADeletePushConfig calls
+// `DELETE …/pushNotificationConfigs/{cfgId}`. Returns an `*APIError`
+// with HTTP 404 when the config doesn't exist — the server never
+// silently no-ops.
+func (c *Client) A2ADeletePushConfig(
+	ctx context.Context,
+	namespace, tenant, taskID, configID string,
+) error {
+	path := fmt.Sprintf("/a2a/%s/%s/v1/tasks/%s/pushNotificationConfigs/%s",
+		a2aSeg(namespace), a2aSeg(tenant), a2aSeg(taskID), a2aSeg(configID))
+	return c.a2aDoJSON(ctx, http.MethodDelete, path, nil, nil,
+		requestOpts{extraHeaders: a2aHeaders})
+}
+
+// ----------------------------------------------------------------------
+// Discovery
+// ----------------------------------------------------------------------
+
+// A2ADiscoverAgent calls
+// `GET /a2a/{namespace}/{tenant}/.well-known/agent.json` — the
+// unauthenticated discovery endpoint.
+//
+// Issued *without* the Authorization header per the A2A spec. Use
+// `A2AGetAuthenticatedExtendedCard` for the authenticated variant.
+func (c *Client) A2ADiscoverAgent(
+	ctx context.Context,
+	namespace, tenant string,
+) (map[string]any, error) {
+	var out map[string]any
+	path := fmt.Sprintf("/a2a/%s/%s/.well-known/agent.json",
+		a2aSeg(namespace), a2aSeg(tenant))
+	err := c.a2aDoJSON(ctx, http.MethodGet, path, nil, &out,
+		requestOpts{skipAuth: true})
+	return out, err
+}
+
+// A2AGetAuthenticatedExtendedCard invokes the JSON-RPC
+// `agent/getAuthenticatedExtendedCard` method. The returned card
+// has `capabilities.extendedAgentCard = true` so a client can
+// confirm the method was reached.
+func (c *Client) A2AGetAuthenticatedExtendedCard(
+	ctx context.Context,
+	namespace, tenant string,
+) (map[string]any, error) {
+	envelope := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "agent/getAuthenticatedExtendedCard",
+	}
+	path := fmt.Sprintf("/a2a/%s/%s", a2aSeg(namespace), a2aSeg(tenant))
+	var reply jsonRPCReply
+	if err := c.a2aDoJSON(ctx, http.MethodPost, path, envelope, &reply,
+		requestOpts{extraHeaders: a2aHeaders}); err != nil {
+		return nil, err
+	}
+	if reply.Error != nil {
+		return nil, &APIError{
+			Code:      fmt.Sprintf("%d", reply.Error.Code),
+			Message:   reply.Error.Message,
+			Retryable: false,
+		}
+	}
+	if len(reply.Result) == 0 {
+		return nil, &APIError{
+			Code:      "JSONRPC",
+			Message:   "JSON-RPC reply had neither result nor error",
+			Retryable: false,
+		}
+	}
+	var card map[string]any
+	if err := json.Unmarshal(reply.Result, &card); err != nil {
+		return nil, &ConnectionError{Message: err.Error()}
+	}
+	return card, nil
+}

--- a/clients/go/acteon/a2a_test.go
+++ b/clients/go/acteon/a2a_test.go
@@ -1,0 +1,294 @@
+package acteon
+
+// A2A Go SDK — factory + URL/header smoke tests.
+//
+// Live HTTP tests would need a running Acteon instance with A2A
+// enabled; these tests exercise the wire surface of the new
+// `a2a.go` module via an `httptest.Server`. The contract under
+// test: factories produce the dict shapes the server expects, URLs
+// are spec-correct, and the `A2A-Version` header lands on every
+// authenticated call.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ----------------------------------------------------------------------
+// Factory helpers
+// ----------------------------------------------------------------------
+
+func TestMakePartText(t *testing.T) {
+	got := MakePartText("hi")
+	if got["text"] != "hi" {
+		t.Errorf("text: got %v", got)
+	}
+}
+
+func TestMakePartURL(t *testing.T) {
+	got := MakePartURL("https://x/y")
+	if got["url"] != "https://x/y" {
+		t.Errorf("url: got %v", got)
+	}
+}
+
+func TestMakePartDataDefaultsToJSON(t *testing.T) {
+	got := MakePartData(map[string]any{"k": 1}, "")
+	if got["mediaType"] != "application/json" {
+		t.Errorf("mediaType default: got %v", got["mediaType"])
+	}
+}
+
+func TestMakePartDataHonorsCustomMediaType(t *testing.T) {
+	got := MakePartData(nil, "application/cloudevents+json")
+	if got["mediaType"] != "application/cloudevents+json" {
+		t.Errorf("mediaType: got %v", got["mediaType"])
+	}
+}
+
+func TestMakeMessageMinimalOmitsTaskIDAndContextID(t *testing.T) {
+	got := MakeMessage("m-1", "user", []map[string]any{MakePartText("hi")}, MakeMessageOptions{})
+	if got["messageId"] != "m-1" || got["role"] != "user" {
+		t.Errorf("identity fields: got %v", got)
+	}
+	// Absent vs. empty matters server-side; the helper must NOT
+	// populate either key when omitted.
+	if _, ok := got["taskId"]; ok {
+		t.Errorf("taskId must be absent when not set: got %v", got)
+	}
+	if _, ok := got["contextId"]; ok {
+		t.Errorf("contextId must be absent when not set: got %v", got)
+	}
+}
+
+func TestMakeMessageThreadsTaskID(t *testing.T) {
+	got := MakeMessage(
+		"m-2", "user",
+		[]map[string]any{MakePartText("yes")},
+		MakeMessageOptions{TaskID: "task-alpha"},
+	)
+	if got["taskId"] != "task-alpha" {
+		t.Errorf("taskId: got %v", got["taskId"])
+	}
+}
+
+func TestMakePushConfigMinimal(t *testing.T) {
+	got := MakePushConfig("https://hook/x", MakePushConfigOptions{})
+	if len(got) != 1 || got["url"] != "https://hook/x" {
+		t.Errorf("minimal: got %v", got)
+	}
+}
+
+func TestMakePushConfigFull(t *testing.T) {
+	got := MakePushConfig("https://hook/x", MakePushConfigOptions{
+		ID:             "cfg-1",
+		Token:          "t",
+		Authentication: map[string]any{"schemes": []string{"api-key"}},
+	})
+	if got["id"] != "cfg-1" || got["token"] != "t" {
+		t.Errorf("full: got %v", got)
+	}
+	if _, ok := got["authentication"]; !ok {
+		t.Errorf("authentication must be present: got %v", got)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Client URLs + headers via httptest.Server
+// ----------------------------------------------------------------------
+
+// capturedRequest records the bits of an inbound request the tests
+// assert on (path, method, headers, body).
+type capturedRequest struct {
+	method  string
+	path    string
+	headers http.Header
+	body    []byte
+}
+
+// newCapturingServer returns an httptest.Server that records every
+// inbound request and responds with the supplied status + body.
+// Returns the URL, a pointer to the latest captured request, and a
+// teardown function (caller must `defer teardown()`).
+//
+// The captured `path` is the **raw** request path — preserves
+// percent-escapes so a test can prove the client encoded reserved
+// characters before sending. `r.URL.Path` would have decoded them
+// back to the unescaped form.
+func newCapturingServer(t *testing.T, status int, body any) (string, *capturedRequest, func()) {
+	t.Helper()
+	captured := &capturedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.method = r.Method
+		// Prefer RawPath when set (the request carried
+		// percent-escapes); fall back to Path otherwise.
+		if r.URL.RawPath != "" {
+			captured.path = r.URL.RawPath
+		} else {
+			captured.path = r.URL.Path
+		}
+		captured.headers = r.Header.Clone()
+		b, _ := io.ReadAll(r.Body)
+		captured.body = b
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if body != nil {
+			_ = json.NewEncoder(w).Encode(body)
+		}
+	}))
+	return srv.URL, captured, srv.Close
+}
+
+func TestA2ASendMessageURLAndA2AVersionHeader(t *testing.T) {
+	url, captured, teardown := newCapturingServer(t, 200, map[string]any{
+		"id":     "task-1",
+		"status": map[string]any{"state": "submitted"},
+	})
+	defer teardown()
+	c := NewClient(url, WithAPIKey("k"))
+	msg := MakeMessage("m-1", "user", []map[string]any{MakePartText("hi")}, MakeMessageOptions{})
+	if _, err := c.A2ASendMessage(context.Background(), "ns", "tnt", msg); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if captured.method != "POST" {
+		t.Errorf("method: got %s", captured.method)
+	}
+	if captured.path != "/a2a/ns/tnt/v1/message:send" {
+		t.Errorf("path: got %s", captured.path)
+	}
+	if got := captured.headers.Get(A2AVersionHeader); got != A2AProtocolVersion {
+		t.Errorf("A2A-Version header: got %q want %q", got, A2AProtocolVersion)
+	}
+	if got := captured.headers.Get("Authorization"); got != "Bearer k" {
+		t.Errorf("Authorization: got %q", got)
+	}
+	// Body must wrap message in {"message": ...} per spec.
+	var body map[string]any
+	if err := json.Unmarshal(captured.body, &body); err != nil {
+		t.Fatalf("body unmarshal: %v", err)
+	}
+	if _, ok := body["message"]; !ok {
+		t.Errorf("body must wrap message: got %v", body)
+	}
+}
+
+func TestA2ACancelTaskKeepsCancelVerbInSegment(t *testing.T) {
+	url, captured, teardown := newCapturingServer(t, 200, map[string]any{
+		"id":     "task-1",
+		"status": map[string]any{"state": "canceled"},
+	})
+	defer teardown()
+	c := NewClient(url)
+	if _, err := c.A2ACancelTask(context.Background(), "ns", "tnt", "task-1"); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	if captured.path != "/a2a/ns/tnt/v1/tasks/task-1:cancel" {
+		t.Errorf("path: got %s", captured.path)
+	}
+	if captured.method != "POST" {
+		t.Errorf("method: got %s", captured.method)
+	}
+}
+
+func TestA2ADeletePushConfigURL(t *testing.T) {
+	url, captured, teardown := newCapturingServer(t, 200, map[string]any{})
+	defer teardown()
+	c := NewClient(url)
+	if err := c.A2ADeletePushConfig(context.Background(), "ns", "tnt", "task-1", "cfg-a"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	want := "/a2a/ns/tnt/v1/tasks/task-1/pushNotificationConfigs/cfg-a"
+	if captured.path != want {
+		t.Errorf("path: got %s want %s", captured.path, want)
+	}
+	if captured.method != "DELETE" {
+		t.Errorf("method: got %s", captured.method)
+	}
+}
+
+func TestA2ADiscoverAgentIsUnauthenticated(t *testing.T) {
+	url, captured, teardown := newCapturingServer(t, 200, map[string]any{
+		"agent_id": "tenant",
+	})
+	defer teardown()
+	// Configure an API key on the client — discovery must still go
+	// out anonymous (A2A spec).
+	c := NewClient(url, WithAPIKey("k"))
+	if _, err := c.A2ADiscoverAgent(context.Background(), "ns", "tnt"); err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if captured.path != "/a2a/ns/tnt/.well-known/agent.json" {
+		t.Errorf("path: got %s", captured.path)
+	}
+	if got := captured.headers.Get("Authorization"); got != "" {
+		t.Errorf("Authorization must be absent on discovery: got %q", got)
+	}
+}
+
+func TestA2AGetAuthenticatedExtendedCardUsesJSONRPCEnvelope(t *testing.T) {
+	url, captured, teardown := newCapturingServer(t, 200, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"result":  map[string]any{"agent_id": "tenant", "capabilities": map[string]any{}},
+	})
+	defer teardown()
+	c := NewClient(url, WithAPIKey("k"))
+	card, err := c.A2AGetAuthenticatedExtendedCard(context.Background(), "ns", "tnt")
+	if err != nil {
+		t.Fatalf("extended card: %v", err)
+	}
+	if captured.path != "/a2a/ns/tnt" {
+		t.Errorf("path: got %s", captured.path)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(captured.body, &body); err != nil {
+		t.Fatalf("body unmarshal: %v", err)
+	}
+	if body["method"] != "agent/getAuthenticatedExtendedCard" {
+		t.Errorf("method field: got %v", body["method"])
+	}
+	// The mixin unwraps the JSON-RPC envelope on the way out.
+	if card["agent_id"] != "tenant" {
+		t.Errorf("unwrapped result: got %v", card)
+	}
+}
+
+func TestA2AGetAuthenticatedExtendedCardJSONRPCErrorSurfacesAsAPIError(t *testing.T) {
+	url, _, teardown := newCapturingServer(t, 200, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"error":   map[string]any{"code": -32001, "message": "task not found"},
+	})
+	defer teardown()
+	c := NewClient(url, WithAPIKey("k"))
+	_, err := c.A2AGetAuthenticatedExtendedCard(context.Background(), "ns", "tnt")
+	if err == nil {
+		t.Fatalf("expected error on JSON-RPC error envelope")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if !strings.Contains(apiErr.Message, "task not found") {
+		t.Errorf("message: got %q", apiErr.Message)
+	}
+}
+
+func TestA2APathSegmentsArePercentEncoded(t *testing.T) {
+	url, captured, teardown := newCapturingServer(t, 200, map[string]any{})
+	defer teardown()
+	c := NewClient(url)
+	// A tenant id with a slash must be percent-encoded so it
+	// cannot leak into additional path components.
+	if _, err := c.A2AGetTask(context.Background(), "ns/escape", "tnt", "t"); err != nil {
+		t.Fatalf("get_task: %v", err)
+	}
+	if !strings.Contains(captured.path, "/ns%2Fescape/") {
+		t.Errorf("path must percent-encode slash: got %s", captured.path)
+	}
+}

--- a/clients/go/acteon/client.go
+++ b/clients/go/acteon/client.go
@@ -113,6 +113,33 @@ func NewClient(baseURL string, opts ...ClientOption) *Client {
 }
 
 func (c *Client) doRequest(ctx context.Context, method, path string, body any) (*http.Response, error) {
+	return c.doRequestExt(ctx, method, path, body, requestOpts{})
+}
+
+// requestOpts carries the optional request-shaping flags that
+// `doRequestExt` honours on top of the base auth + content-type
+// behaviour. Used by the A2A surface to attach `A2A-Version` on
+// authenticated calls and to issue the unauthenticated discovery
+// endpoint.
+type requestOpts struct {
+	// extraHeaders are merged on top of the default headers
+	// (caller wins on collision).
+	extraHeaders map[string]string
+	// skipAuth suppresses the Authorization header even when an
+	// API key is configured on the client.
+	skipAuth bool
+}
+
+// doRequestExt is the request workhorse with hook points for
+// per-request header overrides. `doRequest` is the thin
+// default-opts wrapper that pre-existing callers keep using
+// unchanged.
+func (c *Client) doRequestExt(
+	ctx context.Context,
+	method, path string,
+	body any,
+	opts requestOpts,
+) (*http.Response, error) {
 	var bodyReader io.Reader
 	if body != nil {
 		jsonBody, err := json.Marshal(body)
@@ -128,8 +155,11 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body any) (
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	if c.apiKey != "" {
+	if !opts.skipAuth && c.apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	for k, v := range opts.extraHeaders {
+		req.Header.Set(k, v)
 	}
 
 	resp, err := c.httpClient.Do(req)


### PR DESCRIPTION
Phase 6 SDK update — **Go slot**. Adds \`clients/go/acteon/a2a.go\`
with nine A2A methods on \`Client\`. Mirrors the Rust, Python, and
Node SDKs method-for-method.

The remaining polyglot SDK (Java) follows as a separate PR.

## Public methods on \`Client\`

| Method | Endpoint |
|---|---|
| \`A2ASendMessage\` | \`POST .../v1/message:send\` |
| \`A2AGetTask\` | \`GET .../v1/tasks/{id}\` |
| \`A2ACancelTask\` | \`POST .../v1/tasks/{id}:cancel\` |
| \`A2ASetPushConfig\` | \`POST .../v1/tasks/{id}/pushNotificationConfigs\` |
| \`A2AListPushConfigs\` | \`GET .../v1/tasks/{id}/pushNotificationConfigs\` |
| \`A2AGetPushConfig\` | \`GET …/pushNotificationConfigs/{cfgId}\` |
| \`A2ADeletePushConfig\` | \`DELETE …/pushNotificationConfigs/{cfgId}\` |
| \`A2ADiscoverAgent\` | \`GET .../.well-known/agent.json\` (no auth) |
| \`A2AGetAuthenticatedExtendedCard\` | JSON-RPC \`agent/getAuthenticatedExtendedCard\` |

## Wire shape: \`map[string]any\` + factories

Same rationale as Python/Node: A2A schema is JSON-native and
evolves; pinned Go structs would force a translation layer for
every field change. Factory helpers:

- \`MakePartText(text)\` / \`MakePartURL(href)\` /
  \`MakePartData(value, mediaType)\`
- \`MakeMessage(messageID, role, parts, MakeMessageOptions{TaskID, ContextID})\`
- \`MakePushConfig(url, MakePushConfigOptions{ID, Token, Authentication})\`

## Plumbing changes in \`client.go\`

- \`doRequest\` is now a thin wrapper around the new
  \`doRequestExt\` helper, which accepts a \`requestOpts\` struct
  (\`extraHeaders\`, \`skipAuth\`). **Backward compatible** — every
  pre-existing caller goes through \`doRequest\` unchanged.
- A new \`a2aDoJSON\` wraps \`doRequestExt\` with body reading and
  structured error decoding, mirroring \`busDoJSON\`. Errors map to
  \`*APIError\` with \`Retryable=true\` for 408/425/429/5xx
  (matching the server's classification).

## Tests (\`acteon/a2a_test.go\`, 16 cases)

- **8 factory-helper round-trips** covering absent-field handling
  (\`taskId\` / \`contextId\` MUST NOT appear when omitted — the
  server treats absent vs. empty differently).
- **8 HTTP-level tests** via \`httptest.Server\`: the \`:cancel\`
  verb stays in its segment, the delete URL is built end-to-end,
  the discovery call carries no \`Authorization\` even when an API
  key is configured, the extended-card path uses the JSON-RPC
  envelope, JSON-RPC errors unwrap to \`*APIError\`, and path
  segments are percent-encoded via \`RawPath\` inspection so \`/\`
  in a tenant id cannot leak into the path.

Full local suite: \`go test ./...\` passes for the whole module.

## Pre-commit

- Go: \`go build ./...\` ✅, \`go test ./...\` ✅
- Rust gate not re-run — this PR touches Go only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)