### PR TITLE
perf(a2a): 60s discovery cache to amortize tenant-card scan_keys

### DIFF
--- a/crates/server/src/api/a2a_discovery.rs
+++ b/crates/server/src/api/a2a_discovery.rs
@@ -218,6 +218,13 @@ pub async fn put_agent_card(
         }
         Err(e) => return internal(format!("set has_agent_card flag: {e}")),
     }
+    // A successful card mutation invalidates the discovery cache so
+    // the next read paints the fresh state instead of serving a
+    // stale entry for up to one TTL.
+    state
+        .a2a_discovery_cache
+        .invalidate(&namespace, &tenant)
+        .await;
     (StatusCode::OK, Json(card)).into_response()
 }
 
@@ -263,6 +270,12 @@ pub async fn delete_agent_card(
     // Best-effort flag flip — if the agent is gone (already deleted),
     // there's nothing to update.
     let _ = set_agent_card_flag(&store, &namespace, &tenant, &agent_id, false).await;
+    // Drop the cached aggregated card; the next discovery hit will
+    // observe the removal immediately.
+    state
+        .a2a_discovery_cache
+        .invalidate(&namespace, &tenant)
+        .await;
     StatusCode::NO_CONTENT.into_response()
 }
 
@@ -304,6 +317,15 @@ pub(crate) async fn resolve_tenant_card(
     namespace: &str,
     tenant: &str,
 ) -> Result<Option<AgentCard>, String> {
+    // Cache hit short-circuits the entire scan + aggregation + enrich
+    // pipeline. The cached value is the **post-enrich** card, so both
+    // the public discovery endpoint and the authenticated extended
+    // card consumer use the same shape (the extended-card consumer
+    // marks `capabilities.extendedAgentCard = true` after retrieval,
+    // which is safe to apply to a clone of the cached card).
+    if let Some(cached) = state.a2a_discovery_cache.get(namespace, tenant).await {
+        return Ok(Some((*cached).clone()));
+    }
     let store: Arc<dyn StateStore> = {
         let gw = state.gateway.read().await;
         gw.state_store().clone()
@@ -330,6 +352,12 @@ pub(crate) async fn resolve_tenant_card(
     // documents its own scheme under `acteon.bearer` is not
     // overwritten.
     enrich_with_intrinsic_schemes(&mut card, state.auth.is_some());
+    // Memoize the resolved card. The next discovery hit for the same
+    // tenant inside the TTL window pays only the cache lookup.
+    state
+        .a2a_discovery_cache
+        .insert(namespace, tenant, card.clone())
+        .await;
     Ok(Some(card))
 }
 

--- a/crates/server/src/api/a2a_discovery_cache.rs
+++ b/crates/server/src/api/a2a_discovery_cache.rs
@@ -1,0 +1,276 @@
+//! Short-TTL cache for the A2A discovery endpoint.
+//!
+//! `GET /a2a/{ns}/{tenant}/.well-known/agent.json` is hit by every
+//! A2A peer that wants to learn the tenant's agent surface; its
+//! cold-path cost is `scan_keys(KeyKind::BusAgentCard)` over every
+//! agent registered in the tenant. For a tenant with thousands of
+//! agents that's a meaningful memory + latency spike on each call.
+//!
+//! This cache holds the **resolved** tenant card (verbatim or
+//! aggregated) but **before** the intrinsic-scheme enrichment step,
+//! so it is safe to share between the public discovery endpoint and
+//! the authenticated `agent/getAuthenticatedExtendedCard` JSON-RPC
+//! method.
+//!
+//! TTL is intentionally short (60s by default) so a `PUT` or
+//! `DELETE` of an agent card takes effect quickly — and the mutating
+//! endpoints invalidate the cache entry on write, so a successful
+//! update is immediately visible.
+//!
+//! Concurrency: `tokio::sync::RwLock` around a `HashMap`. The read
+//! path takes the lock in shared mode; writes (insert + invalidate)
+//! take it exclusive. The lock is held for HashMap-lookup time only
+//! — never across an `.await`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use acteon_core::AgentCard;
+use tokio::sync::RwLock;
+
+/// Default cache TTL. Short enough that a `PUT` or `DELETE` takes
+/// effect quickly even without explicit invalidation; long enough to
+/// fold a burst of discovery calls from one A2A peer into a single
+/// scan.
+pub const DEFAULT_DISCOVERY_TTL: Duration = Duration::from_secs(60);
+
+/// Counters exposed for observability. Updated on the hot path with
+/// `Ordering::Relaxed`. Like `PushDeliveryMetrics`, the snapshot is
+/// internally non-consistent — fine for the "hit rate?" use case.
+#[derive(Debug, Default)]
+pub struct DiscoveryCacheMetrics {
+    /// Cache lookups that returned a fresh entry. The hit rate is
+    /// `hits / (hits + misses + expirations)`.
+    pub hits: AtomicU64,
+    /// Cache lookups that found no entry at all (cold cache or
+    /// previously invalidated).
+    pub misses: AtomicU64,
+    /// Cache lookups that found an entry, but it had aged past the
+    /// TTL. Counted separately from `misses` so an operator can
+    /// distinguish "cache is too small" from "TTL is too short".
+    pub expirations: AtomicU64,
+    /// Explicit invalidations (a `PUT` or `DELETE` on an agent
+    /// card).
+    pub invalidations: AtomicU64,
+}
+
+impl DiscoveryCacheMetrics {
+    /// Take an internally-non-consistent snapshot.
+    #[must_use]
+    pub fn snapshot(&self) -> DiscoveryCacheMetricsSnapshot {
+        DiscoveryCacheMetricsSnapshot {
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            expirations: self.expirations.load(Ordering::Relaxed),
+            invalidations: self.invalidations.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Snapshot of [`DiscoveryCacheMetrics`].
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct DiscoveryCacheMetricsSnapshot {
+    pub hits: u64,
+    pub misses: u64,
+    pub expirations: u64,
+    pub invalidations: u64,
+}
+
+type CacheKey = (String, String);
+
+#[derive(Clone)]
+struct CacheEntry {
+    inserted_at: Instant,
+    card: Arc<AgentCard>,
+}
+
+/// Short-TTL discovery cache. Construct once at server startup and
+/// share via `Arc` through `AppState`.
+pub struct DiscoveryCache {
+    inner: RwLock<HashMap<CacheKey, CacheEntry>>,
+    ttl: Duration,
+    metrics: Arc<DiscoveryCacheMetrics>,
+}
+
+impl Default for DiscoveryCache {
+    fn default() -> Self {
+        Self::with_ttl(DEFAULT_DISCOVERY_TTL)
+    }
+}
+
+impl DiscoveryCache {
+    /// Build a fresh cache with the default TTL.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a fresh cache with a custom TTL. Tests use this to
+    /// drive expiration without sleeping a full minute.
+    #[must_use]
+    pub fn with_ttl(ttl: Duration) -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+            ttl,
+            metrics: Arc::new(DiscoveryCacheMetrics::default()),
+        }
+    }
+
+    /// Borrow the metrics handle.
+    #[must_use]
+    pub fn metrics(&self) -> Arc<DiscoveryCacheMetrics> {
+        Arc::clone(&self.metrics)
+    }
+
+    /// Look up a `(namespace, tenant)` entry. Returns `Some(card)` on
+    /// a fresh hit; `None` on either a cold miss or an expired
+    /// entry. Bumps the appropriate counter.
+    pub async fn get(&self, namespace: &str, tenant: &str) -> Option<Arc<AgentCard>> {
+        let key = (namespace.to_string(), tenant.to_string());
+        let cache = self.inner.read().await;
+        match cache.get(&key) {
+            Some(entry) if entry.inserted_at.elapsed() < self.ttl => {
+                self.metrics.hits.fetch_add(1, Ordering::Relaxed);
+                Some(Arc::clone(&entry.card))
+            }
+            Some(_) => {
+                self.metrics.expirations.fetch_add(1, Ordering::Relaxed);
+                None
+            }
+            None => {
+                self.metrics.misses.fetch_add(1, Ordering::Relaxed);
+                None
+            }
+        }
+    }
+
+    /// Insert or replace an entry. Caller already paid for the
+    /// underlying scan; this just memoizes the result.
+    ///
+    /// Also opportunistically prunes expired entries while we hold
+    /// the write lock — keeps the cache size bounded even if no
+    /// reader ever observes an expired entry.
+    pub async fn insert(&self, namespace: &str, tenant: &str, card: AgentCard) {
+        let key = (namespace.to_string(), tenant.to_string());
+        let mut cache = self.inner.write().await;
+        let now = Instant::now();
+        cache.retain(|_, e| now.duration_since(e.inserted_at) < self.ttl);
+        cache.insert(
+            key,
+            CacheEntry {
+                inserted_at: now,
+                card: Arc::new(card),
+            },
+        );
+    }
+
+    /// Drop the entry for `(namespace, tenant)`. Called from the
+    /// agent-card mutation endpoints so a freshly-written card is
+    /// visible to the next discovery call.
+    pub async fn invalidate(&self, namespace: &str, tenant: &str) {
+        let key = (namespace.to_string(), tenant.to_string());
+        let mut cache = self.inner.write().await;
+        if cache.remove(&key).is_some() {
+            self.metrics.invalidations.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Test-only: return the current number of entries. Useful for
+    /// asserting that `insert` actually pruned expired entries.
+    #[cfg(test)]
+    pub async fn len(&self) -> usize {
+        self.inner.read().await.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_card(agent_id: &str) -> AgentCard {
+        AgentCard::new(agent_id, "agents", "demo", "test", "1.0")
+    }
+
+    #[tokio::test]
+    async fn cold_get_returns_none_and_counts_a_miss() {
+        let c = DiscoveryCache::new();
+        assert!(c.get("agents", "demo").await.is_none());
+        let snap = c.metrics().snapshot();
+        assert_eq!(snap.misses, 1);
+        assert_eq!(snap.hits, 0);
+    }
+
+    #[tokio::test]
+    async fn insert_then_get_returns_cached_card_and_counts_a_hit() {
+        let c = DiscoveryCache::new();
+        c.insert("agents", "demo", sample_card("a1")).await;
+        let got = c.get("agents", "demo").await.expect("cache hit");
+        assert_eq!(got.agent_id, "a1");
+        let snap = c.metrics().snapshot();
+        assert_eq!(snap.hits, 1);
+        assert_eq!(snap.misses, 0);
+    }
+
+    #[tokio::test]
+    async fn expired_entry_returns_none_and_counts_an_expiration() {
+        // Use a 1ms TTL so we can deterministically observe
+        // expiration without sleeping a meaningful duration.
+        let c = DiscoveryCache::with_ttl(Duration::from_millis(1));
+        c.insert("agents", "demo", sample_card("a1")).await;
+        tokio::time::sleep(Duration::from_millis(15)).await;
+        assert!(c.get("agents", "demo").await.is_none());
+        let snap = c.metrics().snapshot();
+        // The expired entry is `expirations`, not `misses` — the
+        // distinction matters for tuning TTL vs. cache sizing.
+        assert_eq!(snap.expirations, 1);
+        assert_eq!(snap.misses, 0);
+        assert_eq!(snap.hits, 0);
+    }
+
+    #[tokio::test]
+    async fn invalidate_drops_the_entry_and_counts_an_invalidation() {
+        let c = DiscoveryCache::new();
+        c.insert("agents", "demo", sample_card("a1")).await;
+        c.invalidate("agents", "demo").await;
+        assert!(c.get("agents", "demo").await.is_none());
+        let snap = c.metrics().snapshot();
+        assert_eq!(snap.invalidations, 1);
+        // The post-invalidate get is a cold miss, not an expiration.
+        assert_eq!(snap.misses, 1);
+        assert_eq!(snap.expirations, 0);
+    }
+
+    #[tokio::test]
+    async fn invalidate_of_missing_entry_does_not_count() {
+        let c = DiscoveryCache::new();
+        c.invalidate("agents", "demo").await;
+        // Nothing was removed, so the counter stays at 0 — keeps
+        // the rate-of-actual-cache-invalidations metric honest.
+        assert_eq!(c.metrics().snapshot().invalidations, 0);
+    }
+
+    #[tokio::test]
+    async fn insert_prunes_expired_entries() {
+        let c = DiscoveryCache::with_ttl(Duration::from_millis(1));
+        // Insert two entries, let them age past the TTL, then
+        // insert a third — the prune step inside `insert` must
+        // collapse the cache to a single entry.
+        c.insert("ns1", "tnt", sample_card("a")).await;
+        c.insert("ns2", "tnt", sample_card("b")).await;
+        tokio::time::sleep(Duration::from_millis(15)).await;
+        c.insert("ns3", "tnt", sample_card("c")).await;
+        assert_eq!(c.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn isolated_tenants_do_not_share_entries() {
+        let c = DiscoveryCache::new();
+        c.insert("ns", "tnt-a", sample_card("a")).await;
+        // `tnt-b` shares the namespace but is a distinct cache key.
+        assert!(c.get("ns", "tnt-b").await.is_none());
+        // `tnt-a` is still there.
+        assert!(c.get("ns", "tnt-a").await.is_some());
+    }
+}

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod a2a;
 pub mod a2a_discovery;
+pub mod a2a_discovery_cache;
 pub mod a2a_push;
 pub mod a2a_push_worker;
 pub mod analytics;
@@ -91,6 +92,11 @@ pub struct AppState {
     pub embedding_metrics: Option<Arc<EmbeddingMetrics>>,
     /// Per-tenant SSE connection limit registry.
     pub connection_registry: Option<Arc<ConnectionRegistry>>,
+    /// Short-TTL cache in front of `.well-known/agent.json` and the
+    /// authenticated extended-card lookup. Caches the resolved
+    /// tenant card so a tenant with thousands of registered agents
+    /// doesn't pay for a full `scan_keys` on every discovery call.
+    pub a2a_discovery_cache: Arc<a2a_discovery_cache::DiscoveryCache>,
     /// Semaphore for limiting concurrent dispatch operations.
     pub dispatch_semaphore: Arc<tokio::sync::Semaphore>,
     /// Sanitized configuration snapshot (secrets masked).

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -2370,6 +2370,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .map(|b| Arc::clone(b) as Arc<dyn acteon_rules::EmbeddingEvalSupport>),
         embedding_metrics: embedding_bridge.as_ref().map(|b| b.metrics()),
         connection_registry: Some(connection_registry),
+        a2a_discovery_cache: Arc::new(
+            acteon_server::api::a2a_discovery_cache::DiscoveryCache::new(),
+        ),
         dispatch_semaphore,
         config: config_snapshot,
         ui_path: Some(config.ui.dist_path.clone()),

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -111,6 +111,9 @@ fn build_test_state_with_audit_and_analytics(
         embedding: None,
         embedding_metrics: None,
         connection_registry: None,
+        a2a_discovery_cache: Arc::new(
+            acteon_server::api::a2a_discovery_cache::DiscoveryCache::new(),
+        ),
         dispatch_semaphore: Arc::new(tokio::sync::Semaphore::new(1000)),
         config: ConfigSnapshot::default(),
         ui_path: None,
@@ -1184,6 +1187,9 @@ fn build_approval_state_with_providers(
         embedding: None,
         embedding_metrics: None,
         connection_registry: None,
+        a2a_discovery_cache: Arc::new(
+            acteon_server::api::a2a_discovery_cache::DiscoveryCache::new(),
+        ),
         dispatch_semaphore: Arc::new(tokio::sync::Semaphore::new(1000)),
         config: ConfigSnapshot::default(),
         ui_path: None,

--- a/crates/server/tests/ui_tests.rs
+++ b/crates/server/tests/ui_tests.rs
@@ -44,6 +44,9 @@ async fn ui_serves_index_html() {
         embedding: None,
         embedding_metrics: None,
         connection_registry: None,
+        a2a_discovery_cache: Arc::new(
+            acteon_server::api::a2a_discovery_cache::DiscoveryCache::new(),
+        ),
         dispatch_semaphore: Arc::new(tokio::sync::Semaphore::new(1000)),
         config: ConfigSnapshot::default(),
         ui_path: Some(ui_config.dist_path.clone()),

--- a/crates/simulation/examples/polyglot_client_simulation.rs
+++ b/crates/simulation/examples/polyglot_client_simulation.rs
@@ -68,6 +68,9 @@ impl TestServer {
             embedding: None,
             embedding_metrics: None,
             connection_registry: None,
+            a2a_discovery_cache: std::sync::Arc::new(
+                acteon_server::api::a2a_discovery_cache::DiscoveryCache::new(),
+            ),
             dispatch_semaphore: Arc::new(tokio::sync::Semaphore::new(1000)),
             config: acteon_server::config::ConfigSnapshot::default(),
             ui_path: None,


### PR DESCRIPTION
Adversarial review of the Phase 6 rollout flagged that
\`.well-known/agent.json\` still hits \`scan_keys\` on every
discovery call — a meaningful memory + latency spike for tenants
with thousands of registered agents. Addresses that.

## Scope

### New \`DiscoveryCache\` module

\`crates/server/src/api/a2a_discovery_cache.rs\` —
\`(namespace, tenant) → Arc<AgentCard>\` behind a
\`tokio::sync::RwLock<HashMap>\`. **Default TTL 60s**. Reads take the
lock shared; writes (insert + invalidate) take it exclusive; the
lock is never held across an \`.await\`. \`insert\` opportunistically
prunes expired entries while it has the write lock so the map
stays bounded even when no reader observes the expiration.

### Observability

\`DiscoveryCacheMetrics\` — 4 relaxed \`AtomicU64\` counters
tracking \`hits\`, \`misses\`, \`expirations\`, and \`invalidations\`.
Misses and expirations are counted **separately** so an operator
can distinguish \"cache is too small\" from \"TTL is too short\".
Plumbed via an \`Arc\` exposed by \`cache.metrics()\` for the future
Prometheus exporter.

### Wiring

- \`AppState\` gains an \`Arc<DiscoveryCache>\` field, constructed
  once in \`main.rs\`. Shared across every \`resolve_tenant_card\`
  call so both \`discover_agent\` (REST) and
  \`agent/getAuthenticatedExtendedCard\` (JSON-RPC) consult and
  populate it.
- \`resolve_tenant_card\` consults the cache first; on miss runs
  the scan + aggregate + intrinsic-scheme enrichment pipeline as
  before and stamps the result. The cached value is the
  post-enrich card; the extended-card consumer marks
  \`capabilities.extendedAgentCard = true\` on a clone after
  retrieval, so both consumers see consistent semantics.
- \`put_agent_card\` and \`delete_agent_card\` **invalidate** the
  \`(namespace, tenant)\` entry on success — a freshly-written or
  freshly-deleted card is visible to the next discovery call
  immediately, not after the TTL window elapses.

## Tests (7 new in \`a2a_discovery_cache.rs\`)

- \`cold_get_returns_none_and_counts_a_miss\`
- \`insert_then_get_returns_cached_card_and_counts_a_hit\`
- \`expired_entry_returns_none_and_counts_an_expiration\` — pins
  the miss-vs-expiration metric distinction
- \`invalidate_drops_the_entry_and_counts_an_invalidation\`
- \`invalidate_of_missing_entry_does_not_count\` (the rate
  metric stays honest)
- \`insert_prunes_expired_entries\` while it has the write lock
- \`isolated_tenants_do_not_share_entries\`

Plus the existing 9 \`a2a_discovery::tests\` continue to pass —
the cache integration doesn't touch their pure aggregation logic.

## Pre-commit

- \`cargo fmt --all\` ✅
- \`cargo clippy --workspace --no-deps -- -D warnings\` ✅
- \`cargo test --workspace --lib --bins --tests\` ✅
- \`cargo check --all-targets\` ✅
- \`(cd ui && npm run lint && npm run build)\` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)