### PR TITLE
feat(a2a-push): persistent Dead Letter Queue for terminal + exhausted deliveries

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -120,9 +120,9 @@ pub use stream::{
     timestamp_from_event_id,
 };
 pub use task_push::{
-    MAX_PUSH_SCHEME_ALIAS_BYTES, MAX_PUSH_SCHEMES_PER_CONFIG, MAX_PUSH_TOKEN_BYTES,
-    MAX_PUSH_URL_BYTES, PushAuthentication, TaskPushConfigValidationError,
-    TaskPushNotificationConfig,
+    DlqFailureKind, MAX_DLQ_ERROR_BYTES, MAX_DLQ_EVENT_BYTES, MAX_PUSH_SCHEME_ALIAS_BYTES,
+    MAX_PUSH_SCHEMES_PER_CONFIG, MAX_PUSH_TOKEN_BYTES, MAX_PUSH_URL_BYTES, PushAuthentication,
+    PushDeliveryDlqEntry, TaskPushConfigValidationError, TaskPushNotificationConfig,
 };
 pub use template::{
     Template, TemplateProfile, TemplateProfileField, validate_template_content,

--- a/crates/core/src/task_push.rs
+++ b/crates/core/src/task_push.rs
@@ -27,6 +27,169 @@ use std::fmt;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// Hard cap on the size of a single DLQ entry's serialized event
+/// payload. The worker uses the cap to truncate oversized events
+/// rather than blocking writes — a truncated payload is still
+/// useful for diagnostics.
+pub const MAX_DLQ_EVENT_BYTES: usize = 32 * 1024;
+
+/// Hard cap on the size of a single DLQ entry's `last_error`
+/// message. A misbehaving server can return arbitrarily long error
+/// bodies; the cap keeps the DLQ row bounded.
+pub const MAX_DLQ_ERROR_BYTES: usize = 4 * 1024;
+
+/// Why a delivery landed in the DLQ. Used to drive operator
+/// remediation: `Terminal` means the URL is permanently rejecting
+/// the payload (configuration problem), `Exhausted` means the URL
+/// is intermittently failing (capacity / network problem).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum DlqFailureKind {
+    /// HTTP 4xx outside the transient set — the URL is permanently
+    /// rejecting the payload. Operator should fix the config and
+    /// delete + re-create.
+    Terminal,
+    /// The transient retry budget was exhausted without success.
+    /// Operator can replay the entry once the underlying service is
+    /// healthy.
+    Exhausted,
+}
+
+/// One Dead-Letter-Queue entry recorded when a push-notification
+/// delivery exhausts its retry budget or is permanently rejected by
+/// the receiver. Persisted at `KeyKind::A2aPushDlq` keyed
+/// `{task_id}:{entry_id}` so a prefix-scan by task id lists every
+/// failed delivery for one task.
+///
+/// The `Debug` impl redacts both `event_json` and `last_error`
+/// because each can carry tenant payload bytes a log consumer wasn't
+/// authorized to see.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct PushDeliveryDlqEntry {
+    /// DLQ-entry identifier (`UUIDv7` by convention).
+    pub id: String,
+    /// The push config whose delivery failed.
+    pub config_id: String,
+    /// The Task the event was scoped to.
+    pub task_id: String,
+    /// Namespace + tenant of the task. Stored on the row so a
+    /// cross-tenant DLQ scan stays self-describing.
+    pub namespace: String,
+    /// Tenant of the task.
+    pub tenant: String,
+    /// URL the worker tried to POST to at the moment of failure.
+    /// Snapshotted because the live config may have been edited
+    /// since.
+    pub url: String,
+    /// Whether the failure is terminal or just exhausted.
+    pub failure_kind: DlqFailureKind,
+    /// Last error observed (HTTP status + reason or network
+    /// description). Capped at [`MAX_DLQ_ERROR_BYTES`].
+    pub last_error: String,
+    /// Number of attempts the worker made before giving up.
+    pub attempts: u32,
+    /// Wall-clock time of the first failed attempt.
+    pub first_failed_at: DateTime<Utc>,
+    /// Wall-clock time of the last failed attempt (i.e., when the
+    /// row was written).
+    pub last_failed_at: DateTime<Utc>,
+    /// Serialized `StreamEvent` envelope. Truncated to
+    /// [`MAX_DLQ_EVENT_BYTES`]; truncated entries get a marker
+    /// suffix so consumers can detect it.
+    pub event_json: String,
+}
+
+impl fmt::Debug for PushDeliveryDlqEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PushDeliveryDlqEntry")
+            .field("id", &self.id)
+            .field("config_id", &self.config_id)
+            .field("task_id", &self.task_id)
+            .field("namespace", &self.namespace)
+            .field("tenant", &self.tenant)
+            .field("url", &self.url)
+            .field("failure_kind", &self.failure_kind)
+            .field(
+                "last_error",
+                &format!("[REDACTED {} bytes]", self.last_error.len()),
+            )
+            .field("attempts", &self.attempts)
+            .field("first_failed_at", &self.first_failed_at)
+            .field("last_failed_at", &self.last_failed_at)
+            .field(
+                "event_json",
+                &format!("[REDACTED {} bytes]", self.event_json.len()),
+            )
+            .finish()
+    }
+}
+
+impl PushDeliveryDlqEntry {
+    /// Build a new DLQ entry. `event_json` and `last_error` are
+    /// truncated to their respective caps so a misbehaving event
+    /// or error body can't blow up the DLQ row size.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)] // 1:1 with the persisted row
+    pub fn new(
+        id: impl Into<String>,
+        config_id: impl Into<String>,
+        task_id: impl Into<String>,
+        namespace: impl Into<String>,
+        tenant: impl Into<String>,
+        url: impl Into<String>,
+        failure_kind: DlqFailureKind,
+        last_error: impl Into<String>,
+        attempts: u32,
+        event_json: String,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: id.into(),
+            config_id: config_id.into(),
+            task_id: task_id.into(),
+            namespace: namespace.into(),
+            tenant: tenant.into(),
+            url: url.into(),
+            failure_kind,
+            last_error: truncate(last_error.into(), MAX_DLQ_ERROR_BYTES),
+            attempts,
+            first_failed_at: now,
+            last_failed_at: now,
+            event_json: truncate(event_json, MAX_DLQ_EVENT_BYTES),
+        }
+    }
+
+    /// Storage key shape: `{task_id}:{entry_id}`. The `task_id`
+    /// prefix lets operator tooling list every DLQ entry for one
+    /// task in a single `scan_keys` call.
+    #[must_use]
+    pub fn storage_id(&self) -> String {
+        format!("{}:{}", self.task_id, self.id)
+    }
+}
+
+/// Truncate `s` to at most `cap` bytes, appending a marker suffix
+/// when truncation actually happened. Splits on a char boundary so
+/// a multi-byte UTF-8 codepoint at the boundary isn't sliced in
+/// half.
+fn truncate(mut s: String, cap: usize) -> String {
+    if s.len() <= cap {
+        return s;
+    }
+    // Walk back to a char boundary; UTF-8 codepoints are at most 4
+    // bytes so the walk is bounded.
+    let mut end = cap;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s.truncate(end);
+    s.push_str("…[truncated]");
+    s
+}
+
 /// Maximum length of a push-notification URL. A generous cap that
 /// still bounds the storage row — webhook URLs longer than this in
 /// the wild are almost always misconfiguration.
@@ -377,5 +540,33 @@ mod tests {
         assert!(!s.contains("super-secret-bearer"));
         assert!(!s.contains("never-leak-this"));
         assert!(s.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn dlq_entry_serializes_camelcase_and_redacts_event_in_debug() {
+        let entry = PushDeliveryDlqEntry::new(
+            "entry-1",
+            "cfg-1",
+            "task-1",
+            "agents",
+            "demo",
+            "https://h",
+            DlqFailureKind::Exhausted,
+            "HTTP 503",
+            3,
+            r#"{"id":"evt"}"#.to_string(),
+        );
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["configId"], "cfg-1");
+        assert_eq!(json["taskId"], "task-1");
+        assert_eq!(json["failureKind"], "exhausted");
+        assert_eq!(json["attempts"], 3);
+        assert_eq!(json["eventJson"], r#"{"id":"evt"}"#);
+        // Debug must NOT print the event JSON or last_error body —
+        // both can carry tenant payload data the operator log
+        // wasn't authorized to see.
+        let dbg = format!("{entry:?}");
+        assert!(!dbg.contains(r#""id":"evt""#));
+        assert!(dbg.contains("[REDACTED"));
     }
 }

--- a/crates/server/src/api/a2a_push.rs
+++ b/crates/server/src/api/a2a_push.rs
@@ -432,6 +432,171 @@ fn render_rest_error(err: &PushConfigError) -> Response {
     }
 }
 
+// ---------------------------------------------------------------------
+// Dead-Letter Queue (operator surface)
+//
+// The DLQ is *not* part of the A2A protocol — it lives at
+// `/v1/a2a/{ns}/{tenant}/push-dlq[/{id}]` under Acteon's operator
+// namespace and uses the same Dispatch-permission + `(ns, tenant,
+// a2a, dlq)` grant check as the rest of the operator surface. The
+// REST list returns the most recent entries sorted descending by
+// `last_failed_at` so a fresh failure surfaces first.
+// ---------------------------------------------------------------------
+
+/// Hard cap on the number of DLQ entries one list call returns.
+/// Operator tooling that needs more should narrow the scope with
+/// per-task listing once that's wired (follow-up).
+const MAX_DLQ_LIST: usize = 500;
+
+/// Storage key for one DLQ row.
+fn dlq_key(scope: &TaskScope, task_id: &str, entry_id: &str) -> StateKey {
+    StateKey::new(
+        scope.namespace.clone(),
+        scope.tenant.clone(),
+        KeyKind::A2aPushDlq,
+        format!("{task_id}:{entry_id}"),
+    )
+}
+
+/// List every DLQ entry under (`namespace`, `tenant`), capped at
+/// [`MAX_DLQ_LIST`]. The cap is enforced *after* the scan but
+/// *before* sort so a tenant with > [`MAX_DLQ_LIST`] entries gets a
+/// deterministic suffix rather than a random sample.
+pub(crate) async fn list_dlq(
+    state: &AppState,
+    scope: &TaskScope,
+) -> Result<Vec<acteon_core::PushDeliveryDlqEntry>, PushConfigError> {
+    let store: Arc<dyn StateStore> = {
+        let gw = state.gateway.read().await;
+        gw.state_store().clone()
+    };
+    let entries = store
+        .scan_keys(&scope.namespace, &scope.tenant, KeyKind::A2aPushDlq, None)
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "push-dlq: scan failed");
+            PushConfigError::Internal
+        })?;
+    let mut out: Vec<acteon_core::PushDeliveryDlqEntry> = Vec::with_capacity(entries.len());
+    for (_, raw) in entries {
+        if let Ok(e) = serde_json::from_str::<acteon_core::PushDeliveryDlqEntry>(&raw) {
+            out.push(e);
+        }
+    }
+    // Most-recent-failure first — the operator-friendly default.
+    // `sort_by_key` with a reverse-ordered key keeps clippy happy
+    // without an explicit comparator closure.
+    out.sort_by_key(|e| std::cmp::Reverse(e.last_failed_at));
+    out.truncate(MAX_DLQ_LIST);
+    Ok(out)
+}
+
+/// Load one DLQ entry by id. Walks the full prefix-scan because the
+/// `{task_id}:{entry_id}` key shape requires the `task_id` to address
+/// the row directly; the operator endpoint only takes `entry_id` so
+/// it can identify rows by UUID alone.
+pub(crate) async fn load_dlq_entry(
+    state: &AppState,
+    scope: &TaskScope,
+    entry_id: &str,
+) -> Result<acteon_core::PushDeliveryDlqEntry, PushConfigError> {
+    let store: Arc<dyn StateStore> = {
+        let gw = state.gateway.read().await;
+        gw.state_store().clone()
+    };
+    let entries = store
+        .scan_keys(&scope.namespace, &scope.tenant, KeyKind::A2aPushDlq, None)
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "push-dlq: scan failed");
+            PushConfigError::Internal
+        })?;
+    let suffix = format!(":{entry_id}");
+    for (key_id, raw) in entries {
+        // Keys are stored as `{task_id}:{entry_id}`, so a suffix
+        // match on `:entry_id` is unambiguous (entry ids are
+        // UUIDv7 which don't contain `:`).
+        if key_id.ends_with(&suffix)
+            && let Ok(e) = serde_json::from_str::<acteon_core::PushDeliveryDlqEntry>(&raw)
+        {
+            return Ok(e);
+        }
+    }
+    Err(PushConfigError::ConfigNotFound {
+        task_id: String::new(),
+        config_id: entry_id.to_string(),
+    })
+}
+
+/// Delete one DLQ entry. Loads first to learn the `task_id` (the
+/// caller only gave us `entry_id`); a missing entry yields
+/// `ConfigNotFound` rather than a silent no-op.
+pub(crate) async fn delete_dlq_entry(
+    state: &AppState,
+    scope: &TaskScope,
+    entry_id: &str,
+) -> Result<(), PushConfigError> {
+    let row = load_dlq_entry(state, scope, entry_id).await?;
+    let key = dlq_key(scope, &row.task_id, entry_id);
+    let store: Arc<dyn StateStore> = {
+        let gw = state.gateway.read().await;
+        gw.state_store().clone()
+    };
+    store.delete(&key).await.map_err(|e| {
+        tracing::warn!(error = %e, "push-dlq: delete failed");
+        PushConfigError::Internal
+    })?;
+    Ok(())
+}
+
+/// `GET /v1/a2a/{namespace}/{tenant}/push-dlq` — list DLQ entries.
+pub async fn rest_list_push_dlq(
+    State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant)): Path<(String, String)>,
+) -> Response {
+    if let Some(resp) = guard(&identity, &namespace, &tenant) {
+        return resp;
+    }
+    let scope = TaskScope::new(&namespace, &tenant);
+    match list_dlq(&state, &scope).await {
+        Ok(rows) => (StatusCode::OK, Json(rows)).into_response(),
+        Err(e) => render_rest_error(&e),
+    }
+}
+
+/// `GET /v1/a2a/{namespace}/{tenant}/push-dlq/{entryId}` — read one.
+pub async fn rest_get_push_dlq(
+    State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, entry_id)): Path<(String, String, String)>,
+) -> Response {
+    if let Some(resp) = guard(&identity, &namespace, &tenant) {
+        return resp;
+    }
+    let scope = TaskScope::new(&namespace, &tenant);
+    match load_dlq_entry(&state, &scope, &entry_id).await {
+        Ok(row) => (StatusCode::OK, Json(row)).into_response(),
+        Err(e) => render_rest_error(&e),
+    }
+}
+
+/// `DELETE /v1/a2a/{namespace}/{tenant}/push-dlq/{entryId}`.
+pub async fn rest_delete_push_dlq(
+    State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, entry_id)): Path<(String, String, String)>,
+) -> Response {
+    if let Some(resp) = guard(&identity, &namespace, &tenant) {
+        return resp;
+    }
+    let scope = TaskScope::new(&namespace, &tenant);
+    match delete_dlq_entry(&state, &scope, &entry_id).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => render_rest_error(&e),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -450,5 +615,13 @@ mod tests {
         // UUIDv7s parse and have the version-7 nibble in the right place.
         let parsed = uuid::Uuid::parse_str(&id).expect("uuid parse");
         assert_eq!(parsed.get_version_num(), 7, "UUIDv7 expected");
+    }
+
+    #[test]
+    fn dlq_key_uses_task_then_entry_id_format() {
+        let s = TaskScope::new("agents", "demo");
+        let k = dlq_key(&s, "task-1", "entry-a");
+        assert_eq!(k.id, "task-1:entry-a");
+        assert_eq!(k.kind, KeyKind::A2aPushDlq);
     }
 }

--- a/crates/server/src/api/a2a_push_worker.rs
+++ b/crates/server/src/api/a2a_push_worker.rs
@@ -26,10 +26,14 @@
 //!   treats `408`, `425`, and `429` as transient — they are exactly
 //!   the codes a well-behaved server uses to ask the client to back
 //!   off, so retrying is correct.
-//! - No DLQ in this slice — terminal and exhausted failures are
-//!   counted in `PushDeliveryMetrics` and logged with `error!`. A
-//!   persistent DLQ can layer on later without touching the
-//!   broadcast subscriber.
+//! - Terminal and exhausted failures land in a persistent Dead
+//!   Letter Queue (`KeyKind::A2aPushDlq`) keyed
+//!   `{task_id}:{entry_id}`, with the failing event payload
+//!   truncated to `MAX_DLQ_EVENT_BYTES`. The DLQ write is
+//!   best-effort: a state-store failure is logged with `warn!` and
+//!   counted in `dlq_write_failures` but does not block the
+//!   worker's hot path. Operator CRUD lives at
+//!   `/v1/a2a/{ns}/{tenant}/push-dlq[/{id}]` (see `a2a_push.rs`).
 //!
 //! The HTTP client is provided by the caller — typically the shared
 //! `reqwest::Client` `main.rs` builds once and threads through every
@@ -41,8 +45,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use acteon_core::{StreamEvent, TaskPushNotificationConfig};
-use acteon_state::{KeyKind, StateStore};
+use acteon_core::{DlqFailureKind, PushDeliveryDlqEntry, StreamEvent, TaskPushNotificationConfig};
+use acteon_state::{KeyKind, StateKey, StateStore};
 use tokio::sync::{Mutex, Semaphore, broadcast};
 use tracing::{debug, error, warn};
 
@@ -110,12 +114,22 @@ pub struct PushDeliveryMetrics {
     /// transient set). The retry loop stops on these.
     pub deliveries_terminal: AtomicU64,
     /// Deliveries that exhausted the per-call retry budget without
-    /// succeeding. Candidates for the future DLQ.
+    /// succeeding. Each one writes a DLQ entry — see
+    /// [`Self::dlq_writes`].
     pub deliveries_exhausted: AtomicU64,
     /// `scan_keys` calls actually issued to the state store after
     /// the config-cache check. The cache hit rate is
     /// `1 - state_store_scans / events_dispatched` (approximately).
     pub state_store_scans: AtomicU64,
+    /// DLQ entries successfully written to the state store. Lower
+    /// than `deliveries_terminal + deliveries_exhausted` when the
+    /// state store itself rejects a DLQ write — see
+    /// [`Self::dlq_write_failures`].
+    pub dlq_writes: AtomicU64,
+    /// DLQ entries the worker tried to write but failed (state
+    /// store error, serialization error). Logged with `warn!` so an
+    /// operator can investigate.
+    pub dlq_write_failures: AtomicU64,
 }
 
 impl PushDeliveryMetrics {
@@ -132,6 +146,8 @@ impl PushDeliveryMetrics {
             deliveries_terminal: self.deliveries_terminal.load(Ordering::Relaxed),
             deliveries_exhausted: self.deliveries_exhausted.load(Ordering::Relaxed),
             state_store_scans: self.state_store_scans.load(Ordering::Relaxed),
+            dlq_writes: self.dlq_writes.load(Ordering::Relaxed),
+            dlq_write_failures: self.dlq_write_failures.load(Ordering::Relaxed),
         }
     }
 }
@@ -147,6 +163,8 @@ pub struct PushDeliveryMetricsSnapshot {
     pub deliveries_terminal: u64,
     pub deliveries_exhausted: u64,
     pub state_store_scans: u64,
+    pub dlq_writes: u64,
+    pub dlq_write_failures: u64,
 }
 
 /// Internal state held behind an `Arc` and shared across every
@@ -417,6 +435,21 @@ impl Shared {
                         reason = %reason,
                         "A2A push permanently rejected; not retrying",
                     );
+                    // Persist a DLQ entry so the operator-facing
+                    // surface (`GET /v1/a2a/.../push-dlq`) can
+                    // surface the failure and so a manual cleanup is
+                    // possible. Best-effort — a DLQ write failure
+                    // is logged with `warn!` but does not block the
+                    // worker's hot path.
+                    let attempts_so_far = u32::try_from(attempt + 1).unwrap_or(u32::MAX);
+                    self.write_dlq_entry(
+                        &config,
+                        &event,
+                        DlqFailureKind::Terminal,
+                        &reason,
+                        attempts_so_far,
+                    )
+                    .await;
                     return;
                 }
                 Err(DeliveryError::Transient(reason)) => {
@@ -433,6 +466,16 @@ impl Shared {
                             reason = %reason,
                             "A2A push exhausted retries",
                         );
+                        let attempts_so_far =
+                            u32::try_from(MAX_DELIVERY_ATTEMPTS).unwrap_or(u32::MAX);
+                        self.write_dlq_entry(
+                            &config,
+                            &event,
+                            DlqFailureKind::Exhausted,
+                            &reason,
+                            attempts_so_far,
+                        )
+                        .await;
                         return;
                     }
                     let delay = backoff(attempt);
@@ -447,6 +490,94 @@ impl Shared {
                     );
                     tokio::time::sleep(delay).await;
                 }
+            }
+        }
+    }
+
+    /// Persist a Dead-Letter-Queue entry for a delivery that failed
+    /// terminally or exhausted its retry budget. Best-effort: a
+    /// failure to write the DLQ row is logged with `warn!` and
+    /// counted in `dlq_write_failures` but does not block the
+    /// worker's hot path. The event payload is serialized + the
+    /// core type truncates it to `MAX_DLQ_EVENT_BYTES` so a single
+    /// oversized event can't blow up the DLQ row.
+    async fn write_dlq_entry(
+        &self,
+        config: &TaskPushNotificationConfig,
+        event: &StreamEvent,
+        failure_kind: DlqFailureKind,
+        last_error: &str,
+        attempts: u32,
+    ) {
+        let event_json = match serde_json::to_string(event) {
+            Ok(s) => s,
+            Err(e) => {
+                self.metrics
+                    .dlq_write_failures
+                    .fetch_add(1, Ordering::Relaxed);
+                warn!(
+                    config_id = %config.id,
+                    task_id = %config.task_id,
+                    error = %e,
+                    "A2A push worker: DLQ event serialization failed; skipping DLQ write"
+                );
+                return;
+            }
+        };
+        let entry_id = uuid::Uuid::now_v7().to_string();
+        let entry = PushDeliveryDlqEntry::new(
+            &entry_id,
+            &config.id,
+            &config.task_id,
+            &config.namespace,
+            &config.tenant,
+            &config.url,
+            failure_kind,
+            last_error,
+            attempts,
+            event_json,
+        );
+        let key = StateKey::new(
+            config.namespace.clone(),
+            config.tenant.clone(),
+            KeyKind::A2aPushDlq,
+            entry.storage_id(),
+        );
+        let payload = match serde_json::to_string(&entry) {
+            Ok(s) => s,
+            Err(e) => {
+                self.metrics
+                    .dlq_write_failures
+                    .fetch_add(1, Ordering::Relaxed);
+                warn!(
+                    config_id = %config.id,
+                    task_id = %config.task_id,
+                    error = %e,
+                    "A2A push worker: DLQ entry serialization failed; skipping DLQ write"
+                );
+                return;
+            }
+        };
+        match self.state.set(&key, &payload, None).await {
+            Ok(()) => {
+                self.metrics.dlq_writes.fetch_add(1, Ordering::Relaxed);
+                debug!(
+                    config_id = %config.id,
+                    task_id = %config.task_id,
+                    entry_id = %entry_id,
+                    "A2A push DLQ entry written",
+                );
+            }
+            Err(e) => {
+                self.metrics
+                    .dlq_write_failures
+                    .fetch_add(1, Ordering::Relaxed);
+                warn!(
+                    config_id = %config.id,
+                    task_id = %config.task_id,
+                    error = %e,
+                    "A2A push worker: DLQ state write failed"
+                );
             }
         }
     }
@@ -746,7 +877,8 @@ mod tests {
         save_config(&store, &cfg).await;
         let metrics = Arc::new(PushDeliveryMetrics::default());
         let (tx, rx) = broadcast::channel::<StreamEvent>(8);
-        let worker = PushDeliveryWorker::with_metrics(store, http, rx, Arc::clone(&metrics));
+        let worker =
+            PushDeliveryWorker::with_metrics(Arc::clone(&store), http, rx, Arc::clone(&metrics));
         let handle = tokio::spawn(worker.run());
         tx.send(mk_event("task-1")).unwrap();
         tokio::time::sleep(Duration::from_millis(800)).await;
@@ -760,6 +892,29 @@ mod tests {
         let snap = metrics.snapshot();
         assert_eq!(snap.deliveries_terminal, 1);
         assert_eq!(snap.deliveries_succeeded, 0);
+        // A terminal failure must land a DLQ entry so an operator
+        // can observe it through `/v1/a2a/.../push-dlq`.
+        assert_eq!(snap.dlq_writes, 1);
+        assert_eq!(snap.dlq_write_failures, 0);
+        let dlq_entries = store
+            .scan_keys("agents", "demo", KeyKind::A2aPushDlq, None)
+            .await
+            .unwrap();
+        assert_eq!(dlq_entries.len(), 1, "expected one DLQ row on disk");
+        let (_, raw) = &dlq_entries[0];
+        let row: PushDeliveryDlqEntry = serde_json::from_str(raw).unwrap();
+        assert_eq!(row.failure_kind, DlqFailureKind::Terminal);
+        assert_eq!(row.config_id, "cfg-1");
+        assert_eq!(row.task_id, "task-1");
+        // Attempts is the count of `post_once` calls — exactly 1 on
+        // a terminal classification (no retry).
+        assert_eq!(row.attempts, 1);
+        // `last_error` carries the HTTP status snapshot.
+        assert!(
+            row.last_error.contains("404"),
+            "last_error should carry the status: {}",
+            row.last_error
+        );
     }
 
     /// Adversarial review #3: a 429 must be retried, not terminally
@@ -790,6 +945,57 @@ mod tests {
         let snap = metrics.snapshot();
         assert_eq!(snap.deliveries_succeeded, 1);
         assert_eq!(snap.deliveries_terminal, 0);
+    }
+
+    /// Exhausted transient retries (MAX_DELIVERY_ATTEMPTS of 5xx)
+    /// must land a DLQ entry tagged `Exhausted` with the full
+    /// attempt count. Polls the state store rather than sleeping
+    /// the full ~3s retry cycle to keep the test fast on success.
+    #[tokio::test(flavor = "current_thread", start_paused = false)]
+    async fn exhausted_retries_write_a_dlq_entry() {
+        let store: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+        let http = reqwest::Client::new();
+        let hits = Arc::new(AtomicUsize::new(0));
+        // Every request returns 503 (transient) — the worker burns
+        // through all retries and gives up.
+        let url = start_mock(503, Arc::clone(&hits)).await;
+        let cfg = TaskPushNotificationConfig::new("cfg-x", "task-x", "agents", "demo", &url);
+        save_config(&store, &cfg).await;
+        let metrics = Arc::new(PushDeliveryMetrics::default());
+        let (tx, rx) = broadcast::channel::<StreamEvent>(8);
+        let worker =
+            PushDeliveryWorker::with_metrics(Arc::clone(&store), http, rx, Arc::clone(&metrics));
+        let handle = tokio::spawn(worker.run());
+        tx.send(mk_event("task-x")).unwrap();
+        // Poll for the DLQ row. The retry cycle is 3 attempts +
+        // (1s + 2s) backoff, so allow up to ~5s.
+        let dlq_row = loop {
+            let entries = store
+                .scan_keys("agents", "demo", KeyKind::A2aPushDlq, None)
+                .await
+                .unwrap();
+            if !entries.is_empty() {
+                break entries.into_iter().next().unwrap();
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            if metrics.snapshot().deliveries_exhausted > 0 {
+                // Worker is done but DLQ row not yet visible —
+                // give it one more tick to flush.
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        };
+        drop(tx);
+        let _ = handle.await;
+        let row: PushDeliveryDlqEntry = serde_json::from_str(&dlq_row.1).unwrap();
+        assert_eq!(row.failure_kind, DlqFailureKind::Exhausted);
+        assert_eq!(row.config_id, "cfg-x");
+        assert_eq!(row.task_id, "task-x");
+        // Exhausted entries record the full attempt count.
+        assert_eq!(row.attempts, MAX_DELIVERY_ATTEMPTS as u32);
+        let snap = metrics.snapshot();
+        assert_eq!(snap.deliveries_exhausted, 1);
+        assert_eq!(snap.dlq_writes, 1);
+        assert_eq!(snap.dlq_write_failures, 0);
     }
 
     /// Adversarial review #1: a slow webhook on one tenant must not

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -199,6 +199,17 @@ pub fn router(state: AppState) -> Router {
             "/a2a/{namespace}/{tenant}/v1/tasks/{id}/pushNotificationConfigs/{cfgId}",
             get(a2a_push::rest_get_push_config).delete(a2a_push::rest_delete_push_config),
         )
+        // A2A push delivery DLQ (operator surface). Not part of the
+        // A2A protocol — lives under /v1/a2a/... and uses the
+        // standard A2A dispatch grant.
+        .route(
+            "/v1/a2a/{namespace}/{tenant}/push-dlq",
+            get(a2a_push::rest_list_push_dlq),
+        )
+        .route(
+            "/v1/a2a/{namespace}/{tenant}/push-dlq/{entryId}",
+            get(a2a_push::rest_get_push_dlq).delete(a2a_push::rest_delete_push_dlq),
+        )
         // Rules management
         .route("/v1/rules", get(rules::list_rules))
         .route("/v1/rules/coverage", get(rules::rule_coverage))

--- a/crates/state/state/src/key.rs
+++ b/crates/state/state/src/key.rs
@@ -81,6 +81,12 @@ pub enum KeyKind {
     /// namespace + tenant so a `scan_keys` with a `task_id:` prefix
     /// lists every config bound to a single task.
     A2aTaskPushConfig,
+    /// A2A Push-Delivery Dead Letter Queue entry. Written by the
+    /// push-delivery worker when a delivery exhausts its retry
+    /// budget or is permanently rejected. Keyed
+    /// `{task_id}:{entry_id}` so a prefix-scan by task id lists
+    /// every failed delivery for one task.
+    A2aPushDlq,
     Custom(String),
 }
 
@@ -128,6 +134,7 @@ impl KeyKind {
             Self::A2aMessageDedup => "a2a_message_dedup",
             Self::BusAgentCard => "bus_agent_card",
             Self::A2aTaskPushConfig => "a2a_task_push_config",
+            Self::A2aPushDlq => "a2a_push_dlq",
             Self::Custom(s) => s.as_str(),
         }
     }


### PR DESCRIPTION
Adversarial review of the Phase 6 rollout flagged that terminal
and exhausted push deliveries only logged via \`error!\` — a
production \"Stable\" release wants a persistent DLQ with operator
CRUD. Addresses that.

## Core type (\`crates/core/src/task_push.rs\`)

- New \`PushDeliveryDlqEntry\` struct with full identity
  (\`id\`, \`config_id\`, \`task_id\`, \`namespace\`, \`tenant\`,
  \`url\`), failure metadata (\`failure_kind\`, \`last_error\`,
  \`attempts\`), timestamps (\`first_failed_at\` +
  \`last_failed_at\`), and the truncated event payload
  (\`event_json\`).
- New \`DlqFailureKind\` enum: \`Terminal\` vs. \`Exhausted\` —
  drives operator remediation (\`Terminal\` = config problem,
  \`Exhausted\` = transient capacity/network problem).
- Hard caps: \`MAX_DLQ_EVENT_BYTES\` (32 KiB),
  \`MAX_DLQ_ERROR_BYTES\` (4 KiB). \`truncate\` walks back to a
  UTF-8 char boundary so a multi-byte codepoint at the boundary
  isn't sliced in half; truncated entries get a
  \`…[truncated]\` marker.
- Custom \`Debug\` impl **redacts both \`event_json\` and
  \`last_error\`** because each can carry tenant payload bytes a
  log consumer wasn't authorized to see.

## State (\`crates/state/state/src/key.rs\`)

- New \`KeyKind::A2aPushDlq\`, keyed \`{task_id}:{entry_id}\` so
  a prefix-scan by \`task_id\` lists every failed delivery for one
  task.

## Worker (\`crates/server/src/api/a2a_push_worker.rs\`)

- Both failure-path branches (Terminal + Exhausted) now call a
  new \`write_dlq_entry\` helper. **Best-effort writes**: a
  state-store or serialization failure is logged with \`warn!\`
  and counted in the new \`dlq_write_failures\` counter, never
  blocking the worker's hot path.
- New metrics: \`dlq_writes\` + \`dlq_write_failures\`. The
  delta between \`deliveries_terminal + deliveries_exhausted\`
  and \`dlq_writes + dlq_write_failures\` should always be 0 in
  steady state.
- Module-doc updated to reflect that DLQ shipped (previously read
  \"No DLQ in this slice\").

## Operator REST surface (\`crates/server/src/api/a2a_push.rs\`)

Three new endpoints registered at
\`/v1/a2a/{namespace}/{tenant}/push-dlq[/{entryId}]\`:

| Method | Endpoint |
|---|---|
| \`GET\` | \`/push-dlq\` — list (cap 500, sorted \`last_failed_at\` desc) |
| \`GET\` | \`/push-dlq/{entryId}\` — read one |
| \`DELETE\` | \`/push-dlq/{entryId}\` — delete one |

**Not part of the A2A protocol** — lives under Acteon's operator
namespace and uses the standard A2A dispatch grant
(\`(namespace, tenant, a2a, rpc)\`). Replay-from-DLQ is deferred
to a follow-up; v1 is observability + manual cleanup.

## Tests

- **Two new worker tests**:
  - \`does_not_retry_on_non_transient_4xx\` (extended) — now also
    asserts a single DLQ entry with \`failure_kind=Terminal\`,
    \`attempts=1\`, \`last_error\` containing the HTTP status.
  - \`exhausted_retries_write_a_dlq_entry\` (new) — sends a 503-storm
    event and polls the state store for a DLQ row tagged
    \`Exhausted\` with \`attempts=MAX_DELIVERY_ATTEMPTS\`.
- **One new core test**:
  \`dlq_entry_serializes_camelcase_and_redacts_event_in_debug\`
  pins the camelCase wire shape and confirms the redaction
  contract.
- **One new helper test**: \`dlq_key_uses_task_then_entry_id_format\`
  pins the storage-key shape.

All existing tests continue to pass.

## Pre-commit

- \`cargo fmt --all\` ✅
- \`cargo clippy --workspace --no-deps -- -D warnings\` ✅
- \`cargo test --workspace --lib --bins --tests\` ✅
- \`cargo check --all-targets\` ✅
- \`(cd ui && npm run lint && npm run build)\` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)