### PR TITLE
feat(agents): 3-state operator lifecycle — Active / Suspended / Banned

### DIFF
--- a/clients/go/acteon/bus.go
+++ b/clients/go/acteon/bus.go
@@ -307,6 +307,24 @@ func (c *Client) HeartbeatBusAgent(ctx context.Context, namespace, tenant, agent
 	return &out, nil
 }
 
+// SetBusAgentAdminState sets the operator admin state on an agent
+// (active / suspended / banned). Requires the standard ManageAgent
+// permission. The server returns 400 if req.ExpiresAt is set on
+// anything other than "suspended".
+func (c *Client) SetBusAgentAdminState(
+	ctx context.Context,
+	namespace, tenant, agentID string,
+	req *SetBusAgentAdminState,
+) (*BusAgent, error) {
+	path := fmt.Sprintf("/v1/bus/agents/%s/%s/%s/admin-state",
+		busSeg(namespace), busSeg(tenant), busSeg(agentID))
+	var out BusAgent
+	if _, err := c.busDoJSON(ctx, http.MethodPut, path, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 // =============================================================================
 // Phase 5: Conversations
 // =============================================================================

--- a/clients/go/acteon/bus_models.go
+++ b/clients/go/acteon/bus_models.go
@@ -187,6 +187,42 @@ type BusAgent struct {
 	Labels          map[string]string `json:"labels,omitempty"`
 	CreatedAt       string            `json:"created_at"`
 	UpdatedAt       string            `json:"updated_at"`
+	// AdminState is the operator lifecycle state ("active",
+	// "suspended", or "banned"). Defaults to "active" — see
+	// UnmarshalJSON below.
+	AdminState     string  `json:"admin_state,omitempty"`
+	AdminReason    *string `json:"admin_reason,omitempty"`
+	AdminSetBy     *string `json:"admin_set_by,omitempty"`
+	AdminSetAt     *string `json:"admin_set_at,omitempty"`
+	AdminExpiresAt *string `json:"admin_expires_at,omitempty"`
+}
+
+// UnmarshalJSON is overridden so a server response that pre-dates
+// the admin-state surface (the field is absent entirely) reads as
+// "active" rather than the empty string — keeps operator
+// dashboards from rendering "(empty)" for legacy rows.
+func (a *BusAgent) UnmarshalJSON(data []byte) error {
+	type alias BusAgent // shadow type to avoid recursion
+	var tmp alias
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	if tmp.AdminState == "" {
+		tmp.AdminState = "active"
+	}
+	*a = BusAgent(tmp)
+	return nil
+}
+
+// SetBusAgentAdminState is the request body for
+// Client.SetBusAgentAdminState. ExpiresAt is honored only for
+// AdminState = "suspended"; the server returns 400 if it is set
+// alongside another state.
+type SetBusAgentAdminState struct {
+	AdminState string  `json:"admin_state"`
+	Reason     *string `json:"reason,omitempty"`
+	// RFC-3339 timestamp.
+	ExpiresAt *string `json:"expires_at,omitempty"`
 }
 
 type ListBusAgentsResponse struct {

--- a/clients/go/acteon/bus_test.go
+++ b/clients/go/acteon/bus_test.go
@@ -716,3 +716,79 @@ func TestBusErrorParsing(t *testing.T) {
 		t.Errorf("expected sender error; got %s", apiErr.Message)
 	}
 }
+
+func TestBusAgentAdminStateDefaultsToActiveWhenAbsent(t *testing.T) {
+	// A server that pre-dates the admin-state surface omits the
+	// field entirely. The custom UnmarshalJSON must default it to
+	// "active" so operator code never sees the empty string.
+	body := `{
+		"agent_id":"a1","namespace":"n","tenant":"t",
+		"capabilities":[],"inbox_topic":"n.t.agents-inbox",
+		"status":"online","heartbeat_ttl_ms":60000,
+		"created_at":"2026-05-22T00:00:00Z",
+		"updated_at":"2026-05-22T00:00:00Z"
+	}`
+	var a BusAgent
+	if err := json.Unmarshal([]byte(body), &a); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if a.AdminState != "active" {
+		t.Errorf("AdminState: got %q want %q", a.AdminState, "active")
+	}
+}
+
+func TestBusAgentAdminStateRoundTripsBanned(t *testing.T) {
+	body := `{
+		"agent_id":"a1","namespace":"n","tenant":"t",
+		"capabilities":[],"inbox_topic":"n.t.agents-inbox",
+		"status":"online","heartbeat_ttl_ms":60000,
+		"created_at":"2026-05-22T00:00:00Z",
+		"updated_at":"2026-05-22T00:00:00Z",
+		"admin_state":"banned",
+		"admin_reason":"exfiltration",
+		"admin_set_by":"op@acme.io"
+	}`
+	var a BusAgent
+	if err := json.Unmarshal([]byte(body), &a); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if a.AdminState != "banned" {
+		t.Errorf("AdminState: got %q", a.AdminState)
+	}
+	if a.AdminReason == nil || *a.AdminReason != "exfiltration" {
+		t.Errorf("AdminReason: got %v", a.AdminReason)
+	}
+	if a.AdminSetBy == nil || *a.AdminSetBy != "op@acme.io" {
+		t.Errorf("AdminSetBy: got %v", a.AdminSetBy)
+	}
+}
+
+func TestSetBusAgentAdminStateSerdeDropsOptional(t *testing.T) {
+	// Minimal: only admin_state appears on the wire.
+	raw, err := json.Marshal(&SetBusAgentAdminState{AdminState: "suspended"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got, want := string(raw), `{"admin_state":"suspended"}`; got != want {
+		t.Errorf("minimal: got %s want %s", got, want)
+	}
+
+	// Full: every field appears in the expected snake_case form.
+	reason := "flaky retries"
+	expiry := "2026-05-23T12:00:00Z"
+	raw, err = json.Marshal(&SetBusAgentAdminState{
+		AdminState: "suspended",
+		Reason:     &reason,
+		ExpiresAt:  &expiry,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if parsed["expires_at"] != expiry {
+		t.Errorf("expires_at: got %v", parsed["expires_at"])
+	}
+}

--- a/clients/java/src/main/java/com/acteon/client/ActeonClient.java
+++ b/clients/java/src/main/java/com/acteon/client/ActeonClient.java
@@ -3384,6 +3384,21 @@ public class ActeonClient implements AutoCloseable {
             null, Bus.BusAgent.class);
     }
 
+    /**
+     * Set the operator admin state on an agent (active / suspended
+     * / banned). Requires the standard {@code ManageAgent}
+     * permission. The server returns 400 if
+     * {@code req.expiresAt()} is set on anything other than
+     * {@code "suspended"}.
+     */
+    public Bus.BusAgent setBusAgentAdminState(
+        String namespace, String tenant, String agentId, Bus.SetBusAgentAdminState req
+    ) throws ActeonException {
+        return busSend("PUT",
+            "/v1/bus/agents/" + busSeg(namespace) + "/" + busSeg(tenant) + "/" + busSeg(agentId) + "/admin-state",
+            req, Bus.BusAgent.class);
+    }
+
     // --------------- Phase 5: Conversations ---------------
 
     public Bus.BusConversation createBusConversation(Bus.CreateBusConversation req) throws ActeonException {

--- a/clients/java/src/main/java/com/acteon/client/Bus.java
+++ b/clients/java/src/main/java/com/acteon/client/Bus.java
@@ -191,6 +191,13 @@ public final class Bus {
         }
     }
 
+    /**
+     * Bus agent record. {@code adminState} reflects the operator
+     * lifecycle ("active" / "suspended" / "banned"); the
+     * {@link #adminState()} accessor below defaults a {@code null}
+     * value (server response pre-dated the field) to "active" so
+     * dashboards never render {@code null}.
+     */
     public record BusAgent(
         @JsonProperty("agent_id") String agentId,
         String namespace,
@@ -203,13 +210,47 @@ public final class Bus {
         String description,
         Map<String, String> labels,
         @JsonProperty("created_at") String createdAt,
-        @JsonProperty("updated_at") String updatedAt
-    ) {}
+        @JsonProperty("updated_at") String updatedAt,
+        @JsonProperty("admin_state") String adminStateRaw,
+        @JsonProperty("admin_reason") String adminReason,
+        @JsonProperty("admin_set_by") String adminSetBy,
+        @JsonProperty("admin_set_at") String adminSetAt,
+        @JsonProperty("admin_expires_at") String adminExpiresAt
+    ) {
+        /**
+         * Effective admin state: returns the raw value when set,
+         * otherwise {@code "active"}. Use this instead of
+         * {@link #adminStateRaw()} when rendering or branching on
+         * the state.
+         */
+        public String adminState() {
+            return (adminStateRaw == null || adminStateRaw.isEmpty())
+                ? "active"
+                : adminStateRaw;
+        }
+    }
 
     public record ListBusAgentsResponse(
         List<BusAgent> agents,
         int count
     ) {}
+
+    /**
+     * Body for {@link ActeonClient#setBusAgentAdminState}. The
+     * server returns 400 if {@code expiresAt} is set on anything
+     * other than {@code "suspended"}.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record SetBusAgentAdminState(
+        @JsonProperty("admin_state") String adminState,
+        String reason,
+        @JsonProperty("expires_at") String expiresAt
+    ) {
+        /** Minimal — only the target state. */
+        public SetBusAgentAdminState(String adminState) {
+            this(adminState, null, null);
+        }
+    }
 
     // =========================================================================
     // Phase 5: Conversations

--- a/clients/java/src/test/java/com/acteon/client/BusTest.java
+++ b/clients/java/src/test/java/com/acteon/client/BusTest.java
@@ -538,4 +538,60 @@ class BusTest {
         assertTrue(kinds.contains(Bus.BusConsumeItem.Reconnected.class), kinds.toString());
         assertTrue(opens.get() >= 2, "opens=" + opens.get());
     }
+
+    @Test
+    void busAgentAdminStateDefaultsToActiveWhenAbsent() throws Exception {
+        // A server pre-dating the admin-state surface omits the
+        // field entirely. The custom `adminState()` accessor must
+        // default it to "active" so dashboards never render null.
+        String body = "{"
+            + "\"agent_id\":\"a1\",\"namespace\":\"n\",\"tenant\":\"t\","
+            + "\"capabilities\":[],\"inbox_topic\":\"n.t.agents-inbox\","
+            + "\"status\":\"online\",\"heartbeat_ttl_ms\":60000,"
+            + "\"created_at\":\"2026-05-22T00:00:00Z\","
+            + "\"updated_at\":\"2026-05-22T00:00:00Z\""
+            + "}";
+        Bus.BusAgent a = MAPPER.readValue(body, Bus.BusAgent.class);
+        assertEquals("active", a.adminState());
+        assertNull(a.adminStateRaw());
+        assertNull(a.adminReason());
+    }
+
+    @Test
+    void busAgentAdminStateRoundTripsBanned() throws Exception {
+        String body = "{"
+            + "\"agent_id\":\"a1\",\"namespace\":\"n\",\"tenant\":\"t\","
+            + "\"capabilities\":[],\"inbox_topic\":\"n.t.agents-inbox\","
+            + "\"status\":\"online\",\"heartbeat_ttl_ms\":60000,"
+            + "\"created_at\":\"2026-05-22T00:00:00Z\","
+            + "\"updated_at\":\"2026-05-22T00:00:00Z\","
+            + "\"admin_state\":\"banned\","
+            + "\"admin_reason\":\"exfiltration\","
+            + "\"admin_set_by\":\"op@acme.io\""
+            + "}";
+        Bus.BusAgent a = MAPPER.readValue(body, Bus.BusAgent.class);
+        assertEquals("banned", a.adminState());
+        assertEquals("exfiltration", a.adminReason());
+        assertEquals("op@acme.io", a.adminSetBy());
+    }
+
+    @Test
+    void setBusAgentAdminStateMinimalDropsOptionalFields() throws Exception {
+        // The minimal record constructor sets reason + expires_at
+        // to null; @JsonInclude(NON_NULL) on the record drops them
+        // from the wire form.
+        Bus.SetBusAgentAdminState req = new Bus.SetBusAgentAdminState("suspended");
+        String json = MAPPER.writeValueAsString(req);
+        assertEquals("{\"admin_state\":\"suspended\"}", json);
+    }
+
+    @Test
+    void setBusAgentAdminStateFullIncludesEveryField() throws Exception {
+        Bus.SetBusAgentAdminState req = new Bus.SetBusAgentAdminState(
+            "suspended", "flaky retries", "2026-05-23T12:00:00Z");
+        String json = MAPPER.writeValueAsString(req);
+        assertTrue(json.contains("\"admin_state\":\"suspended\""), json);
+        assertTrue(json.contains("\"reason\":\"flaky retries\""), json);
+        assertTrue(json.contains("\"expires_at\":\"2026-05-23T12:00:00Z\""), json);
+    }
 }

--- a/clients/nodejs/src/bus.test.ts
+++ b/clients/nodejs/src/bus.test.ts
@@ -290,6 +290,67 @@ describe("bus response parsers", () => {
     assert.deepEqual(a.capabilities, []);
   });
 
+  it("agent — adminState defaults to 'active' when absent", () => {
+    // Server pre-dating the admin-state surface returns the agent
+    // without the field. parseBusAgent must default to "active"
+    // so operator dashboards don't render undefined.
+    const a = parseBusAgent({
+      agent_id: "a1",
+      namespace: "n",
+      tenant: "te",
+      capabilities: [],
+      inbox_topic: "n.te.agents.a1",
+      status: "registered",
+      heartbeat_ttl_ms: 30_000,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    });
+    assert.equal(a.adminState, "active");
+    assert.equal(a.adminReason, null);
+    assert.equal(a.adminSetBy, null);
+  });
+
+  it("agent — adminState round-trips banned + reason + set_by", () => {
+    const a = parseBusAgent({
+      agent_id: "a1",
+      namespace: "n",
+      tenant: "te",
+      capabilities: [],
+      inbox_topic: "n.te.agents.a1",
+      status: "online",
+      heartbeat_ttl_ms: 30_000,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      admin_state: "banned",
+      admin_reason: "exfiltration",
+      admin_set_by: "op@acme.io",
+      admin_set_at: "2026-05-23T10:00:00Z",
+    });
+    assert.equal(a.adminState, "banned");
+    assert.equal(a.adminReason, "exfiltration");
+    assert.equal(a.adminSetBy, "op@acme.io");
+  });
+
+  it("setBusAgentAdminStateBody — minimal drops optional fields", async () => {
+    const { setBusAgentAdminStateBody } = await import("./bus_models.js");
+    const body = setBusAgentAdminStateBody({ adminState: "suspended" });
+    assert.deepEqual(body, { admin_state: "suspended" });
+  });
+
+  it("setBusAgentAdminStateBody — full carries snake_case fields", async () => {
+    const { setBusAgentAdminStateBody } = await import("./bus_models.js");
+    const body = setBusAgentAdminStateBody({
+      adminState: "suspended",
+      reason: "flaky retries",
+      expiresAt: "2026-05-23T12:00:00Z",
+    });
+    assert.deepEqual(body, {
+      admin_state: "suspended",
+      reason: "flaky retries",
+      expires_at: "2026-05-23T12:00:00Z",
+    });
+  });
+
   it("conversation — open default", () => {
     const c = parseBusConversation({
       conversation_id: "c1",

--- a/clients/nodejs/src/bus_models.ts
+++ b/clients/nodejs/src/bus_models.ts
@@ -151,6 +151,37 @@ export interface BusAgent {
   labels: Record<string, string>;
   createdAt: string;
   updatedAt: string;
+  /**
+   * Operator lifecycle state: `"active"`, `"suspended"`, or
+   * `"banned"`. Defaults to `"active"` if a server pre-dating
+   * this field returns the agent without it.
+   */
+  adminState: string;
+  adminReason: string | null;
+  adminSetBy: string | null;
+  adminSetAt: string | null;
+  adminExpiresAt: string | null;
+}
+
+/**
+ * Body for `setBusAgentAdminState`. `expiresAt` is honored only
+ * for `adminState === "suspended"`; the server returns 400 if it
+ * is set alongside another state.
+ */
+export interface SetBusAgentAdminState {
+  adminState: "active" | "suspended" | "banned";
+  reason?: string;
+  /** RFC-3339 timestamp. */
+  expiresAt?: string;
+}
+
+export function setBusAgentAdminStateBody(
+  req: SetBusAgentAdminState,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = { admin_state: req.adminState };
+  if (req.reason !== undefined) body.reason = req.reason;
+  if (req.expiresAt !== undefined) body.expires_at = req.expiresAt;
+  return body;
 }
 
 // =============================================================================
@@ -752,6 +783,13 @@ export function parseBusAgent(d: Record<string, unknown>): BusAgent {
     labels: (d.labels as Record<string, string> | undefined) ?? {},
     createdAt: d.created_at as string,
     updatedAt: d.updated_at as string,
+    // Default to "active" for back-compat with servers that
+    // pre-date the admin-state surface.
+    adminState: (d.admin_state as string | undefined) ?? "active",
+    adminReason: (d.admin_reason as string | null | undefined) ?? null,
+    adminSetBy: (d.admin_set_by as string | null | undefined) ?? null,
+    adminSetAt: (d.admin_set_at as string | null | undefined) ?? null,
+    adminExpiresAt: (d.admin_expires_at as string | null | undefined) ?? null,
   };
 }
 

--- a/clients/nodejs/src/client.ts
+++ b/clients/nodejs/src/client.ts
@@ -203,6 +203,7 @@ import {
   type PublishReceipt,
   type RegisterBusAgent,
   type RegisterBusSchema,
+  type SetBusAgentAdminState,
   appendBusConversationMessageBody,
   busApprovalDecisionBody,
   busToolResultLookupParams,
@@ -233,6 +234,7 @@ import {
   publishBusMessageBody,
   registerBusAgentBody,
   registerBusSchemaBody,
+  setBusAgentAdminStateBody,
 } from "./bus_models.js";
 
 /**
@@ -2663,6 +2665,27 @@ export class ActeonClient {
     const response = await this.request(
       "PATCH",
       `/v1/bus/agents/${this.busSeg(namespace)}/${this.busSeg(tenant)}/${this.busSeg(agentId)}/heartbeat`,
+    );
+    if (!response.ok) await this.busThrowFromResponse(response);
+    return parseBusAgent((await response.json()) as Record<string, unknown>);
+  }
+
+  /**
+   * Set the operator admin state on an agent (active / suspended /
+   * banned). Requires the standard `ManageAgent` permission. The
+   * server returns 400 if `req.expiresAt` is set on anything other
+   * than `"suspended"`.
+   */
+  async setBusAgentAdminState(
+    namespace: string,
+    tenant: string,
+    agentId: string,
+    req: SetBusAgentAdminState,
+  ): Promise<BusAgent> {
+    const response = await this.request(
+      "PUT",
+      `/v1/bus/agents/${this.busSeg(namespace)}/${this.busSeg(tenant)}/${this.busSeg(agentId)}/admin-state`,
+      { body: setBusAgentAdminStateBody(req) },
     );
     if (!response.ok) await this.busThrowFromResponse(response);
     return parseBusAgent((await response.json()) as Record<string, unknown>);

--- a/clients/nodejs/src/index.ts
+++ b/clients/nodejs/src/index.ts
@@ -162,6 +162,7 @@ export {
   type ReconnectConfig,
   type RegisterBusAgent,
   type RegisterBusSchema,
+  type SetBusAgentAdminState,
   type StreamChunkEnvelope,
   type StreamEndEnvelope,
   type StreamEndEnvelopeStatus,

--- a/clients/python/acteon_client/__init__.py
+++ b/clients/python/acteon_client/__init__.py
@@ -34,6 +34,7 @@ from .bus_models import (
     PublishReceipt,
     RegisterBusAgent,
     RegisterBusSchema,
+    SetBusAgentAdminState,
 )
 from .models import (
     Action,
@@ -262,4 +263,5 @@ __all__ = [
     "PublishReceipt",
     "RegisterBusAgent",
     "RegisterBusSchema",
+    "SetBusAgentAdminState",
 ]

--- a/clients/python/acteon_client/bus.py
+++ b/clients/python/acteon_client/bus.py
@@ -53,6 +53,7 @@ from .bus_models import (
     ReconnectedInfo,
     RegisterBusAgent,
     RegisterBusSchema,
+    SetBusAgentAdminState,
     StreamChunkEnvelope,
     StreamEndEnvelope,
 )
@@ -279,6 +280,27 @@ class _BusClientMixin:
         resp = self._request(
             "PATCH",
             f"/v1/bus/agents/{_seg(namespace)}/{_seg(tenant)}/{_seg(agent_id)}/heartbeat",
+        )
+        _raise_for_status(resp)
+        return BusAgent.from_dict(resp.json())
+
+    def set_bus_agent_admin_state(
+        self,
+        namespace: str,
+        tenant: str,
+        agent_id: str,
+        req: SetBusAgentAdminState,
+    ) -> BusAgent:
+        """Set the operator admin state on an agent.
+
+        Requires the ``ManageAgent`` permission. The server returns
+        400 if ``req.expires_at`` is set on anything other than
+        ``"suspended"``.
+        """
+        resp = self._request(
+            "PUT",
+            f"/v1/bus/agents/{_seg(namespace)}/{_seg(tenant)}/{_seg(agent_id)}/admin-state",
+            json=req.to_dict(),
         )
         _raise_for_status(resp)
         return BusAgent.from_dict(resp.json())
@@ -863,6 +885,22 @@ class _AsyncBusClientMixin:
         resp = await self._request(
             "PATCH",
             f"/v1/bus/agents/{_seg(namespace)}/{_seg(tenant)}/{_seg(agent_id)}/heartbeat",
+        )
+        _raise_for_status(resp)
+        return BusAgent.from_dict(resp.json())
+
+    async def set_bus_agent_admin_state(
+        self,
+        namespace: str,
+        tenant: str,
+        agent_id: str,
+        req: SetBusAgentAdminState,
+    ) -> BusAgent:
+        """Async counterpart of the sync method of the same name."""
+        resp = await self._request(
+            "PUT",
+            f"/v1/bus/agents/{_seg(namespace)}/{_seg(tenant)}/{_seg(agent_id)}/admin-state",
+            json=req.to_dict(),
         )
         _raise_for_status(resp)
         return BusAgent.from_dict(resp.json())

--- a/clients/python/acteon_client/bus_models.py
+++ b/clients/python/acteon_client/bus_models.py
@@ -331,6 +331,14 @@ class BusAgent:
     labels: dict[str, str]
     created_at: str
     updated_at: str
+    # Operator lifecycle state: "active", "suspended", or "banned".
+    # Defaults to "active" so a response from a pre-admin-state
+    # server (or a row that pre-dates the field) round-trips cleanly.
+    admin_state: str = "active"
+    admin_reason: Optional[str] = None
+    admin_set_by: Optional[str] = None
+    admin_set_at: Optional[str] = None
+    admin_expires_at: Optional[str] = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "BusAgent":
@@ -347,7 +355,33 @@ class BusAgent:
             labels=d.get("labels", {}) or {},
             created_at=d["created_at"],
             updated_at=d["updated_at"],
+            admin_state=d.get("admin_state", "active"),
+            admin_reason=d.get("admin_reason"),
+            admin_set_by=d.get("admin_set_by"),
+            admin_set_at=d.get("admin_set_at"),
+            admin_expires_at=d.get("admin_expires_at"),
         )
+
+
+@dataclass
+class SetBusAgentAdminState:
+    """Request body for ``set_bus_agent_admin_state``.
+
+    ``expires_at`` is honored only for ``admin_state="suspended"``;
+    the server returns 400 if it is set alongside another state.
+    """
+
+    admin_state: str  # "active" | "suspended" | "banned"
+    reason: Optional[str] = None
+    expires_at: Optional[str] = None  # RFC-3339
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"admin_state": self.admin_state}
+        if self.reason is not None:
+            d["reason"] = self.reason
+        if self.expires_at is not None:
+            d["expires_at"] = self.expires_at
+        return d
 
 
 # ============================================================================

--- a/clients/python/tests/test_bus.py
+++ b/clients/python/tests/test_bus.py
@@ -216,6 +216,54 @@ class TestResponseSerde(unittest.TestCase):
         self.assertIsNone(a.last_heartbeat_at)
         self.assertEqual(a.capabilities, [])
 
+    def test_agent_admin_state_defaults_to_active_when_field_absent(self):
+        # A server that pre-dates the admin-state surface omits the
+        # field entirely; the dataclass must default to "active" so
+        # operator dashboards don't render "None".
+        a = BusAgent.from_dict({
+            "agent_id": "a1", "namespace": "n", "tenant": "te",
+            "capabilities": [], "inbox_topic": "n.te.agents.a1",
+            "status": "registered", "heartbeat_ttl_ms": 30_000,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+        })
+        self.assertEqual(a.admin_state, "active")
+        self.assertIsNone(a.admin_reason)
+        self.assertIsNone(a.admin_set_by)
+
+    def test_agent_admin_state_round_trips_banned(self):
+        a = BusAgent.from_dict({
+            "agent_id": "a1", "namespace": "n", "tenant": "te",
+            "capabilities": [], "inbox_topic": "n.te.agents.a1",
+            "status": "online", "heartbeat_ttl_ms": 30_000,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "admin_state": "banned",
+            "admin_reason": "exfiltration",
+            "admin_set_by": "op@acme.io",
+            "admin_set_at": "2026-05-23T10:00:00Z",
+        })
+        self.assertEqual(a.admin_state, "banned")
+        self.assertEqual(a.admin_reason, "exfiltration")
+        self.assertEqual(a.admin_set_by, "op@acme.io")
+
+    def test_set_admin_state_request_drops_optional_nones(self):
+        from acteon_client import SetBusAgentAdminState
+        # Minimal — only admin_state.
+        d = SetBusAgentAdminState(admin_state="suspended").to_dict()
+        self.assertEqual(d, {"admin_state": "suspended"})
+        # Full — every field appears.
+        d = SetBusAgentAdminState(
+            admin_state="suspended",
+            reason="flaky retries",
+            expires_at="2026-05-23T12:00:00Z",
+        ).to_dict()
+        self.assertEqual(d, {
+            "admin_state": "suspended",
+            "reason": "flaky retries",
+            "expires_at": "2026-05-23T12:00:00Z",
+        })
+
     def test_conversation_default_participants(self):
         c = BusConversation.from_dict({
             "conversation_id": "c1", "namespace": "n", "tenant": "te",

--- a/crates/cli/src/commands/bus/agents.rs
+++ b/crates/cli/src/commands/bus/agents.rs
@@ -125,6 +125,10 @@ pub async fn run(ops: &OpsClient, args: &AgentsArgs, format: &OutputFormat) -> a
                 tenant: tenant.clone(),
                 capability: capability.clone(),
                 status: status.clone(),
+                // CLI surface doesn't expose admin-state filtering
+                // yet — add a flag in a follow-up if operator
+                // workflows need it.
+                admin_state: None,
             };
             let resp = ops.client().list_bus_agents(&filter).await?;
             match format {

--- a/crates/client/src/bus.rs
+++ b/crates/client/src/bus.rs
@@ -778,6 +778,35 @@ impl ActeonClient {
         }
     }
 
+    /// Set the operator admin state on an agent (active / suspended
+    /// / banned). Returns the updated agent row.
+    ///
+    /// Requires the standard `ManageAgent` permission on the
+    /// `(namespace, tenant)`. The server returns 400 if `expires_at`
+    /// is set on anything other than `suspended`.
+    pub async fn set_bus_agent_admin_state(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        agent_id: &str,
+        req: &SetBusAgentAdminState,
+    ) -> Result<BusAgent, Error> {
+        let url = self.agent_url(namespace, tenant, agent_id, Some("admin-state"));
+        let resp = self
+            .add_auth(self.client.put(&url))
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))?;
+        if resp.status().is_success() {
+            resp.json::<BusAgent>()
+                .await
+                .map_err(|e| Error::Deserialization(e.to_string()))
+        } else {
+            Err(map_error(resp).await)
+        }
+    }
+
     /// Record a heartbeat. Agents typically call this once per
     /// `heartbeat_ttl_ms / 3` to stay `Online`.
     pub async fn heartbeat_bus_agent(
@@ -1517,10 +1546,28 @@ pub struct BusAgent {
     #[serde(default)]
     pub last_heartbeat_at: Option<String>,
     pub status: String,
+    /// Operator lifecycle state — `"active"`, `"suspended"`, or
+    /// `"banned"`. Defaults to `"active"` (via `#[serde(default)]`)
+    /// for backward compatibility with server responses that
+    /// pre-date the admin-state surface.
+    #[serde(default = "default_admin_state")]
+    pub admin_state: String,
+    #[serde(default)]
+    pub admin_reason: Option<String>,
+    #[serde(default)]
+    pub admin_set_by: Option<String>,
+    #[serde(default)]
+    pub admin_set_at: Option<String>,
+    #[serde(default)]
+    pub admin_expires_at: Option<String>,
     #[serde(default)]
     pub labels: HashMap<String, String>,
     pub created_at: String,
     pub updated_at: String,
+}
+
+fn default_admin_state() -> String {
+    "active".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1539,6 +1586,27 @@ pub struct BusAgentFilter {
     pub capability: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
+    /// Filter by operator admin state (`"active"`, `"suspended"`,
+    /// `"banned"`). Compared against the *effective* state — a
+    /// suspended row past its expiry filters as `"active"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub admin_state: Option<String>,
+}
+
+/// Body for [`ActeonClient::set_bus_agent_admin_state`]. The
+/// `expires_at` field is honored only for `admin_state = "suspended"`;
+/// the server returns 400 if it is set alongside another state.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct SetBusAgentAdminState {
+    /// Target state. One of `"active"`, `"suspended"`, `"banned"`.
+    pub admin_state: String,
+    /// Operator-supplied reason. Surfaced to the agent owner on the
+    /// 403 returned by a blocked `send_to_bus_agent`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Optional RFC-3339 expiry (only honored for `suspended`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/core/src/bus_agent.rs
+++ b/crates/core/src/bus_agent.rs
@@ -46,6 +46,57 @@ pub enum AgentStatus {
     Unknown,
 }
 
+/// **Operator** lifecycle state — distinct from [`AgentStatus`] which
+/// answers "is it alive?". `AgentAdminState` answers "is it
+/// *allowed*?": it is set by the operator and persists across
+/// heartbeats. The two states compose — a `Banned` agent that is
+/// still heartbeating is both `Online` *and* `Banned`, and the route
+/// / discovery / send paths refuse to talk to it.
+///
+/// Defaults to [`AgentAdminState::Active`] for backwards
+/// compatibility — every Agent row registered before this field
+/// existed deserializes as Active via the `#[serde(default)]` on the
+/// field.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum AgentAdminState {
+    /// Normal: routable, discoverable, accepts heartbeats and sends.
+    #[default]
+    Active,
+    /// Temporarily parked. Reversible via `reinstate`. Optionally
+    /// time-boxed by `admin_expires_at`; when set, the agent
+    /// auto-reinstates on read once the expiry has passed.
+    Suspended,
+    /// Operator-banned (compromised / abusive). Kept for the audit
+    /// trail rather than deleted. Reinstating is allowed but
+    /// generally avoided.
+    Banned,
+}
+
+impl AgentAdminState {
+    /// Wire / log token. Matches the `serde(rename_all = "snake_case")`
+    /// representation so admin-state queries on `?admin_state=banned`
+    /// line up.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Suspended => "suspended",
+            Self::Banned => "banned",
+        }
+    }
+
+    /// Whether the route / discovery / send paths should treat this
+    /// agent as usable. `Active` only. The dispatch-time check is
+    /// just this predicate — kept as a method on the state so adding
+    /// a future state (e.g. `ReadOnly`) is one place to edit.
+    #[must_use]
+    pub fn is_routable(self) -> bool {
+        matches!(self, Self::Active)
+    }
+}
+
 /// A bus-resident agent identity.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -88,6 +139,34 @@ pub struct Agent {
     /// and is fetched only by the A2A discovery handler.
     #[serde(default)]
     pub has_agent_card: bool,
+    /// Operator lifecycle state. `Active` by default; set to
+    /// `Suspended` / `Banned` via the `/admin-state` endpoint. The
+    /// route / discovery / send paths consult this on every call —
+    /// see [`AgentAdminState::is_routable`].
+    ///
+    /// `#[serde(default)]` so rows registered before this field
+    /// existed deserialize as `Active`. No migration needed.
+    #[serde(default)]
+    pub admin_state: AgentAdminState,
+    /// Free-form reason recorded by the operator at the time of the
+    /// last admin-state change. Surfaced to the agent owner on the
+    /// `403 Forbidden` returned by a blocked `send`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admin_reason: Option<String>,
+    /// Caller id of the operator who set the current admin state.
+    /// Recorded for the audit trail; never displayed to the agent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admin_set_by: Option<String>,
+    /// Wall-clock time the current admin state was set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admin_set_at: Option<DateTime<Utc>>,
+    /// Optional expiry — when set on a `Suspended` agent, a read
+    /// past this point auto-reinstates the agent (a `Banned` agent
+    /// never auto-reinstates; this field is ignored on `Banned`).
+    /// Lets an operator park a flaky agent for an hour without
+    /// having to remember to come back and flip it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admin_expires_at: Option<DateTime<Utc>>,
     /// Registration time.
     pub created_at: DateTime<Utc>,
     /// Last time the agent record was mutated (register / update /
@@ -119,6 +198,11 @@ impl Agent {
             last_heartbeat_at: None,
             labels: HashMap::new(),
             has_agent_card: false,
+            admin_state: AgentAdminState::Active,
+            admin_reason: None,
+            admin_set_by: None,
+            admin_set_at: None,
+            admin_expires_at: None,
             created_at: now,
             updated_at: now,
         }
@@ -170,6 +254,60 @@ impl Agent {
     #[must_use]
     pub fn status(&self) -> AgentStatus {
         self.status_at(Utc::now())
+    }
+
+    /// Effective admin state as of `now`. Honors `admin_expires_at`:
+    /// a `Suspended` row past its expiry reads as `Active`. A
+    /// `Banned` row ignores the expiry (a ban is not time-boxed by
+    /// design — operator must explicitly reinstate).
+    ///
+    /// This is the predicate the dispatch path should consult; the
+    /// raw `admin_state` field is the *stored* value, not the
+    /// *effective* one.
+    #[must_use]
+    pub fn effective_admin_state_at(&self, now: DateTime<Utc>) -> AgentAdminState {
+        match self.admin_state {
+            AgentAdminState::Suspended => match self.admin_expires_at {
+                Some(expiry) if now >= expiry => AgentAdminState::Active,
+                _ => AgentAdminState::Suspended,
+            },
+            other => other,
+        }
+    }
+
+    /// Convenience — [`Self::effective_admin_state_at`] with
+    /// `Utc::now()`. Most callers want this.
+    #[must_use]
+    pub fn effective_admin_state(&self) -> AgentAdminState {
+        self.effective_admin_state_at(Utc::now())
+    }
+
+    /// Mutate this Agent in-place to the supplied admin state, with
+    /// the operator metadata bundled. Stamps `admin_set_at = now()`
+    /// and `updated_at = now()` so the audit trail captures the
+    /// transition.
+    ///
+    /// `expires_at` is honored only for `Suspended`; a `Banned`
+    /// transition silently drops any supplied expiry (a ban is not
+    /// time-boxed by design — encode the intent in the type rather
+    /// than relying on the caller to remember the rule).
+    pub fn apply_admin_state(
+        &mut self,
+        next: AgentAdminState,
+        reason: Option<String>,
+        set_by: Option<String>,
+        expires_at: Option<DateTime<Utc>>,
+    ) {
+        let now = Utc::now();
+        self.admin_state = next;
+        self.admin_reason = reason;
+        self.admin_set_by = set_by;
+        self.admin_set_at = Some(now);
+        self.admin_expires_at = match next {
+            AgentAdminState::Suspended => expires_at,
+            _ => None,
+        };
+        self.updated_at = now;
     }
 
     /// Validate the agent's identity fields.
@@ -364,5 +502,108 @@ mod tests {
         assert_eq!(back.agent_id, a.agent_id);
         assert_eq!(back.capabilities, a.capabilities);
         assert_eq!(back.labels, a.labels);
+    }
+
+    // --- Admin state ---
+
+    #[test]
+    fn fresh_agent_is_admin_active_by_default() {
+        let a = Agent::new("p", "ns", "t");
+        assert_eq!(a.admin_state, AgentAdminState::Active);
+        assert!(a.admin_reason.is_none());
+        assert!(a.admin_set_by.is_none());
+        assert!(a.admin_set_at.is_none());
+        assert!(a.admin_expires_at.is_none());
+        assert_eq!(a.effective_admin_state(), AgentAdminState::Active);
+    }
+
+    #[test]
+    fn pre_admin_state_json_round_trips_as_active() {
+        // A row persisted before the field existed must deserialize
+        // as Active — the `#[serde(default)]` is what makes the
+        // change non-breaking.
+        let legacy = serde_json::json!({
+            "agent_id": "p",
+            "namespace": "ns",
+            "tenant": "t",
+            "capabilities": [],
+            "heartbeat_ttl_ms": 60_000,
+            "has_agent_card": false,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z"
+        });
+        let a: Agent = serde_json::from_value(legacy).unwrap();
+        assert_eq!(a.admin_state, AgentAdminState::Active);
+    }
+
+    #[test]
+    fn apply_admin_state_bans_and_stamps_metadata() {
+        let mut a = Agent::new("p", "ns", "t");
+        a.apply_admin_state(
+            AgentAdminState::Banned,
+            Some("exfiltration attempt".into()),
+            Some("op@acme.io".into()),
+            // Expiry on a ban is intentionally dropped.
+            Some(Utc::now() + Duration::hours(1)),
+        );
+        assert_eq!(a.admin_state, AgentAdminState::Banned);
+        assert_eq!(a.admin_reason.as_deref(), Some("exfiltration attempt"));
+        assert_eq!(a.admin_set_by.as_deref(), Some("op@acme.io"));
+        assert!(a.admin_set_at.is_some());
+        assert!(
+            a.admin_expires_at.is_none(),
+            "ban must drop the expiry — bans are not time-boxed",
+        );
+    }
+
+    #[test]
+    fn suspend_with_expiry_auto_reinstates_on_effective_read() {
+        let mut a = Agent::new("p", "ns", "t");
+        let now = Utc::now();
+        a.apply_admin_state(
+            AgentAdminState::Suspended,
+            Some("flaky retries".into()),
+            None,
+            Some(now + Duration::minutes(30)),
+        );
+        // Within the window: still Suspended.
+        assert_eq!(
+            a.effective_admin_state_at(now + Duration::minutes(10)),
+            AgentAdminState::Suspended,
+        );
+        // Past the window: reads as Active even though the stored
+        // field is still Suspended (a write only happens on the next
+        // mutating call).
+        assert_eq!(
+            a.effective_admin_state_at(now + Duration::hours(1)),
+            AgentAdminState::Active,
+        );
+        assert_eq!(a.admin_state, AgentAdminState::Suspended);
+    }
+
+    #[test]
+    fn admin_state_is_routable_only_when_active() {
+        assert!(AgentAdminState::Active.is_routable());
+        assert!(!AgentAdminState::Suspended.is_routable());
+        assert!(!AgentAdminState::Banned.is_routable());
+    }
+
+    #[test]
+    fn admin_state_as_str_matches_serde_repr() {
+        // The `?admin_state=banned` query parameter compares
+        // case-sensitively against this token, so the snake_case
+        // serde representation and this string must agree.
+        for state in [
+            AgentAdminState::Active,
+            AgentAdminState::Suspended,
+            AgentAdminState::Banned,
+        ] {
+            let serde_token = serde_json::to_value(state)
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string();
+            assert_eq!(serde_token, state.as_str(), "state={state:?}");
+        }
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -43,7 +43,8 @@ pub use analytics::{
 };
 pub use attachment::{Attachment, ResolvedAttachment};
 pub use bus_agent::{
-    Agent, AgentStatus, AgentValidationError, DEFAULT_AGENT_INBOX_SUFFIX, DEFAULT_HEARTBEAT_TTL_MS,
+    Agent, AgentAdminState, AgentStatus, AgentValidationError, DEFAULT_AGENT_INBOX_SUFFIX,
+    DEFAULT_HEARTBEAT_TTL_MS,
 };
 pub use bus_agent_card::{
     AgentCapabilities, AgentCard, AgentCardValidationError, Extension as AgentCardExtension,

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -2684,6 +2684,10 @@ impl ActeonMcpServer {
                     tenant: p.tenant,
                     capability: p.capability,
                     status: p.status,
+                    // MCP params don't surface admin-state yet;
+                    // add it to ManageBusAgentsParams in a
+                    // follow-up if MCP-driven moderation needs it.
+                    admin_state: None,
                 };
                 ok_or_err(client.list_bus_agents(&filter).await)
             }

--- a/crates/server/src/api/bus.rs
+++ b/crates/server/src/api/bus.rs
@@ -3352,6 +3352,18 @@ pub struct AgentResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_heartbeat_at: Option<DateTime<Utc>>,
     pub status: String,
+    /// Operator lifecycle state — `"active"`, `"suspended"`,
+    /// `"banned"`. Honors `admin_expires_at` (a Suspended row past
+    /// its expiry reads as `"active"`).
+    pub admin_state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub admin_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub admin_set_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub admin_set_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub admin_expires_at: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub labels: HashMap<String, String>,
     pub created_at: DateTime<Utc>,
@@ -3376,6 +3388,11 @@ pub struct ListAgentsParams {
     /// Filter by derived status (`online`, `idle`, `dead`, `unknown`).
     #[serde(default)]
     pub status: Option<String>,
+    /// Filter by operator admin state (`active`, `suspended`,
+    /// `banned`). Compared against the *effective* state — a
+    /// Suspended row past its expiry filters as `active`.
+    #[serde(default)]
+    pub admin_state: Option<String>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -3416,6 +3433,14 @@ fn agent_to_response(a: &acteon_core::Agent) -> AgentResponse {
         heartbeat_ttl_ms: a.heartbeat_ttl_ms,
         last_heartbeat_at: a.last_heartbeat_at,
         status: agent_status_str(a.status()),
+        // Surface the *effective* admin state so a stale Suspended
+        // row past its expiry shows up as active without waiting
+        // for a write to happen.
+        admin_state: a.effective_admin_state().as_str().to_string(),
+        admin_reason: a.admin_reason.clone(),
+        admin_set_by: a.admin_set_by.clone(),
+        admin_set_at: a.admin_set_at,
+        admin_expires_at: a.admin_expires_at,
         labels: a.labels.clone(),
         created_at: a.created_at,
         updated_at: a.updated_at,
@@ -3746,6 +3771,16 @@ pub async fn list_agents(
                     .as_deref()
                     .is_none_or(|s| agent_status_str(a.status()).eq_ignore_ascii_case(s))
             })
+            .filter(|a| {
+                params
+                    .admin_state
+                    .as_deref()
+                    // Compare against the *effective* state so a
+                    // Suspended row past its expiry filters as
+                    // `active` — matches what `agent_to_response`
+                    // returns.
+                    .is_none_or(|s| a.effective_admin_state().as_str().eq_ignore_ascii_case(s))
+            })
             .collect();
         let responses: Vec<AgentResponse> = agents.iter().map(agent_to_response).collect();
         let count = responses.len();
@@ -4045,6 +4080,12 @@ pub async fn heartbeat_agent(
         (status = 503, description = "Bus feature disabled", body = ErrorResponse),
     ),
 )]
+// One handler covers: auth gate, header validation, agent lookup,
+// admin-state check, inbox-topic existence probe, message build +
+// produce, and the bus-feature-off fallback. Splitting would force
+// threading the bus backend handle and the error response type
+// through several helpers for purely cosmetic benefit.
+#[allow(clippy::too_many_lines)]
 pub async fn send_to_agent(
     State(state): State<AppState>,
     #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
@@ -4084,6 +4125,28 @@ pub async fn send_to_agent(
             Ok(a) => a,
             Err(resp) => return resp,
         };
+        // Admin-state enforcement: a Suspended / Banned agent is not
+        // routable. Returns 403 with the operator-supplied reason
+        // (when present) so the caller knows *why* — but never the
+        // operator's identity (`admin_set_by` is omitted).
+        let effective = agent.effective_admin_state();
+        if !effective.is_routable() {
+            let reason_part = agent
+                .admin_reason
+                .as_deref()
+                .map(|r| format!(": {r}"))
+                .unwrap_or_default();
+            return (
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse {
+                    error: format!(
+                        "agent {namespace}/{tenant}/{agent_id} is {}{reason_part}",
+                        effective.as_str(),
+                    ),
+                }),
+            )
+                .into_response();
+        }
         let inbox = agent.effective_inbox_topic();
         // Defensive: confirm the inbox topic is still registered. In
         // normal flow `register_agent` guarantees this, but operators
@@ -4149,6 +4212,123 @@ pub async fn send_to_agent(
             )
                 .into_response(),
         }
+    }
+    #[cfg(not(feature = "bus"))]
+    {
+        let _ = (state, namespace, tenant, agent_id, req);
+        service_unavailable("bus feature not compiled")
+    }
+}
+
+// =========================================================================
+// Agent admin lifecycle — Active / Suspended / Banned
+//
+// One mutation endpoint at `/admin-state` (rather than three separate
+// `/ban`, `/suspend`, `/reinstate` endpoints): keeps the route surface
+// minimal, makes "change state" one auditable event, and lets a future
+// fourth state (e.g. `ReadOnly`) land without inventing a new URL.
+// =========================================================================
+
+/// Request body for `PUT /v1/bus/agents/{ns}/{tenant}/{id}/admin-state`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SetAgentAdminStateRequest {
+    /// Target admin state. One of `"active"`, `"suspended"`,
+    /// `"banned"`.
+    pub admin_state: acteon_core::AgentAdminState,
+    /// Operator-supplied free-text reason. Surfaced to a caller of
+    /// `send_to_agent` on the `403 Forbidden` returned by a blocked
+    /// agent — keep it terse, no secrets.
+    #[serde(default)]
+    pub reason: Option<String>,
+    /// Optional expiry. Honored only for `Suspended`; silently
+    /// dropped for `Active` / `Banned`. A `Suspended` row past this
+    /// point reads as `Active` (auto-reinstate).
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+#[utoipa::path(
+    put,
+    path = "/v1/bus/agents/{namespace}/{tenant}/{agent_id}/admin-state",
+    tag = "bus",
+    request_body = SetAgentAdminStateRequest,
+    responses(
+        (status = 200, description = "Admin state set", body = AgentResponse),
+        (status = 400, description = "Validation failure", body = ErrorResponse),
+        (status = 403, description = "Caller lacks ManageAgent permission", body = ErrorResponse),
+        (status = 404, description = "Agent not found", body = ErrorResponse),
+        (status = 409, description = "CAS contention exhausted", body = ErrorResponse),
+        (status = 503, description = "Bus feature disabled", body = ErrorResponse),
+    ),
+)]
+pub async fn set_agent_admin_state(
+    State(state): State<AppState>,
+    #[cfg(feature = "bus")] axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path((namespace, tenant, agent_id)): Path<(String, String, String)>,
+    Json(req): Json<SetAgentAdminStateRequest>,
+) -> impl IntoResponse {
+    #[cfg(feature = "bus")]
+    {
+        if state.bus_backend.is_none() {
+            return service_unavailable("bus feature not enabled");
+        }
+        // Only operators with `ManageAgent` may flip admin state —
+        // it's a moderation surface, not an end-user one.
+        if let Err(resp) = authorize_bus_op(&identity, &tenant, &namespace, BusOp::ManageAgent) {
+            return resp;
+        }
+        // Reason length: keep DLQ-style cap so a 1MB reason can't
+        // be smuggled into the agent row.
+        if let Some(r) = req.reason.as_deref()
+            && r.len() > 4_096
+        {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "reason exceeds 4096 bytes".to_string(),
+                }),
+            )
+                .into_response();
+        }
+        // Reject an expiry on Active / Banned — Active doesn't need
+        // one, Banned silently drops it but a 400 here makes the
+        // contract explicit to the caller.
+        if req.expires_at.is_some()
+            && !matches!(req.admin_state, acteon_core::AgentAdminState::Suspended)
+        {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "expires_at is only valid for admin_state=suspended".to_string(),
+                }),
+            )
+                .into_response();
+        }
+        let key = StateKey::new(
+            namespace.clone(),
+            tenant.clone(),
+            KeyKind::BusAgent,
+            agent_id.clone(),
+        );
+        let set_by = Some(identity.id.clone());
+        let reason = req.reason.clone();
+        let expires_at = req.expires_at;
+        let target = req.admin_state;
+        let updated = match cas_update::<acteon_core::Agent, _>(
+            &state,
+            &key,
+            &format!("agent {namespace}.{tenant}.{agent_id} not found"),
+            move |agent| {
+                agent.apply_admin_state(target, reason.clone(), set_by.clone(), expires_at);
+                Ok(())
+            },
+        )
+        .await
+        {
+            Ok(a) => a,
+            Err(resp) => return resp,
+        };
+        (StatusCode::OK, Json(agent_to_response(&updated))).into_response()
     }
     #[cfg(not(feature = "bus"))]
     {
@@ -8237,4 +8417,86 @@ fn validate_decision_note(note: Option<&str>) -> Result<(), axum::response::Resp
             .into_response());
     }
     Ok(())
+}
+
+#[cfg(all(test, feature = "bus"))]
+mod tests {
+    //! Unit tests for the admin-state response shape + filter
+    //! semantics. The end-to-end `set_agent_admin_state` flow is
+    //! exercised by the integration test in `crates/server/tests/`;
+    //! these tests pin the wire surface (the field names + the
+    //! effective-state semantics) so a future change can't silently
+    //! degrade them.
+    use super::*;
+    use acteon_core::{Agent, AgentAdminState};
+    use chrono::{Duration, Utc};
+
+    #[test]
+    fn response_carries_admin_state_active_for_fresh_agent() {
+        let a = Agent::new("p", "ns", "demo");
+        let r = agent_to_response(&a);
+        assert_eq!(r.admin_state, "active");
+        assert!(r.admin_reason.is_none());
+        assert!(r.admin_set_by.is_none());
+        assert!(r.admin_set_at.is_none());
+        assert!(r.admin_expires_at.is_none());
+    }
+
+    #[test]
+    fn response_carries_banned_with_reason() {
+        let mut a = Agent::new("p", "ns", "demo");
+        a.apply_admin_state(
+            AgentAdminState::Banned,
+            Some("repeated abuse".into()),
+            Some("op@acme.io".into()),
+            None,
+        );
+        let r = agent_to_response(&a);
+        assert_eq!(r.admin_state, "banned");
+        assert_eq!(r.admin_reason.as_deref(), Some("repeated abuse"));
+        // The operator's identity IS exposed on the admin response —
+        // operators reading the dashboard want to know who acted.
+        // It's only the `send` 403 that omits it.
+        assert_eq!(r.admin_set_by.as_deref(), Some("op@acme.io"));
+        assert!(r.admin_set_at.is_some());
+    }
+
+    #[test]
+    fn response_reports_effective_state_after_suspend_expires() {
+        let mut a = Agent::new("p", "ns", "demo");
+        let past = Utc::now() - Duration::hours(1);
+        a.apply_admin_state(AgentAdminState::Suspended, None, None, Some(past));
+        let r = agent_to_response(&a);
+        // Stored state is Suspended; effective state past the expiry
+        // is Active — the response must show the effective state so
+        // the dashboard doesn't mislead the operator.
+        assert_eq!(r.admin_state, "active");
+    }
+
+    #[test]
+    fn list_params_admin_state_field_round_trips() {
+        // The serde derive on `ListAgentsParams` is what backs the
+        // `?admin_state=banned` query parameter — pin the field name
+        // explicitly so a future rename doesn't silently change the
+        // wire contract.
+        let q: ListAgentsParams =
+            serde_json::from_value(serde_json::json!({"admin_state": "banned"})).unwrap();
+        assert_eq!(q.admin_state.as_deref(), Some("banned"));
+    }
+
+    #[test]
+    fn set_admin_state_request_deserializes_snake_case_enum() {
+        // The body parses the enum via serde — the snake_case
+        // representation must agree with the `as_str()` token the
+        // filter uses, otherwise the operator dashboard would issue
+        // a `banned` body and the agent would show as `Banned` in
+        // the listing but fail to filter on `?admin_state=banned`.
+        let req: SetAgentAdminStateRequest = serde_json::from_value(serde_json::json!({
+            "admin_state": "banned",
+            "reason": "exfiltration"
+        }))
+        .unwrap();
+        assert!(matches!(req.admin_state, AgentAdminState::Banned));
+        assert_eq!(req.reason.as_deref(), Some("exfiltration"));
+    }
 }

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -441,6 +441,13 @@ pub fn router(state: AppState) -> Router {
             "/v1/bus/agents/{namespace}/{tenant}/{agent_id}/send",
             post(bus::send_to_agent),
         )
+        // Agent admin lifecycle — operator sets Active / Suspended /
+        // Banned. Distinct from the derived liveness `status`; see
+        // `AgentAdminState`.
+        .route(
+            "/v1/bus/agents/{namespace}/{tenant}/{agent_id}/admin-state",
+            put(bus::set_agent_admin_state),
+        )
         // Phase 5: Conversations — multi-agent threads on a shared
         // events topic. Messages are keyed by conversation_id for
         // per-thread Kafka FIFO; replay filters on the

--- a/ui/src/api/hooks/useBus.ts
+++ b/ui/src/api/hooks/useBus.ts
@@ -7,7 +7,7 @@
 // `EventStream` infra the rest of the UI uses.
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { apiGet, apiPost, apiDelete } from '../client'
+import { apiGet, apiPost, apiPut, apiDelete } from '../client'
 
 // --------------- Topics ---------------
 
@@ -179,6 +179,13 @@ export interface BusAgent {
   labels?: Record<string, string>
   created_at: string
   updated_at: string
+  // Operator lifecycle state — defaults to "active" when a server
+  // pre-dating the field returns the agent without it.
+  admin_state?: string
+  admin_reason?: string | null
+  admin_set_by?: string | null
+  admin_set_at?: string | null
+  admin_expires_at?: string | null
 }
 
 export interface ListBusAgentsResponse {
@@ -186,7 +193,9 @@ export interface ListBusAgentsResponse {
   count: number
 }
 
-export function useBusAgents(filter: { namespace?: string; tenant?: string } = {}) {
+export function useBusAgents(
+  filter: { namespace?: string; tenant?: string; status?: string; admin_state?: string } = {},
+) {
   return useQuery({
     queryKey: ['bus', 'agents', filter],
     queryFn: async () => {
@@ -206,6 +215,37 @@ export function useDeleteBusAgent() {
     mutationFn: ({ namespace, tenant, agentId }: { namespace: string; tenant: string; agentId: string }) =>
       apiDelete<void>(
         `/v1/bus/agents/${encodeURIComponent(namespace)}/${encodeURIComponent(tenant)}/${encodeURIComponent(agentId)}`,
+      ),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['bus', 'agents'] }),
+  })
+}
+
+// Admin-state mutation. The server validates `expires_at` is only
+// supplied alongside `suspended`; this hook just shuttles the body
+// over the wire and invalidates the agent list on success.
+export interface SetBusAgentAdminState {
+  admin_state: 'active' | 'suspended' | 'banned'
+  reason?: string
+  expires_at?: string  // RFC-3339
+}
+
+export function useSetBusAgentAdminState() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      namespace,
+      tenant,
+      agentId,
+      body,
+    }: {
+      namespace: string
+      tenant: string
+      agentId: string
+      body: SetBusAgentAdminState
+    }) =>
+      apiPut<BusAgent>(
+        `/v1/bus/agents/${encodeURIComponent(namespace)}/${encodeURIComponent(tenant)}/${encodeURIComponent(agentId)}/admin-state`,
+        body,
       ),
     onSuccess: () => void qc.invalidateQueries({ queryKey: ['bus', 'agents'] }),
   })

--- a/ui/src/pages/Bus.tsx
+++ b/ui/src/pages/Bus.tsx
@@ -11,7 +11,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams, useNavigate } from 'react-router-dom'
 import { createColumnHelper } from '@tanstack/react-table'
-import { ShieldCheck, Trash2 } from 'lucide-react'
+import { Ban, Pause, Play, ShieldCheck, Trash2 } from 'lucide-react'
 
 import { PageHeader } from '../components/layout/PageHeader'
 import { DataTable } from '../components/ui/DataTable'
@@ -22,12 +22,14 @@ import { Select } from '../components/ui/Select'
 import { Tabs } from '../components/ui/Tabs'
 import { EmptyState } from '../components/ui/EmptyState'
 import { DeleteConfirmModal } from '../components/ui/DeleteConfirmModal'
+import { Modal } from '../components/ui/Modal'
 import { useToast } from '../components/ui/useToast'
 import { relativeTime, formatCountdown } from '../lib/format'
 import {
   useBusTopics,
   useBusSubscriptions,
   useBusAgents,
+  useSetBusAgentAdminState,
   useBusConversations,
   useBusApprovals,
   useBusSubscriptionLag,
@@ -39,6 +41,7 @@ import {
   type BusTopic,
   type BusSubscription,
   type BusAgent,
+  type SetBusAgentAdminState,
   type BusConversation,
   type BusApprovalStatus,
   type BusApprovalView,
@@ -315,10 +318,20 @@ function LagPill({ lag }: { lag: number }) {
 const agentCol = createColumnHelper<BusAgent>()
 
 function AgentsPanel({ ns, tenant }: { ns: string; tenant: string }) {
-  const { data, isLoading } = useBusAgents({ namespace: ns || undefined, tenant: tenant || undefined })
+  // Admin-state filter is local UI state — passed through as a
+  // query param so the server's /v1/bus/agents handler does the
+  // filtering rather than the browser. An empty string means "all
+  // states" (the absence of the param to the server).
+  const [adminFilter, setAdminFilter] = useState<'' | 'active' | 'suspended' | 'banned'>('')
+  const { data, isLoading } = useBusAgents({
+    namespace: ns || undefined,
+    tenant: tenant || undefined,
+    admin_state: adminFilter || undefined,
+  })
   const del = useDeleteBusAgent()
   const { toast } = useToast()
   const [pending, setPending] = useState<BusAgent | null>(null)
+  const [adminTarget, setAdminTarget] = useState<BusAgent | null>(null)
 
   const columns = [
     agentCol.accessor('agent_id', { header: 'Agent', cell: (i) => <span className={styles.idCell}>{i.getValue()}</span> }),
@@ -331,6 +344,11 @@ function AgentsPanel({ ns, tenant }: { ns: string; tenant: string }) {
     }),
     agentCol.accessor('status', { header: 'Status', cell: (i) => <Badge>{i.getValue()}</Badge> }),
     agentCol.display({
+      id: 'admin_state',
+      header: 'Admin',
+      cell: (i) => <AdminStateBadge row={i.row.original} />,
+    }),
+    agentCol.display({
       id: 'heartbeat',
       header: 'Heartbeat',
       cell: (i) => <Heartbeat row={i.row.original} />,
@@ -339,22 +357,55 @@ function AgentsPanel({ ns, tenant }: { ns: string; tenant: string }) {
       id: 'actions',
       header: '',
       cell: (i) => (
-        <Button
-          variant="danger"
-          size="sm"
-          onClick={(e) => {
-            e.stopPropagation()
-            setPending(i.row.original)
-          }}
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
+        <div style={{ display: 'flex', gap: '0.25rem' }}>
+          <Button
+            variant="secondary"
+            size="sm"
+            title="Set admin state"
+            onClick={(e) => {
+              e.stopPropagation()
+              setAdminTarget(i.row.original)
+            }}
+          >
+            <ShieldCheck className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation()
+              setPending(i.row.original)
+            }}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
       ),
     }),
   ]
 
   return (
     <>
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', marginBottom: '0.75rem' }}>
+        <label style={{ fontSize: '0.875rem', color: 'var(--color-fg-muted, #6b7280)' }}>
+          Admin state:
+        </label>
+        <select
+          value={adminFilter}
+          onChange={(e) => setAdminFilter(e.target.value as typeof adminFilter)}
+          style={{
+            padding: '0.25rem 0.5rem',
+            borderRadius: '0.375rem',
+            border: '1px solid var(--color-border, #d1d5db)',
+            background: 'var(--color-bg, #fff)',
+          }}
+        >
+          <option value="">All</option>
+          <option value="active">Active</option>
+          <option value="suspended">Suspended</option>
+          <option value="banned">Banned</option>
+        </select>
+      </div>
       <DataTable
         data={data ?? []}
         columns={columns}
@@ -383,7 +434,231 @@ function AgentsPanel({ ns, tenant }: { ns: string; tenant: string }) {
           )
         }}
       />
+      {/*
+        The `key` forces a fresh AdminStateModal instance per agent
+        so its internal useState defaults pick up the new agent's
+        admin_state / admin_reason on open, with no effect-driven
+        sync (the React Compiler rejects `setState` inside
+        useEffect).
+      */}
+      {adminTarget && (
+        <AdminStateModal
+          key={`${adminTarget.namespace}/${adminTarget.tenant}/${adminTarget.agent_id}`}
+          agent={adminTarget}
+          onClose={() => setAdminTarget(null)}
+        />
+      )}
     </>
+  )
+}
+
+/**
+ * Tiny coloured badge for the admin-state column. Active = neutral
+ * (it's the boring default and shouldn't dominate the row);
+ * Suspended = warning; Banned = danger.
+ */
+function AdminStateBadge({ row }: { row: BusAgent }) {
+  const state = row.admin_state ?? 'active'
+  const colors: Record<string, { bg: string; fg: string; ring: string }> = {
+    active: { bg: '#f3f4f6', fg: '#374151', ring: '#d1d5db' },
+    suspended: { bg: '#fef3c7', fg: '#92400e', ring: '#fcd34d' },
+    banned: { bg: '#fee2e2', fg: '#991b1b', ring: '#fca5a5' },
+  }
+  const c = colors[state] ?? colors.active
+  return (
+    <span
+      title={row.admin_reason ?? undefined}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        padding: '0.125rem 0.5rem',
+        borderRadius: '9999px',
+        background: c.bg,
+        color: c.fg,
+        boxShadow: `inset 0 0 0 1px ${c.ring}`,
+        fontSize: '0.75rem',
+        fontWeight: 500,
+      }}
+    >
+      {state}
+    </span>
+  )
+}
+
+/**
+ * Admin-state mutation modal. Three buttons (one per state). When
+ * Suspended is chosen, the operator can also set a duration —
+ * server stamps the expiry and auto-reinstates on read past it.
+ *
+ * Banned is one-shot from the UI: we don't expose an `expires_at`
+ * field for it because the server drops the expiry on Banned and a
+ * banned-with-expiry UI would imply auto-reinstate, which is
+ * intentionally not how bans work.
+ */
+// The parent always wraps this in `{agent && <AdminStateModal …
+// key=… />}` so the component only mounts when an agent is
+// selected — every useState default below evaluates exactly once
+// per (agent, open) pair. That keeps us out of the React Compiler's
+// "no setState in useEffect" rule.
+function AdminStateModal({ agent, onClose }: { agent: BusAgent; onClose: () => void }) {
+  const mut = useSetBusAgentAdminState()
+  const { toast } = useToast()
+  const [target, setTarget] = useState<'active' | 'suspended' | 'banned'>(
+    (agent.admin_state as 'active' | 'suspended' | 'banned' | undefined) ?? 'active',
+  )
+  const [reason, setReason] = useState(agent.admin_reason ?? '')
+  // Suspension duration in minutes. 0 = no expiry (operator must
+  // manually reinstate).
+  const [durationMin, setDurationMin] = useState(60)
+
+  const submit = () => {
+    const body: SetBusAgentAdminState = { admin_state: target }
+    if (reason.trim()) body.reason = reason.trim()
+    if (target === 'suspended' && durationMin > 0) {
+      body.expires_at = new Date(Date.now() + durationMin * 60_000).toISOString()
+    }
+    mut.mutate(
+      { namespace: agent.namespace, tenant: agent.tenant, agentId: agent.agent_id, body },
+      {
+        onSuccess: () => {
+          toast('success', `Agent set to ${target}`)
+          onClose()
+        },
+        onError: (err) => toast('error', 'Admin state change failed', (err as Error).message),
+      },
+    )
+  }
+
+  return (
+    <Modal
+      open={!!agent}
+      onClose={onClose}
+      title={`Admin state — ${agent.agent_id}`}
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose} disabled={mut.isPending}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={mut.isPending}>
+            {mut.isPending ? 'Applying…' : 'Apply'}
+          </Button>
+        </>
+      }
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <div>
+          <div style={{ fontSize: '0.875rem', color: 'var(--color-fg-muted, #6b7280)', marginBottom: '0.5rem' }}>
+            Current state: <strong>{agent.admin_state ?? 'active'}</strong>
+            {agent.admin_set_by && (
+              <span> (set by {agent.admin_set_by})</span>
+            )}
+          </div>
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
+            <StateChoice
+              icon={<Play className="h-4 w-4" />}
+              label="Active"
+              value="active"
+              selected={target}
+              onSelect={setTarget}
+            />
+            <StateChoice
+              icon={<Pause className="h-4 w-4" />}
+              label="Suspended"
+              value="suspended"
+              selected={target}
+              onSelect={setTarget}
+            />
+            <StateChoice
+              icon={<Ban className="h-4 w-4" />}
+              label="Banned"
+              value="banned"
+              selected={target}
+              onSelect={setTarget}
+            />
+          </div>
+        </div>
+
+        {target === 'suspended' && (
+          <div>
+            <label style={{ display: 'block', fontSize: '0.875rem', marginBottom: '0.25rem' }}>
+              Auto-reinstate after (minutes, 0 = no expiry)
+            </label>
+            <input
+              type="number"
+              min={0}
+              value={durationMin}
+              onChange={(e) => setDurationMin(Math.max(0, Number(e.target.value) || 0))}
+              style={{
+                width: '100%',
+                padding: '0.375rem 0.5rem',
+                borderRadius: '0.375rem',
+                border: '1px solid var(--color-border, #d1d5db)',
+              }}
+            />
+          </div>
+        )}
+
+        <div>
+          <label style={{ display: 'block', fontSize: '0.875rem', marginBottom: '0.25rem' }}>
+            Reason (surfaced on the 403 to callers; keep terse)
+          </label>
+          <textarea
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            rows={3}
+            maxLength={4096}
+            placeholder={target === 'banned' ? 'e.g. exfiltration attempt' : 'e.g. flaky retries'}
+            style={{
+              width: '100%',
+              padding: '0.375rem 0.5rem',
+              borderRadius: '0.375rem',
+              border: '1px solid var(--color-border, #d1d5db)',
+              fontFamily: 'inherit',
+              resize: 'vertical',
+            }}
+          />
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
+function StateChoice({
+  icon,
+  label,
+  value,
+  selected,
+  onSelect,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: 'active' | 'suspended' | 'banned'
+  selected: string
+  onSelect: (v: 'active' | 'suspended' | 'banned') => void
+}) {
+  const isSelected = selected === value
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(value)}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '0.25rem',
+        flex: 1,
+        padding: '0.75rem',
+        borderRadius: '0.5rem',
+        border: `1px solid ${isSelected ? 'var(--color-primary, #2563eb)' : 'var(--color-border, #d1d5db)'}`,
+        background: isSelected ? 'var(--color-primary-soft, #dbeafe)' : 'transparent',
+        cursor: 'pointer',
+        fontSize: '0.875rem',
+      }}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
   )
 }
 


### PR DESCRIPTION
Adds a first-class **operator admin state** for bus agents,
distinct from the existing derived \`AgentStatus\` liveness. Answers
\"is this agent **allowed**?\" while \`AgentStatus\` keeps answering
\"is it **alive**?\".

Three states: **Active** / **Suspended** / **Banned**. The
register / list / send paths consult the new state; an operator
moderation surface (REST + 5 polyglot SDKs + Admin UI) drives it.

## Core (\`crates/core/src/bus_agent.rs\`)

- New \`AgentAdminState\` enum: \`Active\` / \`Suspended\` /
  \`Banned\`, with \`Active\` as the serde default so legacy rows
  round-trip cleanly — **no migration, no schema break**.
- New \`Agent\` fields: \`admin_state\`, \`admin_reason\`,
  \`admin_set_by\`, \`admin_set_at\`, \`admin_expires_at\`. All
  \`#[serde(default)]\`.
- \`Agent::effective_admin_state[_at]\` — **auto-reinstates** a
  Suspended agent past its expiry on read. Bans intentionally
  ignore expiry (a ban is not time-boxed by design).
- \`AgentAdminState::is_routable()\` — the dispatch-path predicate.
  Active only. Adding a future state (e.g. ReadOnly) is one place
  to edit.

5 new core unit tests including a legacy-row round-trip and an
auto-reinstate test.

## Server (\`crates/server/src/api/bus.rs\`)

- **New endpoint**:
  \`PUT /v1/bus/agents/{ns}/{tenant}/{id}/admin-state\`. Body
  \`{admin_state, reason?, expires_at?}\`. Requires the standard
  \`ManageAgent\` permission. Returns 400 if \`expires_at\` is set
  on anything other than Suspended. **CAS-update** so concurrent
  heartbeats can't lose the flip.
- \`send_to_agent\` now **enforces** the state: a non-routable
  agent gets 403 with the operator-supplied reason (the reason is
  visible to the caller, but \`admin_set_by\` is omitted — operator
  identity isn't leaked to the agent).
- \`AgentResponse\` gains the new fields; surfaces the
  *effective* admin state (so a stale Suspended row past its
  expiry shows as \"active\" without waiting for a write).
- \`ListAgentsParams\` gains \`?admin_state=\`. Compared against
  the *effective* state.
- 5 new server unit tests.

## Polyglot SDKs (5 languages)

Each adds \`set_bus_agent_admin_state\` + the new fields on
\`BusAgent\`, with \`admin_state\` defaulting to \"active\" when a
server pre-dating the field returns it absent.

| Lang | Method | New tests |
|---|---|---|
| **Rust** | \`set_bus_agent_admin_state\` | (existing tests cover it) |
| **Python** | \`set_bus_agent_admin_state\` (sync + async) | 4 |
| **Node** | \`setBusAgentAdminState\` | 4 |
| **Go** | \`SetBusAgentAdminState\` + custom \`UnmarshalJSON\` defaulting | 3 |
| **Java** | \`setBusAgentAdminState\` + custom \`adminState()\` accessor | 4 |

The CLI and MCP-server take \`admin_state: None\` defaults on
\`BusAgentFilter\` for now — exposing the filter end-to-end
through those surfaces is a follow-up.

## Admin UI (\`ui/src/pages/Bus.tsx\`)

- **\"Admin\" column** on the Agents tab with a coloured pill
  (neutral / amber / red) and the operator reason as a tooltip.
- **\`?admin_state=\` filter** in a select above the table — sent
  to the server, not filtered client-side, so the count is honest.
- **Shield-icon action button** per row opens an
  \`AdminStateModal\` with three big choice buttons (Active /
  Suspended / Banned), a reason textarea (max 4 KiB matching the
  server cap), and — for Suspended only — an \"auto-reinstate
  after N minutes\" field.
- \`useSetBusAgentAdminState\` hook in \`useBus.ts\`. The modal is
  remounted per agent via \`key={ns/tenant/id}\` to keep state
  init out of \`useEffect\` (React Compiler bans \`setState\` in
  effects).

The Banned UI is deliberately **one-shot** — no \`expires_at\`
field is offered, because a banned-with-expiry control would
imply auto-reinstate, which is intentionally not how bans work
server-side.

## Pre-commit

- \`cargo fmt --all\` ✅
- \`cargo clippy --workspace --no-deps -- -D warnings\` ✅
- \`cargo test --workspace --lib --bins --tests\` ✅
- \`cargo check --all-targets\` ✅
- \`(cd ui && npm run lint && npm run build)\` ✅
- Python tests: 125 ✅ | Node tests: 107 ✅ | Go tests: green ✅ | Java tests: 105 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)