### PR TITLE
fix(server): close cross-tenant audit/analytics/coverage data leak

### DIFF
--- a/crates/server/src/api/analytics.rs
+++ b/crates/server/src/api/analytics.rs
@@ -94,7 +94,7 @@ pub async fn query_analytics(
                 })),
             );
         }
-        Err(TenantFilterError::Ambiguous(_)) => {
+        Err(TenantFilterError::Ambiguous) => {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!(ErrorResponse {

--- a/crates/server/src/api/analytics.rs
+++ b/crates/server/src/api/analytics.rs
@@ -8,7 +8,7 @@ use utoipa::IntoParams;
 
 use acteon_core::analytics::{AnalyticsInterval, AnalyticsMetric, AnalyticsQuery};
 
-use crate::auth::identity::CallerIdentity;
+use crate::auth::identity::{CallerIdentity, TenantFilterError};
 
 use super::AppState;
 use super::schemas::ErrorResponse;
@@ -62,6 +62,8 @@ pub struct AnalyticsParams {
     ),
     responses(
         (status = 200, description = "Analytics results", body = acteon_core::AnalyticsResponse),
+        (status = 400, description = "Caller is scoped to multiple tenants and gave no `tenant` filter", body = ErrorResponse),
+        (status = 403, description = "Requested tenant is not covered by the caller's grants", body = ErrorResponse),
         (status = 404, description = "Analytics not available", body = ErrorResponse)
     )
 )]
@@ -79,23 +81,35 @@ pub async fn query_analytics(
         );
     };
 
-    // Enforce tenant access.
-    if let Some(ref requested_tenant) = params.tenant
-        && let Some(allowed) = identity.allowed_tenants()
-        && !allowed.contains(&requested_tenant.as_str())
-    {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!(ErrorResponse {
-                error: format!("no grant covers tenant={requested_tenant}"),
-            })),
-        );
-    }
+    // Enforce tenant access. Analytics aggregates server-side and cannot
+    // post-filter, so a multi-tenant caller who names no tenant must be
+    // rejected rather than aggregating across every granted tenant.
+    let tenant = match identity.resolve_tenant_filter(params.tenant.as_deref()) {
+        Ok(tenant) => tenant,
+        Err(TenantFilterError::NotGranted(requested)) => {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!(ErrorResponse {
+                    error: format!("no grant covers tenant={requested}"),
+                })),
+            );
+        }
+        Err(TenantFilterError::Ambiguous(_)) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!(ErrorResponse {
+                    error:
+                        "caller is scoped to multiple tenants; specify an explicit ?tenant= filter"
+                            .into(),
+                })),
+            );
+        }
+    };
 
-    let mut query = AnalyticsQuery {
+    let query = AnalyticsQuery {
         metric: params.metric,
         namespace: params.namespace,
-        tenant: params.tenant,
+        tenant,
         provider: params.provider,
         action_type: params.action_type,
         outcome: params.outcome,
@@ -105,14 +119,6 @@ pub async fn query_analytics(
         group_by: params.group_by,
         top_n: params.top_n,
     };
-
-    // Inject single-tenant caller's tenant if not specified.
-    if query.tenant.is_none()
-        && let Some(allowed) = identity.allowed_tenants()
-        && allowed.len() == 1
-    {
-        query.tenant = Some(allowed[0].to_owned());
-    }
 
     match analytics.query_analytics(&query).await {
         Ok(response) => (StatusCode::OK, Json(serde_json::json!(response))),

--- a/crates/server/src/api/audit.rs
+++ b/crates/server/src/api/audit.rs
@@ -5,7 +5,7 @@ use axum::response::IntoResponse;
 
 use acteon_audit::record::AuditQuery;
 
-use crate::auth::identity::CallerIdentity;
+use crate::auth::identity::{CallerIdentity, TenantFilterError};
 
 use super::AppState;
 use super::schemas::ErrorResponse;
@@ -36,6 +36,8 @@ use super::schemas::ErrorResponse;
     ),
     responses(
         (status = 200, description = "Audit records matching query", body = acteon_audit::AuditPage),
+        (status = 400, description = "Caller is scoped to multiple tenants and gave no `tenant` filter", body = ErrorResponse),
+        (status = 403, description = "Requested tenant is not covered by the caller's grants", body = ErrorResponse),
         (status = 404, description = "Audit not enabled", body = ErrorResponse)
     )
 )]
@@ -53,27 +55,30 @@ pub async fn query_audit(
         );
     };
 
-    // Restrict query to only tenants the caller has access to.
-    // If the caller has a specific tenant filter, verify it's covered by grants.
-    if let Some(ref requested_tenant) = query.tenant {
-        if let Some(allowed) = identity.allowed_tenants()
-            && !allowed.contains(&requested_tenant.as_str())
-        {
+    // Restrict the query to tenants the caller is granted. The audit store
+    // can only filter by a single tenant, so a multi-tenant caller who names
+    // none must be rejected — running unfiltered would return every tenant's
+    // records (see `resolve_tenant_filter`).
+    match identity.resolve_tenant_filter(query.tenant.as_deref()) {
+        Ok(tenant) => query.tenant = tenant,
+        Err(TenantFilterError::NotGranted(requested)) => {
             return (
                 StatusCode::FORBIDDEN,
                 Json(serde_json::json!(ErrorResponse {
-                    error: format!("no grant covers tenant={requested_tenant}"),
+                    error: format!("no grant covers tenant={requested}"),
                 })),
             );
         }
-    } else if let Some(allowed) = identity.allowed_tenants() {
-        // No tenant filter requested but caller is scoped — inject first allowed tenant.
-        // For multi-tenant callers, the API requires an explicit tenant filter.
-        if allowed.len() == 1 {
-            query.tenant = Some(allowed[0].to_owned());
+        Err(TenantFilterError::Ambiguous(_)) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!(ErrorResponse {
+                    error:
+                        "caller is scoped to multiple tenants; specify an explicit ?tenant= filter"
+                            .into(),
+                })),
+            );
         }
-        // If multiple tenants allowed and no filter, we let the query through
-        // and results will contain records from all their granted tenants.
     }
 
     match audit.query(&query).await {

--- a/crates/server/src/api/audit.rs
+++ b/crates/server/src/api/audit.rs
@@ -69,7 +69,7 @@ pub async fn query_audit(
                 })),
             );
         }
-        Err(TenantFilterError::Ambiguous(_)) => {
+        Err(TenantFilterError::Ambiguous) => {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!(ErrorResponse {

--- a/crates/server/src/api/replay.rs
+++ b/crates/server/src/api/replay.rs
@@ -301,7 +301,13 @@ pub async fn replay_audit(
         );
     };
 
-    // Build the audit query from replay parameters.
+    // Build the audit query from replay parameters. NOTE: tenant scoping is
+    // enforced per-record below via `identity.is_authorized(...)` before each
+    // dispatch — records outside the caller's grants are skipped, never
+    // replayed or returned. That per-record gate (not an up-front tenant
+    // filter) is the authorization boundary here, which is why a scoped
+    // caller can replay across a hierarchical tenant subtree; do not replace
+    // it with `resolve_tenant_filter`, which would over-narrow to exact match.
     let audit_query = AuditQuery {
         namespace: query.namespace,
         tenant: query.tenant,

--- a/crates/server/src/api/rules.rs
+++ b/crates/server/src/api/rules.rs
@@ -473,7 +473,7 @@ pub async fn rule_coverage(
                 })),
             );
         }
-        Err(TenantFilterError::Ambiguous(_)) => {
+        Err(TenantFilterError::Ambiguous) => {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!(ErrorResponse {

--- a/crates/server/src/api/rules.rs
+++ b/crates/server/src/api/rules.rs
@@ -15,7 +15,7 @@ use acteon_core::coverage::{CoverageQuery, CoverageReport, build_report};
 use acteon_rules::{RuleTraceEntry, SemanticMatchDetail};
 use acteon_rules_yaml::YamlFrontend;
 
-use crate::auth::identity::CallerIdentity;
+use crate::auth::identity::{CallerIdentity, TenantFilterError};
 use crate::auth::role::Permission;
 
 use super::AppState;
@@ -441,6 +441,7 @@ pub struct CoverageParams {
     params(CoverageParams),
     responses(
         (status = 200, description = "Coverage report", body = CoverageReport),
+        (status = 400, description = "Caller is scoped to multiple tenants and gave no `tenant` filter", body = ErrorResponse),
         (status = 404, description = "Analytics not available", body = ErrorResponse),
         (status = 403, description = "Tenant access denied", body = ErrorResponse)
     )
@@ -459,27 +460,30 @@ pub async fn rule_coverage(
         );
     };
 
-    // Enforce tenant access.
-    if let Some(ref requested_tenant) = params.tenant
-        && let Some(allowed) = identity.allowed_tenants()
-        && !allowed.contains(&requested_tenant.as_str())
-    {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!(ErrorResponse {
-                error: format!("no grant covers tenant={requested_tenant}"),
-            })),
-        );
-    }
-
-    let mut tenant = params.tenant.clone();
-    // Inject single-tenant caller's tenant if not specified.
-    if tenant.is_none()
-        && let Some(allowed) = identity.allowed_tenants()
-        && allowed.len() == 1
-    {
-        tenant = Some(allowed[0].to_owned());
-    }
+    // Enforce tenant access. Coverage aggregates server-side over the audit
+    // store and cannot post-filter, so a multi-tenant caller who names no
+    // tenant must be rejected rather than aggregating across every tenant.
+    let tenant = match identity.resolve_tenant_filter(params.tenant.as_deref()) {
+        Ok(tenant) => tenant,
+        Err(TenantFilterError::NotGranted(requested)) => {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!(ErrorResponse {
+                    error: format!("no grant covers tenant={requested}"),
+                })),
+            );
+        }
+        Err(TenantFilterError::Ambiguous(_)) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!(ErrorResponse {
+                    error:
+                        "caller is scoped to multiple tenants; specify an explicit ?tenant= filter"
+                            .into(),
+                })),
+            );
+        }
+    };
 
     let query = CoverageQuery {
         namespace: params.namespace,

--- a/crates/server/src/auth/identity.rs
+++ b/crates/server/src/auth/identity.rs
@@ -183,19 +183,20 @@ impl CallerIdentity {
         Ok(found)
     }
 
-    /// Resolve the single-tenant equality filter to apply for a query
-    /// endpoint whose backend can only filter by **one** tenant value at a
-    /// time (audit, analytics, rule-coverage). These endpoints delegate
-    /// filtering to the store/aggregator, so an unscoped query returns
-    /// records from *every* tenant — they must never run unfiltered for a
-    /// caller who is restricted to specific tenants.
+    /// Resolve the tenant equality-filter to apply for a query endpoint
+    /// whose backend can only filter by **one** tenant value at a time
+    /// (audit, analytics, rule-coverage). These endpoints delegate filtering
+    /// to the store/aggregator, so an unscoped query returns records from
+    /// *every* tenant — they must never run unfiltered for a caller who is
+    /// restricted to specific tenants.
     ///
     /// Returns:
-    /// - `Ok(None)` — caller has wildcard tenant access and named no
-    ///   tenant; run the query unfiltered.
+    /// - `Ok(None)` — caller has wildcard tenant access and named no tenant;
+    ///   run the query unfiltered.
     /// - `Ok(Some(tenant))` — apply `tenant == <tenant>`. Either the tenant
-    ///   the caller explicitly requested (verified covered by a grant) or,
-    ///   for a caller scoped to exactly one tenant, that tenant.
+    ///   the caller explicitly requested (verified covered by a grant,
+    ///   *hierarchically*) or, for a caller scoped to exactly one tenant,
+    ///   that tenant.
     /// - `Err(TenantFilterError::NotGranted)` — the requested tenant is not
     ///   covered by any grant; map to `403 Forbidden`.
     /// - `Err(TenantFilterError::Ambiguous)` — the caller is scoped to more
@@ -203,36 +204,48 @@ impl CallerIdentity {
     ///   require an explicit `?tenant=` filter. Running unfiltered here is
     ///   the cross-tenant data leak this helper exists to prevent.
     ///
-    /// Note: tenant grants are hierarchical prefixes (a grant on `acme`
-    /// covers `acme.us-east`), but the store filter is exact equality, so a
-    /// caller scoped to `acme` who names no tenant only sees exactly-`acme`
-    /// records, not `acme.*`. That narrowing is intentional — it fails
-    /// closed. Endpoints that must return records across a hierarchical
-    /// subtree should authorize per-record (as `replay` does) rather than
-    /// use this helper.
+    /// Authorization for a *named* tenant is hierarchical: a grant on `acme`
+    /// covers `acme`, `acme.prod`, `acme.us-east`, … (see [`tenant_matches`]),
+    /// so a regional admin can target a sub-tenant by naming it explicitly.
+    ///
+    /// Limitation: the store filter applied to the returned value is exact
+    /// equality, so naming `acme` matches only exactly-`acme` records, not
+    /// `acme.*`, and a caller scoped to multiple tenants cannot aggregate
+    /// across them in one call (hence the `Ambiguous` 400). Returning a whole
+    /// hierarchical subtree, or a union across several granted tenants, in a
+    /// single query requires pushing a prefix/`IN` predicate down into each
+    /// audit/analytics backend — tracked as follow-up work; this helper is
+    /// the fail-closed authorization boundary in the meantime.
+    ///
+    /// [`tenant_matches`]: super::config::tenant_matches
     pub fn resolve_tenant_filter(
         &self,
         requested: Option<&str>,
     ) -> Result<Option<String>, TenantFilterError> {
-        match (requested, self.allowed_tenants()) {
-            // Wildcard tenant access: honor an explicit request, else run
-            // unfiltered. No grant check — the caller can read every tenant.
-            (requested, None) => Ok(requested.map(str::to_owned)),
-            // Scoped caller naming a tenant: it must be covered by a grant.
-            (Some(requested), Some(allowed)) => {
-                if allowed.contains(&requested) {
+        match requested {
+            // Scoped caller naming a tenant: a grant must cover it
+            // hierarchically. `tenant_matches` also returns true for a `*`
+            // grant, so wildcard callers fall through here as authorized.
+            Some(requested) => {
+                if self
+                    .grants
+                    .iter()
+                    .any(|g| super::config::tenant_matches(&g.tenants, requested))
+                {
                     Ok(Some(requested.to_owned()))
                 } else {
                     Err(TenantFilterError::NotGranted(requested.to_owned()))
                 }
             }
-            // Scoped caller, no tenant named: inject iff exactly one is
-            // allowed; otherwise the query is ambiguous and must be rejected.
-            (None, Some(allowed)) => match allowed.as_slice() {
-                [only] => Ok(Some((*only).to_owned())),
-                _ => Err(TenantFilterError::Ambiguous(
-                    allowed.iter().map(|s| (*s).to_owned()).collect(),
-                )),
+            // No tenant named: wildcard callers run unfiltered; a caller
+            // scoped to exactly one tenant gets it injected; a multi-tenant
+            // caller is ambiguous and must name one.
+            None => match self.allowed_tenants() {
+                None => Ok(None),
+                Some(allowed) => match allowed.as_slice() {
+                    [only] => Ok(Some((*only).to_owned())),
+                    _ => Err(TenantFilterError::Ambiguous),
+                },
             },
         }
     }
@@ -262,9 +275,10 @@ pub enum TenantFilterError {
     /// endpoint's backend can only filter by a single tenant, so running
     /// unfiltered would return records from every granted tenant (or, for
     /// an unscoped store scan, all tenants). Map to `400 Bad Request` and
-    /// require an explicit `?tenant=`. Carries the caller's allowed tenants
-    /// for a helpful error message.
-    Ambiguous(Vec<String>),
+    /// require an explicit `?tenant=`. Deliberately carries no payload — the
+    /// caller's tenant set is not echoed back, to avoid disclosing tenant
+    /// topology to a holder of a single key.
+    Ambiguous,
 }
 
 #[cfg(test)]
@@ -492,20 +506,39 @@ mod tests {
     }
 
     #[test]
+    fn tenant_filter_allows_named_hierarchical_subtenant() {
+        // A grant on `acme` authorizes targeting a sub-tenant by name (a
+        // regional admin querying `?tenant=acme.prod`), matching the
+        // hierarchical model `is_authorized` already uses.
+        let id = identity_with(vec![grant(&["acme"], &["*"], &["*"], &["*"])]);
+        assert_eq!(
+            id.resolve_tenant_filter(Some("acme.prod")),
+            Ok(Some("acme.prod".to_owned())),
+        );
+        assert_eq!(
+            id.resolve_tenant_filter(Some("acme.us-east")),
+            Ok(Some("acme.us-east".to_owned())),
+        );
+        // Segment boundary: `acme` must NOT cover the sibling `acmecorp`.
+        assert_eq!(
+            id.resolve_tenant_filter(Some("acmecorp")),
+            Err(TenantFilterError::NotGranted("acmecorp".to_owned())),
+        );
+    }
+
+    #[test]
     fn tenant_filter_multi_tenant_caller_without_filter_is_ambiguous() {
         // The cross-tenant leak this guard prevents: a caller scoped to
-        // two tenants who names none must NOT run an unfiltered query.
+        // two tenants who names none must NOT run an unfiltered query. The
+        // error carries no payload so the tenant set is not disclosed.
         let id = identity_with(vec![
             grant(&["acme"], &["*"], &["*"], &["*"]),
             grant(&["globex"], &["*"], &["*"], &["*"]),
         ]);
-        match id.resolve_tenant_filter(None) {
-            Err(TenantFilterError::Ambiguous(allowed)) => {
-                assert!(allowed.contains(&"acme".to_owned()));
-                assert!(allowed.contains(&"globex".to_owned()));
-            }
-            other => panic!("expected Ambiguous, got {other:?}"),
-        }
+        assert_eq!(
+            id.resolve_tenant_filter(None),
+            Err(TenantFilterError::Ambiguous),
+        );
     }
 
     #[test]

--- a/crates/server/src/auth/identity.rs
+++ b/crates/server/src/auth/identity.rs
@@ -182,6 +182,60 @@ impl CallerIdentity {
         }
         Ok(found)
     }
+
+    /// Resolve the single-tenant equality filter to apply for a query
+    /// endpoint whose backend can only filter by **one** tenant value at a
+    /// time (audit, analytics, rule-coverage). These endpoints delegate
+    /// filtering to the store/aggregator, so an unscoped query returns
+    /// records from *every* tenant — they must never run unfiltered for a
+    /// caller who is restricted to specific tenants.
+    ///
+    /// Returns:
+    /// - `Ok(None)` — caller has wildcard tenant access and named no
+    ///   tenant; run the query unfiltered.
+    /// - `Ok(Some(tenant))` — apply `tenant == <tenant>`. Either the tenant
+    ///   the caller explicitly requested (verified covered by a grant) or,
+    ///   for a caller scoped to exactly one tenant, that tenant.
+    /// - `Err(TenantFilterError::NotGranted)` — the requested tenant is not
+    ///   covered by any grant; map to `403 Forbidden`.
+    /// - `Err(TenantFilterError::Ambiguous)` — the caller is scoped to more
+    ///   than one tenant and named none; map to `400 Bad Request` and
+    ///   require an explicit `?tenant=` filter. Running unfiltered here is
+    ///   the cross-tenant data leak this helper exists to prevent.
+    ///
+    /// Note: tenant grants are hierarchical prefixes (a grant on `acme`
+    /// covers `acme.us-east`), but the store filter is exact equality, so a
+    /// caller scoped to `acme` who names no tenant only sees exactly-`acme`
+    /// records, not `acme.*`. That narrowing is intentional — it fails
+    /// closed. Endpoints that must return records across a hierarchical
+    /// subtree should authorize per-record (as `replay` does) rather than
+    /// use this helper.
+    pub fn resolve_tenant_filter(
+        &self,
+        requested: Option<&str>,
+    ) -> Result<Option<String>, TenantFilterError> {
+        match (requested, self.allowed_tenants()) {
+            // Wildcard tenant access: honor an explicit request, else run
+            // unfiltered. No grant check — the caller can read every tenant.
+            (requested, None) => Ok(requested.map(str::to_owned)),
+            // Scoped caller naming a tenant: it must be covered by a grant.
+            (Some(requested), Some(allowed)) => {
+                if allowed.contains(&requested) {
+                    Ok(Some(requested.to_owned()))
+                } else {
+                    Err(TenantFilterError::NotGranted(requested.to_owned()))
+                }
+            }
+            // Scoped caller, no tenant named: inject iff exactly one is
+            // allowed; otherwise the query is ambiguous and must be rejected.
+            (None, Some(allowed)) => match allowed.as_slice() {
+                [only] => Ok(Some((*only).to_owned())),
+                _ => Err(TenantFilterError::Ambiguous(
+                    allowed.iter().map(|s| (*s).to_owned()).collect(),
+                )),
+            },
+        }
+    }
 }
 
 /// Error returned by [`CallerIdentity::bus_agent_id_for_scope`] when
@@ -195,6 +249,22 @@ pub enum BusAgentIdResolutionError {
         "ambiguous bus agent identity for caller: grants bind to both '{first}' and '{second}'"
     )]
     ConflictingGrants { first: String, second: String },
+}
+
+/// Outcome of [`CallerIdentity::resolve_tenant_filter`] that the caller
+/// must surface as an HTTP error instead of running the query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TenantFilterError {
+    /// The caller requested a tenant not covered by any of their grants.
+    /// Map to `403 Forbidden`.
+    NotGranted(String),
+    /// The caller is scoped to multiple tenants and did not name one. The
+    /// endpoint's backend can only filter by a single tenant, so running
+    /// unfiltered would return records from every granted tenant (or, for
+    /// an unscoped store scan, all tenants). Map to `400 Bad Request` and
+    /// require an explicit `?tenant=`. Carries the caller's allowed tenants
+    /// for a helpful error message.
+    Ambiguous(Vec<String>),
 }
 
 #[cfg(test)]
@@ -383,6 +453,76 @@ mod tests {
         assert_eq!(
             id.bus_agent_id_for_scope("acme.us-east", "agents"),
             Ok(Some("planner-1")),
+        );
+    }
+
+    // ---- resolve_tenant_filter -------------------------------------------
+
+    #[test]
+    fn tenant_filter_wildcard_caller_runs_unfiltered() {
+        let id = identity_with(vec![grant(&["*"], &["*"], &["*"], &["*"])]);
+        // No tenant named: unfiltered (admin sees all).
+        assert_eq!(id.resolve_tenant_filter(None), Ok(None));
+        // Named tenant: honored without a grant check.
+        assert_eq!(
+            id.resolve_tenant_filter(Some("acme")),
+            Ok(Some("acme".to_owned())),
+        );
+    }
+
+    #[test]
+    fn tenant_filter_single_tenant_caller_is_injected() {
+        let id = identity_with(vec![grant(&["acme"], &["*"], &["*"], &["*"])]);
+        // No tenant named: inject the only allowed tenant.
+        assert_eq!(id.resolve_tenant_filter(None), Ok(Some("acme".to_owned())),);
+        // Naming the granted tenant is fine.
+        assert_eq!(
+            id.resolve_tenant_filter(Some("acme")),
+            Ok(Some("acme".to_owned())),
+        );
+    }
+
+    #[test]
+    fn tenant_filter_rejects_uncovered_tenant() {
+        let id = identity_with(vec![grant(&["acme"], &["*"], &["*"], &["*"])]);
+        assert_eq!(
+            id.resolve_tenant_filter(Some("globex")),
+            Err(TenantFilterError::NotGranted("globex".to_owned())),
+        );
+    }
+
+    #[test]
+    fn tenant_filter_multi_tenant_caller_without_filter_is_ambiguous() {
+        // The cross-tenant leak this guard prevents: a caller scoped to
+        // two tenants who names none must NOT run an unfiltered query.
+        let id = identity_with(vec![
+            grant(&["acme"], &["*"], &["*"], &["*"]),
+            grant(&["globex"], &["*"], &["*"], &["*"]),
+        ]);
+        match id.resolve_tenant_filter(None) {
+            Err(TenantFilterError::Ambiguous(allowed)) => {
+                assert!(allowed.contains(&"acme".to_owned()));
+                assert!(allowed.contains(&"globex".to_owned()));
+            }
+            other => panic!("expected Ambiguous, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tenant_filter_multi_tenant_caller_naming_a_tenant_is_scoped() {
+        let id = identity_with(vec![
+            grant(&["acme"], &["*"], &["*"], &["*"]),
+            grant(&["globex"], &["*"], &["*"], &["*"]),
+        ]);
+        // Naming a covered tenant scopes the query to it.
+        assert_eq!(
+            id.resolve_tenant_filter(Some("globex")),
+            Ok(Some("globex".to_owned())),
+        );
+        // Naming an uncovered tenant is still forbidden.
+        assert_eq!(
+            id.resolve_tenant_filter(Some("initech")),
+            Err(TenantFilterError::NotGranted("initech".to_owned())),
         );
     }
 }


### PR DESCRIPTION
## Summary

A caller whose grant covers **2+ specific tenants** (not a wildcard) and who omits the `tenant` query param fell through with `tenant=None`. Filtering is delegated to the store/aggregator, which adds no tenant condition for `None` (e.g. Postgres `build_where_clause` only filters when `Some`), so the query returned records aggregated across **every tenant** — a broken-access-control leak.

Affected endpoints:
- `GET /v1/audit`
- `GET /v1/analytics`
- `GET /v1/rules/coverage`

All three reimplemented tenant scoping inline and had diverged: each injected the tenant only when `allowed.len() == 1` and otherwise let the unfiltered query through.

## Fix

Introduce one shared helper — `CallerIdentity::resolve_tenant_filter(requested)` — and route the three endpoints through it:

| Caller | Requested `?tenant=` | Result |
|---|---|---|
| wildcard | — | unfiltered |
| wildcard | `t` | scoped to `t` |
| scoped | covered `t` | scoped to `t` |
| scoped | uncovered `t` | **403** |
| single-tenant | none | inject sole tenant |
| **multi-tenant** | **none** | **400 — must specify `?tenant=`** ← the closed hole |

## Verified, not assumed

- ✅ `audit` / `analytics` — confirmed leaks.
- 🔎 `rules/coverage` — **same leak, found by sweeping all `allowed.len() == 1` sites** (not in the original report).
- ❌ `replay` — **not a leak**: it authorizes *per record* via `is_authorized(...)` before each dispatch, so it never returns/redispatches other tenants' data and correctly supports hierarchical/multi-tenant replay. Left untouched; added a comment so it isn't "fixed" with an over-strict up-front filter.
- ✅ `silences` / `time_intervals` / `stream` already post-filter by `allowed_tenants`; unchanged.

## Notes

- **Breaking change**: multi-tenant callers must now pass `?tenant=` on the three affected endpoints. Acceptable — no back-compat guarantees.
- Known limitation (documented in the helper): grants are hierarchical prefixes but the store filter is exact equality, so the helper fails *closed* (a caller scoped to `acme` naming no tenant sees only exactly-`acme`, not `acme.*`).
- Follow-up not in scope: verify the MCP server's `query_audit`/`query_analytics` tool paths apply the same scoping if they bypass these HTTP handlers.

## Tests / checks

- 5 new unit tests for `resolve_tenant_filter` (incl. the multi-tenant leak case).
- New 400/403 responses documented in the OpenAPI annotations.
- `cargo fmt` · `cargo clippy --workspace -D warnings` · `cargo test -p acteon-server` (74 + new unit tests pass) · `cargo check --all-targets`. No UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)