### PR TITLE
feat(audit): hierarchical multi-tenant scope for audit/analytics/coverage queries

### DIFF
--- a/crates/audit/audit/src/analytics.rs
+++ b/crates/audit/audit/src/analytics.rs
@@ -213,6 +213,9 @@ impl<S: AuditStore + ?Sized + 'static> AnalyticsStore for InMemoryAnalytics<S> {
                 to: Some(to),
                 limit: Some(batch_size),
                 cursor: cursor.clone(),
+                // Propagate the server-set authorization scope so the paged
+                // store query restricts to the caller's granted tenants.
+                tenant_scope: query.tenant_scope.clone(),
                 ..Default::default()
             };
 
@@ -333,6 +336,8 @@ impl<S: AuditStore + ?Sized + 'static> AnalyticsStore for InMemoryAnalytics<S> {
                 to: Some(to),
                 limit: Some(batch_size),
                 cursor: cursor.clone(),
+                // Propagate the server-set authorization scope to the store.
+                tenant_scope: query.tenant_scope.clone(),
                 ..Default::default()
             };
 
@@ -610,6 +615,7 @@ mod tests {
             to: None,
             group_by: None,
             top_n: None,
+            tenant_scope: Vec::new(),
         };
 
         let result = analytics.query_analytics(&query).await.unwrap();
@@ -638,6 +644,7 @@ mod tests {
             to: None,
             group_by: Some("outcome".to_string()),
             top_n: None,
+            tenant_scope: Vec::new(),
         };
 
         let result = analytics.query_analytics(&query).await.unwrap();
@@ -669,6 +676,7 @@ mod tests {
             to: None,
             group_by: None,
             top_n: Some(3),
+            tenant_scope: Vec::new(),
         };
 
         let result = analytics.query_analytics(&query).await.unwrap();
@@ -700,6 +708,7 @@ mod tests {
             to: None,
             group_by: None,
             top_n: None,
+            tenant_scope: Vec::new(),
         };
 
         let result = analytics.query_analytics(&query).await.unwrap();
@@ -734,6 +743,7 @@ mod tests {
             to: None,
             group_by: None,
             top_n: None,
+            tenant_scope: Vec::new(),
         };
 
         let result = analytics.query_analytics(&query).await.unwrap();
@@ -761,6 +771,7 @@ mod tests {
             to: None,
             group_by: None,
             top_n: None,
+            tenant_scope: Vec::new(),
         };
 
         let result = analytics.query_analytics(&query).await.unwrap();
@@ -810,6 +821,7 @@ mod tests {
             to: None,
             group_by: None,
             top_n: None,
+            tenant_scope: Vec::new(),
         };
 
         let result = analytics.query_analytics(&query).await.unwrap();
@@ -920,6 +932,7 @@ mod tests {
             tenant: Some("acme".into()),
             from: None,
             to: None,
+            tenant_scope: Vec::new(),
         };
         let aggregates = analytics.rule_coverage(&query).await.unwrap();
 
@@ -975,6 +988,7 @@ mod tests {
             tenant: None,
             from: None,
             to: None,
+            tenant_scope: Vec::new(),
         };
         let aggregates = analytics.rule_coverage(&query).await.unwrap();
 
@@ -1014,6 +1028,7 @@ mod tests {
             tenant: None,
             from: Some(now - Duration::hours(3)),
             to: Some(now),
+            tenant_scope: Vec::new(),
         };
         let aggregates = analytics.rule_coverage(&query).await.unwrap();
 

--- a/crates/audit/audit/src/lib.rs
+++ b/crates/audit/audit/src/lib.rs
@@ -15,3 +15,8 @@ pub use error::AuditError;
 pub use record::{A2A_AUDIT_PROVIDER, AuditEventKind, AuditPage, AuditQuery, AuditRecord};
 pub use redact::{RedactConfig, RedactingAuditStore, Redactor};
 pub use store::AuditStore;
+
+/// Hierarchical tenant authorization scope helpers, re-exported from
+/// `acteon-core` so every audit/analytics backend (which all depend on this
+/// crate) can apply scope filtering without taking a direct `acteon-core` dep.
+pub use acteon_core::tenant_scope;

--- a/crates/audit/audit/src/record.rs
+++ b/crates/audit/audit/src/record.rs
@@ -205,6 +205,25 @@ pub struct AuditQuery {
     /// records in chain order with bounded memory.
     #[serde(default)]
     pub sort_by_sequence_asc: bool,
+    /// Server-set tenant authorization scope. The set of tenant grant
+    /// patterns the caller may read; backends restrict results to tenants
+    /// covered hierarchically by one of these (see
+    /// [`acteon_core::tenant_scope`]). Empty = unrestricted.
+    ///
+    /// `#[serde(skip)]` so it can never be set from client input — it is the
+    /// authorization boundary and is populated by the server from grants.
+    #[serde(skip)]
+    pub tenant_scope: Vec<String>,
+}
+
+impl AuditQuery {
+    /// Returns `true` if `tenant` is within this query's authorization scope.
+    /// An empty scope is unrestricted. Used by backends that filter records
+    /// in memory (the in-memory store and the `DynamoDB` scan fallback).
+    #[must_use]
+    pub fn tenant_in_scope(&self, tenant: &str) -> bool {
+        crate::tenant_scope::tenant_in_scope(&self.tenant_scope, tenant)
+    }
 }
 
 impl AuditQuery {

--- a/crates/audit/clickhouse/src/analytics.rs
+++ b/crates/audit/clickhouse/src/analytics.rs
@@ -8,6 +8,7 @@ use acteon_core::analytics::{
     AnalyticsTopEntry,
 };
 use acteon_core::coverage::{CoverageAggregate, CoverageQuery};
+use acteon_core::tenant_scope::like_descendants_pattern;
 
 /// Map an `AnalyticsInterval` to the `ClickHouse` time-truncation function.
 fn interval_to_ch_func(interval: AnalyticsInterval) -> &'static str {
@@ -50,6 +51,19 @@ fn build_analytics_where(
             conditions.push(format!("{col} = ?"));
             binds.push(BindValue::Str(v.clone()));
         }
+    }
+
+    // Hierarchical tenant authorization scope (server-set). Empty scope is
+    // unrestricted; otherwise the record's tenant must be covered by ANY of the
+    // caller's granted patterns (exact match OR dot-descendant).
+    if !query.tenant_scope.is_empty() {
+        let mut scope_terms: Vec<String> = Vec::with_capacity(query.tenant_scope.len());
+        for p in &query.tenant_scope {
+            scope_terms.push("(tenant = ? OR tenant LIKE ?)".to_string());
+            binds.push(BindValue::Str(p.clone()));
+            binds.push(BindValue::Str(like_descendants_pattern(p)));
+        }
+        conditions.push(format!("({})", scope_terms.join(" OR ")));
     }
 
     // Time range: dispatched_at is stored as milliseconds since epoch.
@@ -321,6 +335,19 @@ impl AnalyticsStore for ClickHouseAnalyticsStore {
             binds.push(BindValue::Str(t.clone()));
         }
 
+        // Hierarchical tenant authorization scope (server-set). Empty scope is
+        // unrestricted; otherwise the record's tenant must be covered by ANY of
+        // the caller's granted patterns (exact match OR dot-descendant).
+        if !query.tenant_scope.is_empty() {
+            let mut scope_terms: Vec<String> = Vec::with_capacity(query.tenant_scope.len());
+            for p in &query.tenant_scope {
+                scope_terms.push("(tenant = ? OR tenant LIKE ?)".to_string());
+                binds.push(BindValue::Str(p.clone()));
+                binds.push(BindValue::Str(like_descendants_pattern(p)));
+            }
+            conditions.push(format!("({})", scope_terms.join(" OR ")));
+        }
+
         conditions.push("dispatched_at >= ?".to_string());
         binds.push(BindValue::Millis(from.timestamp_millis()));
         conditions.push("dispatched_at <= ?".to_string());
@@ -357,5 +384,149 @@ impl AnalyticsStore for ClickHouseAnalyticsStore {
                 count: row.cnt,
             })
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    use super::{AnalyticsQuery, BindValue, build_analytics_where};
+    use acteon_core::analytics::{AnalyticsInterval, AnalyticsMetric};
+
+    /// `AnalyticsQuery` has no `Default`; build a minimal base with no filters.
+    fn base_query() -> AnalyticsQuery {
+        AnalyticsQuery {
+            metric: AnalyticsMetric::Volume,
+            namespace: None,
+            tenant: None,
+            provider: None,
+            action_type: None,
+            outcome: None,
+            interval: AnalyticsInterval::Daily,
+            from: None,
+            to: None,
+            group_by: None,
+            top_n: None,
+            tenant_scope: Vec::new(),
+        }
+    }
+
+    /// Render a bind list as comparable strings: `Str` verbatim, `Millis`
+    /// prefixed so the two variants can never collide.
+    fn binds_repr(binds: &[BindValue]) -> Vec<String> {
+        binds
+            .iter()
+            .map(|b| match b {
+                BindValue::Str(s) => format!("s:{s}"),
+                BindValue::Millis(ms) => format!("m:{ms}"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn build_analytics_where_empty_scope_adds_no_scope_predicate() {
+        // An empty scope must be byte-for-byte identical to a no-scope query:
+        // only the time-range conditions remain.
+        let from = Utc.timestamp_opt(1_000, 0).unwrap();
+        let to = Utc.timestamp_opt(2_000, 0).unwrap();
+        let (clause, binds) = build_analytics_where(&base_query(), from, to);
+        assert_eq!(clause, "WHERE dispatched_at >= ? AND dispatched_at <= ?");
+        assert_eq!(
+            binds_repr(&binds),
+            vec![
+                format!("m:{}", from.timestamp_millis()),
+                format!("m:{}", to.timestamp_millis()),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_analytics_where_single_scope_pattern() {
+        let from = Utc.timestamp_opt(1_000, 0).unwrap();
+        let to = Utc.timestamp_opt(2_000, 0).unwrap();
+        let (clause, binds) = build_analytics_where(
+            &AnalyticsQuery {
+                tenant_scope: vec!["acme".to_owned()],
+                ..base_query()
+            },
+            from,
+            to,
+        );
+        assert_eq!(
+            clause,
+            "WHERE ((tenant = ? OR tenant LIKE ?)) \
+             AND dispatched_at >= ? AND dispatched_at <= ?"
+        );
+        assert_eq!(
+            binds_repr(&binds),
+            vec![
+                "s:acme".to_owned(),
+                "s:acme.%".to_owned(),
+                format!("m:{}", from.timestamp_millis()),
+                format!("m:{}", to.timestamp_millis()),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_analytics_where_multi_scope_or_group() {
+        let from = Utc.timestamp_opt(1_000, 0).unwrap();
+        let to = Utc.timestamp_opt(2_000, 0).unwrap();
+        let (clause, binds) = build_analytics_where(
+            &AnalyticsQuery {
+                tenant_scope: vec!["acme".to_owned(), "ac_me".to_owned()],
+                ..base_query()
+            },
+            from,
+            to,
+        );
+        assert_eq!(
+            clause,
+            "WHERE ((tenant = ? OR tenant LIKE ?) OR (tenant = ? OR tenant LIKE ?)) \
+             AND dispatched_at >= ? AND dispatched_at <= ?"
+        );
+        // Note the LIKE-escape of `_` in the second pattern.
+        assert_eq!(
+            binds_repr(&binds),
+            vec![
+                "s:acme".to_owned(),
+                "s:acme.%".to_owned(),
+                "s:ac_me".to_owned(),
+                "s:ac\\_me.%".to_owned(),
+                format!("m:{}", from.timestamp_millis()),
+                format!("m:{}", to.timestamp_millis()),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_analytics_where_scope_anded_with_exact_tenant() {
+        let from = Utc.timestamp_opt(1_000, 0).unwrap();
+        let to = Utc.timestamp_opt(2_000, 0).unwrap();
+        let (clause, binds) = build_analytics_where(
+            &AnalyticsQuery {
+                tenant: Some("acme".to_owned()),
+                tenant_scope: vec!["acme".to_owned()],
+                ..base_query()
+            },
+            from,
+            to,
+        );
+        assert_eq!(
+            clause,
+            "WHERE tenant = ? AND ((tenant = ? OR tenant LIKE ?)) \
+             AND dispatched_at >= ? AND dispatched_at <= ?"
+        );
+        assert_eq!(
+            binds_repr(&binds),
+            vec![
+                "s:acme".to_owned(),
+                "s:acme".to_owned(),
+                "s:acme.%".to_owned(),
+                format!("m:{}", from.timestamp_millis()),
+                format!("m:{}", to.timestamp_millis()),
+            ]
+        );
     }
 }

--- a/crates/audit/clickhouse/src/store.rs
+++ b/crates/audit/clickhouse/src/store.rs
@@ -8,6 +8,7 @@ use acteon_audit::cursor::{AuditCursor, CursorKind};
 use acteon_audit::error::AuditError;
 use acteon_audit::record::{AuditPage, AuditQuery, AuditRecord};
 use acteon_audit::store::AuditStore;
+use acteon_core::tenant_scope::like_descendants_pattern;
 
 use crate::analytics::ClickHouseAnalyticsStore;
 use crate::config::ClickHouseAuditConfig;
@@ -216,6 +217,19 @@ fn build_where_clause(query: &AuditQuery) -> (String, Vec<String>) {
             conditions.push(format!("{col} = ?"));
             binds.push(v.clone());
         }
+    }
+
+    // Hierarchical tenant authorization scope (server-set). Empty scope is
+    // unrestricted; otherwise the record's tenant must be covered by ANY of the
+    // caller's granted patterns (exact match OR dot-descendant).
+    if !query.tenant_scope.is_empty() {
+        let mut scope_terms: Vec<String> = Vec::with_capacity(query.tenant_scope.len());
+        for p in &query.tenant_scope {
+            scope_terms.push("(tenant = ? OR tenant LIKE ?)".to_string());
+            binds.push(p.clone());
+            binds.push(like_descendants_pattern(p));
+        }
+        conditions.push(format!("({})", scope_terms.join(" OR ")));
     }
 
     if let Some(from) = query.from {
@@ -514,5 +528,88 @@ impl AuditStore for ClickHouseAuditStore {
             self.client.clone(),
             self.table.clone(),
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AuditQuery, build_where_clause};
+
+    #[test]
+    fn build_where_clause_no_filters_is_empty() {
+        let (clause, binds) = build_where_clause(&AuditQuery::default());
+        assert!(clause.is_empty());
+        assert!(binds.is_empty());
+    }
+
+    #[test]
+    fn build_where_clause_empty_scope_adds_nothing() {
+        // A query with no tenant_scope must be byte-for-byte identical to a
+        // no-filter query (preserves today's behavior exactly).
+        let baseline = build_where_clause(&AuditQuery::default());
+        let scoped = build_where_clause(&AuditQuery {
+            tenant_scope: Vec::new(),
+            ..Default::default()
+        });
+        assert_eq!(baseline, scoped);
+    }
+
+    #[test]
+    fn build_where_clause_single_scope_pattern() {
+        let (clause, binds) = build_where_clause(&AuditQuery {
+            tenant_scope: vec!["acme".to_owned()],
+            ..Default::default()
+        });
+        assert_eq!(clause, "WHERE ((tenant = ? OR tenant LIKE ?))");
+        assert_eq!(binds, vec!["acme".to_owned(), "acme.%".to_owned()]);
+    }
+
+    #[test]
+    fn build_where_clause_multi_scope_or_group() {
+        let (clause, binds) = build_where_clause(&AuditQuery {
+            tenant_scope: vec!["acme".to_owned(), "globex".to_owned()],
+            ..Default::default()
+        });
+        assert_eq!(
+            clause,
+            "WHERE ((tenant = ? OR tenant LIKE ?) OR (tenant = ? OR tenant LIKE ?))"
+        );
+        assert_eq!(
+            binds,
+            vec![
+                "acme".to_owned(),
+                "acme.%".to_owned(),
+                "globex".to_owned(),
+                "globex.%".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_where_clause_scope_anded_with_exact_tenant() {
+        // The scope group is ANDed with the existing exact tenant filter; binds
+        // appear in SQL order (exact tenant first, then the scope pair).
+        let (clause, binds) = build_where_clause(&AuditQuery {
+            tenant: Some("acme".to_owned()),
+            tenant_scope: vec!["acme".to_owned()],
+            ..Default::default()
+        });
+        assert_eq!(
+            clause,
+            "WHERE tenant = ? AND ((tenant = ? OR tenant LIKE ?))"
+        );
+        assert_eq!(
+            binds,
+            vec!["acme".to_owned(), "acme".to_owned(), "acme.%".to_owned()]
+        );
+    }
+
+    #[test]
+    fn build_where_clause_scope_escapes_like_metachars() {
+        let (_clause, binds) = build_where_clause(&AuditQuery {
+            tenant_scope: vec!["ac_me".to_owned()],
+            ..Default::default()
+        });
+        assert_eq!(binds, vec!["ac_me".to_owned(), "ac\\_me.%".to_owned()]);
     }
 }

--- a/crates/audit/dynamodb/src/store.rs
+++ b/crates/audit/dynamodb/src/store.rs
@@ -194,6 +194,48 @@ impl DynamoDbAuditStore {
 
         (filters, values, names)
     }
+
+    /// Build a tenant-scope `FilterExpression` group for a hierarchical
+    /// authorization scope, used on the Scan path (the `ns_tenant` GSI key is
+    /// exact-match only, so a subtree scope is not expressible as a key
+    /// condition — a documented Scan-vs-GSI perf tradeoff).
+    ///
+    /// For each pattern `p` in `scope`, emits the predicate
+    /// `(#tenant = :scopeN OR begins_with(#tenant, :scopeN_dot))`, where the
+    /// exact match covers `p` itself and `begins_with(p.)` covers dot
+    /// descendants — `begins_with("acme.")` matches `acme.prod` / `acme.x.y`
+    /// but not the sibling `acmecorp`. All patterns are `OR`-ed inside one
+    /// parenthesized group. Values are bound as expression attribute values,
+    /// never interpolated, and `#tenant` is aliased defensively.
+    ///
+    /// Returns `(group, values, names)`. When `scope` is empty, returns
+    /// `(None, empty, empty)` — adds nothing, preserving today's behavior.
+    fn build_scope_filter(
+        scope: &[String],
+    ) -> (
+        Option<String>,
+        HashMap<String, AttributeValue>,
+        HashMap<String, String>,
+    ) {
+        let mut values = HashMap::new();
+        let mut names = HashMap::new();
+        if scope.is_empty() {
+            return (None, values, names);
+        }
+
+        names.insert("#tenant".to_owned(), "tenant".to_owned());
+        let mut terms = Vec::with_capacity(scope.len());
+        for (i, p) in scope.iter().enumerate() {
+            let exact = format!(":scope{i}");
+            let prefix = format!(":scope{i}_dot");
+            terms.push(format!(
+                "(#tenant = {exact} OR begins_with(#tenant, {prefix}))"
+            ));
+            values.insert(exact, AttributeValue::S(p.clone()));
+            values.insert(prefix, AttributeValue::S(format!("{p}.")));
+        }
+        (Some(format!("({})", terms.join(" OR "))), values, names)
+    }
 }
 
 #[async_trait]
@@ -264,11 +306,19 @@ impl AuditStore for DynamoDbAuditStore {
         let limit = query.effective_limit();
 
         // Require at least namespace + tenant for GSI queries, UNLESS
-        // we're searching for specific signing data (IR use case).
+        // we're searching for specific signing data (IR use case) or a
+        // hierarchical tenant scope is in play. `ns_tenant` is a GSI partition
+        // key (exact match only), so a subtree scope (`acme` covering
+        // `acme.prod`, …) is NOT expressible as a key condition and must go
+        // through a Scan with a FilterExpression. This is a deliberate
+        // perf tradeoff (Scan vs GSI) for multi-tenant/subtree reads on
+        // DynamoDB. The server sets EITHER `tenant` (scope empty, GSI path) OR
+        // `tenant_scope` (tenant None, scan path), never both.
         let is_signer_query = query.signer_id.is_some() || query.kid.is_some();
+        let is_scope_query = !query.tenant_scope.is_empty();
         let (namespace, tenant) = match (&query.namespace, &query.tenant) {
             (Some(ns), Some(t)) => (Some(ns.clone()), Some(t.clone())),
-            _ if is_signer_query => (None, None),
+            _ if is_signer_query || is_scope_query => (None, None),
             _ => {
                 // Without namespace+tenant we cannot use the GSI efficiently.
                 // Return empty for now (a full table scan would be expensive).
@@ -441,18 +491,44 @@ impl AuditStore for DynamoDbAuditStore {
                     .map_err(|e| AuditError::Storage(e.to_string()))?;
                 (resp.items().to_vec(), None)
             } else {
-                // IR MODE: Perform a full table scan. This is expensive and should
-                // only be used for cross-tenant investigations by signer_id or kid.
+                // IR / SCOPE MODE: Perform a full table scan. This is expensive
+                // and is used for cross-tenant investigations by signer_id or
+                // kid, and for hierarchical tenant-scope (subtree) reads which
+                // the exact-match `ns_tenant` GSI key cannot express — a
+                // documented Scan-vs-GSI perf tradeoff.
                 tracing::warn!(
                     signer_id = ?query.signer_id,
                     kid = ?query.kid,
+                    scope_patterns = query.tenant_scope.len(),
                     "performing cross-tenant DynamoDB scan for audit records"
                 );
 
-                let filter_expression = if filter_parts.is_empty() {
+                // The scan has no key condition, so AND together: the existing
+                // build_filters() output (provider, fence exclusion, …), a
+                // namespace filter when the query pins a namespace, and the
+                // hierarchical tenant-scope OR-group.
+                let mut scan_parts = filter_parts;
+                let mut scan_values = filter_values;
+                let mut scan_names = filter_names;
+
+                if let Some(ref ns) = query.namespace {
+                    scan_parts.push("#namespace = :ns".to_owned());
+                    scan_values.insert(":ns".to_owned(), AttributeValue::S(ns.clone()));
+                    scan_names.insert("#namespace".to_owned(), "namespace".to_owned());
+                }
+
+                let (scope_group, scope_values, scope_names) =
+                    Self::build_scope_filter(&query.tenant_scope);
+                if let Some(group) = scope_group {
+                    scan_parts.push(group);
+                    scan_values.extend(scope_values);
+                    scan_names.extend(scope_names);
+                }
+
+                let filter_expression = if scan_parts.is_empty() {
                     None
                 } else {
-                    Some(filter_parts.join(" AND "))
+                    Some(scan_parts.join(" AND "))
                 };
 
                 let probe_limit = i32::try_from(limit).unwrap_or(50).saturating_add(1);
@@ -462,10 +538,10 @@ impl AuditStore for DynamoDbAuditStore {
                     .table_name(&self.table_name)
                     .limit(probe_limit);
 
-                for (k, v) in &filter_values {
+                for (k, v) in &scan_values {
                     s = s.expression_attribute_values(k, v.clone());
                 }
-                for (k, v) in &filter_names {
+                for (k, v) in &scan_names {
                     s = s.expression_attribute_names(k, v);
                 }
                 if let Some(ref fe) = filter_expression {
@@ -1020,6 +1096,64 @@ mod tests {
         assert!(parts.iter().any(|p| p.contains("provider")));
         assert!(values.contains_key(":provider"));
         assert!(names.contains_key("#provider"));
+    }
+
+    #[test]
+    fn build_scope_filter_empty_adds_nothing() {
+        let (group, values, names) = DynamoDbAuditStore::build_scope_filter(&[]);
+        assert!(group.is_none());
+        assert!(values.is_empty());
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn build_scope_filter_single_pattern() {
+        let scope = vec!["acme".to_owned()];
+        let (group, values, names) = DynamoDbAuditStore::build_scope_filter(&scope);
+
+        // One OR-group with the exact + begins_with(prefix) predicate.
+        assert_eq!(
+            group.as_deref(),
+            Some("((#tenant = :scope0 OR begins_with(#tenant, :scope0_dot)))")
+        );
+        // Two bound values: the exact pattern and the dot-prefix.
+        assert_eq!(values.len(), 2);
+        assert_eq!(
+            values.get(":scope0"),
+            Some(&AttributeValue::S("acme".to_owned()))
+        );
+        assert_eq!(
+            values.get(":scope0_dot"),
+            Some(&AttributeValue::S("acme.".to_owned()))
+        );
+        // The aliased attribute name.
+        assert_eq!(names.get("#tenant"), Some(&"tenant".to_owned()));
+        assert_eq!(names.len(), 1);
+    }
+
+    #[test]
+    fn build_scope_filter_multiple_patterns_ored() {
+        let scope = vec!["acme".to_owned(), "globex".to_owned()];
+        let (group, values, names) = DynamoDbAuditStore::build_scope_filter(&scope);
+
+        assert_eq!(
+            group.as_deref(),
+            Some(
+                "((#tenant = :scope0 OR begins_with(#tenant, :scope0_dot)) \
+                 OR (#tenant = :scope1 OR begins_with(#tenant, :scope1_dot)))"
+            )
+        );
+        // Two patterns -> four bound values.
+        assert_eq!(values.len(), 4);
+        assert_eq!(
+            values.get(":scope1"),
+            Some(&AttributeValue::S("globex".to_owned()))
+        );
+        assert_eq!(
+            values.get(":scope1_dot"),
+            Some(&AttributeValue::S("globex.".to_owned()))
+        );
+        assert_eq!(names.len(), 1);
     }
 
     #[test]

--- a/crates/audit/elasticsearch/src/store.rs
+++ b/crates/audit/elasticsearch/src/store.rs
@@ -489,6 +489,26 @@ fn build_es_query(query: &AuditQuery) -> serde_json::Value {
         }));
     }
 
+    // Hierarchical tenant authorization scope (server-set). Empty scope is
+    // unrestricted; otherwise the record's tenant must be covered by ANY
+    // granted pattern `p` — either `tenant == p` or `tenant` is a dot
+    // descendant of `p` (prefix `p.`). `serde_json::json!` escapes the
+    // string values, so there is no DSL injection. ES `prefix` matches are
+    // literal (not LIKE), so we use the raw `format!("{p}.")` prefix.
+    if !query.tenant_scope.is_empty() {
+        let mut should: Vec<serde_json::Value> = Vec::with_capacity(query.tenant_scope.len() * 2);
+        for p in &query.tenant_scope {
+            should.push(serde_json::json!({ "term": { "tenant": p } }));
+            should.push(serde_json::json!({ "prefix": { "tenant": format!("{p}.") } }));
+        }
+        filter_clauses.push(serde_json::json!({
+            "bool": {
+                "should": should,
+                "minimum_should_match": 1
+            }
+        }));
+    }
+
     if must_clauses.is_empty() && filter_clauses.is_empty() {
         serde_json::json!({ "match_all": {} })
     } else {
@@ -498,5 +518,69 @@ fn build_es_query(query: &AuditQuery) -> serde_json::Value {
                 "filter": filter_clauses
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_es_query;
+    use acteon_audit::record::AuditQuery;
+
+    #[test]
+    fn tenant_scope_embeds_should_term_and_prefix_clauses() {
+        let query = AuditQuery {
+            tenant_scope: vec!["acme".to_owned(), "globex.eu".to_owned()],
+            ..Default::default()
+        };
+
+        let json = build_es_query(&query);
+        let filter = json["bool"]["filter"]
+            .as_array()
+            .expect("filter clauses present");
+
+        // Exactly one tenant-scope clause (the bool/should group).
+        let scope_clause = filter
+            .iter()
+            .find(|c| c.get("bool").is_some())
+            .expect("tenant-scope bool clause present");
+
+        assert_eq!(scope_clause["bool"]["minimum_should_match"], 1);
+
+        let should = scope_clause["bool"]["should"]
+            .as_array()
+            .expect("should array present");
+
+        // Two clauses per pattern: an exact term plus a dot-descendant prefix.
+        assert_eq!(should.len(), 4);
+        assert_eq!(
+            should[0],
+            serde_json::json!({ "term": { "tenant": "acme" } })
+        );
+        assert_eq!(
+            should[1],
+            serde_json::json!({ "prefix": { "tenant": "acme." } })
+        );
+        assert_eq!(
+            should[2],
+            serde_json::json!({ "term": { "tenant": "globex.eu" } })
+        );
+        assert_eq!(
+            should[3],
+            serde_json::json!({ "prefix": { "tenant": "globex.eu." } })
+        );
+    }
+
+    #[test]
+    fn empty_tenant_scope_adds_no_clause() {
+        let scoped = build_es_query(&AuditQuery {
+            tenant_scope: Vec::new(),
+            ..Default::default()
+        });
+
+        // Byte-for-byte identical to a fully-default (no-filter) query.
+        let baseline = build_es_query(&AuditQuery::default());
+        assert_eq!(scoped, baseline);
+        // And no `bool`/`should` group sneaks in — it's a bare match_all.
+        assert_eq!(scoped, serde_json::json!({ "match_all": {} }));
     }
 }

--- a/crates/audit/memory/src/store.rs
+++ b/crates/audit/memory/src/store.rs
@@ -86,6 +86,12 @@ impl AuditStore for MemoryAuditStore {
                 if !matches_filter(query.tenant.as_ref(), &rec.tenant) {
                     return None;
                 }
+                // Hierarchical tenant authorization scope (server-set). Empty
+                // scope is unrestricted; otherwise the record's tenant must be
+                // covered by one of the caller's granted patterns.
+                if !query.tenant_in_scope(&rec.tenant) {
+                    return None;
+                }
                 if !matches_filter(query.provider.as_ref(), &rec.provider) {
                     return None;
                 }
@@ -586,5 +592,74 @@ mod tests {
         let page = store.query(&q).await.unwrap();
         assert_eq!(page.total, Some(1));
         assert_eq!(page.records[0].id, "r2");
+    }
+
+    /// Seed one record per tenant and return the store.
+    async fn store_with_tenants(tenants: &[&str]) -> MemoryAuditStore {
+        let store = MemoryAuditStore::new();
+        for (i, t) in tenants.iter().enumerate() {
+            let mut r = make_record(&format!("r{i}"), &format!("a{i}"));
+            r.tenant = (*t).to_owned();
+            store.record(r).await.unwrap();
+        }
+        store
+    }
+
+    #[tokio::test]
+    async fn tenant_scope_returns_union_of_granted_subtrees() {
+        let store = store_with_tenants(&[
+            "acme",
+            "acme.prod",
+            "acme.prod.eu",
+            "acmecorp", // sibling — must NOT match `acme`
+            "globex",
+            "initech", // ungranted
+        ])
+        .await;
+
+        let page = store
+            .query(&AuditQuery {
+                tenant_scope: vec!["acme".to_owned(), "globex".to_owned()],
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let mut got: Vec<String> = page.records.iter().map(|r| r.tenant.clone()).collect();
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                "acme".to_owned(),
+                "acme.prod".to_owned(),
+                "acme.prod.eu".to_owned(),
+                "globex".to_owned(),
+            ],
+            "scope must return the acme + globex subtrees, excluding acmecorp and initech",
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_tenant_scope_is_unrestricted() {
+        let store = store_with_tenants(&["acme", "globex", "initech"]).await;
+        let page = store.query(&AuditQuery::default()).await.unwrap();
+        assert_eq!(page.records.len(), 3, "empty scope returns every tenant");
+    }
+
+    #[tokio::test]
+    async fn explicit_tenant_intersects_with_scope() {
+        // Defensive: when both an exact tenant and a scope are present they are
+        // ANDed (the server normally sets one or the other, never both).
+        let store = store_with_tenants(&["acme", "acme.prod"]).await;
+        let page = store
+            .query(&AuditQuery {
+                tenant: Some("acme.prod".to_owned()),
+                tenant_scope: vec!["acme".to_owned()],
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(page.records.len(), 1);
+        assert_eq!(page.records[0].tenant, "acme.prod");
     }
 }

--- a/crates/audit/postgres/src/analytics.rs
+++ b/crates/audit/postgres/src/analytics.rs
@@ -50,6 +50,24 @@ fn build_analytics_where(
         }
     }
 
+    // Tenant-scope OR-group: restrict to tenants covered hierarchically by any
+    // pattern in the scope. Empty scope adds nothing (preserves prior behavior).
+    if !query.tenant_scope.is_empty() {
+        let mut scope_terms = Vec::with_capacity(query.tenant_scope.len());
+        for p in &query.tenant_scope {
+            let exact_idx = idx;
+            binds.push(p.clone());
+            idx += 1;
+            let like_idx = idx;
+            binds.push(acteon_core::tenant_scope::like_descendants_pattern(p));
+            idx += 1;
+            scope_terms.push(format!(
+                "(tenant = ${exact_idx} OR tenant LIKE ${like_idx})"
+            ));
+        }
+        conditions.push(format!("({})", scope_terms.join(" OR ")));
+    }
+
     // Time range is always applied.
     conditions.push(format!("dispatched_at >= ${idx}"));
     let from_idx = idx;
@@ -327,6 +345,24 @@ impl AnalyticsStore for PostgresAnalyticsStore {
             idx += 1;
         }
 
+        // Tenant-scope OR-group: restrict to tenants covered hierarchically by
+        // any pattern in the scope. Empty scope adds nothing.
+        if !query.tenant_scope.is_empty() {
+            let mut scope_terms = Vec::with_capacity(query.tenant_scope.len());
+            for p in &query.tenant_scope {
+                let exact_idx = idx;
+                binds.push(p.clone());
+                idx += 1;
+                let like_idx = idx;
+                binds.push(acteon_core::tenant_scope::like_descendants_pattern(p));
+                idx += 1;
+                scope_terms.push(format!(
+                    "(tenant = ${exact_idx} OR tenant LIKE ${like_idx})"
+                ));
+            }
+            conditions.push(format!("({})", scope_terms.join(" OR ")));
+        }
+
         conditions.push(format!("dispatched_at >= ${idx}"));
         idx += 1;
         conditions.push(format!("dispatched_at <= ${idx}"));
@@ -364,5 +400,90 @@ impl AnalyticsStore for PostgresAnalyticsStore {
                 count: row.cnt as u64,
             })
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_query() -> AnalyticsQuery {
+        AnalyticsQuery {
+            metric: AnalyticsMetric::Volume,
+            namespace: None,
+            tenant: None,
+            provider: None,
+            action_type: None,
+            outcome: None,
+            interval: AnalyticsInterval::Daily,
+            from: None,
+            to: None,
+            group_by: None,
+            top_n: None,
+            tenant_scope: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn empty_scope_adds_no_tenant_scope_predicate() {
+        let now = Utc::now();
+        // With no string filters and an empty scope, the only conditions are
+        // the always-applied time range — unchanged from prior behavior.
+        let query = base_query();
+        let (clause, binds, next_idx) = build_analytics_where(&query, now, now);
+
+        assert_eq!(clause, "WHERE dispatched_at >= $1 AND dispatched_at <= $2");
+        assert!(binds.is_empty());
+        assert_eq!(next_idx, 3);
+    }
+
+    #[test]
+    fn non_empty_scope_produces_or_group() {
+        let now = Utc::now();
+        let mut query = base_query();
+        query.tenant_scope = vec!["acme".to_string(), "globex.eu".to_string()];
+
+        let (clause, binds, next_idx) = build_analytics_where(&query, now, now);
+
+        assert_eq!(
+            clause,
+            "WHERE ((tenant = $1 OR tenant LIKE $2) OR (tenant = $3 OR tenant LIKE $4)) \
+             AND dispatched_at >= $5 AND dispatched_at <= $6"
+        );
+        assert_eq!(
+            binds,
+            vec![
+                "acme".to_string(),
+                "acme.%".to_string(),
+                "globex.eu".to_string(),
+                "globex.eu.%".to_string(),
+            ]
+        );
+        assert_eq!(next_idx, 7);
+    }
+
+    #[test]
+    fn scope_anded_with_exact_tenant_filter() {
+        let now = Utc::now();
+        let mut query = base_query();
+        query.tenant = Some("acme.team".to_string());
+        query.tenant_scope = vec!["acme".to_string()];
+
+        let (clause, binds, next_idx) = build_analytics_where(&query, now, now);
+
+        assert_eq!(
+            clause,
+            "WHERE tenant = $1 AND ((tenant = $2 OR tenant LIKE $3)) \
+             AND dispatched_at >= $4 AND dispatched_at <= $5"
+        );
+        assert_eq!(
+            binds,
+            vec![
+                "acme.team".to_string(),
+                "acme".to_string(),
+                "acme.%".to_string(),
+            ]
+        );
+        assert_eq!(next_idx, 6);
     }
 }

--- a/crates/audit/postgres/src/store.rs
+++ b/crates/audit/postgres/src/store.rs
@@ -423,6 +423,24 @@ fn build_where_clause(query: &AuditQuery) -> (String, Vec<String>, Option<u32>, 
         }
     }
 
+    // Tenant-scope OR-group: restrict to tenants covered hierarchically by any
+    // pattern in the scope. Empty scope adds nothing (preserves prior behavior).
+    if !query.tenant_scope.is_empty() {
+        let mut scope_terms = Vec::with_capacity(query.tenant_scope.len());
+        for p in &query.tenant_scope {
+            let exact_idx = bind_idx;
+            binds.push(p.clone());
+            bind_idx += 1;
+            let like_idx = bind_idx;
+            binds.push(acteon_core::tenant_scope::like_descendants_pattern(p));
+            bind_idx += 1;
+            scope_terms.push(format!(
+                "(tenant = ${exact_idx} OR tenant LIKE ${like_idx})"
+            ));
+        }
+        conditions.push(format!("({})", scope_terms.join(" OR ")));
+    }
+
     let from_idx = if query.from.is_some() {
         conditions.push(format!("dispatched_at >= ${bind_idx}"));
         let idx = bind_idx;
@@ -528,5 +546,80 @@ impl From<AuditRow> for AuditRecord {
             kid: row.kid,
             canonical_hash: row.canonical_hash,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_scope_adds_no_tenant_scope_predicate() {
+        // A fully-empty query (no filters, empty scope) must produce exactly
+        // the same WHERE clause and binds as today — byte-for-byte unchanged.
+        let query = AuditQuery::default();
+        let (where_clause, binds, from_idx, to_idx, bind_idx) = build_where_clause(&query);
+
+        assert_eq!(where_clause, "");
+        assert!(binds.is_empty());
+        assert_eq!(from_idx, None);
+        assert_eq!(to_idx, None);
+        assert_eq!(bind_idx, 1);
+    }
+
+    #[test]
+    fn non_empty_scope_produces_or_group() {
+        let mut query = AuditQuery::default();
+        query.tenant_scope = vec!["acme".to_string(), "globex.eu".to_string()];
+
+        let (where_clause, binds, from_idx, to_idx, bind_idx) = build_where_clause(&query);
+
+        // One parenthesized OR-group, two terms (one per pattern).
+        assert_eq!(
+            where_clause,
+            "WHERE ((tenant = $1 OR tenant LIKE $2) OR (tenant = $3 OR tenant LIKE $4))"
+        );
+        // Two binds per pattern: exact value + descendant LIKE pattern.
+        assert_eq!(
+            binds,
+            vec![
+                "acme".to_string(),
+                "acme.%".to_string(),
+                "globex.eu".to_string(),
+                "globex.eu.%".to_string(),
+            ]
+        );
+        assert_eq!(from_idx, None);
+        assert_eq!(to_idx, None);
+        assert_eq!(bind_idx, 5);
+    }
+
+    #[test]
+    fn scope_anded_with_exact_tenant_and_time_range() {
+        let now = chrono::Utc::now();
+        let mut query = AuditQuery::default();
+        query.tenant = Some("acme.team".to_string());
+        query.tenant_scope = vec!["acme".to_string()];
+        query.from = Some(now);
+        query.to = Some(now);
+
+        let (where_clause, binds, from_idx, to_idx, bind_idx) = build_where_clause(&query);
+
+        assert_eq!(
+            where_clause,
+            "WHERE tenant = $1 AND ((tenant = $2 OR tenant LIKE $3)) \
+             AND dispatched_at >= $4 AND dispatched_at <= $5"
+        );
+        assert_eq!(
+            binds,
+            vec![
+                "acme.team".to_string(),
+                "acme".to_string(),
+                "acme.%".to_string(),
+            ]
+        );
+        assert_eq!(from_idx, Some(4));
+        assert_eq!(to_idx, Some(5));
+        assert_eq!(bind_idx, 6);
     }
 }

--- a/crates/cli/src/commands/rules.rs
+++ b/crates/cli/src/commands/rules.rs
@@ -196,6 +196,8 @@ async fn run_coverage(
         tenant: tenant.clone(),
         from: effective_from,
         to: effective_to,
+        // Authorization scope is applied server-side from grants.
+        ..Default::default()
     };
 
     let report = ops.rules_coverage(&query).await?;

--- a/crates/core/src/analytics.rs
+++ b/crates/core/src/analytics.rs
@@ -69,6 +69,14 @@ pub struct AnalyticsQuery {
     /// Number of top entries to return for `TopActionTypes` (default: 10).
     #[serde(default)]
     pub top_n: Option<usize>,
+    /// Server-set tenant authorization scope (hierarchical grant patterns the
+    /// caller may read). Backends restrict aggregation to tenants covered by
+    /// one of these; empty = unrestricted. See [`crate::tenant_scope`].
+    ///
+    /// `#[serde(skip)]` so clients can never set it — it is populated by the
+    /// server from the caller's grants.
+    #[serde(skip)]
+    pub tenant_scope: Vec<String>,
 }
 
 fn default_interval() -> AnalyticsInterval {

--- a/crates/core/src/coverage.rs
+++ b/crates/core/src/coverage.rs
@@ -26,6 +26,15 @@ pub struct CoverageQuery {
     /// End of the time range (inclusive). Defaults to now.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub to: Option<DateTime<Utc>>,
+    /// Server-set tenant authorization scope (hierarchical grant patterns the
+    /// caller may read). The coverage aggregation is restricted to tenants
+    /// covered by one of these; empty = unrestricted. See
+    /// [`crate::tenant_scope`].
+    ///
+    /// `#[serde(skip)]` so clients can never set it — it is populated by the
+    /// server from the caller's grants.
+    #[serde(skip)]
+    pub tenant_scope: Vec<String>,
 }
 
 /// A single aggregated row emitted by an audit backend for rule coverage.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod state_machine;
 pub mod stream;
 pub mod task_push;
 pub mod template;
+pub mod tenant_scope;
 pub mod time_interval;
 pub mod types;
 

--- a/crates/core/src/tenant_scope.rs
+++ b/crates/core/src/tenant_scope.rs
@@ -1,0 +1,109 @@
+//! Hierarchical tenant authorization scope, shared across audit/analytics
+//! backends.
+//!
+//! A *scope* is the set of tenant grant patterns a caller is authorized to read
+//! (e.g. `["acme", "globex"]`). It is set by the server from the caller's grants
+//! — never from client input — and threaded into queries so each backend
+//! restricts results to the caller's authorized tenants.
+//!
+//! Matching is hierarchical and segment-aware, mirroring grant semantics: a
+//! pattern `acme` covers `acme` and any descendant (`acme.us-east`,
+//! `acme.prod.eu`, …) but NOT the sibling `acmecorp`.
+//!
+//! An empty scope means "unrestricted" (a wildcard-tenant caller). A scope must
+//! never contain `"*"` — represent wildcard access with an empty scope instead.
+
+/// Returns `true` if `tenant` is within the authorization `scope`.
+///
+/// An empty `scope` is unrestricted and matches every tenant. Otherwise the
+/// tenant must equal, or be a hierarchical descendant of, at least one pattern.
+#[must_use]
+pub fn tenant_in_scope(scope: &[String], tenant: &str) -> bool {
+    scope.is_empty() || scope.iter().any(|p| tenant_covered_by(p, tenant))
+}
+
+/// Returns `true` if grant pattern `p` covers `tenant` hierarchically: an exact
+/// match, or `tenant` is a dot-delimited descendant of `p`.
+///
+/// Segment-aware: `acme` covers `acme` and `acme.prod` but not `acmecorp`. This
+/// mirrors the server's grant `tenant_matches` semantics (kept in sync).
+#[must_use]
+pub fn tenant_covered_by(p: &str, tenant: &str) -> bool {
+    if p == tenant {
+        return true;
+    }
+    // Descendant: `tenant` is `p` followed by a `.` separator and more.
+    tenant.len() > p.len() + 1 && tenant.as_bytes()[p.len()] == b'.' && tenant.starts_with(p)
+}
+
+/// Escape a literal string for safe use inside a SQL `LIKE` pattern, escaping
+/// the metacharacters `\`, `%`, and `_` with `\` (the default `LIKE` escape
+/// character for both `PostgreSQL` and `ClickHouse`).
+#[must_use]
+pub fn escape_like(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    for c in s.chars() {
+        if matches!(c, '\\' | '%' | '_') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// Build the `LIKE` pattern matching every hierarchical descendant of
+/// `pattern` (i.e. `pattern.<anything>`), with the literal portion escaped.
+/// Pair with an exact `tenant = pattern` check for full subtree coverage.
+#[must_use]
+pub fn like_descendants_pattern(pattern: &str) -> String {
+    format!("{}.%", escape_like(pattern))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(items: &[&str]) -> Vec<String> {
+        items.iter().map(|x| (*x).to_owned()).collect()
+    }
+
+    #[test]
+    fn empty_scope_is_unrestricted() {
+        assert!(tenant_in_scope(&[], "anything"));
+        assert!(tenant_in_scope(&[], "acme.prod"));
+    }
+
+    #[test]
+    fn exact_and_descendant_match() {
+        let scope = s(&["acme"]);
+        assert!(tenant_in_scope(&scope, "acme"));
+        assert!(tenant_in_scope(&scope, "acme.prod"));
+        assert!(tenant_in_scope(&scope, "acme.prod.eu"));
+    }
+
+    #[test]
+    fn sibling_does_not_match() {
+        let scope = s(&["acme"]);
+        assert!(!tenant_in_scope(&scope, "acmecorp"));
+        assert!(!tenant_in_scope(&scope, "acme-corp"));
+        assert!(!tenant_in_scope(&scope, "globex"));
+    }
+
+    #[test]
+    fn union_across_patterns() {
+        let scope = s(&["acme", "globex"]);
+        assert!(tenant_in_scope(&scope, "acme.us-east"));
+        assert!(tenant_in_scope(&scope, "globex"));
+        assert!(tenant_in_scope(&scope, "globex.eu"));
+        assert!(!tenant_in_scope(&scope, "initech"));
+    }
+
+    #[test]
+    fn like_escaping() {
+        assert_eq!(escape_like("ac_me"), "ac\\_me");
+        assert_eq!(escape_like("ac%me"), "ac\\%me");
+        assert_eq!(escape_like("a\\b"), "a\\\\b");
+        assert_eq!(like_descendants_pattern("acme"), "acme.%");
+        assert_eq!(like_descendants_pattern("ac_me"), "ac\\_me.%");
+    }
+}

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -1645,6 +1645,9 @@ impl ActeonMcpServer {
             to,
             group_by: p.group_by,
             top_n: p.top_n,
+            // Authorization scope is applied server-side from grants; clients
+            // never set it (the field is `#[serde(skip)]`).
+            tenant_scope: Vec::new(),
         };
 
         match self.ops.query_analytics(query).await {

--- a/crates/server/src/api/analytics.rs
+++ b/crates/server/src/api/analytics.rs
@@ -62,7 +62,6 @@ pub struct AnalyticsParams {
     ),
     responses(
         (status = 200, description = "Analytics results", body = acteon_core::AnalyticsResponse),
-        (status = 400, description = "Caller is scoped to multiple tenants and gave no `tenant` filter", body = ErrorResponse),
         (status = 403, description = "Requested tenant is not covered by the caller's grants", body = ErrorResponse),
         (status = 404, description = "Analytics not available", body = ErrorResponse)
     )
@@ -81,11 +80,11 @@ pub async fn query_analytics(
         );
     };
 
-    // Enforce tenant access. Analytics aggregates server-side and cannot
-    // post-filter, so a multi-tenant caller who names no tenant must be
-    // rejected rather than aggregating across every granted tenant.
-    let tenant = match identity.resolve_tenant_filter(params.tenant.as_deref()) {
-        Ok(tenant) => tenant,
+    // Enforce tenant access. A named tenant is pinned exactly; an unnamed
+    // scoped caller gets a hierarchical authorization scope so analytics
+    // aggregates across the union of their granted subtrees.
+    let resolved = match identity.resolve_tenant_query_scope(params.tenant.as_deref()) {
+        Ok(resolved) => resolved,
         Err(TenantFilterError::NotGranted(requested)) => {
             return (
                 StatusCode::FORBIDDEN,
@@ -94,22 +93,12 @@ pub async fn query_analytics(
                 })),
             );
         }
-        Err(TenantFilterError::Ambiguous) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!(ErrorResponse {
-                    error:
-                        "caller is scoped to multiple tenants; specify an explicit ?tenant= filter"
-                            .into(),
-                })),
-            );
-        }
     };
 
     let query = AnalyticsQuery {
         metric: params.metric,
         namespace: params.namespace,
-        tenant,
+        tenant: resolved.tenant,
         provider: params.provider,
         action_type: params.action_type,
         outcome: params.outcome,
@@ -118,6 +107,7 @@ pub async fn query_analytics(
         to: params.to,
         group_by: params.group_by,
         top_n: params.top_n,
+        tenant_scope: resolved.scope,
     };
 
     match analytics.query_analytics(&query).await {

--- a/crates/server/src/api/audit.rs
+++ b/crates/server/src/api/audit.rs
@@ -36,7 +36,6 @@ use super::schemas::ErrorResponse;
     ),
     responses(
         (status = 200, description = "Audit records matching query", body = acteon_audit::AuditPage),
-        (status = 400, description = "Caller is scoped to multiple tenants and gave no `tenant` filter", body = ErrorResponse),
         (status = 403, description = "Requested tenant is not covered by the caller's grants", body = ErrorResponse),
         (status = 404, description = "Audit not enabled", body = ErrorResponse)
     )
@@ -55,27 +54,20 @@ pub async fn query_audit(
         );
     };
 
-    // Restrict the query to tenants the caller is granted. The audit store
-    // can only filter by a single tenant, so a multi-tenant caller who names
-    // none must be rejected — running unfiltered would return every tenant's
-    // records (see `resolve_tenant_filter`).
-    match identity.resolve_tenant_filter(query.tenant.as_deref()) {
-        Ok(tenant) => query.tenant = tenant,
+    // Restrict the query to tenants the caller is granted. A named tenant is
+    // pinned exactly; an unnamed scoped caller gets a hierarchical authorization
+    // scope so the backend returns the union of their granted subtrees. The
+    // scope rides in the query struct (server-set, never client-settable).
+    match identity.resolve_tenant_query_scope(query.tenant.as_deref()) {
+        Ok(resolved) => {
+            query.tenant = resolved.tenant;
+            query.tenant_scope = resolved.scope;
+        }
         Err(TenantFilterError::NotGranted(requested)) => {
             return (
                 StatusCode::FORBIDDEN,
                 Json(serde_json::json!(ErrorResponse {
                     error: format!("no grant covers tenant={requested}"),
-                })),
-            );
-        }
-        Err(TenantFilterError::Ambiguous) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!(ErrorResponse {
-                    error:
-                        "caller is scoped to multiple tenants; specify an explicit ?tenant= filter"
-                            .into(),
                 })),
             );
         }

--- a/crates/server/src/api/rules.rs
+++ b/crates/server/src/api/rules.rs
@@ -441,7 +441,6 @@ pub struct CoverageParams {
     params(CoverageParams),
     responses(
         (status = 200, description = "Coverage report", body = CoverageReport),
-        (status = 400, description = "Caller is scoped to multiple tenants and gave no `tenant` filter", body = ErrorResponse),
         (status = 404, description = "Analytics not available", body = ErrorResponse),
         (status = 403, description = "Tenant access denied", body = ErrorResponse)
     )
@@ -460,11 +459,11 @@ pub async fn rule_coverage(
         );
     };
 
-    // Enforce tenant access. Coverage aggregates server-side over the audit
-    // store and cannot post-filter, so a multi-tenant caller who names no
-    // tenant must be rejected rather than aggregating across every tenant.
-    let tenant = match identity.resolve_tenant_filter(params.tenant.as_deref()) {
-        Ok(tenant) => tenant,
+    // Enforce tenant access. A named tenant is pinned exactly; an unnamed
+    // scoped caller gets a hierarchical authorization scope so coverage
+    // aggregates across the union of their granted subtrees.
+    let resolved = match identity.resolve_tenant_query_scope(params.tenant.as_deref()) {
+        Ok(resolved) => resolved,
         Err(TenantFilterError::NotGranted(requested)) => {
             return (
                 StatusCode::FORBIDDEN,
@@ -473,23 +472,14 @@ pub async fn rule_coverage(
                 })),
             );
         }
-        Err(TenantFilterError::Ambiguous) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!(ErrorResponse {
-                    error:
-                        "caller is scoped to multiple tenants; specify an explicit ?tenant= filter"
-                            .into(),
-                })),
-            );
-        }
     };
 
     let query = CoverageQuery {
         namespace: params.namespace,
-        tenant,
+        tenant: resolved.tenant,
         from: params.from,
         to: params.to,
+        tenant_scope: resolved.scope,
     };
 
     let aggregates = match analytics.rule_coverage(&query).await {

--- a/crates/server/src/auth/identity.rs
+++ b/crates/server/src/auth/identity.rs
@@ -183,69 +183,65 @@ impl CallerIdentity {
         Ok(found)
     }
 
-    /// Resolve the tenant equality-filter to apply for a query endpoint
-    /// whose backend can only filter by **one** tenant value at a time
-    /// (audit, analytics, rule-coverage). These endpoints delegate filtering
-    /// to the store/aggregator, so an unscoped query returns records from
-    /// *every* tenant — they must never run unfiltered for a caller who is
-    /// restricted to specific tenants.
+    /// Resolve the tenant filter **and** authorization scope to apply for a
+    /// query endpoint whose backend delegates filtering to the store/aggregator
+    /// (audit, analytics, rule-coverage). Such a query must never run unscoped
+    /// for a caller restricted to specific tenants, or it would return records
+    /// from every tenant.
     ///
-    /// Returns:
-    /// - `Ok(None)` — caller has wildcard tenant access and named no tenant;
-    ///   run the query unfiltered.
-    /// - `Ok(Some(tenant))` — apply `tenant == <tenant>`. Either the tenant
-    ///   the caller explicitly requested (verified covered by a grant,
-    ///   *hierarchically*) or, for a caller scoped to exactly one tenant,
-    ///   that tenant.
-    /// - `Err(TenantFilterError::NotGranted)` — the requested tenant is not
-    ///   covered by any grant; map to `403 Forbidden`.
-    /// - `Err(TenantFilterError::Ambiguous)` — the caller is scoped to more
-    ///   than one tenant and named none; map to `400 Bad Request` and
-    ///   require an explicit `?tenant=` filter. Running unfiltered here is
-    ///   the cross-tenant data leak this helper exists to prevent.
+    /// The returned [`TenantQueryScope`] carries two complementary pieces:
+    /// - `tenant`: an explicit single-tenant filter the caller requested
+    ///   (validated to be within their grants), or `None`.
+    /// - `scope`: the caller's hierarchical grant patterns. The backend
+    ///   restricts results to tenants covered by one of these (`p` covers `p`
+    ///   and `p.*`). Empty = unrestricted.
     ///
-    /// Authorization for a *named* tenant is hierarchical: a grant on `acme`
-    /// covers `acme`, `acme.prod`, `acme.us-east`, … (see [`tenant_matches`]),
-    /// so a regional admin can target a sub-tenant by naming it explicitly.
-    ///
-    /// Limitation: the store filter applied to the returned value is exact
-    /// equality, so naming `acme` matches only exactly-`acme` records, not
-    /// `acme.*`, and a caller scoped to multiple tenants cannot aggregate
-    /// across them in one call (hence the `Ambiguous` 400). Returning a whole
-    /// hierarchical subtree, or a union across several granted tenants, in a
-    /// single query requires pushing a prefix/`IN` predicate down into each
-    /// audit/analytics backend — tracked as follow-up work; this helper is
-    /// the fail-closed authorization boundary in the meantime.
+    /// Behavior:
+    /// - Caller names a tenant → it must be covered by a grant
+    ///   (hierarchically, via [`tenant_matches`], so a grant on `acme`
+    ///   authorizes `acme.prod`). The exact filter fully bounds the query, so
+    ///   `scope` is left empty — this keeps key-addressed backends (`DynamoDB`)
+    ///   on their efficient exact-match path. `Err(NotGranted)` (→ 403) if not
+    ///   covered.
+    /// - Caller names nothing, wildcard tenant access → unrestricted
+    ///   (`tenant = None`, empty `scope`).
+    /// - Caller names nothing, scoped → `tenant = None` with `scope` set to the
+    ///   caller's grant patterns. The backend returns the **union of the
+    ///   granted subtrees** — multi-tenant callers aggregate across their
+    ///   tenants without having to name one.
     ///
     /// [`tenant_matches`]: super::config::tenant_matches
-    pub fn resolve_tenant_filter(
+    pub fn resolve_tenant_query_scope(
         &self,
         requested: Option<&str>,
-    ) -> Result<Option<String>, TenantFilterError> {
+    ) -> Result<TenantQueryScope, TenantFilterError> {
         match requested {
-            // Scoped caller naming a tenant: a grant must cover it
-            // hierarchically. `tenant_matches` also returns true for a `*`
-            // grant, so wildcard callers fall through here as authorized.
+            // Named tenant: a grant must cover it hierarchically. `tenant_matches`
+            // also returns true for a `*` grant, so wildcard callers are
+            // authorized here. The exact equality filter fully bounds the query.
             Some(requested) => {
                 if self
                     .grants
                     .iter()
                     .any(|g| super::config::tenant_matches(&g.tenants, requested))
                 {
-                    Ok(Some(requested.to_owned()))
+                    Ok(TenantQueryScope {
+                        tenant: Some(requested.to_owned()),
+                        scope: Vec::new(),
+                    })
                 } else {
                     Err(TenantFilterError::NotGranted(requested.to_owned()))
                 }
             }
-            // No tenant named: wildcard callers run unfiltered; a caller
-            // scoped to exactly one tenant gets it injected; a multi-tenant
-            // caller is ambiguous and must name one.
+            // No tenant named: wildcard callers run unrestricted; a scoped
+            // caller's grant patterns become the authorization scope so the
+            // backend returns the union of their granted subtrees.
             None => match self.allowed_tenants() {
-                None => Ok(None),
-                Some(allowed) => match allowed.as_slice() {
-                    [only] => Ok(Some((*only).to_owned())),
-                    _ => Err(TenantFilterError::Ambiguous),
-                },
+                None => Ok(TenantQueryScope::default()),
+                Some(allowed) => Ok(TenantQueryScope {
+                    tenant: None,
+                    scope: allowed.into_iter().map(str::to_owned).collect(),
+                }),
             },
         }
     }
@@ -264,21 +260,26 @@ pub enum BusAgentIdResolutionError {
     ConflictingGrants { first: String, second: String },
 }
 
-/// Outcome of [`CallerIdentity::resolve_tenant_filter`] that the caller
-/// must surface as an HTTP error instead of running the query.
+/// The tenant filter and authorization scope resolved by
+/// [`CallerIdentity::resolve_tenant_query_scope`] for a query endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TenantQueryScope {
+    /// Explicit single-tenant filter the caller requested, validated to be
+    /// within their grants. `None` = no explicit narrowing.
+    pub tenant: Option<String>,
+    /// Hierarchical grant patterns bounding which tenants the caller may read.
+    /// Empty = unrestricted (wildcard caller, or an explicit in-grant `tenant`
+    /// already bounds the query). Fed into the backend query's `tenant_scope`.
+    pub scope: Vec<String>,
+}
+
+/// Error returned by [`CallerIdentity::resolve_tenant_query_scope`] that the
+/// caller must surface as an HTTP error instead of running the query.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TenantFilterError {
     /// The caller requested a tenant not covered by any of their grants.
     /// Map to `403 Forbidden`.
     NotGranted(String),
-    /// The caller is scoped to multiple tenants and did not name one. The
-    /// endpoint's backend can only filter by a single tenant, so running
-    /// unfiltered would return records from every granted tenant (or, for
-    /// an unscoped store scan, all tenants). Map to `400 Bad Request` and
-    /// require an explicit `?tenant=`. Deliberately carries no payload — the
-    /// caller's tenant set is not echoed back, to avoid disclosing tenant
-    /// topology to a holder of a single key.
-    Ambiguous,
 }
 
 #[cfg(test)]
@@ -470,91 +471,98 @@ mod tests {
         );
     }
 
-    // ---- resolve_tenant_filter -------------------------------------------
+    // ---- resolve_tenant_query_scope --------------------------------------
+
+    fn scope(tenant: Option<&str>, patterns: &[&str]) -> TenantQueryScope {
+        TenantQueryScope {
+            tenant: tenant.map(str::to_owned),
+            scope: patterns.iter().map(|s| (*s).to_owned()).collect(),
+        }
+    }
 
     #[test]
-    fn tenant_filter_wildcard_caller_runs_unfiltered() {
+    fn tenant_scope_wildcard_caller_is_unrestricted() {
         let id = identity_with(vec![grant(&["*"], &["*"], &["*"], &["*"])]);
-        // No tenant named: unfiltered (admin sees all).
-        assert_eq!(id.resolve_tenant_filter(None), Ok(None));
-        // Named tenant: honored without a grant check.
+        // No tenant named: unrestricted (no filter, empty scope → sees all).
+        assert_eq!(id.resolve_tenant_query_scope(None), Ok(scope(None, &[])));
+        // Named tenant: honored as an exact filter, no extra scope.
         assert_eq!(
-            id.resolve_tenant_filter(Some("acme")),
-            Ok(Some("acme".to_owned())),
+            id.resolve_tenant_query_scope(Some("acme")),
+            Ok(scope(Some("acme"), &[])),
         );
     }
 
     #[test]
-    fn tenant_filter_single_tenant_caller_is_injected() {
+    fn tenant_scope_single_tenant_caller_gets_subtree_scope() {
         let id = identity_with(vec![grant(&["acme"], &["*"], &["*"], &["*"])]);
-        // No tenant named: inject the only allowed tenant.
-        assert_eq!(id.resolve_tenant_filter(None), Ok(Some("acme".to_owned())),);
-        // Naming the granted tenant is fine.
+        // No tenant named: scope to the granted pattern so the backend returns
+        // the whole `acme` subtree (acme, acme.prod, …), not just exact `acme`.
         assert_eq!(
-            id.resolve_tenant_filter(Some("acme")),
-            Ok(Some("acme".to_owned())),
+            id.resolve_tenant_query_scope(None),
+            Ok(scope(None, &["acme"])),
+        );
+        // Naming the granted tenant pins it exactly (no extra scope needed).
+        assert_eq!(
+            id.resolve_tenant_query_scope(Some("acme")),
+            Ok(scope(Some("acme"), &[])),
         );
     }
 
     #[test]
-    fn tenant_filter_rejects_uncovered_tenant() {
+    fn tenant_scope_rejects_uncovered_named_tenant() {
         let id = identity_with(vec![grant(&["acme"], &["*"], &["*"], &["*"])]);
         assert_eq!(
-            id.resolve_tenant_filter(Some("globex")),
+            id.resolve_tenant_query_scope(Some("globex")),
             Err(TenantFilterError::NotGranted("globex".to_owned())),
         );
     }
 
     #[test]
-    fn tenant_filter_allows_named_hierarchical_subtenant() {
-        // A grant on `acme` authorizes targeting a sub-tenant by name (a
-        // regional admin querying `?tenant=acme.prod`), matching the
-        // hierarchical model `is_authorized` already uses.
+    fn tenant_scope_allows_named_hierarchical_subtenant() {
+        // A grant on `acme` authorizes naming a sub-tenant (a regional admin
+        // querying `?tenant=acme.prod`), matching the hierarchical model.
         let id = identity_with(vec![grant(&["acme"], &["*"], &["*"], &["*"])]);
         assert_eq!(
-            id.resolve_tenant_filter(Some("acme.prod")),
-            Ok(Some("acme.prod".to_owned())),
-        );
-        assert_eq!(
-            id.resolve_tenant_filter(Some("acme.us-east")),
-            Ok(Some("acme.us-east".to_owned())),
+            id.resolve_tenant_query_scope(Some("acme.prod")),
+            Ok(scope(Some("acme.prod"), &[])),
         );
         // Segment boundary: `acme` must NOT cover the sibling `acmecorp`.
         assert_eq!(
-            id.resolve_tenant_filter(Some("acmecorp")),
+            id.resolve_tenant_query_scope(Some("acmecorp")),
             Err(TenantFilterError::NotGranted("acmecorp".to_owned())),
         );
     }
 
     #[test]
-    fn tenant_filter_multi_tenant_caller_without_filter_is_ambiguous() {
-        // The cross-tenant leak this guard prevents: a caller scoped to
-        // two tenants who names none must NOT run an unfiltered query. The
-        // error carries no payload so the tenant set is not disclosed.
+    fn tenant_scope_multi_tenant_caller_without_filter_unions_grants() {
+        // The former `Ambiguous` 400 case: a caller scoped to two tenants who
+        // names none now aggregates across both granted subtrees via `scope`.
         let id = identity_with(vec![
             grant(&["acme"], &["*"], &["*"], &["*"]),
             grant(&["globex"], &["*"], &["*"], &["*"]),
         ]);
-        assert_eq!(
-            id.resolve_tenant_filter(None),
-            Err(TenantFilterError::Ambiguous),
-        );
+        let resolved = id
+            .resolve_tenant_query_scope(None)
+            .expect("multi-tenant caller is no longer rejected");
+        assert_eq!(resolved.tenant, None);
+        assert!(resolved.scope.contains(&"acme".to_owned()));
+        assert!(resolved.scope.contains(&"globex".to_owned()));
     }
 
     #[test]
-    fn tenant_filter_multi_tenant_caller_naming_a_tenant_is_scoped() {
+    fn tenant_scope_multi_tenant_caller_naming_a_tenant_pins_it() {
         let id = identity_with(vec![
             grant(&["acme"], &["*"], &["*"], &["*"]),
             grant(&["globex"], &["*"], &["*"], &["*"]),
         ]);
-        // Naming a covered tenant scopes the query to it.
+        // Naming a covered tenant pins the query to it (exact filter).
         assert_eq!(
-            id.resolve_tenant_filter(Some("globex")),
-            Ok(Some("globex".to_owned())),
+            id.resolve_tenant_query_scope(Some("globex")),
+            Ok(scope(Some("globex"), &[])),
         );
         // Naming an uncovered tenant is still forbidden.
         assert_eq!(
-            id.resolve_tenant_filter(Some("initech")),
+            id.resolve_tenant_query_scope(Some("initech")),
             Err(TenantFilterError::NotGranted("initech".to_owned())),
         );
     }

--- a/crates/simulation/examples/analytics_simulation.rs
+++ b/crates/simulation/examples/analytics_simulation.rs
@@ -171,6 +171,7 @@ async fn main() {
             to: None,
             group_by: None,
             top_n: None,
+            tenant_scope: Vec::new(),
         })
         .await
         .unwrap();
@@ -190,6 +191,7 @@ async fn main() {
             to: None,
             group_by: Some("outcome".to_string()),
             top_n: None,
+            tenant_scope: Vec::new(),
         })
         .await
         .unwrap();
@@ -209,6 +211,7 @@ async fn main() {
             to: None,
             group_by: None,
             top_n: Some(5),
+            tenant_scope: Vec::new(),
         })
         .await
         .unwrap();
@@ -228,6 +231,7 @@ async fn main() {
             to: None,
             group_by: None,
             top_n: None,
+            tenant_scope: Vec::new(),
         })
         .await
         .unwrap();
@@ -247,6 +251,7 @@ async fn main() {
             to: Some(now),
             group_by: None,
             top_n: None,
+            tenant_scope: Vec::new(),
         })
         .await
         .unwrap();
@@ -266,6 +271,7 @@ async fn main() {
             to: None,
             group_by: Some("provider".to_string()),
             top_n: None,
+            tenant_scope: Vec::new(),
         })
         .await
         .unwrap();

--- a/crates/simulation/examples/rule_coverage_simulation.rs
+++ b/crates/simulation/examples/rule_coverage_simulation.rs
@@ -218,6 +218,7 @@ async fn main() {
         tenant: Some("acme".to_string()),
         from: None, // default: last 7 days
         to: None,
+        ..Default::default()
     };
     let aggregates = analytics.rule_coverage(&query).await.unwrap();
 

--- a/docs/book/backends/dynamodb-audit.md
+++ b/docs/book/backends/dynamodb-audit.md
@@ -49,6 +49,19 @@ The `ns_tenant` attribute is a composite key in the format `"{namespace}#{tenant
 
 All GSIs use `ALL` projection for flexibility.
 
+> ⚠️ **Performance: hierarchical/multi-tenant reads trigger a table Scan.**
+> Because `ns_tenant` is an exact-match partition key, it cannot express a
+> hierarchical or multi-tenant authorization scope (e.g. a caller granted
+> `acme` reading the whole `acme.*` subtree, or a caller scoped to several
+> tenants). When such a caller queries `GET /v1/audit` **without** naming an
+> exact `?tenant=`, the backend falls back to a DynamoDB **`Scan`** with a
+> `begins_with(tenant, …)` filter — which reads the whole table and is far
+> more expensive than the GSI key path. To stay on the efficient path,
+> scoped callers should pass an explicit `?tenant=` (an exact, in-grant
+> tenant), or use the ClickHouse/PostgreSQL audit backends — both do
+> hierarchical scope matching as an indexed prefix range. See
+> [API Key Scoping](../features/api-key-scoping.md#tenant-scoping-of-read-queries).
+
 ## Hash Chain Support
 
 DynamoDB supports hash chain integrity for [SOC2/HIPAA compliance mode](../features/compliance-mode.md). When `hash_chain = true`:

--- a/docs/book/features/api-key-scoping.md
+++ b/docs/book/features/api-key-scoping.md
@@ -227,11 +227,32 @@ or reads scoped data:
 |----------|----------------|
 | `POST /v1/dispatch` | Each action against the full `(tenant, namespace, provider, action_type)` tuple |
 | `POST /v1/dispatch/batch` | Every action in the batch; **one failure rejects the whole batch** |
+| `GET /v1/audit` | Restricted to the caller's tenant scope (see below) |
 | `GET /v1/audit/{id}` | The audit record's tenant/namespace/provider/action_type |
 | `POST /v1/audit/{id}/replay` | Same as dispatch |
 | `POST /v1/audit/replay` | Each record individually; out-of-scope records are skipped |
-| `GET /v1/analytics` | Tenant filter auto-injected for single-tenant callers |
-| `GET /v1/rules/coverage` | Tenant filter auto-injected for single-tenant callers |
+| `GET /v1/analytics` | Restricted to the caller's tenant scope (see below) |
+| `GET /v1/rules/coverage` | Restricted to the caller's tenant scope (see below) |
+
+### Tenant scoping of read queries
+
+`GET /v1/audit`, `GET /v1/analytics`, and `GET /v1/rules/coverage` delegate
+filtering to the audit/analytics backend, so the server constrains every
+query to the caller's authorized tenants — hierarchically, matching grant
+semantics:
+
+- **Wildcard caller** (`tenants = ["*"]`) — unrestricted; an explicit
+  `?tenant=` is honored as-is.
+- **Caller names a tenant** (`?tenant=acme.us-east`) — allowed only if a grant
+  covers it (a grant on `acme` covers `acme.us-east`); the query is pinned to
+  that exact tenant. A tenant outside every grant returns **403**.
+- **Scoped caller, no `?tenant=`** — the query returns the **union of the
+  caller's granted subtrees**. A grant on `acme` returns `acme` and every
+  `acme.*` record; grants on `acme` + `globex` aggregate across both. No
+  tenant needs to be named, and no records outside the grants are ever
+  returned.
+
+This boundary is server-set and cannot be influenced by client input.
 
 Role-based permissions (admin / operator / viewer) are enforced separately
 and orthogonally — a viewer cannot dispatch even with a matching grant, and

--- a/docs/book/reference/roadmap.md
+++ b/docs/book/reference/roadmap.md
@@ -13,6 +13,13 @@ Planned features and enhancements for Acteon, ordered by estimated value/effort 
 
 ## Medium Effort
 
+### DynamoDB Hierarchical Tenant Index
+
+Hierarchical/multi-tenant audit reads currently fall back to a table `Scan` on the DynamoDB backend, because the `ns_tenant` composite partition key only supports exact match (see [DynamoDB Audit Backend](../backends/dynamodb-audit.md)). Add a sparse GSI keyed on `namespace` (PK) + `tenant` (SK) so a scoped read becomes a `begins_with(tenant, "acme.")` **Query** (indexed range) instead of a full Scan. Requires a write-time projection of the new key attributes and a one-time backfill. Only worth doing if users run scoped multi-tenant audit reads at volume on DynamoDB (ClickHouse/Postgres already handle this as an indexed prefix range).
+
+**Crates:** `acteon-audit-dynamodb`
+**Complexity:** Medium (~600 LOC + backfill/migration)
+
 ### Cursor-Based Audit Pagination
 
 `AuditQuery` currently uses offset-based pagination exclusively. This is efficient for Postgres/ClickHouse because rule coverage aggregation uses native `GROUP BY` and bypasses paging, but non-SQL audit backends (Memory, Elasticsearch, DynamoDB) fall through to `InMemoryAnalytics`, which pages with offsets internally and hits the classic linear-degradation anti-pattern on large scans.


### PR DESCRIPTION
Follow-up to #199 (the cross-tenant leak fix). #199 stopped the leak by rejecting a multi-tenant scoped caller who named no `?tenant=` with **400 Ambiguous**, and kept results at exact-tenant equality. As called out in that PR's review, the *correct* model is to push tenant authorization into the query layer so the read endpoints honor Acteon's **hierarchical, multi-tenant grant model**. This PR does that and removes the 400.

## Behavior change

| Caller | `?tenant=` | Before (#199) | Now |
|---|---|---|---|
| grant `acme` | — | only exactly-`acme` records | **whole `acme` subtree** (`acme`, `acme.prod`, `acme.us-east`, …) |
| grant `acme` + `globex` | — | **400** | **union of both subtrees** |
| grant `acme` | `acme.prod` | exact `acme.prod` | exact `acme.prod` (unchanged) |
| grant `acme` | `globex` | 403 | 403 (unchanged) |
| wildcard | any/none | unrestricted | unrestricted (unchanged) |

Endpoints: `GET /v1/audit`, `GET /v1/analytics`, `GET /v1/rules/coverage`.

## Design — scope rides *inside* the query structs

No trait signature changes, **no SDK/wire changes**:

- New `acteon_core::tenant_scope` (re-exported as `acteon_audit::tenant_scope`): `tenant_in_scope` / `tenant_covered_by` (segment-aware: `acme` covers `acme.prod` but not `acmecorp`), `escape_like`, `like_descendants_pattern`.
- `AuditQuery` / `AnalyticsQuery` / `CoverageQuery` gain a `#[serde(skip)] tenant_scope: Vec<String>` — **server-set from grants, never client-settable**, absent from the OpenAPI/SDK surface. Empty = unrestricted.
- `CallerIdentity::resolve_tenant_query_scope` replaces `resolve_tenant_filter` (and the obsolete `TenantFilterError::Ambiguous`): named in-grant tenant → exact filter + empty scope (keeps DynamoDB on its GSI key path); unnamed scoped caller → grant patterns as scope; wildcard → unrestricted.
- Each backend ANDs the scope in when non-empty:
  - **Postgres / ClickHouse**: `(tenant = $p OR tenant LIKE <p.%>)` OR-grouped, fully **parameterized**, backslash-escaped LIKE.
  - **Elasticsearch**: `bool.should[{term},{prefix "p."}]`, `minimum_should_match: 1`.
  - **In-memory**: `query.tenant_in_scope(&rec.tenant)`.
  - **DynamoDB**: `ns_tenant` is a composite partition key (exact match only) and can't express prefixes, so a scope query routes to a **Scan** with `begins_with(#tenant, "p.")` — a documented perf tradeoff.
  - `InMemoryAnalytics` propagates the scope into the `AuditQuery` batches it pages.
- `cleanup_expired` is **untouched** — system-level retention reaping, not a caller-scoped read.

## Tests

- Core helper unit tests (hierarchy, sibling exclusion, LIKE escaping).
- Per-backend query-builder unit tests (Postgres/ClickHouse/ES/DynamoDB): exact + LIKE/`begins_with` predicate, bind counts/order, empty-scope no-op, metachar escaping.
- In-memory **end-to-end** tests: subtree union, sibling/ungranted exclusion, exact ∩ scope.
- `cargo fmt` · `clippy --workspace -D warnings` · full workspace test suite (40 binaries, 0 failures) · all 4 backend crates `--all-features` · `cargo check --all-targets`. No UI or polyglot-SDK changes.

## Known follow-up

The MCP server's `query_audit`/`query_analytics`/`rule_coverage` tool paths set an **empty scope (unrestricted)**, preserving current behavior. If MCP callers can be tenant-scoped, MCP must resolve and set scope too — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)