### PR TITLE
fix(client): repair AnalyticsQuery doctest broken since #200

### DIFF
--- a/crates/client/src/analytics.rs
+++ b/crates/client/src/analytics.rs
@@ -30,6 +30,7 @@ impl ActeonClient {
     ///     to: None,
     ///     group_by: None,
     ///     top_n: None,
+    ///     tenant_scope: Vec::new(), // server-set from grants; leave empty
     /// };
     ///
     /// let response = client.query_analytics(&query).await?;


### PR DESCRIPTION
## Problem

The CI **Test** job has been red on `main` since **#200** (which added the server-set `tenant_scope` field to `AnalyticsQuery`). The `ActeonClient::query_analytics` doc example builds the struct with a full field literal and wasn't updated, so it fails to compile under `cargo test --doc`:

```
crates/client/src/analytics.rs - analytics::ActeonClient::query_analytics (line 16) ... FAILED
error[E0063]: missing field `tenant_scope` in initializer of `AnalyticsQuery`
```

It slipped through because doctests are **not** compiled by the `--lib --bins --tests` fast path (the CLAUDE.md local default) nor by `cargo check --all-targets` — only the full-suite CI **Test** job runs them, and **Test is not a required check**, so it rode along through #200, #201, and #202.

## Fix

Add `tenant_scope: Vec::new()` to the doc example (the field is `#[serde(skip)]` and server-populated from grants, so a client never sends it). Verified with a full `cargo test --workspace --doc --no-fail-fast` — **all doctests pass; this was the only break.**

## Process note

I'd been enabling auto-merge without confirming the non-required **Test** check, relying on the local fast path that skips doctests. Going forward I'll run `cargo test --workspace` (incl. doctests) before merging anything that touches a widely-constructed type, and verify the Test check rather than only the required ones. Worth considering making **Test** a required status check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)