### PR TITLE
feat(gateway): two-phase compliance audit — intent record before execution

### DIFF
--- a/crates/gateway/src/audit_helpers.rs
+++ b/crates/gateway/src/audit_helpers.rs
@@ -393,3 +393,64 @@ pub(crate) fn build_audit_record(
         },
     }
 }
+
+/// Build a **pre-execution intent** audit record: a durable "about to handle
+/// this action with this verdict" marker written *before* the provider side
+/// effect. In compliance mode the gateway writes this synchronously and fails
+/// closed if it cannot be persisted — so an action that can't be recorded is
+/// never executed. Mirrors [`build_audit_record`] but carries a synthetic
+/// `pending` outcome (no result is known yet); the matching outcome record is
+/// appended after execution.
+#[allow(clippy::cast_possible_wrap)]
+pub(crate) fn build_intent_audit_record(
+    id: String,
+    action: &Action,
+    verdict: &RuleVerdict,
+    dispatched_at: chrono::DateTime<chrono::Utc>,
+    ttl_seconds: Option<u64>,
+    store_payload: bool,
+    caller: Option<&Caller>,
+) -> AuditRecord {
+    let expires_at = ttl_seconds.map(|secs| dispatched_at + chrono::Duration::seconds(secs as i64));
+    let action_payload = if store_payload {
+        Some(action.payload.clone())
+    } else {
+        None
+    };
+    AuditRecord {
+        id,
+        action_id: action.id.to_string(),
+        chain_id: None,
+        namespace: action.namespace.to_string(),
+        tenant: action.tenant.to_string(),
+        provider: action.provider.to_string(),
+        action_type: action.action_type.clone(),
+        verdict: verdict.as_tag().to_owned(),
+        matched_rule: matched_rule_name(verdict),
+        outcome: "pending".to_owned(),
+        action_payload,
+        verdict_details: serde_json::json!({ "verdict": verdict.as_tag() }),
+        outcome_details: serde_json::json!({ "phase": "intent" }),
+        metadata: enrich_audit_metadata(action),
+        dispatched_at,
+        completed_at: dispatched_at,
+        duration_ms: 0,
+        expires_at,
+        caller_id: caller.map_or_else(String::new, |c| c.id.clone()),
+        auth_method: caller.map_or_else(String::new, |c| c.auth_method.clone()),
+        record_hash: None,
+        previous_hash: None,
+        sequence_number: None,
+        attachment_metadata: Vec::new(),
+        signature: action.signature.clone(),
+        signer_id: action.signer_id.clone(),
+        kid: action.kid.clone(),
+        canonical_hash: if action.signature.is_some() {
+            use sha2::Digest;
+            let hash = sha2::Sha256::digest(action.canonical_bytes());
+            Some(hex::encode(hash))
+        } else {
+            None
+        },
+    }
+}

--- a/crates/gateway/src/error.rs
+++ b/crates/gateway/src/error.rs
@@ -50,6 +50,15 @@ pub enum GatewayError {
     /// An attachment could not be resolved.
     #[error("attachment error: {0}")]
     Attachment(String),
+
+    /// The pre-execution **intent** audit record could not be durably
+    /// persisted in compliance mode (`sync_audit_writes`). The gateway fails
+    /// **closed before executing the provider**, so the action did NOT run —
+    /// no side effect occurred and there is nothing unaudited to reconcile.
+    /// This is the genuine compliance guarantee: an action that cannot be
+    /// recorded is never executed.
+    #[error("intent audit write failed; action not executed (compliance fail-closed): {0}")]
+    AuditWriteFailed(String),
 }
 
 impl GatewayError {

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -345,13 +345,18 @@ impl Gateway {
     /// When `sync_audit_writes` is enabled, the caller awaits the write inline
     /// so the audit record is guaranteed to be persisted before the dispatch
     /// pipeline returns.
-    async fn emit_audit_record(&self, audit: &Arc<dyn AuditStore>, record: AuditRecord) {
-        let sync = self
-            .compliance_config
+    /// Whether compliance mode requires synchronous, durable audit writes
+    /// (SOC2/HIPAA `sync_audit_writes`). When true, the dispatch pipeline
+    /// writes a pre-execution intent record and fails closed if it cannot be
+    /// persisted, so an action that can't be recorded is never executed.
+    fn sync_audit_writes(&self) -> bool {
+        self.compliance_config
             .as_ref()
-            .is_some_and(|c| c.sync_audit_writes);
+            .is_some_and(|c| c.sync_audit_writes)
+    }
 
-        if sync {
+    async fn emit_audit_record(&self, audit: &Arc<dyn AuditStore>, record: AuditRecord) {
+        if self.sync_audit_writes() {
             if let Err(e) = audit.record(record).await {
                 warn!(error = %e, "audit recording failed (sync)");
             }
@@ -447,7 +452,7 @@ impl Gateway {
         );
 
         // In dry-run mode, skip lock acquisition, state mutation, and audit.
-        let guard = if dry_run {
+        let mut guard = if dry_run {
             None
         } else {
             // 2. Acquire the distributed lock with a 30-second TTL and 5-second timeout.
@@ -762,6 +767,38 @@ impl Gateway {
 
             info!(?outcome, "dispatch complete (muted by time interval)");
             return Ok(outcome);
+        }
+
+        // 3f. Compliance fail-closed (pre-execution intent record).
+        //     In `sync_audit_writes` mode, durably record the INTENT to handle
+        //     this action *before* any provider side effect. If the record
+        //     cannot be persisted we abort here — nothing executes, so there
+        //     is no unaudited or duplicated side effect (the genuine
+        //     compliance guarantee). Other deployments are unaffected: they
+        //     keep the single post-execution (async, best-effort) outcome
+        //     record written in step 5.
+        if self.sync_audit_writes()
+            && let Some(ref audit) = self.audit
+        {
+            let intent = build_intent_audit_record(
+                format!("{event_id}-intent"),
+                &action,
+                &verdict,
+                dispatched_at,
+                self.effective_audit_ttl(&action.namespace, &action.tenant),
+                self.audit_store_payload,
+                caller,
+            );
+            if let Err(e) = audit.record(intent).await {
+                warn!(error = %e, "intent audit write failed — failing dispatch closed before execution");
+                // Release the lock before aborting so a retry is not blocked
+                // until the lock TTL. Nothing has executed, so there is no
+                // side effect to reconcile.
+                if let Some(g) = guard.take() {
+                    let _ = g.release().await;
+                }
+                return Err(GatewayError::AuditWriteFailed(e.to_string()));
+            }
         }
 
         // 4. Handle the verdict.
@@ -6112,7 +6149,8 @@ impl acteon_state::StateStore for BorrowedStateStore<'_> {
 // -- Audit helpers (moved to audit_helpers.rs) -------------------------------
 
 use crate::audit_helpers::{
-    build_audit_record, enrich_audit_metadata, is_adjacent_in_path, matched_rule_name,
+    build_audit_record, build_intent_audit_record, enrich_audit_metadata, is_adjacent_in_path,
+    matched_rule_name,
 };
 
 #[cfg(test)]
@@ -10407,6 +10445,164 @@ mod tests {
         assert!(
             matches!(tenant_blocked, ActionOutcome::QuotaExceeded { .. }),
             "11th dispatch should trip the tenant-wide cap"
+        );
+    }
+
+    // -- Compliance two-phase (intent) audit ----------------------------------
+
+    /// Audit store for compliance tests: collects every record, or fails
+    /// every write when `fail` is set.
+    struct TestAudit {
+        fail: bool,
+        records: Arc<Mutex<Vec<acteon_audit::AuditRecord>>>,
+    }
+
+    #[async_trait]
+    impl acteon_audit::AuditStore for TestAudit {
+        async fn record(
+            &self,
+            entry: acteon_audit::AuditRecord,
+        ) -> Result<(), acteon_audit::AuditError> {
+            if self.fail {
+                return Err(acteon_audit::AuditError::Storage(
+                    "synthetic failure".into(),
+                ));
+            }
+            self.records.lock().unwrap().push(entry);
+            Ok(())
+        }
+        async fn get_by_action_id(
+            &self,
+            _: &str,
+        ) -> Result<Option<acteon_audit::AuditRecord>, acteon_audit::AuditError> {
+            Ok(None)
+        }
+        async fn get_by_id(
+            &self,
+            _: &str,
+        ) -> Result<Option<acteon_audit::AuditRecord>, acteon_audit::AuditError> {
+            Ok(None)
+        }
+        async fn query(
+            &self,
+            _: &acteon_audit::AuditQuery,
+        ) -> Result<acteon_audit::AuditPage, acteon_audit::AuditError> {
+            Ok(acteon_audit::AuditPage {
+                records: Vec::new(),
+                total: Some(0),
+                limit: 0,
+                offset: 0,
+                next_cursor: None,
+            })
+        }
+        async fn cleanup_expired(&self) -> Result<u64, acteon_audit::AuditError> {
+            Ok(0)
+        }
+    }
+
+    /// Build a gateway with a `CapturingProvider` (so we can assert whether
+    /// the provider was actually invoked), the given audit store, and an
+    /// optional compliance config. Returns the gateway and the provider's
+    /// captured-payloads handle.
+    fn build_compliance_gateway(
+        audit: Arc<dyn acteon_audit::AuditStore>,
+        compliance: Option<acteon_core::ComplianceConfig>,
+    ) -> (crate::gateway::Gateway, Arc<Mutex<Vec<serde_json::Value>>>) {
+        let (provider, captured) = CapturingProvider::new("email");
+        let mut builder = GatewayBuilder::new()
+            .state(Arc::new(MemoryStateStore::new()))
+            .lock(Arc::new(MemoryDistributedLock::new()))
+            .rules(vec![])
+            .provider(Arc::new(provider))
+            .audit(audit)
+            .executor_config(ExecutorConfig {
+                max_retries: 0,
+                execution_timeout: Duration::from_secs(5),
+                max_concurrent: 10,
+                ..ExecutorConfig::default()
+            });
+        if let Some(c) = compliance {
+            builder = builder.compliance_config(c);
+        }
+        (builder.build().expect("gateway should build"), captured)
+    }
+
+    #[tokio::test]
+    async fn compliance_intent_write_failure_aborts_before_execution() {
+        // The whole point: in compliance mode, if the pre-execution intent
+        // record can't be persisted, the dispatch fails closed BEFORE the
+        // provider runs — no side effect, so nothing unaudited or duplicated.
+        let records = Arc::new(Mutex::new(Vec::new()));
+        let (gw, captured) = build_compliance_gateway(
+            Arc::new(TestAudit {
+                fail: true,
+                records,
+            }),
+            Some(acteon_core::ComplianceConfig::new(
+                acteon_core::ComplianceMode::Soc2,
+            )),
+        );
+        let err = gw
+            .dispatch(test_action(), None)
+            .await
+            .expect_err("intent audit failure must fail dispatch closed");
+        assert!(
+            matches!(err, crate::error::GatewayError::AuditWriteFailed(_)),
+            "expected AuditWriteFailed, got {err:?}",
+        );
+        assert!(
+            captured.lock().unwrap().is_empty(),
+            "provider must NOT be invoked when the intent audit write fails",
+        );
+    }
+
+    #[tokio::test]
+    async fn compliance_happy_path_writes_intent_then_outcome() {
+        // Healthy audit in compliance mode: the provider runs and BOTH a
+        // pending intent record and the outcome record are persisted.
+        let records = Arc::new(Mutex::new(Vec::new()));
+        let (gw, captured) = build_compliance_gateway(
+            Arc::new(TestAudit {
+                fail: false,
+                records: Arc::clone(&records),
+            }),
+            Some(acteon_core::ComplianceConfig::new(
+                acteon_core::ComplianceMode::Soc2,
+            )),
+        );
+        let outcome = gw.dispatch(test_action(), None).await.unwrap();
+        assert!(matches!(outcome, ActionOutcome::Executed(_)));
+        assert_eq!(captured.lock().unwrap().len(), 1, "provider invoked once");
+        let recs = records.lock().unwrap();
+        assert_eq!(recs.len(), 2, "one intent + one outcome record");
+        assert_eq!(recs[0].outcome, "pending", "first record is the intent");
+        assert_ne!(recs[1].outcome, "pending", "second record is the outcome");
+        // Both records share the action id; the intent id is derived from it.
+        assert_eq!(recs[0].action_id, recs[1].action_id);
+    }
+
+    #[tokio::test]
+    async fn non_compliance_audit_failure_does_not_fail_dispatch() {
+        // Without compliance there is no intent record and audit writes are
+        // fire-and-forget — a failing store must NOT fail the dispatch, and
+        // the provider still runs (unchanged behavior).
+        let records = Arc::new(Mutex::new(Vec::new()));
+        let (gw, captured) = build_compliance_gateway(
+            Arc::new(TestAudit {
+                fail: true,
+                records,
+            }),
+            None,
+        );
+        let outcome = gw.dispatch(test_action(), None).await;
+        assert!(
+            outcome.is_ok(),
+            "fire-and-forget audit must not fail dispatch: {outcome:?}",
+        );
+        assert_eq!(
+            captured.lock().unwrap().len(),
+            1,
+            "provider runs normally without compliance",
         );
     }
 }

--- a/docs/architecture/compliance-mode.md
+++ b/docs/architecture/compliance-mode.md
@@ -250,22 +250,31 @@ pipeline:
 
 ```
 Normal mode (sync_audit_writes = false):
-  1. Build audit record
-  2. tokio::spawn(audit_store.record(record))    ← fire and forget
-  3. Return dispatch outcome immediately
+  1. Execute action
+  2. Build audit record
+  3. tokio::spawn(audit_store.record(record))    ← fire and forget
+  4. Return dispatch outcome immediately
 
-Compliance mode (sync_audit_writes = true):
-  1. Build audit record
-  2. audit_store.record(record).await             ← inline await
-  3. Return dispatch outcome after write confirmed
+Compliance mode (sync_audit_writes = true) — two-phase, fail-closed:
+  1. Build + write INTENT record (pending)        ← inline await, BEFORE execute
+       └─ on failure: release lock, return AuditWriteFailed, DO NOT execute
+  2. Execute action
+  3. Build + write OUTCOME record                 ← inline await; best-effort
+       └─ on failure: warn (intent record already durable ⇒ recoverable)
+  4. Return dispatch outcome
 ```
+
+The intent record is what makes the guarantee real: an action that cannot be
+durably recorded is **never executed**, so a degraded audit backend rejects
+new dispatches instead of producing unaudited (or, on caller retry,
+duplicated) side effects.
 
 ### Trade-offs
 
 | Aspect | Async (default) | Sync (compliance) |
 |--------|----------------|-------------------|
-| Dispatch latency | Lower (audit write off critical path) | Higher (audit write on critical path) |
-| Audit completeness | Best effort (crash before write = lost record) | Guaranteed (response implies persisted) |
+| Dispatch latency | Lower (audit write off critical path) | Higher (two writes on critical path) |
+| Audit completeness | Best effort (crash before write = lost record) | Guaranteed (intent persisted before execution) |
 | Throughput | Higher (write buffered) | Lower (serialized with dispatch) |
 | Regulatory compliance | Insufficient for SOC2/HIPAA | Meets audit trail requirements |
 

--- a/docs/book/features/compliance-mode.md
+++ b/docs/book/features/compliance-mode.md
@@ -16,20 +16,23 @@ When compliance mode is enabled, the gateway wraps the audit store with two deco
 
 2. **`ComplianceAuditStore`** -- enforces immutability by rejecting delete and update operations on audit records. Only active when `immutable_audit = true`.
 
-Additionally, when `sync_audit_writes = true`, the dispatch pipeline awaits the audit write inline rather than spawning it as a background task. This guarantees the audit record is persisted before the dispatch response is returned.
+Additionally, when `sync_audit_writes = true`, the dispatch pipeline writes audit records **synchronously** and uses a **two-phase, fail-closed** scheme so an action that cannot be durably recorded is never executed:
+
+1. **Intent record (before execution).** A `pending` audit record is written *before* the provider runs. If this write fails, the dispatch **fails closed** with `AuditWriteFailed` and the provider is never called — no side effect occurs, so there is nothing unaudited or duplicated to reconcile. (The lock is released first, so a retry isn't blocked.)
+2. **Outcome record (after execution).** Once the action runs, the outcome record is appended. This write is awaited but best-effort: if it fails, the `pending` intent record is already on the hash-chained trail, so the action is recoverable from the audit log rather than invisible. (A retry-storm fail-closed *here* is deliberately avoided — the side effect already happened, and failing the caller would invite duplicate, still-executed actions.)
+
+Outside compliance mode the audit write is a single fire-and-forget background task (no intent record), unchanged.
 
 ```
-Dispatch Pipeline with Compliance Mode:
+Dispatch Pipeline with Compliance Mode (sync_audit_writes = true):
 
   1. Acquire distributed lock
   2. Check quotas
   3. Evaluate rules
-  4. Execute action
-  5. Build audit record
-  6. Hash chain decorator:  compute hash, link to previous
-  7. Compliance decorator:  enforce immutability
-  8. Write audit record     (sync when sync_audit_writes = true)
-  9. Return outcome
+  4. Write INTENT record (pending)   ← fail here ⇒ FAIL CLOSED, do not execute
+  5. Execute action
+  6. Build + hash-chain + write OUTCOME record (best-effort; intent already durable)
+  7. Return outcome
 ```
 
 ## Configuration
@@ -205,11 +208,11 @@ This interacts with [data retention policies](data-retention.md): when both `imm
 
 When `sync_audit_writes = true`, the dispatch pipeline blocks until the audit record is confirmed written to the backend. This guarantees:
 
-- Every executed action has a corresponding audit record
-- No audit record is lost due to process crash between dispatch and async write
+- Every executed action has a corresponding audit record — guaranteed by the **pre-execution intent record**: if it can't be written, the action never runs (`AuditWriteFailed`)
+- No audit record is lost due to a process crash between dispatch and an async write — the intent record is durable before the provider is called
 - Regulatory requirements for complete audit trails are satisfied
 
-The trade-off is higher dispatch latency (the audit write is on the critical path).
+The trade-off is higher dispatch latency (two synchronous audit writes are on the critical path), and that a degraded audit backend will **reject** new dispatches in compliance mode rather than execute them unrecorded.
 
 ## API Reference
 


### PR DESCRIPTION
Replaces the closed **#204**. That PR failed closed *after* the provider executed — which review correctly called a dangerous half-measure: it turned a successful-but-unaudited action into an error, and since plain `Allow` actions have no at-most-once (only the opt-in `Deduplicate` verdict does), a retrying caller would **re-execute** → duplicate, still-unaudited side effects during an audit outage. This is the **correct two-phase design** that review recommended.

## Design

In `sync_audit_writes` (SOC2/HIPAA) mode the dispatch pipeline now:

1. **Writes a `pending` intent record _before_ executing the provider.** If that write fails → release the lock, return `GatewayError::AuditWriteFailed`, **do not execute**. No side effect occurs, so nothing is unaudited or duplicated. *This* is the real fail-closed guarantee: an action that can't be recorded is never executed.
2. **Executes** the provider.
3. **Appends the outcome record** (awaited, but **best-effort**): if it fails, the durable intent record is already on the hash-chained trail → the action is recoverable from the log, not invisible. Deliberately does **not** fail the caller here — that's the retry/duplicate trap #204 fell into.

Non-compliance deployments are unchanged (no intent record; single fire-and-forget outcome write).

## Why this is correct (and #204 wasn't)

| | #204 (post-exec fail-closed) | This PR (pre-exec intent) |
|---|---|---|
| Audit-outage, plain `Allow`, retrying caller | action runs, caller errors, **retries re-execute** → N unaudited side effects | intent write fails → **action never runs**, caller errors, retry also no-ops at the gate → 0 side effects |
| `AuditWriteFailed` semantics | ambiguous ("did it run?") | accurate: **not executed** |

## Implementation notes
- `build_intent_audit_record` mirrors the outcome record with a synthetic `pending` outcome — **no new `ActionOutcome` variant**, so no exhaustive-match ripple across the codebase/UI.
- Lock released before the abort error so a retry isn't blocked until the lock TTL.

## Tests
A configurable `TestAudit` proves:
- intent-write failure **aborts before the provider runs** (asserts the `CapturingProvider` is never invoked) and returns `AuditWriteFailed`;
- compliance happy path persists **both** a `pending` intent and the outcome record for the same action id;
- without compliance, a failing audit store does **not** fail the dispatch and the provider still runs.

`cargo fmt` · `clippy --workspace -D warnings` · gateway/core/audit lib+tests · **doctests** · `cargo check --all-targets` — all green. Docs updated (`compliance-mode.md`, both pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)