### PR TITLE
feat(audit): exclude compliance intent records from analytics; label in UI/CLI

### DIFF
--- a/crates/audit/audit/src/analytics.rs
+++ b/crates/audit/audit/src/analytics.rs
@@ -228,6 +228,11 @@ impl<S: AuditStore + ?Sized + 'static> AnalyticsStore for InMemoryAnalytics<S> {
             }
         }
 
+        // Exclude pre-execution intent records (compliance two-phase): they
+        // are part of the audit trail but must not double-count operational
+        // metrics (volume, outcome breakdown, error rate, top-N).
+        all_records.retain(|r| !r.is_intent());
+
         let total_count = all_records.len() as u64;
 
         // Group records into buckets.
@@ -344,6 +349,11 @@ impl<S: AuditStore + ?Sized + 'static> AnalyticsStore for InMemoryAnalytics<S> {
             let page = self.store.query(&audit_query).await?;
 
             for record in page.records {
+                // Skip pre-execution intent records — coverage counts real
+                // outcomes, not the two-phase compliance intent markers.
+                if record.is_intent() {
+                    continue;
+                }
                 let key = (
                     record.namespace,
                     record.tenant,
@@ -625,6 +635,47 @@ mod tests {
         // All bucket counts should sum to total_count.
         let sum: u64 = result.buckets.iter().map(|b| b.count).sum();
         assert_eq!(sum, 30);
+    }
+
+    #[tokio::test]
+    async fn analytics_excludes_intent_records() {
+        // Pre-execution intent (`pending`) records are on the audit trail but
+        // must not double-count operational metrics.
+        let store = Arc::new(MemoryAuditStore::new());
+        let now = Utc::now();
+        store.add_record(make_record(
+            "default", "t1", "email", "send", "executed", 10, now,
+        ));
+        store.add_record(make_record(
+            "default",
+            "t1",
+            "email",
+            "send",
+            crate::INTENT_OUTCOME,
+            0,
+            now,
+        ));
+        let analytics = InMemoryAnalytics::new(store);
+
+        let query = AnalyticsQuery {
+            metric: AnalyticsMetric::Volume,
+            namespace: None,
+            tenant: None,
+            provider: None,
+            action_type: None,
+            outcome: None,
+            interval: AnalyticsInterval::Daily,
+            from: None,
+            to: None,
+            group_by: None,
+            top_n: None,
+            tenant_scope: Vec::new(),
+        };
+        let result = analytics.query_analytics(&query).await.unwrap();
+        assert_eq!(
+            result.total_count, 1,
+            "the pending intent record must be excluded; only the executed record counts",
+        );
     }
 
     #[tokio::test]

--- a/crates/audit/audit/src/lib.rs
+++ b/crates/audit/audit/src/lib.rs
@@ -12,7 +12,9 @@ pub use compliance::{ComplianceAuditStore, HashChainAuditStore};
 pub use cursor::{AuditCursor, CursorKind};
 pub use encrypt::EncryptingAuditStore;
 pub use error::AuditError;
-pub use record::{A2A_AUDIT_PROVIDER, AuditEventKind, AuditPage, AuditQuery, AuditRecord};
+pub use record::{
+    A2A_AUDIT_PROVIDER, AuditEventKind, AuditPage, AuditQuery, AuditRecord, INTENT_OUTCOME,
+};
 pub use redact::{RedactConfig, RedactingAuditStore, Redactor};
 pub use store::AuditStore;
 

--- a/crates/audit/audit/src/record.rs
+++ b/crates/audit/audit/src/record.rs
@@ -49,7 +49,7 @@ impl AuditEventKind {
 pub const A2A_AUDIT_PROVIDER: &str = "a2a";
 
 /// The `outcome` value stamped on a **pre-execution intent** audit record
-/// (compliance two-phase fail-closed). It is never a real [`ActionOutcome`]
+/// (compliance two-phase fail-closed). It is never a real `ActionOutcome`
 /// tag, so it uniquely identifies an intent record. Intent records stay on
 /// the (tamper-evident) audit trail and are returned by raw audit queries —
 /// an auditor pairs each with its outcome record, and a *lone* intent record

--- a/crates/audit/audit/src/record.rs
+++ b/crates/audit/audit/src/record.rs
@@ -48,6 +48,15 @@ impl AuditEventKind {
 /// dispatches, so they share this synthetic marker.
 pub const A2A_AUDIT_PROVIDER: &str = "a2a";
 
+/// The `outcome` value stamped on a **pre-execution intent** audit record
+/// (compliance two-phase fail-closed). It is never a real [`ActionOutcome`]
+/// tag, so it uniquely identifies an intent record. Intent records stay on
+/// the (tamper-evident) audit trail and are returned by raw audit queries —
+/// an auditor pairs each with its outcome record, and a *lone* intent record
+/// signals a crash mid-dispatch — but they are **excluded from analytics and
+/// rule coverage** so they don't double-count operational metrics.
+pub const INTENT_OUTCOME: &str = "pending";
+
 /// A single audit record capturing the full lifecycle of a dispatched action.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -144,6 +153,17 @@ pub struct AuditRecord {
     /// the audit record does not carry in its entirety).
     #[serde(default)]
     pub canonical_hash: Option<String>,
+}
+
+impl AuditRecord {
+    /// Whether this is a pre-execution **intent** record (compliance
+    /// two-phase fail-closed), identified by its synthetic [`INTENT_OUTCOME`].
+    /// Such records are part of the audit trail but are excluded from
+    /// analytics / rule coverage so they don't double-count metrics.
+    #[must_use]
+    pub fn is_intent(&self) -> bool {
+        self.outcome == INTENT_OUTCOME
+    }
 }
 
 /// Query parameters for searching audit records.

--- a/crates/audit/clickhouse/src/analytics.rs
+++ b/crates/audit/clickhouse/src/analytics.rs
@@ -66,6 +66,11 @@ fn build_analytics_where(
         conditions.push(format!("({})", scope_terms.join(" OR ")));
     }
 
+    // Exclude pre-execution intent records (compliance two-phase): on the
+    // audit trail but never counted in analytics.
+    conditions.push("outcome <> ?".to_string());
+    binds.push(BindValue::Str(acteon_audit::INTENT_OUTCOME.to_owned()));
+
     // Time range: dispatched_at is stored as milliseconds since epoch.
     conditions.push("dispatched_at >= ?".to_string());
     binds.push(BindValue::Millis(from.timestamp_millis()));
@@ -348,6 +353,10 @@ impl AnalyticsStore for ClickHouseAnalyticsStore {
             conditions.push(format!("({})", scope_terms.join(" OR ")));
         }
 
+        // Exclude pre-execution intent records from coverage counts.
+        conditions.push("outcome <> ?".to_string());
+        binds.push(BindValue::Str(acteon_audit::INTENT_OUTCOME.to_owned()));
+
         conditions.push("dispatched_at >= ?".to_string());
         binds.push(BindValue::Millis(from.timestamp_millis()));
         conditions.push("dispatched_at <= ?".to_string());
@@ -431,10 +440,14 @@ mod tests {
         let from = Utc.timestamp_opt(1_000, 0).unwrap();
         let to = Utc.timestamp_opt(2_000, 0).unwrap();
         let (clause, binds) = build_analytics_where(&base_query(), from, to);
-        assert_eq!(clause, "WHERE dispatched_at >= ? AND dispatched_at <= ?");
+        assert_eq!(
+            clause,
+            "WHERE outcome <> ? AND dispatched_at >= ? AND dispatched_at <= ?"
+        );
         assert_eq!(
             binds_repr(&binds),
             vec![
+                "s:pending".to_owned(),
                 format!("m:{}", from.timestamp_millis()),
                 format!("m:{}", to.timestamp_millis()),
             ]
@@ -456,13 +469,14 @@ mod tests {
         assert_eq!(
             clause,
             "WHERE ((tenant = ? OR tenant LIKE ?)) \
-             AND dispatched_at >= ? AND dispatched_at <= ?"
+             AND outcome <> ? AND dispatched_at >= ? AND dispatched_at <= ?"
         );
         assert_eq!(
             binds_repr(&binds),
             vec![
                 "s:acme".to_owned(),
                 "s:acme.%".to_owned(),
+                "s:pending".to_owned(),
                 format!("m:{}", from.timestamp_millis()),
                 format!("m:{}", to.timestamp_millis()),
             ]
@@ -484,7 +498,7 @@ mod tests {
         assert_eq!(
             clause,
             "WHERE ((tenant = ? OR tenant LIKE ?) OR (tenant = ? OR tenant LIKE ?)) \
-             AND dispatched_at >= ? AND dispatched_at <= ?"
+             AND outcome <> ? AND dispatched_at >= ? AND dispatched_at <= ?"
         );
         // Note the LIKE-escape of `_` in the second pattern.
         assert_eq!(
@@ -494,6 +508,7 @@ mod tests {
                 "s:acme.%".to_owned(),
                 "s:ac_me".to_owned(),
                 "s:ac\\_me.%".to_owned(),
+                "s:pending".to_owned(),
                 format!("m:{}", from.timestamp_millis()),
                 format!("m:{}", to.timestamp_millis()),
             ]
@@ -516,7 +531,7 @@ mod tests {
         assert_eq!(
             clause,
             "WHERE tenant = ? AND ((tenant = ? OR tenant LIKE ?)) \
-             AND dispatched_at >= ? AND dispatched_at <= ?"
+             AND outcome <> ? AND dispatched_at >= ? AND dispatched_at <= ?"
         );
         assert_eq!(
             binds_repr(&binds),
@@ -524,6 +539,7 @@ mod tests {
                 "s:acme".to_owned(),
                 "s:acme".to_owned(),
                 "s:acme.%".to_owned(),
+                "s:pending".to_owned(),
                 format!("m:{}", from.timestamp_millis()),
                 format!("m:{}", to.timestamp_millis()),
             ]

--- a/crates/audit/postgres/src/analytics.rs
+++ b/crates/audit/postgres/src/analytics.rs
@@ -68,6 +68,12 @@ fn build_analytics_where(
         conditions.push(format!("({})", scope_terms.join(" OR ")));
     }
 
+    // Exclude pre-execution intent records (compliance two-phase): they live
+    // on the audit trail but must never count toward analytics metrics.
+    conditions.push(format!("outcome <> ${idx}"));
+    binds.push(acteon_audit::INTENT_OUTCOME.to_owned());
+    idx += 1;
+
     // Time range is always applied.
     conditions.push(format!("dispatched_at >= ${idx}"));
     let from_idx = idx;
@@ -363,6 +369,11 @@ impl AnalyticsStore for PostgresAnalyticsStore {
             conditions.push(format!("({})", scope_terms.join(" OR ")));
         }
 
+        // Exclude pre-execution intent records from coverage counts.
+        conditions.push(format!("outcome <> ${idx}"));
+        binds.push(acteon_audit::INTENT_OUTCOME.to_owned());
+        idx += 1;
+
         conditions.push(format!("dispatched_at >= ${idx}"));
         idx += 1;
         conditions.push(format!("dispatched_at <= ${idx}"));
@@ -427,14 +438,17 @@ mod tests {
     #[test]
     fn empty_scope_adds_no_tenant_scope_predicate() {
         let now = Utc::now();
-        // With no string filters and an empty scope, the only conditions are
-        // the always-applied time range — unchanged from prior behavior.
+        // No string filters / empty scope: only the intent-exclusion guard
+        // and the always-applied time range remain.
         let query = base_query();
         let (clause, binds, next_idx) = build_analytics_where(&query, now, now);
 
-        assert_eq!(clause, "WHERE dispatched_at >= $1 AND dispatched_at <= $2");
-        assert!(binds.is_empty());
-        assert_eq!(next_idx, 3);
+        assert_eq!(
+            clause,
+            "WHERE outcome <> $1 AND dispatched_at >= $2 AND dispatched_at <= $3"
+        );
+        assert_eq!(binds, vec!["pending".to_string()]);
+        assert_eq!(next_idx, 4);
     }
 
     #[test]
@@ -448,7 +462,7 @@ mod tests {
         assert_eq!(
             clause,
             "WHERE ((tenant = $1 OR tenant LIKE $2) OR (tenant = $3 OR tenant LIKE $4)) \
-             AND dispatched_at >= $5 AND dispatched_at <= $6"
+             AND outcome <> $5 AND dispatched_at >= $6 AND dispatched_at <= $7"
         );
         assert_eq!(
             binds,
@@ -457,9 +471,10 @@ mod tests {
                 "acme.%".to_string(),
                 "globex.eu".to_string(),
                 "globex.eu.%".to_string(),
+                "pending".to_string(),
             ]
         );
-        assert_eq!(next_idx, 7);
+        assert_eq!(next_idx, 8);
     }
 
     #[test]
@@ -474,7 +489,7 @@ mod tests {
         assert_eq!(
             clause,
             "WHERE tenant = $1 AND ((tenant = $2 OR tenant LIKE $3)) \
-             AND dispatched_at >= $4 AND dispatched_at <= $5"
+             AND outcome <> $4 AND dispatched_at >= $5 AND dispatched_at <= $6"
         );
         assert_eq!(
             binds,
@@ -482,8 +497,9 @@ mod tests {
                 "acme.team".to_string(),
                 "acme".to_string(),
                 "acme.%".to_string(),
+                "pending".to_string(),
             ]
         );
-        assert_eq!(next_idx, 6);
+        assert_eq!(next_idx, 7);
     }
 }

--- a/crates/cli/src/commands/audit.rs
+++ b/crates/cli/src/commands/audit.rs
@@ -166,12 +166,19 @@ async fn run_query(
                     "Audit query results"
                 );
                 for rec in &page.records {
+                    // Mark compliance intent ("pending") records so they aren't
+                    // mistaken for stuck/in-flight jobs.
+                    let outcome = if rec.is_intent() {
+                        format!("{} (audit intent)", rec.outcome)
+                    } else {
+                        rec.outcome.clone()
+                    };
                     info!(
                         timestamp = %rec.dispatched_at,
                         action_type = %rec.action_type,
                         provider = %rec.provider,
                         verdict = %rec.verdict,
-                        outcome = %rec.outcome,
+                        outcome = %outcome,
                         id = %&rec.action_id[..8.min(rec.action_id.len())],
                         "Audit record"
                     );
@@ -211,7 +218,12 @@ async fn run_get(ops: &OpsClient, action_id: &str, format: &OutputFormat) -> any
                 info!(provider = %rec.provider, "  Provider");
                 info!(action_type = %rec.action_type, "  Action Type");
                 info!(verdict = %rec.verdict, "  Verdict");
-                info!(outcome = %rec.outcome, "  Outcome");
+                let outcome = if rec.is_intent() {
+                    format!("{} (audit intent)", rec.outcome)
+                } else {
+                    rec.outcome.clone()
+                };
+                info!(outcome = %outcome, "  Outcome");
                 info!(duration_ms = rec.duration_ms, "  Duration");
                 info!(dispatched_at = %rec.dispatched_at, "  Dispatched");
                 if let Some(ref rule) = rec.matched_rule {

--- a/crates/client/src/audit.rs
+++ b/crates/client/src/audit.rs
@@ -58,6 +58,12 @@ pub struct AuditPage {
     pub next_cursor: Option<String>,
 }
 
+/// The `outcome` value stamped on a pre-execution **intent** audit record in
+/// compliance (two-phase fail-closed) mode. Such records are part of the audit
+/// trail but represent "about to execute," not a completed outcome — display
+/// them distinctly so an operator doesn't mistake one for a stuck job.
+pub const INTENT_OUTCOME: &str = "pending";
+
 /// An audit record.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuditRecord {
@@ -92,6 +98,15 @@ pub struct AuditRecord {
     /// Monotonic sequence number within the `(namespace, tenant)` pair (compliance mode).
     #[serde(default)]
     pub sequence_number: Option<u64>,
+}
+
+impl AuditRecord {
+    /// Whether this is a compliance pre-execution **intent** record (see
+    /// [`INTENT_OUTCOME`]) rather than a completed action outcome.
+    #[must_use]
+    pub fn is_intent(&self) -> bool {
+        self.outcome == INTENT_OUTCOME
+    }
 }
 
 /// Query parameters for bulk audit replay.

--- a/crates/gateway/src/audit_helpers.rs
+++ b/crates/gateway/src/audit_helpers.rs
@@ -427,7 +427,7 @@ pub(crate) fn build_intent_audit_record(
         action_type: action.action_type.clone(),
         verdict: verdict.as_tag().to_owned(),
         matched_rule: matched_rule_name(verdict),
-        outcome: "pending".to_owned(),
+        outcome: acteon_audit::INTENT_OUTCOME.to_owned(),
         action_payload,
         verdict_details: serde_json::json!({ "verdict": verdict.as_tag() }),
         outcome_details: serde_json::json!({ "phase": "intent" }),

--- a/ui/src/components/ui/Badge.tsx
+++ b/ui/src/components/ui/Badge.tsx
@@ -32,6 +32,9 @@ const outcomeVariant: Record<string, keyof typeof variants> = {
   CircuitOpen: 'error',
   Scheduled: 'pending',
   StateChanged: 'info',
+  // Compliance two-phase: a pre-execution intent record, surfaced distinctly
+  // so it isn't mistaken for a stuck/in-flight job.
+  'Audit Intent': 'info',
   // Chain statuses
   running: 'info',
   completed: 'success',

--- a/ui/src/pages/Actions.tsx
+++ b/ui/src/pages/Actions.tsx
@@ -22,6 +22,12 @@ const col = createColumnHelper<AuditRecord>()
 
 const outcomeOptions = ['Executed', 'Failed', 'Suppressed', 'Deduplicated', 'Rerouted', 'Throttled', 'PendingApproval', 'ChainStarted', 'CircuitOpen', 'Scheduled', 'DryRun'].map((v) => ({ value: v, label: v }))
 
+// The server stamps `pending` on a compliance pre-execution intent record
+// (two-phase fail-closed). Show it as "Audit Intent" so operators don't read
+// it as a stuck/in-flight job.
+const INTENT_OUTCOME = 'pending'
+const outcomeLabel = (outcome: string) => (outcome === INTENT_OUTCOME ? 'Audit Intent' : outcome)
+
 export function Actions() {
   const [searchParams, setSearchParams] = useSearchParams()
   const { toast } = useToast()
@@ -76,7 +82,7 @@ export function Actions() {
     col.accessor('tenant', { header: 'Tenant' }),
     col.accessor('action_type', { header: 'Type' }),
     col.accessor('verdict', { header: 'Verdict', cell: (info) => <Badge>{info.getValue()}</Badge> }),
-    col.accessor('outcome', { header: 'Outcome', cell: (info) => <Badge>{info.getValue()}</Badge> }),
+    col.accessor('outcome', { header: 'Outcome', cell: (info) => <Badge>{outcomeLabel(info.getValue())}</Badge> }),
     col.accessor('duration_ms', {
       header: 'Duration',
       cell: (info) => <span className={styles.durationCell}>{info.getValue()}ms</span>,
@@ -164,7 +170,7 @@ export function Actions() {
                   'Action Type': selected.action_type,
                   'Verdict': selected.verdict,
                   'Matched Rule': selected.matched_rule ?? '-',
-                  'Outcome': selected.outcome,
+                  'Outcome': outcomeLabel(selected.outcome),
                   'Duration': `${selected.duration_ms}ms`,
                   'Dispatched': selected.dispatched_at,
                   'Caller': selected.caller_id,


### PR DESCRIPTION
Follow-up to #205. The two-phase compliance audit writes a `pending` **intent** record before execution, so SOC2/HIPAA deployments now emit two audit rows per action. That surfaced two issues, both fixed here.

## 1. Analytics double-count — a regression from #205 (compliance mode only)
Volume counted both the intent and outcome rows, the outcome breakdown showed ~50% "pending", and the error-rate denominator doubled. Intent records are now **excluded from analytics + rule coverage across every aggregator**:
- **InMemoryAnalytics** (memory / DynamoDB / Elasticsearch fall-through): `retain(|r| !r.is_intent())` before counting; `continue` in coverage.
- **Postgres / ClickHouse** native analytics: `outcome <> ?` guard in both `build_analytics_where` and `rule_coverage`.

Driven by a single shared marker — `acteon_audit::INTENT_OUTCOME` (`"pending"`) + `AuditRecord::is_intent()` — also used when *writing* the intent record, so there's one source of truth. Intent records stay on the tamper-evident trail and are still returned by **raw** audit queries (a *lone* intent record signals a crash mid-dispatch).

## 2. Operator confusion — the #205 reviewer's "Final Note"
`pending` records rendered as a neutral badge in the UI and printed raw in the CLI, indistinguishable from a stuck/in-flight job. Now labeled **"Audit Intent"**:
- **Admin UI** audit trail — `Badge` maps it to an `info` variant; the table cell + detail view show "Audit Intent".
- **CLI** `acteon audit` — annotated `(audit intent)` in both list and get output. The client gains its own `INTENT_OUTCOME` + `is_intent()` (consistent with its existing self-owned audit types; CLI/client don't depend on `acteon-audit`).

The operational outcome filter dropdown is intentionally left unchanged (it offers real outcomes, not the intent marker).

## Tests / checks
- InMemoryAnalytics excludes the `pending` record from volume (new test).
- Postgres/ClickHouse `build_analytics_where` + `rule_coverage` tests updated to assert the `outcome <> ?` guard and the shifted bind counts.
- `cargo fmt` · `clippy --workspace -D warnings` · all crate lib/tests · Postgres/ClickHouse `--all-features` · doctests · `cargo check --all-targets` · **`ui` lint + build** — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)