### PR TITLE
ci: run GCP provider tests (acteon-gcp --features full)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
         run: cargo nextest run -p acteon-aws --features full --lib --tests
       - name: Test Azure providers
         run: cargo nextest run -p acteon-azure --features full --lib --tests
+      - name: Test GCP providers
+        run: cargo nextest run -p acteon-gcp --features full --lib --tests
       - name: Build server with opt-in messaging providers
         run: cargo check -p acteon-server --features extras-alerting
       - name: Run doctests


### PR DESCRIPTION
The CI **Test** job runs the feature-gated **AWS** and **Azure** provider suites but had **no GCP equivalent**. `acteon-gcp`'s pubsub/storage modules are behind `default = []` features, so its **45 tests never ran in CI** — a silent regression blind spot for a shipped provider.

Adds `Test GCP providers: cargo nextest run -p acteon-gcp --features full --lib --tests`, mirroring the AWS/Azure steps. It runs **inside the existing `Test` job**, so it adds no new required-check context (relevant to the branch-protection half of survey #2).

Verified locally: `cargo test -p acteon-gcp --features full --lib --tests` → **45 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)