### PR TITLE
feat(clients): add quotas `principal` list filter to polyglot SDKs

### DIFF
--- a/clients/go/acteon/client.go
+++ b/clients/go/acteon/client.go
@@ -1147,10 +1147,11 @@ func (c *Client) CreateQuota(ctx context.Context, req *CreateQuotaRequest) (*Quo
 }
 
 // ListQuotas lists quota policies with optional namespace, tenant,
-// and provider filters. Pass "generic" as the provider filter to
-// match only policies without a provider scope; pass a provider
-// name (e.g. "slack") to match only per-provider policies.
-func (c *Client) ListQuotas(ctx context.Context, namespace, tenant, provider *string) (*ListQuotasResponse, error) {
+// provider, and principal filters. Pass "generic" as the provider
+// filter to match only policies without a provider scope; pass a
+// provider name (e.g. "slack") to match only per-provider policies.
+// principal filters to policies scoped to a given caller.
+func (c *Client) ListQuotas(ctx context.Context, namespace, tenant, provider, principal *string) (*ListQuotasResponse, error) {
 	params := url.Values{}
 	if namespace != nil {
 		params.Set("namespace", *namespace)
@@ -1160,6 +1161,9 @@ func (c *Client) ListQuotas(ctx context.Context, namespace, tenant, provider *st
 	}
 	if provider != nil {
 		params.Set("provider", *provider)
+	}
+	if principal != nil {
+		params.Set("principal", *principal)
 	}
 
 	path := "/v1/quotas"

--- a/clients/java/src/main/java/com/acteon/client/ActeonClient.java
+++ b/clients/java/src/main/java/com/acteon/client/ActeonClient.java
@@ -1379,12 +1379,13 @@ public class ActeonClient implements AutoCloseable {
     }
 
     /**
-     * Lists quota policies with optional namespace, tenant, and
-     * provider filters. Pass "generic" as the provider filter to
+     * Lists quota policies with optional namespace, tenant, provider,
+     * and principal filters. Pass "generic" as the provider filter to
      * match only policies without a provider scope, or a provider
-     * name (e.g. "slack") to match only per-provider policies.
+     * name (e.g. "slack") to match only per-provider policies. The
+     * principal filter matches policies scoped to a given caller.
      */
-    public ListQuotasResponse listQuotas(String namespace, String tenant, String provider) throws ActeonException {
+    public ListQuotasResponse listQuotas(String namespace, String tenant, String provider, String principal) throws ActeonException {
         try {
             List<String> params = new ArrayList<>();
             if (namespace != null) {
@@ -1395,6 +1396,9 @@ public class ActeonClient implements AutoCloseable {
             }
             if (provider != null) {
                 params.add("provider=" + URLEncoder.encode(provider, StandardCharsets.UTF_8));
+            }
+            if (principal != null) {
+                params.add("principal=" + URLEncoder.encode(principal, StandardCharsets.UTF_8));
             }
 
             String path = "/v1/quotas";

--- a/clients/nodejs/src/client.ts
+++ b/clients/nodejs/src/client.ts
@@ -1145,11 +1145,13 @@ export class ActeonClient {
     namespace?: string,
     tenant?: string,
     provider?: string,
+    principal?: string,
   ): Promise<ListQuotasResponse> {
     const params = new URLSearchParams();
     if (namespace !== undefined) params.set("namespace", namespace);
     if (tenant !== undefined) params.set("tenant", tenant);
     if (provider !== undefined) params.set("provider", provider);
+    if (principal !== undefined) params.set("principal", principal);
     const response = await this.request("GET", "/v1/quotas", { params: params.toString() ? params : undefined });
 
     if (response.ok) {

--- a/clients/python/acteon_client/client.py
+++ b/clients/python/acteon_client/client.py
@@ -1108,6 +1108,7 @@ class ActeonClient(_A2AClientMixin, _BusClientMixin):
         namespace: Optional[str] = None,
         tenant: Optional[str] = None,
         provider: Optional[str] = None,
+        principal: Optional[str] = None,
     ) -> "ListQuotasResponse":
         """List quota policies.
 
@@ -1119,6 +1120,8 @@ class ActeonClient(_A2AClientMixin, _BusClientMixin):
                 without a provider scope, or a provider name (e.g.
                 ``"slack"``) to match only per-provider policies
                 for that provider.
+            principal: Optional principal (caller) scope filter. Matches
+                policies scoped to that principal.
 
         Returns:
             List of quota policies.
@@ -1134,6 +1137,8 @@ class ActeonClient(_A2AClientMixin, _BusClientMixin):
             params["tenant"] = tenant
         if provider is not None:
             params["provider"] = provider
+        if principal is not None:
+            params["principal"] = principal
         response = self._request("GET", "/v1/quotas", params=params)
 
         if response.status_code == 200:
@@ -3151,10 +3156,12 @@ class AsyncActeonClient(_AsyncA2AClientMixin, _AsyncBusClientMixin):
         namespace: Optional[str] = None,
         tenant: Optional[str] = None,
         provider: Optional[str] = None,
+        principal: Optional[str] = None,
     ) -> "ListQuotasResponse":
         """List quota policies, optionally filtered by namespace,
-        tenant, and provider scope (``"generic"`` matches generic
-        policies; a provider name matches per-provider policies)."""
+        tenant, provider scope (``"generic"`` matches generic policies;
+        a provider name matches per-provider policies), and principal
+        (caller) scope."""
         params: dict = {}
         if namespace is not None:
             params["namespace"] = namespace
@@ -3162,6 +3169,8 @@ class AsyncActeonClient(_AsyncA2AClientMixin, _AsyncBusClientMixin):
             params["tenant"] = tenant
         if provider is not None:
             params["provider"] = provider
+        if principal is not None:
+            params["principal"] = principal
         response = await self._request("GET", "/v1/quotas", params=params)
         if response.status_code == 200:
             return ListQuotasResponse.from_dict(response.json())


### PR DESCRIPTION
## Gap (survey #4, verified)

PR #198 added per-principal quota scoping and the `principal` list-filter to the **server** (`GET /v1/quotas?principal=`) and the **Rust client**, and shipped the `principal`/`per_principal` data-model fields to all SDKs — but the `list_quotas` **method signature** was never updated in the polyglot clients. So Python/Node/Go/Java operators can't filter quotas by principal (e.g. to inspect a specific API key's budget), despite #198's commit message claiming the SDKs were updated.

## Change

Add the optional `principal` filter to the list method in all four SDKs, appended as `?principal=` exactly like the existing namespace/tenant/provider filters, matching the Rust client's `(namespace, tenant, provider, principal)` order:

- **Python** — sync + async `list_quotas` (`principal: Optional[str] = None`)
- **Node** — `listQuotas` (`principal?: string`)
- **Go** — `ListQuotas(ctx, namespace, tenant, provider, principal *string)`
- **Java** — `listQuotas(String namespace, String tenant, String provider, String principal)`

No callers, tests, READMEs, or docs reference the old signature, so nothing else changes.

## Verification
- **Python**: `python -m py_compile` ✓
- **Go**: `go build ./...` + `go vet ./...` ✓
- **Node**: `tsc` build ✓
- **Java**: edited to match, but **not compiled locally** (no JRE/Maven on this machine).

> Note: the polyglot SDKs have **no CI** at all (`ci.yml` only builds Rust + the `ui/`), which is exactly why this `principal` gap and #198's mismatch went unnoticed. Worth a follow-up to add per-language SDK CI jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)