### PR TITLE
feat(state-memory): background TTL sweeper for the in-memory backend

### DIFF
--- a/crates/server/src/config/state.rs
+++ b/crates/server/src/config/state.rs
@@ -49,6 +49,19 @@ pub struct StateConfig {
     /// Accept invalid certificates for Redis (dev/test only).
     #[serde(default)]
     pub tls_insecure: Option<bool>,
+
+    /// How often (seconds) the `memory` backend sweeps TTL-expired entries
+    /// and locks. The memory store evicts lazily on read, so entries that
+    /// are never read again (one-shot dedup keys, settled counters, locks
+    /// whose holder crashed) would otherwise accumulate. Defaults to 60s;
+    /// set to `0` to disable the background sweeper. Ignored by other
+    /// backends, which delegate expiry to the underlying store.
+    #[serde(default = "default_memory_sweep_interval_secs")]
+    pub memory_sweep_interval_secs: u64,
+}
+
+fn default_memory_sweep_interval_secs() -> u64 {
+    60
 }
 
 impl Default for StateConfig {
@@ -66,6 +79,7 @@ impl Default for StateConfig {
             tls_enabled: None,
             tls_ca_cert_path: None,
             tls_insecure: None,
+            memory_sweep_interval_secs: default_memory_sweep_interval_secs(),
         }
     }
 }

--- a/crates/server/src/state_factory.rs
+++ b/crates/server/src/state_factory.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use acteon_state::{DistributedLock, StateStore};
 #[cfg(feature = "dynamodb")]
@@ -21,7 +22,7 @@ pub type StatePair = (Arc<dyn StateStore>, Arc<dyn DistributedLock>);
 #[allow(clippy::unused_async)]
 pub async fn create_state(config: &StateConfig) -> Result<StatePair, ServerError> {
     match config.backend.as_str() {
-        "memory" => Ok(create_memory()),
+        "memory" => Ok(create_memory(config.memory_sweep_interval_secs)),
         #[cfg(feature = "redis")]
         "redis" => create_redis(config),
         #[cfg(feature = "postgres")]
@@ -34,10 +35,49 @@ pub async fn create_state(config: &StateConfig) -> Result<StatePair, ServerError
     }
 }
 
-fn create_memory() -> StatePair {
+fn create_memory(sweep_interval_secs: u64) -> StatePair {
     let store = Arc::new(MemoryStateStore::new());
     let lock = Arc::new(MemoryDistributedLock::new());
+
+    // The memory backend evicts TTL'd entries lazily on read, so a
+    // background sweeper is needed to reclaim entries that are never read
+    // again. Other backends delegate expiry to the underlying store.
+    if sweep_interval_secs > 0 {
+        spawn_memory_sweeper(
+            Arc::clone(&store),
+            Arc::clone(&lock),
+            Duration::from_secs(sweep_interval_secs),
+        );
+    }
+
     (store, lock)
+}
+
+/// Spawn a background task that periodically reclaims TTL-expired entries
+/// and locks from the in-memory backend.
+fn spawn_memory_sweeper(
+    store: Arc<MemoryStateStore>,
+    lock: Arc<MemoryDistributedLock>,
+    interval: Duration,
+) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        // The first tick fires immediately; skip it so the first real sweep
+        // happens one interval in, by which point entries may have expired.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            let entries = store.sweep_expired();
+            let locks = lock.sweep_expired();
+            if entries > 0 || locks > 0 {
+                tracing::debug!(
+                    entries,
+                    locks,
+                    "memory backend swept TTL-expired entries and locks"
+                );
+            }
+        }
+    });
 }
 
 #[cfg(feature = "redis")]

--- a/crates/state/memory/src/lock.rs
+++ b/crates/state/memory/src/lock.rs
@@ -25,7 +25,9 @@ impl LockEntry {
 /// In-memory [`DistributedLock`] backed by a [`DashMap`].
 ///
 /// Lock expiry is lazy: expired entries are evicted on the next acquire
-/// attempt for the same lock name.
+/// attempt for the same lock name. Call
+/// [`sweep_expired`](MemoryDistributedLock::sweep_expired) periodically to
+/// also reclaim locks whose name is never contended again.
 #[derive(Debug, Clone, Default)]
 pub struct MemoryDistributedLock {
     locks: Arc<DashMap<String, LockEntry>>,
@@ -35,6 +37,27 @@ impl MemoryDistributedLock {
     /// Create a new in-memory distributed lock manager.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Proactively evict every lock whose TTL has elapsed. Returns the
+    /// number of expired locks removed.
+    ///
+    /// Lock expiry is otherwise lazy — an expired lock is only removed on
+    /// the next [`try_acquire`](MemoryDistributedLock::try_acquire) for the
+    /// *same* name. A lock whose holder crashed (so
+    /// [`MemoryLockGuard::release`] never runs) and whose name is never
+    /// contended again would linger forever. Call this periodically from a
+    /// background task to bound memory.
+    pub fn sweep_expired(&self) -> usize {
+        let mut removed = 0usize;
+        self.locks.retain(|_, entry| {
+            let keep = !entry.is_expired();
+            if !keep {
+                removed += 1;
+            }
+            keep
+        });
+        removed
     }
 }
 
@@ -177,6 +200,30 @@ mod tests {
             .await
             .unwrap();
         assert!(guard2.is_some(), "should acquire after TTL expiry");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn sweep_expired_reclaims_unreleased_locks() {
+        let lock = MemoryDistributedLock::new();
+
+        // Acquire and deliberately leak the guard (model a holder that
+        // crashed without calling `release`).
+        let _guard = lock
+            .try_acquire("orphaned", Duration::from_secs(30))
+            .await
+            .unwrap()
+            .expect("should acquire");
+
+        // While the TTL is live, the sweep leaves it alone.
+        assert_eq!(lock.sweep_expired(), 0);
+
+        // Advance past the TTL *without re-acquiring* the same name, so the
+        // lazy eviction in `try_acquire` never runs.
+        tokio::time::advance(Duration::from_secs(31)).await;
+
+        // The sweep reclaims the expired lock; a second pass is a no-op.
+        assert_eq!(lock.sweep_expired(), 1);
+        assert_eq!(lock.sweep_expired(), 0);
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/state/memory/src/store.rs
+++ b/crates/state/memory/src/store.rs
@@ -33,9 +33,10 @@ fn expiry_from_ttl(ttl: Option<Duration>) -> Option<Instant> {
 
 /// In-memory [`StateStore`] backed by a [`DashMap`].
 ///
-/// Entries are lazily evicted on read when their TTL has elapsed. This
-/// implementation is fully synchronous internally; the async trait methods
-/// return immediately.
+/// Entries are lazily evicted on read when their TTL has elapsed; call
+/// [`sweep_expired`](MemoryStateStore::sweep_expired) periodically to also
+/// reclaim entries that are never read again. This implementation is fully
+/// synchronous internally; the async trait methods return immediately.
 pub struct MemoryStateStore {
     data: DashMap<String, Entry>,
     /// Sorted index for timeout queries: maps `expiration_ms` -> set of keys.
@@ -69,6 +70,40 @@ impl MemoryStateStore {
     /// Create a new, empty in-memory state store.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Proactively evict every entry whose TTL has elapsed and drop any
+    /// empty index buckets. Returns the number of data entries removed.
+    ///
+    /// Expired entries are normally evicted lazily — `Entry::is_expired`
+    /// is only consulted when a key is read (`get`, `scan_*`). A TTL'd
+    /// entry that is never read again — a one-shot dedup key, a counter
+    /// that settles and is never inspected — would otherwise occupy the
+    /// map forever, a slow leak in long-running processes. Call this
+    /// periodically from a background task to bound memory.
+    ///
+    /// The `timeout` and `chain_ready` indexes are drained by their
+    /// `remove_*_index` counterparts as keys are processed, so this only
+    /// GCs empty buckets defensively, ensuring the `BTreeMap`s never
+    /// retain dead timestamp keys.
+    pub fn sweep_expired(&self) -> usize {
+        let mut removed = 0usize;
+        self.data.retain(|_, entry| {
+            let keep = !entry.is_expired();
+            if !keep {
+                removed += 1;
+            }
+            keep
+        });
+
+        if let Ok(mut index) = self.timeout_index.write() {
+            index.retain(|_, keys| !keys.is_empty());
+        }
+        if let Ok(mut index) = self.chain_ready_index.write() {
+            index.retain(|_, keys| !keys.is_empty());
+        }
+
+        removed
     }
 
     /// Render a [`StateKey`] into the string used as the map key.
@@ -425,6 +460,63 @@ mod tests {
         // Lazy eviction: get should return None.
         let val = store.get(&key).await.unwrap();
         assert!(val.is_none(), "value should be expired");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn sweep_expired_removes_unread_ttl_entries() {
+        let store = MemoryStateStore::new();
+
+        // A one-shot dedup key with a TTL that nothing ever reads back.
+        let transient = test_key(KeyKind::Dedup, "one-shot");
+        store
+            .set(&transient, "v", Some(Duration::from_secs(60)))
+            .await
+            .unwrap();
+        // A key with no TTL that must survive sweeps forever.
+        let permanent = test_key(KeyKind::State, "permanent");
+        store.set(&permanent, "keep", None).await.unwrap();
+
+        // Before the TTL elapses the sweep removes nothing.
+        assert_eq!(store.sweep_expired(), 0);
+
+        // Advance past the TTL *without ever reading* the transient key, so
+        // lazy eviction never had a chance to fire.
+        tokio::time::advance(Duration::from_secs(61)).await;
+
+        // The sweep reclaims the expired entry proactively, and a second
+        // pass is a no-op. The permanent entry is untouched.
+        assert_eq!(store.sweep_expired(), 1);
+        assert_eq!(store.sweep_expired(), 0);
+        assert_eq!(
+            store.get(&permanent).await.unwrap().as_deref(),
+            Some("keep"),
+            "no-TTL entry must survive sweeps"
+        );
+    }
+
+    #[tokio::test]
+    async fn sweep_expired_drops_empty_index_buckets() {
+        let store = MemoryStateStore::new();
+
+        // Simulate a drained-but-not-removed bucket (e.g. a key removed via
+        // a path that left the bucket empty) lingering in the index.
+        store.timeout_index.write().unwrap().insert(123, Vec::new());
+        store
+            .chain_ready_index
+            .write()
+            .unwrap()
+            .insert(456, Vec::new());
+
+        let _ = store.sweep_expired();
+
+        assert!(
+            store.timeout_index.read().unwrap().is_empty(),
+            "empty timeout buckets should be GC'd"
+        );
+        assert!(
+            store.chain_ready_index.read().unwrap().is_empty(),
+            "empty chain-ready buckets should be GC'd"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/examples/full.toml
+++ b/examples/full.toml
@@ -19,6 +19,12 @@ backend = "memory"
 # region = "us-east-1"
 # table_name = "acteon_state"
 
+# Memory backend only: how often (seconds) to sweep TTL-expired entries and
+# locks. The in-memory store evicts lazily on read, so this reclaims entries
+# that are never read again (one-shot dedup keys, settled counters, locks
+# whose holder crashed). Default 60; set to 0 to disable the sweeper.
+# memory_sweep_interval_secs = 60
+
 [audit]
 # Set to true to enable audit trail recording
 enabled = false


### PR DESCRIPTION
## The leak (survey #5, verified)

The in-memory state store and lock evict expired entries **lazily** — only when a key is read (`get`/`scan_*`, `store.rs:151`) or a lock name is re-acquired (`lock.rs` `try_acquire`). An entry that is never touched again therefore **lives forever**:

- a one-shot dedup key set with a TTL and never re-queried,
- a counter that settles and is never inspected,
- a lock whose holder crashed before `release()` and whose name is never contended again.

In a long-running process these accumulate without bound — a slow memory leak in the **default** backend.

### What is *not* leaking (checked, so the fix stays scoped)
The `timeout_index` / `chain_ready_index` `BTreeMap`s are drained by `remove_*_index`, and **every** background worker (`timeout`, `scheduled`, `chain_advance`, `recurring`) calls the matching `remove_*` after processing a key. So those buckets drain in steady state — I did **not** add aggressive index sweeping that could drop an un-consumed timeout/ready signal. The sweep only GCs *empty* buckets defensively.

## Change

- `MemoryStateStore::sweep_expired() -> usize` — `retain(!is_expired)` over the data map + empty-bucket GC on both indexes. Pure, sync, dependency-free.
- `MemoryDistributedLock::sweep_expired() -> usize` — `retain(!is_expired)` over the lock map.
- Server spawns a background task (`state_factory.rs`) that calls both on an interval, logging the reclaimed count at `debug`.
- Configurable via `state.memory_sweep_interval_secs` (default **60s**; **0 disables**). Ignored by other backends, which delegate expiry to the underlying store. Documented in `examples/full.toml`.

## Tests (paused tokio time)
- `sweep_expired_removes_unread_ttl_entries` — set a TTL'd key, advance past the TTL **without ever reading it**, assert the sweep reclaims it (1) and a no-TTL key survives.
- `sweep_expired_reclaims_unreleased_locks` — acquire + leak the guard (crashed holder), advance past TTL **without re-acquiring**, assert the sweep reclaims it.
- `sweep_expired_drops_empty_index_buckets` — defensive empty-bucket GC.

Both leak tests prove the sweep removes what lazy eviction *never would* (no read / no re-acquire path is ever taken).

## Verification
`cargo fmt`, `clippy -D warnings`, `cargo test --workspace --lib --bins --tests` (exit 0), `cargo check --all-targets`, and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` all clean. (The doc check caught — and I fixed — a private-intra-doc-link to `Entry::is_expired`, the same class of break as #206.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)