### PR TITLE
fix(server): enforce tenant authorization across CRUD/query endpoint families

### DIFF
--- a/crates/server/src/api/chains.rs
+++ b/crates/server/src/api/chains.rs
@@ -11,6 +11,19 @@ use acteon_state::{KeyKind, StateKey};
 
 use super::AppState;
 use super::schemas::ErrorResponse;
+use crate::auth::identity::CallerIdentity;
+
+/// Build a `403 Forbidden` response for a caller whose grants don't cover
+/// the requested `(namespace, tenant)`.
+fn tenant_forbidden(namespace: &str, tenant: &str) -> axum::response::Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(ErrorResponse {
+            error: format!("forbidden: no grant covers tenant={tenant} namespace={namespace}"),
+        }),
+    )
+        .into_response()
+}
 
 /// Query parameters for listing chain executions.
 #[derive(Debug, Deserialize, IntoParams)]
@@ -188,8 +201,12 @@ fn status_to_string(s: &ChainStatus) -> String {
 )]
 pub async fn list_chains(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Query(params): Query<ChainQueryParams>,
 ) -> impl IntoResponse {
+    if !identity.can_manage_scope(&params.tenant, &params.namespace) {
+        return tenant_forbidden(&params.namespace, &params.tenant);
+    }
     let gw = state.gateway.read().await;
     let status_filter = params.status.as_deref().and_then(parse_status_filter);
 
@@ -245,9 +262,13 @@ pub async fn list_chains(
 )]
 pub async fn get_chain(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(chain_id): Path<String>,
     Query(params): Query<ChainNamespaceParams>,
 ) -> impl IntoResponse {
+    if !identity.can_manage_scope(&params.tenant, &params.namespace) {
+        return tenant_forbidden(&params.namespace, &params.tenant);
+    }
     let gw = state.gateway.read().await;
 
     match gw
@@ -352,9 +373,13 @@ pub async fn get_chain(
 )]
 pub async fn cancel_chain(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(chain_id): Path<String>,
     Json(params): Json<ChainCancelRequest>,
 ) -> impl IntoResponse {
+    if !identity.can_manage_scope(&params.tenant, &params.namespace) {
+        return tenant_forbidden(&params.namespace, &params.tenant);
+    }
     let gw = state.gateway.read().await;
 
     match gw
@@ -423,9 +448,13 @@ pub async fn cancel_chain(
 )]
 pub async fn get_chain_dag(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(chain_id): Path<String>,
     Query(params): Query<ChainNamespaceParams>,
 ) -> impl IntoResponse {
+    if !identity.can_manage_scope(&params.tenant, &params.namespace) {
+        return tenant_forbidden(&params.namespace, &params.tenant);
+    }
     let gw = state.gateway.read().await;
 
     // Load the chain state to find the chain name and build the DAG.
@@ -891,9 +920,13 @@ pub struct StepAttemptResponse {
 )]
 pub async fn get_chain_history(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(chain_id): Path<String>,
     Query(params): Query<ChainNamespaceParams>,
 ) -> impl IntoResponse {
+    if !identity.can_manage_scope(&params.tenant, &params.namespace) {
+        return tenant_forbidden(&params.namespace, &params.tenant);
+    }
     let gw = state.gateway.read().await;
 
     match gw

--- a/crates/server/src/api/dlq.rs
+++ b/crates/server/src/api/dlq.rs
@@ -9,6 +9,29 @@ use utoipa::ToSchema;
 
 use super::AppState;
 use super::schemas::ErrorResponse;
+use crate::auth::identity::CallerIdentity;
+use crate::auth::role::Permission;
+
+/// `403` for a caller without unrestricted (wildcard) tenant grants. The DLQ
+/// is a single global queue spanning every tenant; the gateway does not
+/// support draining a tenant-scoped slice, so cross-tenant callers must be
+/// fully unrestricted to read or drain it.
+fn require_global_access(identity: &CallerIdentity) -> Option<axum::response::Response> {
+    if identity.allowed_tenants().is_some() {
+        return Some(
+            (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!(ErrorResponse {
+                    error: "the dead-letter queue spans all tenants; access requires \
+                            unrestricted (wildcard) tenant grants"
+                        .into(),
+                })),
+            )
+                .into_response(),
+        );
+    }
+    None
+}
 
 /// Response for DLQ stats endpoint.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -71,11 +94,17 @@ pub struct DlqDrainResponse {
         (status = 200, description = "DLQ statistics", body = DlqStatsResponse)
     )
 )]
-pub async fn dlq_stats(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn dlq_stats(
+    State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
+) -> impl IntoResponse {
+    if let Some(resp) = require_global_access(&identity) {
+        return resp;
+    }
     let gw = state.gateway.read().await;
     let enabled = gw.dlq_enabled();
     let count = gw.dlq_len().await.unwrap_or(0);
-    (StatusCode::OK, Json(DlqStatsResponse { enabled, count }))
+    (StatusCode::OK, Json(DlqStatsResponse { enabled, count })).into_response()
 }
 
 /// `POST /v1/dlq/drain` -- drain all entries from the dead-letter queue.
@@ -90,7 +119,25 @@ pub async fn dlq_stats(State(state): State<AppState>) -> impl IntoResponse {
         (status = 404, description = "DLQ not enabled", body = ErrorResponse)
     )
 )]
-pub async fn dlq_drain(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn dlq_drain(
+    State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
+) -> impl IntoResponse {
+    // Draining is a destructive, cross-tenant operation: require a write
+    // role and unrestricted tenant access.
+    if !identity.role.has_permission(Permission::Dispatch) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!(ErrorResponse {
+                error: "draining the dead-letter queue requires admin or operator role".into(),
+            })),
+        )
+            .into_response();
+    }
+    if let Some(resp) = require_global_access(&identity) {
+        return resp;
+    }
+
     let gw = state.gateway.read().await;
 
     if !gw.dlq_enabled() {
@@ -99,7 +146,8 @@ pub async fn dlq_drain(State(state): State<AppState>) -> impl IntoResponse {
             Json(serde_json::json!(ErrorResponse {
                 error: "dead-letter queue is not enabled".into(),
             })),
-        );
+        )
+            .into_response();
     }
 
     let entries: Vec<DlqEntry> = gw
@@ -126,4 +174,5 @@ pub async fn dlq_drain(State(state): State<AppState>) -> impl IntoResponse {
         StatusCode::OK,
         Json(serde_json::json!(DlqDrainResponse { entries, count })),
     )
+        .into_response()
 }

--- a/crates/server/src/api/dlq.rs
+++ b/crates/server/src/api/dlq.rs
@@ -12,18 +12,24 @@ use super::schemas::ErrorResponse;
 use crate::auth::identity::CallerIdentity;
 use crate::auth::role::Permission;
 
-/// `403` for a caller without unrestricted (wildcard) tenant grants. The DLQ
-/// is a single global queue spanning every tenant; the gateway does not
-/// support draining a tenant-scoped slice, so cross-tenant callers must be
-/// fully unrestricted to read or drain it.
+/// `403` for a caller that is not fully unrestricted. The DLQ is a single
+/// global queue and the gateway offers no per-scope draining; each entry
+/// exposes its namespace, tenant, and provider. A caller may therefore only
+/// touch it if it holds a grant that is wildcard on EVERY one of those
+/// dimensions — a wildcard *tenant* grant that is still namespace- or
+/// provider-scoped must not pass, or it would read entries for namespaces /
+/// providers it holds no grant for.
 fn require_global_access(identity: &CallerIdentity) -> Option<axum::response::Response> {
-    if identity.allowed_tenants().is_some() {
+    let unrestricted = identity.allowed_tenants().is_none()
+        && identity.allowed_namespaces().is_none()
+        && identity.allowed_providers().is_none();
+    if !unrestricted {
         return Some(
             (
                 StatusCode::FORBIDDEN,
                 Json(serde_json::json!(ErrorResponse {
-                    error: "the dead-letter queue spans all tenants; access requires \
-                            unrestricted (wildcard) tenant grants"
+                    error: "the dead-letter queue spans all tenants, namespaces, and \
+                            providers; access requires fully unrestricted (wildcard) grants"
                         .into(),
                 })),
             )

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -129,6 +129,17 @@ pub async fn list_events(
             })),
         ));
     }
+    if !identity.can_manage_scope(&params.tenant, &params.namespace) {
+        return Ok((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!(ErrorResponse {
+                error: format!(
+                    "forbidden: no grant covers tenant={} namespace={}",
+                    params.tenant, params.namespace
+                ),
+            })),
+        ));
+    }
 
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
@@ -238,6 +249,17 @@ pub async fn get_event(
             })),
         ));
     }
+    if !identity.can_manage_scope(&params.tenant, &params.namespace) {
+        return Ok((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!(ErrorResponse {
+                error: format!(
+                    "forbidden: no grant covers tenant={} namespace={}",
+                    params.tenant, params.namespace
+                ),
+            })),
+        ));
+    }
 
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
@@ -319,6 +341,17 @@ pub async fn transition_event(
             StatusCode::FORBIDDEN,
             Json(serde_json::json!(ErrorResponse {
                 error: "insufficient permissions".into(),
+            })),
+        ));
+    }
+    if !identity.can_manage_scope(&request.tenant, &request.namespace) {
+        return Ok((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!(ErrorResponse {
+                error: format!(
+                    "forbidden: no grant covers tenant={} namespace={}",
+                    request.tenant, request.namespace
+                ),
             })),
         ));
     }

--- a/crates/server/src/api/groups.rs
+++ b/crates/server/src/api/groups.rs
@@ -121,7 +121,21 @@ pub async fn list_groups(
     let group_manager = gw.group_manager();
 
     let pending = group_manager.list_pending_groups();
-    let total = group_manager.active_group_count();
+    let active_total = group_manager.active_group_count();
+
+    // Tenant authorization: only surface groups the caller's grants cover
+    // (hierarchical). Prevents cross-tenant enumeration of event groups.
+    let pending: Vec<_> = pending
+        .into_iter()
+        .filter(|g| identity.can_manage_scope(&g.tenant, &g.namespace))
+        .collect();
+    // Wildcard callers see the true global active count; scoped callers see
+    // only their visible groups, to avoid leaking cross-tenant volume.
+    let total = if identity.allowed_tenants().is_none() {
+        active_total
+    } else {
+        pending.len()
+    };
 
     let groups: Vec<GroupSummary> = pending.iter().map(GroupSummary::from).collect();
 
@@ -167,6 +181,17 @@ pub async fn get_group(
 
     match group_manager.get_group(&group_key) {
         Some(group) => {
+            if !identity.can_manage_scope(&group.tenant, &group.namespace) {
+                return Ok((
+                    StatusCode::FORBIDDEN,
+                    Json(serde_json::json!(ErrorResponse {
+                        error: format!(
+                            "forbidden: no grant covers tenant={} namespace={}",
+                            group.tenant, group.namespace
+                        ),
+                    })),
+                ));
+            }
             let event_fingerprints: Vec<String> = group
                 .events
                 .iter()
@@ -224,6 +249,23 @@ pub async fn flush_group(
 
     let gw = state.gateway.read().await;
     let group_manager = gw.group_manager();
+
+    // Authorize against the group's own scope *before* mutating it. A group
+    // that exists but is outside the caller's grants → 403; a non-existent
+    // group falls through to the flush below and returns 404.
+    if let Some(group) = group_manager.get_group(&group_key)
+        && !identity.can_manage_scope(&group.tenant, &group.namespace)
+    {
+        return Ok((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!(ErrorResponse {
+                error: format!(
+                    "forbidden: no grant covers tenant={} namespace={}",
+                    group.tenant, group.namespace
+                ),
+            })),
+        ));
+    }
 
     // Try to flush the group
     match group_manager.flush_group(&group_key) {

--- a/crates/server/src/api/quotas.rs
+++ b/crates/server/src/api/quotas.rs
@@ -20,6 +20,7 @@ use acteon_state::{KeyKind, StateKey};
 
 use super::AppState;
 use super::schemas::ErrorResponse;
+use crate::auth::identity::CallerIdentity;
 
 // ---------------------------------------------------------------------------
 // Request / response types
@@ -375,6 +376,14 @@ fn error_response(status: StatusCode, message: &str) -> axum::response::Response
         .into_response()
 }
 
+/// `403 Forbidden` for a caller whose grants don't cover `(namespace, tenant)`.
+fn tenant_forbidden(namespace: &str, tenant: &str) -> axum::response::Response {
+    error_response(
+        StatusCode::FORBIDDEN,
+        &format!("forbidden: no grant covers tenant={tenant} namespace={namespace}"),
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -397,8 +406,12 @@ fn error_response(status: StatusCode, message: &str) -> axum::response::Response
 #[allow(clippy::too_many_lines)]
 pub async fn create_quota(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Json(req): Json<CreateQuotaRequest>,
 ) -> impl IntoResponse {
+    if !identity.can_manage_scope(&req.tenant, &req.namespace) {
+        return tenant_forbidden(&req.namespace, &req.tenant);
+    }
     // Validate identifiers first — reject colon injection and
     // oversized names before we touch the state store.
     if let Err(e) = validate_quota_scope_identifier(&req.namespace) {
@@ -563,6 +576,7 @@ pub async fn create_quota(
 )]
 pub async fn list_quotas(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Query(params): Query<ListQuotasParams>,
 ) -> impl IntoResponse {
     let gw = state.gateway.read().await;
@@ -582,6 +596,12 @@ pub async fn list_quotas(
         let Ok(policy) = serde_json::from_str::<QuotaPolicy>(&value) else {
             continue;
         };
+
+        // Tenant authorization: only surface policies the caller's grants
+        // cover (hierarchical). Prevents cross-tenant enumeration.
+        if !identity.can_manage_scope(&policy.tenant, &policy.namespace) {
+            continue;
+        }
 
         // Apply namespace filter.
         if let Some(ref ns) = params.namespace
@@ -660,12 +680,19 @@ pub async fn list_quotas(
         (status = 500, description = "Internal server error", body = ErrorResponse),
     )
 )]
-pub async fn get_quota(State(state): State<AppState>, Path(id): Path<String>) -> impl IntoResponse {
+pub async fn get_quota(
+    State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
 
     match load_quota(state_store.as_ref(), &id).await {
         Ok(Some(policy)) => {
+            if !identity.can_manage_scope(&policy.tenant, &policy.namespace) {
+                return tenant_forbidden(&policy.namespace, &policy.tenant);
+            }
             let usage = read_usage(state_store.as_ref(), &policy).await.ok();
             (
                 StatusCode::OK,
@@ -699,6 +726,7 @@ pub async fn get_quota(State(state): State<AppState>, Path(id): Path<String>) ->
 )]
 pub async fn update_quota(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
     Json(req): Json<UpdateQuotaRequest>,
 ) -> impl IntoResponse {
@@ -715,6 +743,10 @@ pub async fn update_quota(
         }
         Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e),
     };
+
+    if !identity.can_manage_scope(&policy.tenant, &policy.namespace) {
+        return tenant_forbidden(&policy.namespace, &policy.tenant);
+    }
 
     // Apply updates.
     if let Some(max) = req.max_actions {
@@ -784,6 +816,7 @@ pub async fn update_quota(
 )]
 pub async fn delete_quota(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     let gw = state.gateway.read().await;
@@ -799,6 +832,10 @@ pub async fn delete_quota(
         }
         Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e),
     };
+
+    if !identity.can_manage_scope(&policy.tenant, &policy.namespace) {
+        return tenant_forbidden(&policy.namespace, &policy.tenant);
+    }
 
     // Remove from state store.
     let key = quota_state_key(&id);
@@ -839,6 +876,7 @@ pub async fn delete_quota(
 )]
 pub async fn get_quota_usage(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     let gw = state.gateway.read().await;
@@ -854,6 +892,10 @@ pub async fn get_quota_usage(
         }
         Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e),
     };
+
+    if !identity.can_manage_scope(&policy.tenant, &policy.namespace) {
+        return tenant_forbidden(&policy.namespace, &policy.tenant);
+    }
 
     let now = Utc::now();
     let Some(counter_id) = quota_counter_key(

--- a/crates/server/src/api/quotas.rs
+++ b/crates/server/src/api/quotas.rs
@@ -21,6 +21,7 @@ use acteon_state::{KeyKind, StateKey};
 use super::AppState;
 use super::schemas::ErrorResponse;
 use crate::auth::identity::CallerIdentity;
+use crate::auth::role::Permission;
 
 // ---------------------------------------------------------------------------
 // Request / response types
@@ -967,7 +968,20 @@ pub async fn get_quota_usage(
         (status = 500, description = "Reload failed", body = ErrorResponse),
     )
 )]
-pub async fn reload_static_quotas(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn reload_static_quotas(
+    State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
+) -> impl IntoResponse {
+    // Reconciling the static-quotas file is a global, cross-tenant
+    // operation (it can upsert and delete TOML-sourced policies across every
+    // tenant), so require a write role rather than letting any authenticated
+    // caller trigger it.
+    if !identity.role.has_permission(Permission::Dispatch) {
+        return error_response(
+            StatusCode::FORBIDDEN,
+            "reloading static quotas requires admin or operator role",
+        );
+    }
     let Some(handle) = state.static_quotas.clone() else {
         return error_response(
             StatusCode::BAD_REQUEST,

--- a/crates/server/src/api/recurring.rs
+++ b/crates/server/src/api/recurring.rs
@@ -22,6 +22,15 @@ use acteon_state::{KeyKind, StateKey};
 
 use super::AppState;
 use super::schemas::ErrorResponse;
+use crate::auth::identity::CallerIdentity;
+
+/// `403 Forbidden` for a caller whose grants don't cover `(namespace, tenant)`.
+fn tenant_forbidden(namespace: &str, tenant: &str) -> axum::response::Response {
+    error_response(
+        StatusCode::FORBIDDEN,
+        &format!("forbidden: no grant covers tenant={tenant} namespace={namespace}"),
+    )
+}
 
 // ---------------------------------------------------------------------------
 // Request / response types
@@ -545,8 +554,12 @@ fn validate_cron_input(
 )]
 pub async fn create_recurring(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Json(req): Json<CreateRecurringRequest>,
 ) -> impl IntoResponse {
+    if !identity.can_manage_scope(&req.tenant, &req.namespace) {
+        return tenant_forbidden(&req.namespace, &req.tenant);
+    }
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
     let enc = gw.payload_encryptor();
@@ -642,8 +655,12 @@ pub async fn create_recurring(
 )]
 pub async fn list_recurring(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Query(params): Query<ListRecurringParams>,
 ) -> impl IntoResponse {
+    if !identity.can_manage_scope(&params.tenant, &params.namespace) {
+        return tenant_forbidden(&params.namespace, &params.tenant);
+    }
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
     let enc = gw.payload_encryptor();
@@ -738,9 +755,13 @@ pub async fn list_recurring(
 )]
 pub async fn get_recurring(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
     Query(params): Query<RecurringNamespaceParams>,
 ) -> impl IntoResponse {
+    if !identity.can_manage_scope(&params.tenant, &params.namespace) {
+        return tenant_forbidden(&params.namespace, &params.tenant);
+    }
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
     let enc = gw.payload_encryptor();
@@ -794,9 +815,13 @@ pub async fn get_recurring(
 #[allow(clippy::similar_names)]
 pub async fn update_recurring(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
     Json(req): Json<UpdateRecurringRequest>,
 ) -> impl IntoResponse {
+    if !identity.can_manage_scope(&req.tenant, &req.namespace) {
+        return tenant_forbidden(&req.namespace, &req.tenant);
+    }
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
     let enc = gw.payload_encryptor();
@@ -973,9 +998,13 @@ pub async fn update_recurring(
 )]
 pub async fn delete_recurring(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
     Query(params): Query<RecurringNamespaceParams>,
 ) -> impl IntoResponse {
+    if !identity.can_manage_scope(&params.tenant, &params.namespace) {
+        return tenant_forbidden(&params.namespace, &params.tenant);
+    }
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
     let enc = gw.payload_encryptor();
@@ -1059,9 +1088,13 @@ pub async fn delete_recurring(
 #[allow(clippy::similar_names)]
 pub async fn pause_recurring(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
     Json(req): Json<RecurringLifecycleRequest>,
 ) -> impl IntoResponse {
+    if !identity.can_manage_scope(&req.tenant, &req.namespace) {
+        return tenant_forbidden(&req.namespace, &req.tenant);
+    }
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
     let enc = gw.payload_encryptor();
@@ -1146,9 +1179,13 @@ pub async fn pause_recurring(
 #[allow(clippy::similar_names)]
 pub async fn resume_recurring(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
     Json(req): Json<RecurringLifecycleRequest>,
 ) -> impl IntoResponse {
+    if !identity.can_manage_scope(&req.tenant, &req.namespace) {
+        return tenant_forbidden(&req.namespace, &req.tenant);
+    }
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
     let enc = gw.payload_encryptor();

--- a/crates/server/src/api/retention.rs
+++ b/crates/server/src/api/retention.rs
@@ -17,6 +17,7 @@ use acteon_state::{KeyKind, StateKey};
 
 use super::AppState;
 use super::schemas::ErrorResponse;
+use crate::auth::identity::CallerIdentity;
 
 // ---------------------------------------------------------------------------
 // Request / response types
@@ -218,6 +219,14 @@ fn error_response(status: StatusCode, message: &str) -> axum::response::Response
         .into_response()
 }
 
+/// `403 Forbidden` for a caller whose grants don't cover `(namespace, tenant)`.
+fn tenant_forbidden(namespace: &str, tenant: &str) -> axum::response::Response {
+    error_response(
+        StatusCode::FORBIDDEN,
+        &format!("forbidden: no grant covers tenant={tenant} namespace={namespace}"),
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -238,8 +247,12 @@ fn error_response(status: StatusCode, message: &str) -> axum::response::Response
 )]
 pub async fn create_retention(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Json(req): Json<CreateRetentionRequest>,
 ) -> impl IntoResponse {
+    if !identity.can_manage_scope(&req.tenant, &req.namespace) {
+        return tenant_forbidden(&req.namespace, &req.tenant);
+    }
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
 
@@ -323,6 +336,7 @@ pub async fn create_retention(
 )]
 pub async fn list_retention(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Query(params): Query<ListRetentionParams>,
 ) -> impl IntoResponse {
     let gw = state.gateway.read().await;
@@ -342,6 +356,12 @@ pub async fn list_retention(
         let Ok(policy) = serde_json::from_str::<RetentionPolicy>(&value) else {
             continue;
         };
+
+        // Tenant authorization: only surface policies the caller's grants
+        // cover (hierarchical). Prevents cross-tenant enumeration.
+        if !identity.can_manage_scope(&policy.tenant, &policy.namespace) {
+            continue;
+        }
 
         // Apply namespace filter.
         if let Some(ref ns) = params.namespace
@@ -394,17 +414,23 @@ pub async fn list_retention(
 )]
 pub async fn get_retention(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
 
     match load_retention(state_store.as_ref(), &id).await {
-        Ok(Some(policy)) => (
-            StatusCode::OK,
-            Json(serde_json::json!(policy_to_response(&policy))),
-        )
-            .into_response(),
+        Ok(Some(policy)) => {
+            if !identity.can_manage_scope(&policy.tenant, &policy.namespace) {
+                return tenant_forbidden(&policy.namespace, &policy.tenant);
+            }
+            (
+                StatusCode::OK,
+                Json(serde_json::json!(policy_to_response(&policy))),
+            )
+                .into_response()
+        }
         Ok(None) => error_response(
             StatusCode::NOT_FOUND,
             &format!("retention policy not found: {id}"),
@@ -430,6 +456,7 @@ pub async fn get_retention(
 )]
 pub async fn update_retention(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
     Json(req): Json<UpdateRetentionRequest>,
 ) -> impl IntoResponse {
@@ -446,6 +473,10 @@ pub async fn update_retention(
         }
         Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e),
     };
+
+    if !identity.can_manage_scope(&policy.tenant, &policy.namespace) {
+        return tenant_forbidden(&policy.namespace, &policy.tenant);
+    }
 
     // Apply updates.
     if let Some(enabled) = req.enabled {
@@ -512,6 +543,7 @@ pub async fn update_retention(
 )]
 pub async fn delete_retention(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     let gw = state.gateway.read().await;
@@ -527,6 +559,10 @@ pub async fn delete_retention(
         }
         Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e),
     };
+
+    if !identity.can_manage_scope(&policy.tenant, &policy.namespace) {
+        return tenant_forbidden(&policy.namespace, &policy.tenant);
+    }
 
     // Remove from state store.
     let key = retention_state_key(&id);

--- a/crates/server/src/api/swarm.rs
+++ b/crates/server/src/api/swarm.rs
@@ -14,6 +14,7 @@ use utoipa::{IntoParams, ToSchema};
 
 use super::AppState;
 use super::schemas::ErrorResponse;
+use crate::auth::identity::CallerIdentity;
 
 /// Query parameters for listing swarm runs.
 #[derive(Debug, Deserialize, IntoParams)]
@@ -114,6 +115,7 @@ const MAX_API_PAGE: usize = 500;
 )]
 pub async fn list_swarm_runs(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Query(params): Query<ListSwarmRunsParams>,
 ) -> impl IntoResponse {
     #[cfg(feature = "swarm")]
@@ -157,7 +159,14 @@ pub async fn list_swarm_runs(
             limit: effective_limit,
             offset: params.offset,
         };
-        let (runs, total) = registry.list(&filter);
+        let (runs, _total) = registry.list(&filter);
+        // Tenant authorization: drop runs outside the caller's grants so a
+        // `?tenant=victim` (or unscoped) query cannot read other tenants' runs.
+        let runs: Vec<_> = runs
+            .into_iter()
+            .filter(|r| identity.can_manage_scope(&r.tenant, &r.namespace))
+            .collect();
+        let total = runs.len();
         let body = SwarmRunList {
             runs: runs.into_iter().map(to_api_snapshot).collect(),
             total,
@@ -166,7 +175,7 @@ pub async fn list_swarm_runs(
     }
     #[cfg(not(feature = "swarm"))]
     {
-        let _ = (state, params);
+        let _ = (state, params, identity);
         (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(ErrorResponse {
@@ -189,6 +198,7 @@ pub async fn list_swarm_runs(
 )]
 pub async fn get_swarm_run(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(run_id): Path<String>,
 ) -> impl IntoResponse {
     #[cfg(feature = "swarm")]
@@ -203,7 +213,21 @@ pub async fn get_swarm_run(
                 .into_response();
         };
         match registry.get(&run_id) {
-            Some(snap) => (StatusCode::OK, Json(to_api_snapshot(snap))).into_response(),
+            Some(snap) => {
+                if !identity.can_manage_scope(&snap.tenant, &snap.namespace) {
+                    return (
+                        StatusCode::FORBIDDEN,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "forbidden: no grant covers tenant={} namespace={}",
+                                snap.tenant, snap.namespace
+                            ),
+                        }),
+                    )
+                        .into_response();
+                }
+                (StatusCode::OK, Json(to_api_snapshot(snap))).into_response()
+            }
             None => (
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse {
@@ -215,7 +239,7 @@ pub async fn get_swarm_run(
     }
     #[cfg(not(feature = "swarm"))]
     {
-        let _ = (state, run_id);
+        let _ = (state, run_id, identity);
         (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(ErrorResponse {
@@ -238,6 +262,7 @@ pub async fn get_swarm_run(
 )]
 pub async fn cancel_swarm_run(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(run_id): Path<String>,
 ) -> impl IntoResponse {
     #[cfg(feature = "swarm")]
@@ -251,6 +276,29 @@ pub async fn cancel_swarm_run(
             )
                 .into_response();
         };
+        // Authorize against the run's own scope *before* mutating it.
+        let Some(snap) = registry.get(&run_id) else {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("swarm run not found: {run_id}"),
+                }),
+            )
+                .into_response();
+        };
+        if !identity.can_manage_scope(&snap.tenant, &snap.namespace) {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse {
+                    error: format!(
+                        "forbidden: no grant covers tenant={} namespace={}",
+                        snap.tenant, snap.namespace
+                    ),
+                }),
+            )
+                .into_response();
+        }
+        drop(snap);
         match registry.cancel(&run_id).await {
             Ok(snap) => (StatusCode::OK, Json(to_api_snapshot(snap))).into_response(),
             Err(acteon_swarm_provider::SwarmProviderError::NotFound(_)) => (
@@ -271,7 +319,7 @@ pub async fn cancel_swarm_run(
     }
     #[cfg(not(feature = "swarm"))]
     {
-        let _ = (state, run_id);
+        let _ = (state, run_id, identity);
         (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(ErrorResponse {

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -3541,3 +3541,142 @@ async fn a2a_message_send_allowed_for_unbound_caller() {
         "an unbound caller must pass the lifecycle gate: {body}"
     );
 }
+
+// -- Tenant-authorization sweep -------------------------------------------
+//
+// Cross-tenant isolation on the CRUD/query endpoint families that previously
+// trusted caller-supplied `namespace`/`tenant` with no grant check (chains,
+// recurring, quotas, retention, events, dlq, …). A caller scoped to
+// `tenant-1` must be refused (`403`) when it names another tenant, and a
+// wildcard caller must still be allowed. These run through the real auth
+// middleware, so they also prove the `Extension<CallerIdentity>` wiring.
+
+fn wildcard_admin_grant() -> Grant {
+    Grant {
+        tenants: vec!["*".to_string()],
+        namespaces: vec!["*".to_string()],
+        providers: vec!["*".to_string()],
+        actions: vec!["*".to_string()],
+        agent_id: None,
+    }
+}
+
+async fn auth_get_status(app: axum::Router, uri: &str) -> StatusCode {
+    app.oneshot(
+        Request::builder()
+            .method(http::Method::GET)
+            .uri(uri)
+            .header(http::header::AUTHORIZATION, "Bearer test-raw-key")
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await
+    .unwrap()
+    .status()
+}
+
+async fn auth_post_status(app: axum::Router, uri: &str, body: serde_json::Value) -> StatusCode {
+    app.oneshot(
+        Request::builder()
+            .method(http::Method::POST)
+            .uri(uri)
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .header(http::header::AUTHORIZATION, "Bearer test-raw-key")
+            .body(Body::from(body.to_string()))
+            .unwrap(),
+    )
+    .await
+    .unwrap()
+    .status()
+}
+
+#[tokio::test]
+async fn tenant_authz_chains_list_denies_cross_tenant() {
+    let app = build_app(build_test_state_with_auth(vec![default_test_grant()]));
+    let status = auth_get_status(app, "/v1/chains?namespace=notifications&tenant=tenant-2").await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn tenant_authz_chains_list_allows_in_scope() {
+    let app = build_app(build_test_state_with_auth(vec![default_test_grant()]));
+    let status = auth_get_status(app, "/v1/chains?namespace=notifications&tenant=tenant-1").await;
+    assert_ne!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn tenant_authz_chains_get_denies_cross_tenant() {
+    let app = build_app(build_test_state_with_auth(vec![default_test_grant()]));
+    let status = auth_get_status(
+        app,
+        "/v1/chains/some-id?namespace=notifications&tenant=tenant-2",
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn tenant_authz_recurring_list_denies_cross_tenant() {
+    let app = build_app(build_test_state_with_auth(vec![default_test_grant()]));
+    let status =
+        auth_get_status(app, "/v1/recurring?namespace=notifications&tenant=tenant-2").await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn tenant_authz_events_list_denies_cross_tenant() {
+    let app = build_app(build_test_state_with_auth(vec![default_test_grant()]));
+    let status = auth_get_status(app, "/v1/events?namespace=notifications&tenant=tenant-2").await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn tenant_authz_quota_create_denies_cross_tenant() {
+    let app = build_app(build_test_state_with_auth(vec![default_test_grant()]));
+    let body = serde_json::json!({
+        "namespace": "notifications",
+        "tenant": "tenant-2",
+        "max_actions": 1000,
+        "window": "daily",
+        "overage_behavior": "block",
+    });
+    let status = auth_post_status(app, "/v1/quotas", body).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn tenant_authz_quota_create_allows_wildcard() {
+    let app = build_app(build_test_state_with_auth(vec![wildcard_admin_grant()]));
+    let body = serde_json::json!({
+        "namespace": "notifications",
+        "tenant": "tenant-2",
+        "max_actions": 1000,
+        "window": "daily",
+        "overage_behavior": "block",
+    });
+    let status = auth_post_status(app, "/v1/quotas", body).await;
+    assert_ne!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn tenant_authz_retention_create_denies_cross_tenant() {
+    let app = build_app(build_test_state_with_auth(vec![default_test_grant()]));
+    let body = serde_json::json!({ "namespace": "notifications", "tenant": "tenant-2" });
+    let status = auth_post_status(app, "/v1/retention", body).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn tenant_authz_dlq_stats_denies_scoped_caller() {
+    // The DLQ is a single global queue; a tenant-scoped caller must be refused.
+    let app = build_app(build_test_state_with_auth(vec![default_test_grant()]));
+    let status = auth_get_status(app, "/v1/dlq/stats").await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn tenant_authz_dlq_stats_allows_wildcard() {
+    let app = build_app(build_test_state_with_auth(vec![wildcard_admin_grant()]));
+    let status = auth_get_status(app, "/v1/dlq/stats").await;
+    assert_ne!(status, StatusCode::FORBIDDEN);
+}

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -3680,3 +3680,20 @@ async fn tenant_authz_dlq_stats_allows_wildcard() {
     let status = auth_get_status(app, "/v1/dlq/stats").await;
     assert_ne!(status, StatusCode::FORBIDDEN);
 }
+
+#[tokio::test]
+async fn tenant_authz_dlq_stats_denies_namespace_scoped_wildcard_tenant() {
+    // A grant that is wildcard on tenant but scoped on namespace must NOT
+    // pass the global-access gate: the DLQ spans every namespace and exposes
+    // each entry's namespace, so wildcard-tenant alone is insufficient.
+    let grant = Grant {
+        tenants: vec!["*".to_string()],
+        namespaces: vec!["notifications".to_string()],
+        providers: vec!["*".to_string()],
+        actions: vec!["*".to_string()],
+        agent_id: None,
+    };
+    let app = build_app(build_test_state_with_auth(vec![grant]));
+    let status = auth_get_status(app, "/v1/dlq/stats").await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}


### PR DESCRIPTION
## The hole (survey theme #1, verified)

PRs #199/#200 fixed cross-tenant scoping on the **audit + analytics** endpoints — but the *same* hole was wide open on nearly every other endpoint family. The fresh codebase survey found **2 critical + 5 high** findings, all one root cause: handlers took caller-supplied `namespace`/`tenant` (or looked a resource up by id) and **never consulted `CallerIdentity`**.

Any authenticated caller could read — and in several cases **create, cancel, or delete** — another tenant's:
- **chains** 🔴 (read + cancel any tenant's chain executions)
- **recurring actions** 🔴 (cross-tenant read/create/delete of scheduled actions + payloads)
- **quota policies** 🟠 (raise/disable a competitor's limits)
- **retention / compliance-hold config** 🟠 (enumerate + mutate)
- **swarm runs** 🟠 (list/get/cancel)
- **dead-letter payloads** 🟠 (global drain returned + deleted *every* tenant's failed actions)
- **events / groups** 🟠 (gated only by `AuditRead`, which every role holds)

## The fix

Applied the established `CallerIdentity` pattern (the `silences` endpoint is the reference) uniformly across **~31 handlers in 8 files**:

| Shape | Rule |
|---|---|
| request carries ns/tenant | `can_manage_scope()` at handler entry (tenant-keyed lookups make this sufficient) |
| resource looked up by **id alone** | load, then `can_manage_scope()` on the **resource's own** scope → 403 (not 404) |
| in-memory list scan | per-item `can_manage_scope()` post-filter |
| destructive op | authorize the resource's scope **before** mutating (swarm cancel, group flush) |

The **DLQ** is a single global queue with no gateway-level tenant slicing, so its stats/drain require **fully unrestricted** grants (wildcard on tenant *and* namespace *and* provider), and drain additionally needs a write role. `reload_static_quotas` (a global TOML reconcile) is now gated on a write role.

## Adversarial review

After the initial implementation I ran an 8-agent review (one per file) hunting for bypasses. It found **0 critical**, **1 high** (the DLQ gate originally checked only the tenant dimension — a namespace-scoped/​wildcard-tenant grant slipped through), and **1 low** (the un-touched `reload_static_quotas`). Both are fixed in the second commit, with a regression test for the DLQ case.

## Tests

11 end-to-end tests through the **real auth middleware** (so they also prove the `Extension<CallerIdentity>` wiring): cross-tenant → 403, in-scope/wildcard → allowed, and the namespace-scoped DLQ denial.

## Verification
`cargo fmt`, `clippy --workspace` + `clippy -p acteon-server --features swarm` (both `-D warnings`), `cargo test -p acteon-server` (284 unit + 88 integration), and `cargo check --all-targets` — all clean.

> Note: no UI/SDK changes — these are server-side authorization guards on existing endpoints; the request/response shapes are unchanged (callers that were already correctly scoped see no difference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)