### PR TITLE
fix(state): make timeout/chain-ready re-indexing replace-by-key

### DIFF
--- a/crates/state/dynamodb/src/store.rs
+++ b/crates/state/dynamodb/src/store.rs
@@ -52,6 +52,59 @@ impl DynamoStateStore {
         }
     }
 
+    /// Delete every index item in `partition_key` whose `key` attribute equals
+    /// `canonical`. The sort key embeds the timestamp, so a given key may have
+    /// items under several sort keys after re-indexing; this removes all of
+    /// them. Shared by the `index_*` methods (to make re-indexing replace the
+    /// key's deadline rather than leave a stale duplicate, matching Redis /
+    /// Postgres) and the `remove_*` methods.
+    async fn delete_index_entries(
+        &self,
+        partition_key: &str,
+        canonical: &str,
+    ) -> Result<(), StateError> {
+        let mut exclusive_start_key = None;
+        loop {
+            let mut query = self
+                .client
+                .query()
+                .table_name(&self.table_name)
+                .key_condition_expression("pk = :pk")
+                .filter_expression("#key_attr = :key_val")
+                .expression_attribute_names("#key_attr", "key")
+                .expression_attribute_values(":pk", AttributeValue::S(partition_key.to_owned()))
+                .expression_attribute_values(":key_val", AttributeValue::S(canonical.to_owned()));
+
+            if let Some(start_key) = exclusive_start_key {
+                query = query.set_exclusive_start_key(Some(start_key));
+            }
+
+            let response = query
+                .send()
+                .await
+                .map_err(|e| StateError::Backend(e.to_string()))?;
+
+            for item in response.items() {
+                if let Some(AttributeValue::S(sk)) = item.get("sk") {
+                    self.client
+                        .delete_item()
+                        .table_name(&self.table_name)
+                        .key("pk", AttributeValue::S(partition_key.to_owned()))
+                        .key("sk", AttributeValue::S(sk.clone()))
+                        .send()
+                        .await
+                        .map_err(|e| StateError::Backend(e.to_string()))?;
+                }
+            }
+
+            exclusive_start_key = response.last_evaluated_key().cloned();
+            if exclusive_start_key.is_none() {
+                break;
+            }
+        }
+        Ok(())
+    }
+
     /// Return the current epoch seconds.
     fn now_epoch() -> i64 {
         chrono::Utc::now().timestamp()
@@ -561,6 +614,12 @@ impl StateStore for DynamoStateStore {
         let partition_key = format!("{}:timeout_index", self.prefix);
         let sort_key = format!("{expires_at_ms:020}#{canonical}");
 
+        // Replace-by-key: drop any prior entry (under a different timestamp
+        // sort key) so re-indexing updates the deadline rather than leaving a
+        // stale duplicate that re-fires.
+        self.delete_index_entries(&partition_key, &canonical)
+            .await?;
+
         self.client
             .put_item()
             .table_name(&self.table_name)
@@ -579,53 +638,9 @@ impl StateStore for DynamoStateStore {
     }
 
     async fn remove_timeout_index(&self, key: &StateKey) -> Result<(), StateError> {
-        let canonical = key.canonical();
         let partition_key = format!("{}:timeout_index", self.prefix);
-
-        // We need to find and delete the item. Since we don't know the expires_at_ms,
-        // we query for items with this key and delete them.
-        let mut exclusive_start_key = None;
-
-        loop {
-            let mut query = self
-                .client
-                .query()
-                .table_name(&self.table_name)
-                .key_condition_expression("pk = :pk")
-                .filter_expression("#key_attr = :key_val")
-                .expression_attribute_names("#key_attr", "key")
-                .expression_attribute_values(":pk", AttributeValue::S(partition_key.clone()))
-                .expression_attribute_values(":key_val", AttributeValue::S(canonical.clone()));
-
-            if let Some(start_key) = exclusive_start_key {
-                query = query.set_exclusive_start_key(Some(start_key));
-            }
-
-            let response = query
-                .send()
-                .await
-                .map_err(|e| StateError::Backend(e.to_string()))?;
-
-            for item in response.items() {
-                if let Some(AttributeValue::S(sk)) = item.get("sk") {
-                    self.client
-                        .delete_item()
-                        .table_name(&self.table_name)
-                        .key("pk", AttributeValue::S(partition_key.clone()))
-                        .key("sk", AttributeValue::S(sk.clone()))
-                        .send()
-                        .await
-                        .map_err(|e| StateError::Backend(e.to_string()))?;
-                }
-            }
-
-            exclusive_start_key = response.last_evaluated_key().cloned();
-            if exclusive_start_key.is_none() {
-                break;
-            }
-        }
-
-        Ok(())
+        self.delete_index_entries(&partition_key, &key.canonical())
+            .await
     }
 
     async fn get_expired_timeouts(&self, now_ms: i64) -> Result<Vec<String>, StateError> {
@@ -675,6 +690,11 @@ impl StateStore for DynamoStateStore {
         let partition_key = format!("{}:chain_ready_index", self.prefix);
         let sort_key = format!("{ready_at_ms:020}#{canonical}");
 
+        // Replace-by-key: drop any prior entry so re-indexing updates the
+        // ready time rather than leaving a stale duplicate that re-fires.
+        self.delete_index_entries(&partition_key, &canonical)
+            .await?;
+
         self.client
             .put_item()
             .table_name(&self.table_name)
@@ -690,52 +710,9 @@ impl StateStore for DynamoStateStore {
     }
 
     async fn remove_chain_ready_index(&self, key: &StateKey) -> Result<(), StateError> {
-        let canonical = key.canonical();
         let partition_key = format!("{}:chain_ready_index", self.prefix);
-
-        // We don't know the ready_at_ms, so query for items with this key and delete them.
-        let mut exclusive_start_key = None;
-
-        loop {
-            let mut query = self
-                .client
-                .query()
-                .table_name(&self.table_name)
-                .key_condition_expression("pk = :pk")
-                .filter_expression("#key_attr = :key_val")
-                .expression_attribute_names("#key_attr", "key")
-                .expression_attribute_values(":pk", AttributeValue::S(partition_key.clone()))
-                .expression_attribute_values(":key_val", AttributeValue::S(canonical.clone()));
-
-            if let Some(start_key) = exclusive_start_key {
-                query = query.set_exclusive_start_key(Some(start_key));
-            }
-
-            let response = query
-                .send()
-                .await
-                .map_err(|e| StateError::Backend(e.to_string()))?;
-
-            for item in response.items() {
-                if let Some(AttributeValue::S(sk)) = item.get("sk") {
-                    self.client
-                        .delete_item()
-                        .table_name(&self.table_name)
-                        .key("pk", AttributeValue::S(partition_key.clone()))
-                        .key("sk", AttributeValue::S(sk.clone()))
-                        .send()
-                        .await
-                        .map_err(|e| StateError::Backend(e.to_string()))?;
-                }
-            }
-
-            exclusive_start_key = response.last_evaluated_key().cloned();
-            if exclusive_start_key.is_none() {
-                break;
-            }
-        }
-
-        Ok(())
+        self.delete_index_entries(&partition_key, &key.canonical())
+            .await
     }
 
     async fn get_ready_chains(&self, now_ms: i64) -> Result<Vec<String>, StateError> {

--- a/crates/state/memory/src/store.rs
+++ b/crates/state/memory/src/store.rs
@@ -110,6 +110,27 @@ impl MemoryStateStore {
     fn render_key(key: &StateKey) -> String {
         key.canonical()
     }
+
+    /// Remove every occurrence of `canonical` from a sorted timeout/ready
+    /// index, dropping any bucket left empty.
+    ///
+    /// Shared by the `index_*` methods (so a re-index *replaces* the key's
+    /// deadline instead of leaving a stale duplicate in an older bucket —
+    /// matching Redis `ZADD` and Postgres `UPSERT`) and the `remove_*`
+    /// methods. `O(N)` over the buckets, but (re)indexing and removal are
+    /// infrequent relative to reads.
+    fn remove_key_from_index(index: &mut BTreeMap<i64, Vec<String>>, canonical: &str) {
+        let mut empty_buckets = Vec::new();
+        for (ts, keys) in index.iter_mut() {
+            keys.retain(|k| k != canonical);
+            if keys.is_empty() {
+                empty_buckets.push(*ts);
+            }
+        }
+        for bucket in empty_buckets {
+            index.remove(&bucket);
+        }
+    }
 }
 
 #[async_trait]
@@ -333,6 +354,9 @@ impl StateStore for MemoryStateStore {
             .timeout_index
             .write()
             .map_err(|_| StateError::Backend("timeout index lock poisoned".into()))?;
+        // Replace-by-key: drop any prior entry so re-indexing updates the
+        // deadline rather than leaving a stale duplicate that re-fires.
+        Self::remove_key_from_index(&mut index, &canonical);
         index.entry(expires_at_ms).or_default().push(canonical);
         Ok(())
     }
@@ -343,20 +367,7 @@ impl StateStore for MemoryStateStore {
             .timeout_index
             .write()
             .map_err(|_| StateError::Backend("timeout index lock poisoned".into()))?;
-
-        // We need to find and remove the key from the index.
-        // Since we don't know the expiration time, we iterate through all entries.
-        // This is O(N) in the worst case, but removal is infrequent.
-        let mut empty_buckets = Vec::new();
-        for (expires_at, keys) in index.iter_mut() {
-            keys.retain(|k| k != &canonical);
-            if keys.is_empty() {
-                empty_buckets.push(*expires_at);
-            }
-        }
-        for bucket in empty_buckets {
-            index.remove(&bucket);
-        }
+        Self::remove_key_from_index(&mut index, &canonical);
         Ok(())
     }
 
@@ -381,6 +392,9 @@ impl StateStore for MemoryStateStore {
             .chain_ready_index
             .write()
             .map_err(|_| StateError::Backend("chain ready index lock poisoned".into()))?;
+        // Replace-by-key: drop any prior entry so re-indexing updates the
+        // ready time rather than leaving a stale duplicate that re-fires.
+        Self::remove_key_from_index(&mut index, &canonical);
         index.entry(ready_at_ms).or_default().push(canonical);
         Ok(())
     }
@@ -391,17 +405,7 @@ impl StateStore for MemoryStateStore {
             .chain_ready_index
             .write()
             .map_err(|_| StateError::Backend("chain ready index lock poisoned".into()))?;
-
-        let mut empty_buckets = Vec::new();
-        for (ready_at, keys) in index.iter_mut() {
-            keys.retain(|k| k != &canonical);
-            if keys.is_empty() {
-                empty_buckets.push(*ready_at);
-            }
-        }
-        for bucket in empty_buckets {
-            index.remove(&bucket);
-        }
+        Self::remove_key_from_index(&mut index, &canonical);
         Ok(())
     }
 

--- a/crates/state/state/src/testing.rs
+++ b/crates/state/state/src/testing.rs
@@ -25,6 +25,8 @@ pub async fn run_store_conformance_tests(store: &dyn StateStore) -> Result<(), S
     test_increment(store).await?;
     test_compare_and_swap(store).await?;
     test_ttl_set(store).await?;
+    test_timeout_index_reindex_replaces(store).await?;
+    test_chain_ready_index_reindex_replaces(store).await?;
     Ok(())
 }
 
@@ -124,6 +126,64 @@ async fn test_ttl_set(store: &dyn StateStore) -> Result<(), StateError> {
         .await?;
     let val = store.get(&key).await?;
     assert_eq!(val.as_deref(), Some("ephemeral"));
+    Ok(())
+}
+
+/// Re-indexing a timeout for a key must REPLACE its deadline, not leave a
+/// stale duplicate in the old bucket. Redis (`ZADD`) and Postgres (`UPSERT`)
+/// do this natively; memory and `DynamoDB` must too, or a re-scheduled
+/// recurring/event-timeout fires off-schedule (and the stale entry never
+/// drains).
+async fn test_timeout_index_reindex_replaces(store: &dyn StateStore) -> Result<(), StateError> {
+    let key = test_key(KeyKind::EventTimeout, "reindex");
+    let canonical = key.canonical();
+
+    store.index_timeout(&key, 1_000).await?;
+    // Re-index forward WITHOUT removing first (the recurring/event re-arm path).
+    store.index_timeout(&key, 5_000).await?;
+
+    // The key moved forward: it must NOT still be due at the old time.
+    let due_early = store.get_expired_timeouts(2_000).await?;
+    assert!(
+        !due_early.contains(&canonical),
+        "re-indexed timeout key must not linger in its old, earlier bucket",
+    );
+
+    // At/after the new deadline it must appear EXACTLY ONCE.
+    let due_late = store.get_expired_timeouts(6_000).await?;
+    let count = due_late.iter().filter(|k| **k == canonical).count();
+    assert_eq!(
+        count, 1,
+        "re-indexed timeout key must appear exactly once, not duplicated",
+    );
+
+    store.remove_timeout_index(&key).await?;
+    Ok(())
+}
+
+/// Same contract as [`test_timeout_index_reindex_replaces`] for the
+/// chain-ready index.
+async fn test_chain_ready_index_reindex_replaces(store: &dyn StateStore) -> Result<(), StateError> {
+    let key = test_key(KeyKind::PendingChains, "reindex");
+    let canonical = key.canonical();
+
+    store.index_chain_ready(&key, 1_000).await?;
+    store.index_chain_ready(&key, 5_000).await?;
+
+    let ready_early = store.get_ready_chains(2_000).await?;
+    assert!(
+        !ready_early.contains(&canonical),
+        "re-indexed chain-ready key must not linger in its old, earlier bucket",
+    );
+
+    let ready_late = store.get_ready_chains(6_000).await?;
+    let count = ready_late.iter().filter(|k| **k == canonical).count();
+    assert_eq!(
+        count, 1,
+        "re-indexed chain-ready key must appear exactly once, not duplicated",
+    );
+
+    store.remove_chain_ready_index(&key).await?;
     Ok(())
 }
 


### PR DESCRIPTION
## The bug (survey theme #5, verified — refines #210)

`index_timeout` / `index_chain_ready` **added** an entry rather than **replacing** the key's existing one on two backends:
- **memory** — `index.entry(ms).or_default().push(canonical)` pushes into a new score bucket without removing the old.
- **DynamoDB** — `put_item` with a timestamp-embedded sort key (`{ms}#{canonical}`) creates a new item without deleting the prior one.

Redis (`ZADD` updates the member's score) and Postgres (`ON CONFLICT (key) DO UPDATE`) already replace-by-key.

The recurring worker claims-and-fires an occurrence but **does not remove its timeout-index entry** before the consumer re-indexes the *next* occurrence. So on memory/DynamoDB a key accumulates entries across buckets; the stale earlier entry keeps being returned by `get_expired_timeouts`/`get_ready_chains`, and once the 60s CAS claim TTL lapses it **fires again** — off-schedule / duplicate recurring dispatch and event-timeout firing. The stale entries also never drain (a slow index leak — the angle I under-weighted when I added the memory TTL sweeper in #210).

## The fix

Make both backends replace-by-key:
- **memory** — drop any prior occurrence before pushing, via a shared `remove_key_from_index` helper (also now used by the `remove_*` methods).
- **DynamoDB** — delete all existing items for the canonical key before the put, via a shared `delete_index_entries` helper (the same paginated query+filter+delete the `remove_*` methods already used).

## Tests

Two new **conformance** tests (`test_{timeout,chain_ready}_index_reindex_replaces`) assert that a re-indexed key (a) does **not** linger in its old, earlier bucket and (b) appears **exactly once** at the new deadline. Because they live in the shared conformance suite, every backend is verified: memory passes now, Redis/Postgres already satisfy the contract, and the DynamoDB fix makes it pass there too.

## Verification
`cargo fmt`, `clippy --workspace -D warnings`, memory + state conformance tests, `cargo check --all-targets` — all clean. (DynamoDB/Redis/Postgres conformance need Docker and aren't in CI; verified the query/SQL by inspection against the shared contract.)

> Part of survey theme #5 (state/audit correctness). Follow-ups: the chain `step_results[]` panic beyond #208's guard, and DynamoDB audit pagination dropping `LastEvaluatedKey`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)