### PR TITLE
fix(state-dynamodb): write index entry before deleting old (no dangling delete)

### DIFF
--- a/crates/state/dynamodb/src/store.rs
+++ b/crates/state/dynamodb/src/store.rs
@@ -62,6 +62,7 @@ impl DynamoStateStore {
         &self,
         partition_key: &str,
         canonical: &str,
+        keep_sort_key: Option<&str>,
     ) -> Result<(), StateError> {
         let mut exclusive_start_key = None;
         loop {
@@ -86,6 +87,11 @@ impl DynamoStateStore {
 
             for item in response.items() {
                 if let Some(AttributeValue::S(sk)) = item.get("sk") {
+                    // Never delete the entry the caller just wrote (the
+                    // put-before-delete ordering in `index_*` relies on this).
+                    if keep_sort_key == Some(sk.as_str()) {
+                        continue;
+                    }
                     self.client
                         .delete_item()
                         .table_name(&self.table_name)
@@ -614,18 +620,20 @@ impl StateStore for DynamoStateStore {
         let partition_key = format!("{}:timeout_index", self.prefix);
         let sort_key = format!("{expires_at_ms:020}#{canonical}");
 
-        // Replace-by-key: drop any prior entry (under a different timestamp
-        // sort key) so re-indexing updates the deadline rather than leaving a
-        // stale duplicate that re-fires.
-        self.delete_index_entries(&partition_key, &canonical)
-            .await?;
-
+        // Replace-by-key, written PUT-BEFORE-DELETE so a transient error or
+        // crash can never leave the key un-indexed (which would orphan a
+        // recurring action or in-flight chain). Write the new entry first,
+        // then drop any stale entries under OLDER timestamp sort keys (keeping
+        // the one we just wrote). If the cleanup delete fails, a transient
+        // duplicate lingers — self-healing on the next re-index/remove and
+        // guarded by the per-key CAS claim — which is strictly safer than
+        // losing the entry.
         self.client
             .put_item()
             .table_name(&self.table_name)
-            .item("pk", AttributeValue::S(partition_key))
-            .item("sk", AttributeValue::S(sort_key))
-            .item("key", AttributeValue::S(canonical))
+            .item("pk", AttributeValue::S(partition_key.clone()))
+            .item("sk", AttributeValue::S(sort_key.clone()))
+            .item("key", AttributeValue::S(canonical.clone()))
             .item(
                 "expires_at_ms",
                 AttributeValue::N(expires_at_ms.to_string()),
@@ -634,12 +642,24 @@ impl StateStore for DynamoStateStore {
             .await
             .map_err(|e| StateError::Backend(e.to_string()))?;
 
+        if let Err(e) = self
+            .delete_index_entries(&partition_key, &canonical, Some(&sort_key))
+            .await
+        {
+            tracing::warn!(
+                error = %e,
+                key = %canonical,
+                "failed to prune stale timeout-index entries after re-index; \
+                 a transient duplicate may linger until the next re-index"
+            );
+        }
+
         Ok(())
     }
 
     async fn remove_timeout_index(&self, key: &StateKey) -> Result<(), StateError> {
         let partition_key = format!("{}:timeout_index", self.prefix);
-        self.delete_index_entries(&partition_key, &key.canonical())
+        self.delete_index_entries(&partition_key, &key.canonical(), None)
             .await
     }
 
@@ -690,28 +710,39 @@ impl StateStore for DynamoStateStore {
         let partition_key = format!("{}:chain_ready_index", self.prefix);
         let sort_key = format!("{ready_at_ms:020}#{canonical}");
 
-        // Replace-by-key: drop any prior entry so re-indexing updates the
-        // ready time rather than leaving a stale duplicate that re-fires.
-        self.delete_index_entries(&partition_key, &canonical)
-            .await?;
-
+        // Replace-by-key, PUT-BEFORE-DELETE: write the new entry first so a
+        // transient error / crash can never orphan an in-flight chain, then
+        // prune stale entries under older sort keys (keeping the new one). A
+        // failed cleanup leaves a self-healing duplicate, never a lost entry.
         self.client
             .put_item()
             .table_name(&self.table_name)
-            .item("pk", AttributeValue::S(partition_key))
-            .item("sk", AttributeValue::S(sort_key))
-            .item("key", AttributeValue::S(canonical))
+            .item("pk", AttributeValue::S(partition_key.clone()))
+            .item("sk", AttributeValue::S(sort_key.clone()))
+            .item("key", AttributeValue::S(canonical.clone()))
             .item("ready_at_ms", AttributeValue::N(ready_at_ms.to_string()))
             .send()
             .await
             .map_err(|e| StateError::Backend(e.to_string()))?;
+
+        if let Err(e) = self
+            .delete_index_entries(&partition_key, &canonical, Some(&sort_key))
+            .await
+        {
+            tracing::warn!(
+                error = %e,
+                key = %canonical,
+                "failed to prune stale chain-ready-index entries after re-index; \
+                 a transient duplicate may linger until the next re-index"
+            );
+        }
 
         Ok(())
     }
 
     async fn remove_chain_ready_index(&self, key: &StateKey) -> Result<(), StateError> {
         let partition_key = format!("{}:chain_ready_index", self.prefix);
-        self.delete_index_entries(&partition_key, &key.canonical())
+        self.delete_index_entries(&partition_key, &key.canonical(), None)
             .await
     }
 


### PR DESCRIPTION
## The regression (review of #213)

A reviewer flagged this on #213 and they're right. #213 made DynamoDB `index_timeout`/`index_chain_ready` replace-by-key — but **DELETE-then-PUT**:

```
self.delete_index_entries(...).await?;   // delete old
self.client.put_item()...                // then put new
```

Those are two separate network calls. If the delete commits and the put then fails (a transient DynamoDB error, or a gateway crash in between), the key is left **un-indexed** — a recurring action silently stops recurring, an in-flight chain is orphaned and never resumes. The pre-#213 code only ever *added* duplicates, so #213 traded harmless (dedup-guarded, self-healing) duplicate firing for **permanent loss** of a critical orchestration marker.

## The fix

Reorder to **PUT-before-DELETE**:
1. Write the new entry first — so the key can never end up un-indexed.
2. Then prune stale entries under older timestamp sort keys, **keeping** the one just written (new `keep_sort_key` arg on the shared `delete_index_entries`).
3. If that cleanup delete fails, it's logged and swallowed: a transient duplicate lingers — self-healing on the next re-index/remove and bounded by the per-key CAS claim — **never a lost entry**.

This is the reviewer's preferred option (put-first, accept transient duplicates), corrected to delete only the *old* entries. Cleaner than `TransactWriteItems`, which would need a non-atomic query-to-find-old-keys first plus 2× write cost.

- **Memory is unaffected** — its `remove`+`push` run under a single write lock with no network or crash window (atomic).
- `remove_*_index` still deletes everything (`keep_sort_key = None`).
- The #213 re-index conformance tests still hold: the success path yields the same single replace-by-key entry.

## Verification
`cargo fmt`, `clippy --workspace -D warnings`, state/memory tests, `cargo check --all-targets` — all clean. (DynamoDB conformance needs Docker / isn't in CI; verified by inspection against the query/put/delete semantics — same constraint as #213.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)