### PR TITLE
fix(providers): treat 5xx/408 as retryable in discord/pagerduty/slack/teams/twilio

### DIFF
--- a/crates/integrations/discord/src/error.rs
+++ b/crates/integrations/discord/src/error.rs
@@ -15,6 +15,16 @@ pub enum DiscordError {
     #[error("Discord API error: {0}")]
     Api(String),
 
+    /// The Discord API returned a **transient** non-success response
+    /// (5xx server error or 408 Request Timeout). The request body was
+    /// fine; the server was temporarily unable to handle it.
+    ///
+    /// Surfaced as `ProviderError::Connection` so the gateway's retry
+    /// logic re-queues the dispatch instead of dropping the notification
+    /// on the floor during a brief Discord outage.
+    #[error("Discord transient error: {0}")]
+    Transient(String),
+
     /// The action payload is missing required fields or has invalid structure.
     #[error("invalid payload: {0}")]
     InvalidPayload(String),
@@ -29,6 +39,7 @@ impl From<DiscordError> for ProviderError {
         match err {
             DiscordError::Http(e) => ProviderError::Connection(e.to_string()),
             DiscordError::Api(msg) => ProviderError::ExecutionFailed(msg),
+            DiscordError::Transient(msg) => ProviderError::Connection(msg),
             DiscordError::InvalidPayload(msg) => ProviderError::Serialization(msg),
             DiscordError::RateLimited => ProviderError::RateLimited,
         }
@@ -51,6 +62,19 @@ mod tests {
         let provider_err: ProviderError = DiscordError::Api("invalid webhook".into()).into();
         assert!(!provider_err.is_retryable());
         assert!(matches!(provider_err, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn transient_error_maps_to_retryable_connection() {
+        // 5xx / 408 live-blip errors must be retried instead of
+        // dropping the notification on the floor.
+        let provider_err: ProviderError =
+            DiscordError::Transient("HTTP 503: service unavailable".into()).into();
+        assert!(
+            provider_err.is_retryable(),
+            "transient errors must be retryable"
+        );
+        assert!(matches!(provider_err, ProviderError::Connection(_)));
     }
 
     #[test]

--- a/crates/integrations/discord/src/provider.rs
+++ b/crates/integrations/discord/src/provider.rs
@@ -98,6 +98,20 @@ impl DiscordProvider {
             return Err(DiscordError::RateLimited.into());
         }
 
+        // 5xx (server error) and 408 (Request Timeout) are transient: the
+        // request body was fine, the server was temporarily unable to handle
+        // it. These must be retried rather than dropped, otherwise a brief
+        // Discord blip would permanently lose the notification.
+        if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
+            let response_body = response.text().await.unwrap_or_default();
+            warn!(%status, "Discord transient error — will be retried by gateway");
+            return Err(DiscordError::Transient(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&response_body)
+            ))
+            .into());
+        }
+
         if !status.is_success() {
             let response_body = response.text().await.unwrap_or_default();
             return Err(DiscordError::Api(format!(

--- a/crates/integrations/pagerduty/src/error.rs
+++ b/crates/integrations/pagerduty/src/error.rs
@@ -23,6 +23,12 @@ pub enum PagerDutyError {
     #[error("rate limited by PagerDuty")]
     RateLimited,
 
+    /// 5xx server error or 408 Request Timeout — the request was fine, the
+    /// server was temporarily unable to handle it. Surfaced as
+    /// `ProviderError::Connection` so the gateway retries instead of dropping.
+    #[error("PagerDuty transient error: {0}")]
+    Transient(String),
+
     /// The requested `PagerDuty` service ID is not in the configured services map.
     #[error("unknown PagerDuty service: {0}")]
     UnknownService(String),
@@ -39,6 +45,7 @@ impl From<PagerDutyError> for ProviderError {
             PagerDutyError::Api(msg) => ProviderError::ExecutionFailed(msg),
             PagerDutyError::InvalidPayload(msg) => ProviderError::Serialization(msg),
             PagerDutyError::RateLimited => ProviderError::RateLimited,
+            PagerDutyError::Transient(msg) => ProviderError::Connection(msg),
             PagerDutyError::UnknownService(msg) => ProviderError::Configuration(msg),
             PagerDutyError::NoDefaultService => ProviderError::Configuration(
                 "no service_id in payload and no default service configured".into(),
@@ -63,6 +70,14 @@ mod tests {
         let provider_err: ProviderError = PagerDutyError::Api("bad request".into()).into();
         assert!(!provider_err.is_retryable());
         assert!(matches!(provider_err, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn transient_maps_to_retryable_connection() {
+        let provider_err: ProviderError =
+            PagerDutyError::Transient("HTTP 503: service unavailable".into()).into();
+        assert!(provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::Connection(_)));
     }
 
     #[test]

--- a/crates/integrations/pagerduty/src/provider.rs
+++ b/crates/integrations/pagerduty/src/provider.rs
@@ -80,6 +80,16 @@ impl PagerDutyProvider {
             return Err(PagerDutyError::RateLimited);
         }
 
+        // 5xx and 408 are transient: retry rather than drop the notification.
+        if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
+            let body = response.text().await.unwrap_or_default();
+            warn!(%status, "PagerDuty transient error — will be retried by gateway");
+            return Err(PagerDutyError::Transient(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            )));
+        }
+
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
             return Err(PagerDutyError::Api(format!(

--- a/crates/integrations/slack/src/error.rs
+++ b/crates/integrations/slack/src/error.rs
@@ -15,6 +15,16 @@ pub enum SlackError {
     #[error("Slack API error: {0}")]
     Api(String),
 
+    /// The Slack API returned a **transient** non-success response
+    /// (5xx server error or 408 Request Timeout). The request body was
+    /// fine; the server was temporarily unable to handle it.
+    ///
+    /// Surfaced as `ProviderError::Connection` so the gateway's retry
+    /// logic re-queues the dispatch instead of dropping the notification
+    /// on the floor during a brief Slack outage.
+    #[error("Slack transient error: {0}")]
+    Transient(String),
+
     /// The action payload is missing required fields or has invalid structure.
     #[error("invalid payload: {0}")]
     InvalidPayload(String),
@@ -29,6 +39,7 @@ impl From<SlackError> for ProviderError {
         match err {
             SlackError::Http(e) => ProviderError::Connection(e.to_string()),
             SlackError::Api(msg) => ProviderError::ExecutionFailed(msg),
+            SlackError::Transient(msg) => ProviderError::Connection(msg),
             SlackError::InvalidPayload(msg) => ProviderError::Serialization(msg),
             SlackError::RateLimited => ProviderError::RateLimited,
         }
@@ -51,6 +62,19 @@ mod tests {
         let provider_err: ProviderError = SlackError::Api("invalid_auth".into()).into();
         assert!(!provider_err.is_retryable());
         assert!(matches!(provider_err, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn transient_error_maps_to_retryable_connection() {
+        // 5xx / 408 live-blip errors must be retried instead of
+        // dropping the notification on the floor.
+        let provider_err: ProviderError =
+            SlackError::Transient("HTTP 503: service unavailable".into()).into();
+        assert!(
+            provider_err.is_retryable(),
+            "transient errors must be retryable"
+        );
+        assert!(matches!(provider_err, ProviderError::Connection(_)));
     }
 
     #[test]

--- a/crates/integrations/slack/src/provider.rs
+++ b/crates/integrations/slack/src/provider.rs
@@ -88,6 +88,19 @@ impl SlackProvider {
             return Err(SlackError::RateLimited);
         }
 
+        // 5xx (server error) and 408 (Request Timeout) are transient: the
+        // request body was fine, the server was temporarily unable to handle
+        // it. These must be retried rather than dropped, otherwise a brief
+        // Slack blip would permanently lose the notification.
+        if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
+            let body = response.text().await.unwrap_or_default();
+            warn!(%status, "Slack transient error — will be retried by gateway");
+            return Err(SlackError::Transient(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            )));
+        }
+
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
             return Err(SlackError::Api(format!(

--- a/crates/integrations/teams/src/error.rs
+++ b/crates/integrations/teams/src/error.rs
@@ -22,6 +22,12 @@ pub enum TeamsError {
     /// The provider received an HTTP 429 (Too Many Requests) response.
     #[error("rate limited by Teams")]
     RateLimited,
+
+    /// 5xx server error or 408 Request Timeout — the request was fine, the
+    /// server was temporarily unable to handle it. Surfaced as
+    /// `ProviderError::Connection` so the gateway retries instead of dropping.
+    #[error("Teams transient error: {0}")]
+    Transient(String),
 }
 
 impl From<TeamsError> for ProviderError {
@@ -31,6 +37,7 @@ impl From<TeamsError> for ProviderError {
             TeamsError::Api(msg) => ProviderError::ExecutionFailed(msg),
             TeamsError::InvalidPayload(msg) => ProviderError::Serialization(msg),
             TeamsError::RateLimited => ProviderError::RateLimited,
+            TeamsError::Transient(msg) => ProviderError::Connection(msg),
         }
     }
 }
@@ -44,6 +51,14 @@ mod tests {
         let provider_err: ProviderError = TeamsError::RateLimited.into();
         assert!(provider_err.is_retryable());
         assert!(matches!(provider_err, ProviderError::RateLimited));
+    }
+
+    #[test]
+    fn transient_maps_to_retryable() {
+        let provider_err: ProviderError =
+            TeamsError::Transient("HTTP 503: service unavailable".into()).into();
+        assert!(provider_err.is_retryable());
+        assert!(matches!(provider_err, ProviderError::Connection(_)));
     }
 
     #[test]

--- a/crates/integrations/teams/src/provider.rs
+++ b/crates/integrations/teams/src/provider.rs
@@ -105,6 +105,17 @@ impl Provider for TeamsProvider {
             return Err(TeamsError::RateLimited.into());
         }
 
+        // 5xx and 408 are transient: retry rather than drop the notification.
+        if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
+            let body = response.text().await.unwrap_or_default();
+            warn!(%status, "Teams transient error — will be retried by gateway");
+            return Err(TeamsError::Transient(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            ))
+            .into());
+        }
+
         if !status.is_success() {
             let response_body = response.text().await.unwrap_or_default();
             return Err(TeamsError::Api(format!(

--- a/crates/integrations/twilio/src/error.rs
+++ b/crates/integrations/twilio/src/error.rs
@@ -15,6 +15,16 @@ pub enum TwilioError {
     #[error("Twilio API error: {0}")]
     Api(String),
 
+    /// The Twilio API returned a **transient** non-success response
+    /// (5xx server error or 408 Request Timeout). The request body was
+    /// fine; the server was temporarily unable to handle it.
+    ///
+    /// Surfaced as `ProviderError::Connection` so the gateway's retry
+    /// logic re-queues the dispatch instead of dropping the notification
+    /// on the floor during a brief Twilio outage.
+    #[error("Twilio transient error: {0}")]
+    Transient(String),
+
     /// The action payload is missing required fields or has invalid structure.
     #[error("invalid payload: {0}")]
     InvalidPayload(String),
@@ -29,6 +39,7 @@ impl From<TwilioError> for ProviderError {
         match err {
             TwilioError::Http(e) => ProviderError::Connection(e.to_string()),
             TwilioError::Api(msg) => ProviderError::ExecutionFailed(msg),
+            TwilioError::Transient(msg) => ProviderError::Connection(msg),
             TwilioError::InvalidPayload(msg) => ProviderError::Serialization(msg),
             TwilioError::RateLimited => ProviderError::RateLimited,
         }
@@ -51,6 +62,19 @@ mod tests {
         let provider_err: ProviderError = TwilioError::Api("invalid_auth".into()).into();
         assert!(!provider_err.is_retryable());
         assert!(matches!(provider_err, ProviderError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn transient_error_maps_to_retryable_connection() {
+        // 5xx / 408 live-blip errors must be retried instead of
+        // dropping the notification on the floor.
+        let provider_err: ProviderError =
+            TwilioError::Transient("HTTP 503: service unavailable".into()).into();
+        assert!(
+            provider_err.is_retryable(),
+            "transient errors must be retryable"
+        );
+        assert!(matches!(provider_err, ProviderError::Connection(_)));
     }
 
     #[test]

--- a/crates/integrations/twilio/src/provider.rs
+++ b/crates/integrations/twilio/src/provider.rs
@@ -99,6 +99,19 @@ impl TwilioProvider {
             return Err(TwilioError::RateLimited);
         }
 
+        // 5xx (server error) and 408 (Request Timeout) are transient: the
+        // request body was fine, the server was temporarily unable to handle
+        // it. These must be retried rather than dropped, otherwise a brief
+        // Twilio blip would permanently lose the notification.
+        if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
+            let body = response.text().await.unwrap_or_default();
+            warn!(%status, "Twilio transient error — will be retried by gateway");
+            return Err(TwilioError::Transient(format!(
+                "HTTP {status}: {}",
+                truncate_error_body(&body)
+            )));
+        }
+
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
             return Err(TwilioError::Api(format!(


### PR DESCRIPTION
## The bug (survey theme #3, verified)

Five HTTP integration providers — **discord, pagerduty, slack, teams, twilio** — checked only for `429`, then mapped **every** other non-2xx (including `500/502/503/504` and `408`) to their `Api(...)` variant → `ProviderError::ExecutionFailed`, which `is_retryable()` returns **false** for. So a brief upstream blip permanently **dropped the notification** instead of letting the gateway retry it. (The other 6 providers — opsgenie, telegram, pushover, victorops, webhook, wechat — already handle this correctly.)

## The fix

For each of the five, mirroring the correct providers:
- **error.rs**: add a `Transient(String)` variant that maps to `ProviderError::Connection` (retryable), not `ExecutionFailed`.
- **provider.rs**: in the response handler, `if status.is_server_error() || status == REQUEST_TIMEOUT` → `Transient`, placed **before** the generic `!status.is_success()` arm (after it, the check is dead code).
- 429/auth handling and post-success app-level JSON parsing are untouched; `health_check`'s non-success arm is intentionally left (a 5xx there correctly reports *unhealthy* — no retry).
- Each gains a test asserting `Transient` → retryable `ProviderError::Connection`.

## How it was built
5 parallel agents (one per provider) applied the OpsGenie reference, each followed by an adversarial verifier that confirmed: `Transient → Connection` (not `ExecutionFailed`), the 5xx arm **precedes** the generic arm (not dead code), and 429/auth/app-JSON untouched. (The verifiers' only flag was a false-positive "other files changed" — an artifact of 5 agents sharing one working tree.) I then verified placement myself, fixed two `doc_markdown` lints, and confirmed the whole workspace.

## Verification
`cargo fmt`, `clippy --workspace -D warnings`, the 5 provider test suites (incl. each new `transient → retryable` test), `cargo check --all-targets` — all clean.

> Theme #3 follow-ups (separate PRs): AWS/Azure/GCP `classify_*_error` have the same 5xx-as-permanent bug; unbounded response-body reads (OOM) in these providers + S3/GCS object downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)