### PR TITLE
fix(cloud): classify transient 5xx as retryable in AWS/Azure/GCP error mappers

### DIFF
--- a/crates/aws/src/error.rs
+++ b/crates/aws/src/error.rs
@@ -4,9 +4,17 @@ use thiserror::Error;
 /// Errors specific to AWS provider operations.
 #[derive(Debug, Error)]
 pub enum AwsProviderError {
-    /// The AWS SDK returned an error from the service.
+    /// The AWS SDK returned a **permanent** service error (a malformed or
+    /// unauthorized request). Surfaced as `ExecutionFailed` and not retried.
     #[error("AWS service error: {0}")]
     ServiceError(String),
+
+    /// A **transient** AWS service error (5xx / `ServiceUnavailable` /
+    /// `InternalError` / `SlowDown`). The request was fine; the service was
+    /// briefly unavailable. Surfaced as `ProviderError::Connection` so the
+    /// gateway retries instead of dropping the action on a momentary blip.
+    #[error("AWS transient service error: {0}")]
+    Transient(String),
 
     /// The request was throttled by the AWS service.
     #[error("AWS request throttled")]
@@ -38,7 +46,10 @@ impl From<AwsProviderError> for ProviderError {
         match err {
             AwsProviderError::ServiceError(msg) => ProviderError::ExecutionFailed(msg),
             AwsProviderError::Throttled => ProviderError::RateLimited,
-            AwsProviderError::Connection(msg) => ProviderError::Connection(msg),
+            // Transient 5xx and genuine connection errors are both retryable.
+            AwsProviderError::Transient(msg) | AwsProviderError::Connection(msg) => {
+                ProviderError::Connection(msg)
+            }
             AwsProviderError::Timeout => ProviderError::Timeout(std::time::Duration::from_secs(30)),
             AwsProviderError::InvalidPayload(msg) => ProviderError::Serialization(msg),
             AwsProviderError::CredentialError(msg) | AwsProviderError::Configuration(msg) => {
@@ -64,6 +75,19 @@ pub fn classify_sdk_error(error_str: &str) -> AwsProviderError {
         || lower.contains("network")
     {
         AwsProviderError::Connection(error_str.to_owned())
+    } else if lower.contains("serviceunavailable")
+        || lower.contains("service unavailable")
+        || lower.contains("internalerror")
+        || lower.contains("internal error")
+        || lower.contains("internalfailure")
+        || lower.contains("internalservererror")
+        || lower.contains("internal server error")
+        || lower.contains("slowdown")
+        || lower.contains("slow down")
+    {
+        // 5xx-class service errors are transient: the request was valid, the
+        // service was briefly unavailable. Retry rather than drop.
+        AwsProviderError::Transient(error_str.to_owned())
     } else {
         AwsProviderError::ServiceError(error_str.to_owned())
     }
@@ -85,6 +109,36 @@ mod tests {
         let err: ProviderError = AwsProviderError::Timeout.into();
         assert!(matches!(err, ProviderError::Timeout(_)));
         assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn service_unavailable_is_transient_and_retryable() {
+        let err = classify_sdk_error("ServiceUnavailable: SNS is temporarily unavailable");
+        assert!(matches!(err, AwsProviderError::Transient(_)));
+        let perr: ProviderError = err.into();
+        assert!(perr.is_retryable());
+        assert!(matches!(perr, ProviderError::Connection(_)));
+    }
+
+    #[test]
+    fn internal_error_is_transient() {
+        assert!(matches!(
+            classify_sdk_error("InternalError: an internal error occurred"),
+            AwsProviderError::Transient(_)
+        ));
+        assert!(matches!(
+            classify_sdk_error("InternalServerError (status 500)"),
+            AwsProviderError::Transient(_)
+        ));
+    }
+
+    #[test]
+    fn permanent_service_error_stays_permanent() {
+        // A genuine 4xx-class error (bad request) must NOT become retryable.
+        let err = classify_sdk_error("ValidationError: topic ARN is malformed");
+        assert!(matches!(err, AwsProviderError::ServiceError(_)));
+        let perr: ProviderError = err.into();
+        assert!(!perr.is_retryable());
     }
 
     #[test]

--- a/crates/azure/src/error.rs
+++ b/crates/azure/src/error.rs
@@ -4,9 +4,17 @@ use thiserror::Error;
 /// Errors specific to Azure provider operations.
 #[derive(Debug, Error)]
 pub enum AzureProviderError {
-    /// The Azure service returned an error.
+    /// The Azure service returned a **permanent** error (malformed or
+    /// unauthorized request). Surfaced as `ExecutionFailed` and not retried.
     #[error("Azure service error: {0}")]
     ServiceError(String),
+
+    /// A **transient** Azure service error (5xx / `ServiceUnavailable` /
+    /// `InternalServerError` / `ServerBusy`). The request was fine; the
+    /// service was briefly unavailable. Surfaced as `ProviderError::Connection`
+    /// so the gateway retries instead of dropping the action.
+    #[error("Azure transient service error: {0}")]
+    Transient(String),
 
     /// The request was throttled by the Azure service.
     #[error("Azure request throttled")]
@@ -38,7 +46,10 @@ impl From<AzureProviderError> for ProviderError {
         match err {
             AzureProviderError::ServiceError(msg) => ProviderError::ExecutionFailed(msg),
             AzureProviderError::Throttled => ProviderError::RateLimited,
-            AzureProviderError::Connection(msg) => ProviderError::Connection(msg),
+            // Transient 5xx and genuine connection errors are both retryable.
+            AzureProviderError::Transient(msg) | AzureProviderError::Connection(msg) => {
+                ProviderError::Connection(msg)
+            }
             AzureProviderError::Timeout => {
                 ProviderError::Timeout(std::time::Duration::from_secs(30))
             }
@@ -70,6 +81,18 @@ pub fn classify_azure_error(error_str: &str) -> AzureProviderError {
         || lower.contains("network")
     {
         AzureProviderError::Connection(error_str.to_owned())
+    } else if lower.contains("serviceunavailable")
+        || lower.contains("service unavailable")
+        || lower.contains("internalservererror")
+        || lower.contains("internal server error")
+        || lower.contains("internalerror")
+        || lower.contains("internal error")
+        || lower.contains("serverbusy")
+        || lower.contains("server busy")
+    {
+        // 5xx-class service errors are transient: the request was valid, the
+        // service was briefly unavailable. Retry rather than drop.
+        AzureProviderError::Transient(error_str.to_owned())
     } else {
         AzureProviderError::ServiceError(error_str.to_owned())
     }
@@ -144,6 +167,31 @@ mod tests {
     fn classify_connection() {
         let err = classify_azure_error("Connection refused: 10.0.0.1:443");
         assert!(matches!(err, AzureProviderError::Connection(_)));
+    }
+
+    #[test]
+    fn service_unavailable_is_transient_and_retryable() {
+        let err = classify_azure_error("ServiceUnavailable (status: 503)");
+        assert!(matches!(err, AzureProviderError::Transient(_)));
+        let perr: ProviderError = err.into();
+        assert!(perr.is_retryable());
+        assert!(matches!(perr, ProviderError::Connection(_)));
+    }
+
+    #[test]
+    fn server_busy_is_transient() {
+        assert!(matches!(
+            classify_azure_error("ServerBusy: the service bus is currently busy"),
+            AzureProviderError::Transient(_)
+        ));
+    }
+
+    #[test]
+    fn permanent_service_error_stays_permanent() {
+        let err = classify_azure_error("AuthorizationFailure: invalid signature");
+        assert!(matches!(err, AzureProviderError::ServiceError(_)));
+        let perr: ProviderError = err.into();
+        assert!(!perr.is_retryable());
     }
 
     #[test]

--- a/crates/gcp/src/error.rs
+++ b/crates/gcp/src/error.rs
@@ -4,9 +4,18 @@ use thiserror::Error;
 /// Errors specific to GCP provider operations.
 #[derive(Debug, Error)]
 pub enum GcpProviderError {
-    /// The GCP service returned an error.
+    /// The GCP service returned a **permanent** error (malformed or
+    /// unauthorized request). Surfaced as `ExecutionFailed` and not retried.
     #[error("GCP service error: {0}")]
     ServiceError(String),
+
+    /// A **transient** GCP service error (`INTERNAL` / `ABORTED` / 5xx /
+    /// backend error). The request was fine; the service was briefly unable to
+    /// handle it. Surfaced as `ProviderError::Connection` so the gateway
+    /// retries instead of dropping the action. (`UNAVAILABLE` is already
+    /// routed to `Connection`.)
+    #[error("GCP transient service error: {0}")]
+    Transient(String),
 
     /// The request was throttled by the GCP service.
     #[error("GCP request throttled")]
@@ -38,7 +47,10 @@ impl From<GcpProviderError> for ProviderError {
         match err {
             GcpProviderError::ServiceError(msg) => ProviderError::ExecutionFailed(msg),
             GcpProviderError::Throttled => ProviderError::RateLimited,
-            GcpProviderError::Connection(msg) => ProviderError::Connection(msg),
+            // Transient 5xx and genuine connection errors are both retryable.
+            GcpProviderError::Transient(msg) | GcpProviderError::Connection(msg) => {
+                ProviderError::Connection(msg)
+            }
             GcpProviderError::Timeout => ProviderError::Timeout(std::time::Duration::from_secs(30)),
             GcpProviderError::InvalidPayload(msg) => ProviderError::Serialization(msg),
             GcpProviderError::CredentialError(msg) | GcpProviderError::Configuration(msg) => {
@@ -73,6 +85,17 @@ pub fn classify_gcp_error(error_str: &str) -> GcpProviderError {
         || lower.contains("unavailable")
     {
         GcpProviderError::Connection(error_str.to_owned())
+    } else if lower.contains("internal")
+        || lower.contains("aborted")
+        || lower.contains("backend error")
+        || lower.contains("backenderror")
+        || lower.contains("bad gateway")
+        || lower.contains("gateway timeout")
+    {
+        // 5xx-class / INTERNAL / ABORTED are transient: the request was valid,
+        // the service was briefly unable to handle it. Retry rather than drop.
+        // (UNAVAILABLE is handled in the connection arm above.)
+        GcpProviderError::Transient(error_str.to_owned())
     } else {
         GcpProviderError::ServiceError(error_str.to_owned())
     }
@@ -157,6 +180,36 @@ mod tests {
     fn classify_unavailable() {
         let err = classify_gcp_error("UNAVAILABLE: service is not reachable");
         assert!(matches!(err, GcpProviderError::Connection(_)));
+    }
+
+    #[test]
+    fn internal_is_transient_and_retryable() {
+        let err = classify_gcp_error("status: INTERNAL, message: backend transient failure");
+        assert!(matches!(err, GcpProviderError::Transient(_)));
+        let perr: ProviderError = err.into();
+        assert!(perr.is_retryable());
+        assert!(matches!(perr, ProviderError::Connection(_)));
+    }
+
+    #[test]
+    fn aborted_and_backend_error_are_transient() {
+        assert!(matches!(
+            classify_gcp_error("ABORTED: the operation was aborted due to a conflict"),
+            GcpProviderError::Transient(_)
+        ));
+        assert!(matches!(
+            classify_gcp_error("503: backend error"),
+            GcpProviderError::Transient(_)
+        ));
+    }
+
+    #[test]
+    fn permanent_service_error_stays_permanent() {
+        // PERMISSION_DENIED / NOT_FOUND etc. must stay non-retryable.
+        let err = classify_gcp_error("PERMISSION_DENIED: caller lacks permission");
+        assert!(matches!(err, GcpProviderError::ServiceError(_)));
+        let perr: ProviderError = err.into();
+        assert!(!perr.is_retryable());
     }
 
     #[test]


### PR DESCRIPTION
## The bug (survey theme #3, verified — incl. the completeness-critic's GCP note)

`classify_sdk_error` (AWS), `classify_azure_error`, and `classify_gcp_error` matched throttling / timeout / connection patterns, then dumped **everything else** into `ServiceError` → `ProviderError::ExecutionFailed`, which `is_retryable()` returns **false** for. So genuinely transient service errors — `ServiceUnavailable`, `InternalError`/`InternalServerError`, S3 `SlowDown`, Azure `ServerBusy`, GCP `INTERNAL`/`ABORTED` — were misclassified as **permanent** and the action was dropped instead of retried on a momentary blip. (GCP already routed the literal `UNAVAILABLE` to `Connection`, but nothing else.)

## The fix

Each provider gets a `Transient(String)` variant → `ProviderError::Connection` (retryable), and a classifier branch **before** the final `ServiceError` catch-all matching the 5xx-class indicators:

| Provider | New transient matches |
|----------|----------------------|
| AWS | `serviceunavailable`, `internal{error,failure,servererror}`, `slow down` |
| Azure | `serviceunavailable`, `internal server error`, `serverbusy` |
| GCP | `internal`, `aborted`, `backend error`, `bad gateway`, `gateway timeout` |

Each gains tests asserting a transient string → retryable `ProviderError::Connection`, **and** that a genuine permanent error (`ValidationError` / `AuthorizationFailure` / `PERMISSION_DENIED`) stays non-retryable. Erring toward retryable is the safe direction — a misclassified *permanent* error costs a few wasted retries; a misclassified *transient* one silently drops the action.

## Verification
`clippy -p {aws,azure,gcp} --features full -D warnings`, the three test suites (90 / 41 / 48, incl. the new transient + permanent assertions), plus default `clippy --workspace` and `cargo check --all-targets` — all clean.

> Theme #3: integration providers landed in #217; this is the cloud slice. Remaining follow-up: unbounded response-body / S3+GCS object-download reads (OOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)