### PR TITLE
fix(providers): bound HTTP response-body reads to prevent OOM

### DIFF
--- a/crates/integrations/discord/src/provider.rs
+++ b/crates/integrations/discord/src/provider.rs
@@ -1,5 +1,8 @@
 use acteon_core::{Action, ProviderResponse};
-use acteon_provider::{DispatchContext, Provider, ProviderError, truncate_error_body};
+use acteon_provider::{
+    DispatchContext, MAX_ERROR_BODY_READ_BYTES, Provider, ProviderError, read_bounded_body,
+    truncate_error_body,
+};
 use reqwest::Client;
 use serde::Deserialize;
 use tracing::{debug, info, instrument, warn};
@@ -103,7 +106,7 @@ impl DiscordProvider {
         // it. These must be retried rather than dropped, otherwise a brief
         // Discord blip would permanently lose the notification.
         if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
-            let response_body = response.text().await.unwrap_or_default();
+            let response_body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             warn!(%status, "Discord transient error — will be retried by gateway");
             return Err(DiscordError::Transient(format!(
                 "HTTP {status}: {}",
@@ -113,7 +116,7 @@ impl DiscordProvider {
         }
 
         if !status.is_success() {
-            let response_body = response.text().await.unwrap_or_default();
+            let response_body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(DiscordError::Api(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&response_body)
@@ -236,7 +239,7 @@ impl Provider for DiscordProvider {
         }
 
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(ProviderError::Connection(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&body)

--- a/crates/integrations/opsgenie/src/provider.rs
+++ b/crates/integrations/opsgenie/src/provider.rs
@@ -1,5 +1,7 @@
 use acteon_core::{Action, ProviderResponse};
-use acteon_provider::{Provider, ProviderError, truncate_error_body};
+use acteon_provider::{
+    MAX_ERROR_BODY_READ_BYTES, Provider, ProviderError, read_bounded_body, truncate_error_body,
+};
 use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use reqwest::Client;
 use serde::Deserialize;
@@ -160,7 +162,7 @@ impl OpsGenieProvider {
             return Err(OpsGenieError::RateLimited);
         }
         if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(OpsGenieError::Unauthorized(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&body)
@@ -172,7 +174,7 @@ impl OpsGenieProvider {
         // rather than dropped, otherwise a 10-second OpsGenie blip
         // would permanently lose alerts.
         if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             warn!(%status, "OpsGenie transient error — will be retried by gateway");
             return Err(OpsGenieError::Transient(format!(
                 "HTTP {status}: {}",
@@ -180,7 +182,7 @@ impl OpsGenieProvider {
             )));
         }
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(OpsGenieError::Api(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&body)

--- a/crates/integrations/pagerduty/src/provider.rs
+++ b/crates/integrations/pagerduty/src/provider.rs
@@ -1,5 +1,7 @@
 use acteon_core::{Action, ProviderResponse};
-use acteon_provider::{Provider, ProviderError, truncate_error_body};
+use acteon_provider::{
+    MAX_ERROR_BODY_READ_BYTES, Provider, ProviderError, read_bounded_body, truncate_error_body,
+};
 use reqwest::Client;
 use serde::Deserialize;
 use tracing::{debug, instrument, warn};
@@ -82,7 +84,7 @@ impl PagerDutyProvider {
 
         // 5xx and 408 are transient: retry rather than drop the notification.
         if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             warn!(%status, "PagerDuty transient error — will be retried by gateway");
             return Err(PagerDutyError::Transient(format!(
                 "HTTP {status}: {}",
@@ -91,7 +93,7 @@ impl PagerDutyProvider {
         }
 
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(PagerDutyError::Api(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&body)

--- a/crates/integrations/pushover/src/provider.rs
+++ b/crates/integrations/pushover/src/provider.rs
@@ -1,5 +1,7 @@
 use acteon_core::{Action, ProviderResponse};
-use acteon_provider::{Provider, ProviderError, truncate_error_body};
+use acteon_provider::{
+    MAX_ERROR_BODY_READ_BYTES, Provider, ProviderError, read_bounded_body, truncate_error_body,
+};
 use reqwest::Client;
 use serde::Deserialize;
 use tracing::{debug, instrument, warn};
@@ -220,14 +222,14 @@ impl PushoverProvider {
             return Err(PushoverError::RateLimited);
         }
         if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(PushoverError::Unauthorized(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&body)
             )));
         }
         if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             warn!(%status, "Pushover transient error — will be retried by gateway");
             return Err(PushoverError::Transient(format!(
                 "HTTP {status}: {}",
@@ -235,7 +237,7 @@ impl PushoverProvider {
             )));
         }
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(PushoverError::Api(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&body)

--- a/crates/integrations/slack/src/provider.rs
+++ b/crates/integrations/slack/src/provider.rs
@@ -1,5 +1,8 @@
 use acteon_core::{Action, ProviderResponse};
-use acteon_provider::{DispatchContext, Provider, ProviderError, truncate_error_body};
+use acteon_provider::{
+    DispatchContext, MAX_ERROR_BODY_READ_BYTES, Provider, ProviderError, read_bounded_body,
+    truncate_error_body,
+};
 use reqwest::Client;
 use serde::Deserialize;
 use tracing::{debug, info, instrument, warn};
@@ -93,7 +96,7 @@ impl SlackProvider {
         // it. These must be retried rather than dropped, otherwise a brief
         // Slack blip would permanently lose the notification.
         if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             warn!(%status, "Slack transient error — will be retried by gateway");
             return Err(SlackError::Transient(format!(
                 "HTTP {status}: {}",
@@ -102,7 +105,7 @@ impl SlackProvider {
         }
 
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(SlackError::Api(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&body)
@@ -212,7 +215,7 @@ impl Provider for SlackProvider {
                     })?;
 
                 if !upload_response.status().is_success() {
-                    let body = upload_response.text().await.unwrap_or_default();
+                    let body = read_bounded_body(upload_response, MAX_ERROR_BODY_READ_BYTES).await;
                     warn!(filename = %resolved.filename, "Slack file upload failed: {body}");
                 }
             }
@@ -247,7 +250,7 @@ impl Provider for SlackProvider {
         }
 
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(ProviderError::Connection(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&body)

--- a/crates/integrations/teams/src/provider.rs
+++ b/crates/integrations/teams/src/provider.rs
@@ -1,5 +1,8 @@
 use acteon_core::{Action, ProviderResponse};
-use acteon_provider::{Provider, ProviderError, truncate_error_body};
+use acteon_provider::{
+    MAX_ERROR_BODY_READ_BYTES, MAX_RESPONSE_BODY_READ_BYTES, Provider, ProviderError,
+    read_bounded_body, truncate_error_body,
+};
 use reqwest::Client;
 use serde::Deserialize;
 use tracing::{debug, instrument, warn};
@@ -107,7 +110,7 @@ impl Provider for TeamsProvider {
 
         // 5xx and 408 are transient: retry rather than drop the notification.
         if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             warn!(%status, "Teams transient error — will be retried by gateway");
             return Err(TeamsError::Transient(format!(
                 "HTTP {status}: {}",
@@ -117,7 +120,7 @@ impl Provider for TeamsProvider {
         }
 
         if !status.is_success() {
-            let response_body = response.text().await.unwrap_or_default();
+            let response_body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(TeamsError::Api(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&response_body)
@@ -126,7 +129,7 @@ impl Provider for TeamsProvider {
         }
 
         // Teams returns literal "1" with HTTP 200 on success (not JSON).
-        let response_text = response.text().await.unwrap_or_default();
+        let response_text = read_bounded_body(response, MAX_RESPONSE_BODY_READ_BYTES).await;
 
         let response_body = serde_json::json!({
             "ok": true,
@@ -158,7 +161,7 @@ impl Provider for TeamsProvider {
         }
 
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(ProviderError::Connection(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&body)

--- a/crates/integrations/telegram/src/provider.rs
+++ b/crates/integrations/telegram/src/provider.rs
@@ -1,5 +1,7 @@
 use acteon_core::{Action, ProviderResponse};
-use acteon_provider::{Provider, ProviderError, truncate_error_body};
+use acteon_provider::{
+    MAX_ERROR_BODY_READ_BYTES, Provider, ProviderError, read_bounded_body, truncate_error_body,
+};
 use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use reqwest::Client;
 use serde::Deserialize;
@@ -201,7 +203,7 @@ impl TelegramProvider {
             // a duration, but surfacing the hint in the log lets
             // operators see how long Telegram wants the bot to
             // back off without digging into request traces.
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             let retry_after = serde_json::from_str::<TelegramApiResponse>(&body)
                 .ok()
                 .and_then(|r| r.parameters)
@@ -223,14 +225,14 @@ impl TelegramProvider {
                 | reqwest::StatusCode::FORBIDDEN
                 | reqwest::StatusCode::NOT_FOUND
         ) {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(TelegramError::Unauthorized(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&body)
             )));
         }
         if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             warn!(%status, "Telegram transient error — will be retried by gateway");
             return Err(TelegramError::Transient(format!(
                 "HTTP {status}: {}",
@@ -238,7 +240,7 @@ impl TelegramProvider {
             )));
         }
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(TelegramError::Api(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&body)

--- a/crates/integrations/twilio/src/provider.rs
+++ b/crates/integrations/twilio/src/provider.rs
@@ -1,5 +1,7 @@
 use acteon_core::{Action, ProviderResponse};
-use acteon_provider::{Provider, ProviderError, truncate_error_body};
+use acteon_provider::{
+    MAX_ERROR_BODY_READ_BYTES, Provider, ProviderError, read_bounded_body, truncate_error_body,
+};
 use reqwest::Client;
 use serde::Deserialize;
 use tracing::{debug, instrument, warn};
@@ -104,7 +106,7 @@ impl TwilioProvider {
         // it. These must be retried rather than dropped, otherwise a brief
         // Twilio blip would permanently lose the notification.
         if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             warn!(%status, "Twilio transient error — will be retried by gateway");
             return Err(TwilioError::Transient(format!(
                 "HTTP {status}: {}",
@@ -113,7 +115,7 @@ impl TwilioProvider {
         }
 
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(TwilioError::Api(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&body)
@@ -192,7 +194,7 @@ impl Provider for TwilioProvider {
         }
 
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(ProviderError::Connection(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&body)

--- a/crates/integrations/victorops/src/provider.rs
+++ b/crates/integrations/victorops/src/provider.rs
@@ -1,5 +1,7 @@
 use acteon_core::{Action, ProviderResponse};
-use acteon_provider::{Provider, ProviderError, truncate_error_body};
+use acteon_provider::{
+    MAX_ERROR_BODY_READ_BYTES, Provider, ProviderError, read_bounded_body, truncate_error_body,
+};
 use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use reqwest::Client;
 use serde::Deserialize;
@@ -149,14 +151,14 @@ impl VictorOpsProvider {
             return Err(VictorOpsError::RateLimited);
         }
         if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(VictorOpsError::Unauthorized(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&body)
             )));
         }
         if status.is_server_error() || status == reqwest::StatusCode::REQUEST_TIMEOUT {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             warn!(%status, "VictorOps transient error — will be retried by gateway");
             return Err(VictorOpsError::Transient(format!(
                 "HTTP {status}: {}",
@@ -164,7 +166,7 @@ impl VictorOpsProvider {
             )));
         }
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(VictorOpsError::Api(format!(
                 "HTTP {status}: {}",
                 truncate_error_body(&body)

--- a/crates/integrations/webhook/src/provider.rs
+++ b/crates/integrations/webhook/src/provider.rs
@@ -1,5 +1,8 @@
 use acteon_core::{Action, ProviderResponse};
-use acteon_provider::{DispatchContext, Provider, ProviderError, truncate_error_body};
+use acteon_provider::{
+    DispatchContext, MAX_ERROR_BODY_READ_BYTES, MAX_RESPONSE_BODY_READ_BYTES, Provider,
+    ProviderError, read_bounded_body, truncate_error_body,
+};
 use hmac::{Hmac, Mac};
 use reqwest::Client;
 use sha2::Sha256;
@@ -9,6 +12,17 @@ use crate::config::{AuthMethod, HttpMethod, PayloadMode, WebhookConfig};
 use crate::error::WebhookError;
 
 type HmacSha256 = Hmac<Sha256>;
+
+/// Parse a response body string into a JSON value, falling back to a structured
+/// envelope (`status_code` + raw `body`) when the body is not valid JSON.
+fn parse_response_body(status_code: u16, response_text: &str) -> serde_json::Value {
+    serde_json::from_str(response_text).unwrap_or_else(|_| {
+        serde_json::json!({
+            "status_code": status_code,
+            "body": response_text,
+        })
+    })
+}
 
 /// Generic HTTP webhook provider that dispatches actions to any HTTP endpoint.
 ///
@@ -140,20 +154,22 @@ impl WebhookProvider {
             return Err(WebhookError::RateLimited.into());
         }
 
-        let response_text = response.text().await.unwrap_or_default();
-        let response_body: serde_json::Value =
-            serde_json::from_str(&response_text).unwrap_or_else(|_| {
-                serde_json::json!({
-                    "status_code": status_code,
-                    "body": response_text,
-                })
-            });
-
         if self.is_success_status(status_code) {
+            // Success path: the endpoint URL is caller-supplied, so bound the
+            // read — a hostile/compromised endpoint must not be able to OOM the
+            // gateway by replying 2xx with a giant body.
+            let response_text = read_bounded_body(response, MAX_RESPONSE_BODY_READ_BYTES).await;
+            let response_body = parse_response_body(status_code, &response_text);
             let mut provider_response = ProviderResponse::success(response_body);
             provider_response.headers = response_headers;
             Ok(provider_response)
         } else {
+            // Error path: bound the read so a hostile endpoint can't OOM the
+            // gateway with a giant error body. `truncate_error_body` still
+            // trims the stored message — the two are complementary.
+            let response_text =
+                truncate_error_body(&read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await);
+            let response_body = parse_response_body(status_code, &response_text);
             let mut provider_response = ProviderResponse::failure(response_body);
             provider_response.headers = response_headers;
             Ok(provider_response)
@@ -284,7 +300,7 @@ impl Provider for WebhookProvider {
         }
 
         if status.is_server_error() {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_body(response, MAX_ERROR_BODY_READ_BYTES).await;
             return Err(ProviderError::Connection(format!(
                 "health check failed: HTTP {status}: {}",
                 truncate_error_body(&body)

--- a/crates/integrations/wechat/src/provider.rs
+++ b/crates/integrations/wechat/src/provider.rs
@@ -3,7 +3,9 @@ use std::time::{Duration, Instant};
 
 use acteon_core::{Action, ProviderResponse};
 use acteon_crypto::{ExposeSecret, SecretString};
-use acteon_provider::{Provider, ProviderError, truncate_error_body};
+use acteon_provider::{
+    MAX_ERROR_BODY_READ_BYTES, Provider, ProviderError, read_bounded_body, truncate_error_body,
+};
 use reqwest::Client;
 use serde::Deserialize;
 use tokio::sync::Mutex;
@@ -15,46 +17,6 @@ use crate::types::{
     WeChatApiResponse, WeChatMsgType, WeChatSendRequest, WeChatTextBody, WeChatTextCardBody,
     WeChatTokenResponse,
 };
-
-/// Maximum number of bytes to read from an error-response body
-/// before giving up. A misbehaving upstream (or malicious
-/// man-in-the-middle proxy) could otherwise stream an unbounded
-/// body and force Acteon to allocate gigabytes just to produce
-/// an error message. 2 KiB is plenty for the `errcode + errmsg`
-/// envelope that `WeChat` actually returns — the rest would be
-/// truncated by [`truncate_error_body`] anyway.
-const MAX_ERROR_BODY_READ_BYTES: usize = 2048;
-
-/// Read at most `max_bytes` bytes from a `reqwest::Response`
-/// body and return them as a lossy UTF-8 string.
-///
-/// Unlike [`reqwest::Response::text`], which reads the entire
-/// body into memory before returning, this helper pumps
-/// `Response::chunk()` in a loop and stops as soon as the
-/// configured byte limit is reached. A response whose
-/// `Content-Length` is huge (or unbounded) gets truncated at
-/// the caller's hard limit rather than `OOMing` the process.
-async fn read_bounded_body(mut response: reqwest::Response, max_bytes: usize) -> String {
-    let mut buf: Vec<u8> = Vec::with_capacity(max_bytes.min(1024));
-    while buf.len() < max_bytes {
-        match response.chunk().await {
-            Ok(Some(chunk)) => {
-                let remaining = max_bytes - buf.len();
-                let take = chunk.len().min(remaining);
-                buf.extend_from_slice(&chunk[..take]);
-                if chunk.len() > remaining {
-                    // Hit the cap mid-chunk — drop the rest of
-                    // this chunk and stop pulling.
-                    break;
-                }
-            }
-            // End of stream or transport error — either way,
-            // stop reading and return whatever we have so far.
-            Ok(None) | Err(_) => break,
-        }
-    }
-    String::from_utf8_lossy(&buf).to_string()
-}
 
 // -- WeChat errcode classification ---------------------------------------
 //

--- a/crates/provider/src/http.rs
+++ b/crates/provider/src/http.rs
@@ -1,0 +1,43 @@
+//! Shared HTTP response helpers for providers.
+
+/// Default cap for reading an HTTP **error**-response body. Error bodies are
+/// only used for diagnostics (and truncated again by
+/// [`truncate_error_body`](crate::truncate_error_body)), so a few KiB is
+/// plenty — reading more just risks `OOM`ing the process on a hostile or
+/// compromised endpoint that returns a huge body.
+pub const MAX_ERROR_BODY_READ_BYTES: usize = 2048;
+
+/// Default cap for reading a **success**-response body that is returned to the
+/// caller (e.g. a webhook's response payload). Generous enough for any
+/// legitimate ack, but bounded so a hostile or user-controlled endpoint can't
+/// OOM the gateway by replying `200` with a giant body.
+pub const MAX_RESPONSE_BODY_READ_BYTES: usize = 1_048_576;
+
+/// Read at most `max_bytes` of a [`reqwest::Response`] body and return it as a
+/// lossy UTF-8 string.
+///
+/// Unlike [`reqwest::Response::text`], which reads the **entire** body into
+/// memory before returning, this pumps [`reqwest::Response::chunk`] in a loop
+/// and stops as soon as the byte cap is reached. A response whose
+/// `Content-Length` is huge (or unbounded/chunked) is truncated at the cap
+/// rather than read fully — so an action's target endpoint cannot OOM the
+/// gateway by replying with a giant body.
+pub async fn read_bounded_body(mut response: reqwest::Response, max_bytes: usize) -> String {
+    let mut buf: Vec<u8> = Vec::with_capacity(max_bytes.min(1024));
+    while buf.len() < max_bytes {
+        match response.chunk().await {
+            Ok(Some(chunk)) => {
+                let remaining = max_bytes - buf.len();
+                let take = chunk.len().min(remaining);
+                buf.extend_from_slice(&chunk[..take]);
+                if chunk.len() > remaining {
+                    // Hit the cap mid-chunk — drop the rest and stop pulling.
+                    break;
+                }
+            }
+            // End of stream or transport error — return what we have.
+            Ok(None) | Err(_) => break,
+        }
+    }
+    String::from_utf8_lossy(&buf).to_string()
+}

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -9,8 +9,14 @@ pub mod resource_lookup;
 #[cfg(feature = "webhook")]
 pub mod webhook;
 
+// Shared HTTP response helpers (bounded body reads) — require reqwest.
+#[cfg(feature = "reqwest")]
+pub mod http;
+
 pub use context::DispatchContext;
 pub use error::{ProviderError, truncate_error_body};
+#[cfg(feature = "reqwest")]
+pub use http::{MAX_ERROR_BODY_READ_BYTES, MAX_RESPONSE_BODY_READ_BYTES, read_bounded_body};
 pub use log::LogProvider;
 pub use provider::{DynProvider, Provider};
 pub use registry::ProviderRegistry;


### PR DESCRIPTION
## The bug (survey theme #3, verified)

Every integration provider **except WeChat** read error-response bodies with the unbounded `response.text().await` (or `.bytes()`) before truncating the message — pulling the **entire** body into memory first. A hostile or compromised target endpoint could OOM the gateway by replying with a giant body. For the **webhook** provider the endpoint URL is **caller-supplied**, so this is a real cross-tenant DoS.

## The fix

A shared `read_bounded_body(response, max_bytes)` in `acteon-provider` (gated on the `reqwest` feature every provider already pulls via `trace-context`) pumps `Response::chunk()` and stops at the cap instead of reading the whole body. Plus `MAX_ERROR_BODY_READ_BYTES` (2 KiB) and `MAX_RESPONSE_BODY_READ_BYTES` (1 MiB). WeChat's local copy is removed in favor of the shared one — **one implementation, not 11**.

- All 10 unbounded providers now read **error** bodies via the bounded helper.
- The **webhook** + **Teams** *success* bodies (returned to the caller) are also bounded at 1 MiB — webhook because its endpoint is caller-controlled; Teams because its success body is a trivial `"1"`. Other providers' success paths parse a small JSON status with `response.json()` from trusted vendor APIs and are left unchanged (matching the established WeChat pattern).

## How it was built
A shared helper (authored directly) + 11 parallel agents (10 swaps + WeChat dedupe), each with per-provider adversarial verification confirming: every error-path read is bounded, the success-path `response.json()` is untouched, and the helper is imported (not duplicated). **0 issues** flagged. I then bounded the webhook/Teams caller-facing success bodies myself and fixed a `needless_pass_by_value` lint.

## Verification
`cargo fmt`, `clippy --workspace -D warnings`, the provider + webhook/teams/wechat test suites, `cargo check --all-targets` — all clean.

> Completes theme #3's body-bounds. Remaining theme-#3 follow-up: S3 `get_object` / GCS `download_object` stream whole objects into a `Vec<u8>` (size-cap / streaming — a different fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)