### PR TITLE
fix(clients): correct bus-subscription path in all 4 polyglot SDKs (was 404)

### DIFF
--- a/clients/go/acteon/bus.go
+++ b/clients/go/acteon/bus.go
@@ -167,8 +167,8 @@ func (c *Client) ListBusSubscriptions(ctx context.Context, filter *ListBusSubscr
 	return out.Subscriptions, nil
 }
 
-func (c *Client) GetBusSubscription(ctx context.Context, subID string) (*BusSubscription, error) {
-	path := fmt.Sprintf("/v1/bus/subscriptions/%s", busSeg(subID))
+func (c *Client) GetBusSubscription(ctx context.Context, namespace, tenant, subID string) (*BusSubscription, error) {
+	path := fmt.Sprintf("/v1/bus/subscriptions/%s/%s/%s", busSeg(namespace), busSeg(tenant), busSeg(subID))
 	var out BusSubscription
 	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
 		return nil, err
@@ -176,14 +176,14 @@ func (c *Client) GetBusSubscription(ctx context.Context, subID string) (*BusSubs
 	return &out, nil
 }
 
-func (c *Client) DeleteBusSubscription(ctx context.Context, subID string) error {
-	path := fmt.Sprintf("/v1/bus/subscriptions/%s", busSeg(subID))
+func (c *Client) DeleteBusSubscription(ctx context.Context, namespace, tenant, subID string) error {
+	path := fmt.Sprintf("/v1/bus/subscriptions/%s/%s/%s", busSeg(namespace), busSeg(tenant), busSeg(subID))
 	_, err := c.busDoJSON(ctx, http.MethodDelete, path, nil, nil)
 	return err
 }
 
-func (c *Client) GetBusSubscriptionLag(ctx context.Context, subID string) (*BusLag, error) {
-	path := fmt.Sprintf("/v1/bus/subscriptions/%s/lag", busSeg(subID))
+func (c *Client) GetBusSubscriptionLag(ctx context.Context, namespace, tenant, subID string) (*BusLag, error) {
+	path := fmt.Sprintf("/v1/bus/subscriptions/%s/%s/%s/lag", busSeg(namespace), busSeg(tenant), busSeg(subID))
 	var out BusLag
 	if _, err := c.busDoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
 		return nil, err

--- a/clients/java/src/main/java/com/acteon/client/ActeonClient.java
+++ b/clients/java/src/main/java/com/acteon/client/ActeonClient.java
@@ -3314,16 +3314,21 @@ public class ActeonClient implements AutoCloseable {
         return resp.subscriptions() == null ? List.of() : resp.subscriptions();
     }
 
-    public Bus.BusSubscription getBusSubscription(String subId) throws ActeonException {
-        return busSend("GET", "/v1/bus/subscriptions/" + busSeg(subId), null, Bus.BusSubscription.class);
+    public Bus.BusSubscription getBusSubscription(String namespace, String tenant, String subId) throws ActeonException {
+        return busSend("GET",
+            "/v1/bus/subscriptions/" + busSeg(namespace) + "/" + busSeg(tenant) + "/" + busSeg(subId),
+            null, Bus.BusSubscription.class);
     }
 
-    public void deleteBusSubscription(String subId) throws ActeonException {
-        busSendVoid("DELETE", "/v1/bus/subscriptions/" + busSeg(subId), null);
+    public void deleteBusSubscription(String namespace, String tenant, String subId) throws ActeonException {
+        busSendVoid("DELETE",
+            "/v1/bus/subscriptions/" + busSeg(namespace) + "/" + busSeg(tenant) + "/" + busSeg(subId), null);
     }
 
-    public Bus.BusLag getBusSubscriptionLag(String subId) throws ActeonException {
-        return busSend("GET", "/v1/bus/subscriptions/" + busSeg(subId) + "/lag", null, Bus.BusLag.class);
+    public Bus.BusLag getBusSubscriptionLag(String namespace, String tenant, String subId) throws ActeonException {
+        return busSend("GET",
+            "/v1/bus/subscriptions/" + busSeg(namespace) + "/" + busSeg(tenant) + "/" + busSeg(subId) + "/lag",
+            null, Bus.BusLag.class);
     }
 
     // --------------- Phase 3: Schemas ---------------

--- a/clients/nodejs/src/client.ts
+++ b/clients/nodejs/src/client.ts
@@ -2536,27 +2536,39 @@ export class ActeonClient {
     return (body.subscriptions ?? []).map(parseBusSubscription);
   }
 
-  async getBusSubscription(subId: string): Promise<BusSubscription> {
+  async getBusSubscription(
+    namespace: string,
+    tenant: string,
+    subId: string,
+  ): Promise<BusSubscription> {
     const response = await this.request(
       "GET",
-      `/v1/bus/subscriptions/${this.busSeg(subId)}`,
+      `/v1/bus/subscriptions/${this.busSeg(namespace)}/${this.busSeg(tenant)}/${this.busSeg(subId)}`,
     );
     if (!response.ok) await this.busThrowFromResponse(response);
     return parseBusSubscription((await response.json()) as Record<string, unknown>);
   }
 
-  async deleteBusSubscription(subId: string): Promise<void> {
+  async deleteBusSubscription(
+    namespace: string,
+    tenant: string,
+    subId: string,
+  ): Promise<void> {
     const response = await this.request(
       "DELETE",
-      `/v1/bus/subscriptions/${this.busSeg(subId)}`,
+      `/v1/bus/subscriptions/${this.busSeg(namespace)}/${this.busSeg(tenant)}/${this.busSeg(subId)}`,
     );
     if (!response.ok) await this.busThrowFromResponse(response);
   }
 
-  async getBusSubscriptionLag(subId: string): Promise<BusLag> {
+  async getBusSubscriptionLag(
+    namespace: string,
+    tenant: string,
+    subId: string,
+  ): Promise<BusLag> {
     const response = await this.request(
       "GET",
-      `/v1/bus/subscriptions/${this.busSeg(subId)}/lag`,
+      `/v1/bus/subscriptions/${this.busSeg(namespace)}/${this.busSeg(tenant)}/${this.busSeg(subId)}/lag`,
     );
     if (!response.ok) await this.busThrowFromResponse(response);
     return parseBusLag((await response.json()) as Record<string, unknown>);

--- a/clients/python/acteon_client/bus.py
+++ b/clients/python/acteon_client/bus.py
@@ -176,17 +176,30 @@ class _BusClientMixin:
         _raise_for_status(resp)
         return [BusSubscription.from_dict(s) for s in resp.json().get("subscriptions", [])]
 
-    def get_bus_subscription(self, sub_id: str) -> BusSubscription:
-        resp = self._request("GET", f"/v1/bus/subscriptions/{_seg(sub_id)}")
+    def get_bus_subscription(
+        self, namespace: str, tenant: str, sub_id: str
+    ) -> BusSubscription:
+        resp = self._request(
+            "GET",
+            f"/v1/bus/subscriptions/{_seg(namespace)}/{_seg(tenant)}/{_seg(sub_id)}",
+        )
         _raise_for_status(resp)
         return BusSubscription.from_dict(resp.json())
 
-    def delete_bus_subscription(self, sub_id: str) -> None:
-        resp = self._request("DELETE", f"/v1/bus/subscriptions/{_seg(sub_id)}")
+    def delete_bus_subscription(self, namespace: str, tenant: str, sub_id: str) -> None:
+        resp = self._request(
+            "DELETE",
+            f"/v1/bus/subscriptions/{_seg(namespace)}/{_seg(tenant)}/{_seg(sub_id)}",
+        )
         _raise_for_status(resp)
 
-    def get_bus_subscription_lag(self, sub_id: str) -> BusLag:
-        resp = self._request("GET", f"/v1/bus/subscriptions/{_seg(sub_id)}/lag")
+    def get_bus_subscription_lag(
+        self, namespace: str, tenant: str, sub_id: str
+    ) -> BusLag:
+        resp = self._request(
+            "GET",
+            f"/v1/bus/subscriptions/{_seg(namespace)}/{_seg(tenant)}/{_seg(sub_id)}/lag",
+        )
         _raise_for_status(resp)
         return BusLag.from_dict(resp.json())
 
@@ -779,17 +792,32 @@ class _AsyncBusClientMixin:
         _raise_for_status(resp)
         return [BusSubscription.from_dict(s) for s in resp.json().get("subscriptions", [])]
 
-    async def get_bus_subscription(self, sub_id: str) -> BusSubscription:
-        resp = await self._request("GET", f"/v1/bus/subscriptions/{_seg(sub_id)}")
+    async def get_bus_subscription(
+        self, namespace: str, tenant: str, sub_id: str
+    ) -> BusSubscription:
+        resp = await self._request(
+            "GET",
+            f"/v1/bus/subscriptions/{_seg(namespace)}/{_seg(tenant)}/{_seg(sub_id)}",
+        )
         _raise_for_status(resp)
         return BusSubscription.from_dict(resp.json())
 
-    async def delete_bus_subscription(self, sub_id: str) -> None:
-        resp = await self._request("DELETE", f"/v1/bus/subscriptions/{_seg(sub_id)}")
+    async def delete_bus_subscription(
+        self, namespace: str, tenant: str, sub_id: str
+    ) -> None:
+        resp = await self._request(
+            "DELETE",
+            f"/v1/bus/subscriptions/{_seg(namespace)}/{_seg(tenant)}/{_seg(sub_id)}",
+        )
         _raise_for_status(resp)
 
-    async def get_bus_subscription_lag(self, sub_id: str) -> BusLag:
-        resp = await self._request("GET", f"/v1/bus/subscriptions/{_seg(sub_id)}/lag")
+    async def get_bus_subscription_lag(
+        self, namespace: str, tenant: str, sub_id: str
+    ) -> BusLag:
+        resp = await self._request(
+            "GET",
+            f"/v1/bus/subscriptions/{_seg(namespace)}/{_seg(tenant)}/{_seg(sub_id)}/lag",
+        )
         _raise_for_status(resp)
         return BusLag.from_dict(resp.json())
 


### PR DESCRIPTION
## The bug (survey theme — SDK parity, verified)

The server registers per-subscription routes with **three** path segments — `/v1/bus/subscriptions/{namespace}/{tenant}/{id}` (and `…/lag`, `…/ack`, `…/deadletter`) — but **all four** polyglot SDKs built a **single-segment** `/v1/bus/subscriptions/{id}`. So `getBusSubscription` / `deleteBusSubscription` / `getBusSubscriptionLag` returned **404 for every SDK user**. The Rust client already builds the correct 3-segment path (`subscription_url(namespace, tenant, id, …)`).

## The fix

Change the three methods to take `(namespace, tenant, sub_id)` and build the 3-segment path, matching the Rust client + server routes:
- **Python** — sync + async
- **Node** — `getBusSubscription` / `deleteBusSubscription` / `getBusSubscriptionLag`
- **Go** — `GetBusSubscription` / `DeleteBusSubscription` / `GetBusSubscriptionLag`
- **Java** — same three

No callers exist (the methods always 404'd), so the signature change breaks nothing.

## Verification
Python `py_compile`, Go `build` + `vet`, Node `tsc` — all pass. Java is edited to match but **not compiled locally** (no JRE/Maven; the polyglot SDKs have no CI — itself a known gap).

> Follow-up: the `ack` and `deadletter` subscription endpoints are still **missing** from the polyglot SDKs entirely (the Rust client has them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)