### PR TITLE
fix(rules): guard integer arithmetic panics in rule evaluation

### DIFF
--- a/crates/rules/rules/src/engine/eval.rs
+++ b/crates/rules/rules/src/engine/eval.rs
@@ -307,8 +307,14 @@ pub(crate) async fn eval_binary(
     match op {
         // Arithmetic
         BinaryOp::Add => eval_add(&left, &right),
-        BinaryOp::Sub => eval_arithmetic(&left, &right, |a, b| a - b, |a, b| a - b, "subtract"),
-        BinaryOp::Mul => eval_arithmetic(&left, &right, |a, b| a * b, |a, b| a * b, "multiply"),
+        // Use wrapping integer ops (matching `eval_add`) so an overflowing
+        // rule expression over a user payload can't panic the evaluator thread.
+        BinaryOp::Sub => {
+            eval_arithmetic(&left, &right, i64::wrapping_sub, |a, b| a - b, "subtract")
+        }
+        BinaryOp::Mul => {
+            eval_arithmetic(&left, &right, i64::wrapping_mul, |a, b| a * b, "multiply")
+        }
         BinaryOp::Div => eval_div(&left, &right),
         BinaryOp::Mod => eval_mod(&left, &right),
 
@@ -381,7 +387,11 @@ fn eval_div(left: &Value, right: &Value) -> Result<Value, RuleError> {
         (Value::Int(_) | Value::Float(_), Value::Float(f)) if *f == 0.0 => {
             Err(RuleError::Evaluation("division by zero".into()))
         }
-        (Value::Int(a), Value::Int(b)) => Ok(Value::Int(a / b)),
+        // `b == 0` is handled above, so `checked_div` only returns `None` for
+        // `i64::MIN / -1`, which would otherwise panic the evaluator thread.
+        (Value::Int(a), Value::Int(b)) => a.checked_div(*b).map(Value::Int).ok_or_else(|| {
+            RuleError::Evaluation("integer division overflow (i64::MIN / -1)".into())
+        }),
         (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a / b)),
         (Value::Int(a), Value::Float(b)) => Ok(Value::Float(*a as f64 / b)),
         (Value::Float(a), Value::Int(b)) => Ok(Value::Float(a / *b as f64)),
@@ -398,7 +408,11 @@ fn eval_div(left: &Value, right: &Value) -> Result<Value, RuleError> {
 fn eval_mod(left: &Value, right: &Value) -> Result<Value, RuleError> {
     match (left, right) {
         (Value::Int(_), Value::Int(0)) => Err(RuleError::Evaluation("modulo by zero".into())),
-        (Value::Int(a), Value::Int(b)) => Ok(Value::Int(a % b)),
+        // As with division, guard `i64::MIN % -1`, which panics.
+        (Value::Int(a), Value::Int(b)) => a
+            .checked_rem(*b)
+            .map(Value::Int)
+            .ok_or_else(|| RuleError::Evaluation("integer modulo overflow (i64::MIN % -1)".into())),
         (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a % b)),
         (Value::Int(a), Value::Float(b)) => Ok(Value::Float(*a as f64 % b)),
         (Value::Float(a), Value::Int(b)) => Ok(Value::Float(a % *b as f64)),
@@ -533,5 +547,56 @@ fn eval_in(left: &Value, right: &Value) -> Result<Value, RuleError> {
             "in: right-hand side must be list, map, or string, got {}",
             right.type_name()
         ))),
+    }
+}
+
+#[cfg(test)]
+mod arithmetic_safety_tests {
+    use super::*;
+
+    #[test]
+    fn division_of_i64_min_by_neg_one_errors_not_panics() {
+        // `i64::MIN / -1` overflows and panics with the raw `/` operator —
+        // reachable from a rule like `payload.a / payload.b` over user input.
+        let r = eval_div(&Value::Int(i64::MIN), &Value::Int(-1));
+        assert!(matches!(r, Err(RuleError::Evaluation(_))), "got {r:?}");
+    }
+
+    #[test]
+    fn modulo_of_i64_min_by_neg_one_errors_not_panics() {
+        let r = eval_mod(&Value::Int(i64::MIN), &Value::Int(-1));
+        assert!(matches!(r, Err(RuleError::Evaluation(_))), "got {r:?}");
+    }
+
+    #[test]
+    fn division_and_modulo_by_zero_still_error() {
+        assert!(matches!(
+            eval_div(&Value::Int(5), &Value::Int(0)),
+            Err(RuleError::Evaluation(_))
+        ));
+        assert!(matches!(
+            eval_mod(&Value::Int(5), &Value::Int(0)),
+            Err(RuleError::Evaluation(_))
+        ));
+    }
+
+    #[test]
+    fn normal_division_and_modulo_unaffected() {
+        assert!(matches!(
+            eval_div(&Value::Int(10), &Value::Int(3)),
+            Ok(Value::Int(3))
+        ));
+        assert!(matches!(
+            eval_mod(&Value::Int(10), &Value::Int(3)),
+            Ok(Value::Int(1))
+        ));
+    }
+
+    #[test]
+    fn subtract_and_multiply_int_ops_wrap_not_panic() {
+        // The Sub/Mul dispatch now uses wrapping ops (matching Add), so an
+        // overflowing constant can't panic the evaluator in a debug build.
+        assert_eq!((i64::MIN).wrapping_sub(1), i64::MAX);
+        assert_eq!((i64::MAX).wrapping_mul(2), -2);
     }
 }

--- a/crates/rules/rules/src/ir/optimize.rs
+++ b/crates/rules/rules/src/ir/optimize.rs
@@ -81,8 +81,15 @@ fn fold_binary(op: BinaryOp, lhs: Expr, rhs: Expr) -> Expr {
         (BinaryOp::Add, Expr::Int(a), Expr::Int(b)) => Expr::Int(a.wrapping_add(*b)),
         (BinaryOp::Sub, Expr::Int(a), Expr::Int(b)) => Expr::Int(a.wrapping_sub(*b)),
         (BinaryOp::Mul, Expr::Int(a), Expr::Int(b)) => Expr::Int(a.wrapping_mul(*b)),
-        (BinaryOp::Div, Expr::Int(a), Expr::Int(b)) if *b != 0 => Expr::Int(a / b),
-        (BinaryOp::Mod, Expr::Int(a), Expr::Int(b)) if *b != 0 => Expr::Int(a % b),
+        // Guard `i64::MIN / -1` (and `% -1`) as well as zero: both panic. When
+        // the guard fails the node is left un-folded and the evaluator's
+        // checked div/rem surfaces it as an error instead of crashing.
+        (BinaryOp::Div, Expr::Int(a), Expr::Int(b)) if *b != 0 && !(*a == i64::MIN && *b == -1) => {
+            Expr::Int(a / b)
+        }
+        (BinaryOp::Mod, Expr::Int(a), Expr::Int(b)) if *b != 0 && !(*a == i64::MIN && *b == -1) => {
+            Expr::Int(a % b)
+        }
 
         // Float arithmetic
         (BinaryOp::Add, Expr::Float(a), Expr::Float(b)) => Expr::Float(a + b),
@@ -303,6 +310,24 @@ mod tests {
             Box::new(Expr::Int(0)),
         );
         assert!(matches!(optimize(expr), Expr::Binary(BinaryOp::Div, _, _)));
+    }
+
+    #[test]
+    fn fold_no_div_or_mod_i64_min_by_neg_one() {
+        // `i64::MIN / -1` and `i64::MIN % -1` overflow and panic; the folder
+        // must leave them un-folded (the evaluator surfaces them as errors)
+        // rather than crashing the optimizer.
+        for op in [BinaryOp::Div, BinaryOp::Mod] {
+            let expr = Expr::Binary(
+                op.clone(),
+                Box::new(Expr::Int(i64::MIN)),
+                Box::new(Expr::Int(-1)),
+            );
+            assert!(
+                matches!(optimize(expr), Expr::Binary(_, _, _)),
+                "{op:?} of i64::MIN by -1 must not be folded",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## The bug (survey theme — panic safety, verified)

A rule condition is evaluated over the (attacker-influenced) action **payload**, so its integer arithmetic must never panic the evaluator thread. Three gaps:

1. **`eval_div` / `eval_mod`** guarded division/modulo **by zero** but not the other overflow case — **`i64::MIN / -1`** (and `% -1`), which the raw `/` and `%` operators panic on in **every** build. Reachable from a rule like `payload.a / payload.b` over user input → gateway-thread panic (DoS).
2. **`Sub` / `Mul`** used raw `a - b` / `a * b` → panic on overflow in **debug** builds (silent wrap in release).
3. The **constant folder** (`optimize.rs`) folded `a / b` / `a % b` guarded only on `b != 0`, so a literal `i64::MIN / -1` panicked at **optimize** time.

## The fix
- `eval_div`/`eval_mod` → `checked_div`/`checked_rem`, surfacing the overflow as a `RuleError::Evaluation` (the `b == 0` arms already handle that case, so `None` means only the `MIN/-1` overflow).
- `Sub`/`Mul` → `i64::wrapping_sub`/`i64::wrapping_mul`, matching the already-safe `eval_add`.
- folder guard extended to `b != 0 && !(a == i64::MIN && b == -1)` — the node is left un-folded and the evaluator's checked op surfaces the error.

## Tests
`i64::MIN / -1` and `% -1` → error (not panic); div/mod by zero → still error; normal cases unaffected; the folder leaves `i64::MIN / -1` un-folded.

## Verification
`cargo fmt`, `clippy -p acteon-rules -D warnings`, `cargo test -p acteon-rules` (180), `cargo check --all-targets` — all clean.

> Follow-up: the CEL parser/evaluator has no recursion-depth limit (stack overflow on deeply nested expressions) — a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)