### PR TITLE
fix(ui): use snake_case outcome values so badges colour and filters match

### DIFF
--- a/ui/e2e/actions.spec.ts
+++ b/ui/e2e/actions.spec.ts
@@ -44,8 +44,10 @@ test.describe('Actions / Audit Trail', () => {
 
   test('filter by outcome works', async ({ page }) => {
     const outcomeSelect = page.locator('select').first()
-    await outcomeSelect.selectOption('Executed')
-    await expect(page).toHaveURL(/outcome=Executed/)
+    // The option value is the snake_case string the server actually stores
+    // (e.g. `executed`); a PascalCase value would silently match nothing.
+    await outcomeSelect.selectOption('executed')
+    await expect(page).toHaveURL(/outcome=executed/)
   })
 
   test('namespace filter updates URL', async ({ page }) => {

--- a/ui/e2e/dashboard.spec.ts
+++ b/ui/e2e/dashboard.spec.ts
@@ -61,11 +61,12 @@ test.describe('Dashboard', () => {
     // Wait for stats to load
     await page.waitForTimeout(1000)
 
-    // Click the "Failed" stat card to go to audit with outcome=Failed
+    // Click the "Failed" stat card → audit filtered by the snake_case outcome
+    // the server actually stores (a PascalCase value would match nothing).
     const failedCard = page.getByText('Failed', { exact: true }).first()
     if (await failedCard.isVisible()) {
       await failedCard.click()
-      await expect(page).toHaveURL(/audit/)
+      await expect(page).toHaveURL(/audit\?outcome=failed/)
     }
   })
 })

--- a/ui/src/components/ui/Badge.tsx
+++ b/ui/src/components/ui/Badge.tsx
@@ -16,32 +16,42 @@ const sizes = {
   md: styles.md,
 }
 
+// IMPORTANT: keys must match the EXACT strings the server emits. Action
+// outcomes and most status enums serialize as snake_case (e.g. the gateway's
+// `outcome_tag`, `GroupState`'s `rename_all = "snake_case"`), so the keys here
+// are snake_case too. Previously the action-outcome keys were PascalCase, so
+// every outcome badge fell through to `neutral` (grey) and the outcome filter
+// matched nothing.
 const outcomeVariant: Record<string, keyof typeof variants> = {
-  Executed: 'success',
-  Deduplicated: 'neutral',
-  Suppressed: 'error',
-  Silenced: 'info',
-  Muted: 'neutral',
-  Rerouted: 'info',
-  Throttled: 'warning',
-  Failed: 'error',
-  Grouped: 'pending',
-  PendingApproval: 'warning',
-  ChainStarted: 'info',
-  DryRun: 'neutral',
-  CircuitOpen: 'error',
-  Scheduled: 'pending',
-  StateChanged: 'info',
-  // Compliance two-phase: a pre-execution intent record, surfaced distinctly
-  // so it isn't mistaken for a stuck/in-flight job.
+  // Action outcomes (gateway `outcome_tag`, snake_case)
+  executed: 'success',
+  deduplicated: 'neutral',
+  suppressed: 'error',
+  silenced: 'info',
+  muted: 'neutral',
+  rerouted: 'info',
+  throttled: 'warning',
+  failed: 'error',
+  grouped: 'pending',
+  pending_approval: 'warning',
+  chain_started: 'info',
+  dry_run: 'neutral',
+  circuit_open: 'error',
+  scheduled: 'pending',
+  state_changed: 'info',
+  recurring_created: 'info',
+  quota_exceeded: 'warning',
+  // Compliance two-phase: a pre-execution intent record (outcome `pending`,
+  // relabelled `Audit Intent` for display) — surfaced distinctly so it isn't
+  // mistaken for a stuck/in-flight job.
   'Audit Intent': 'info',
   // Chain statuses
   running: 'info',
   completed: 'success',
-  failed: 'error',
   cancelled: 'warning',
   timed_out: 'warning',
   waiting_sub_chain: 'info',
+  waiting_parallel: 'info',
   pending: 'neutral',
   skipped: 'neutral',
   // Circuit states
@@ -55,25 +65,23 @@ const outcomeVariant: Record<string, keyof typeof variants> = {
   approved: 'success',
   rejected: 'error',
   expired: 'warning',
-  // Group states
-  Pending: 'warning',
-  Notified: 'info',
-  Resolved: 'success',
-  // Recurring action states
+  // Event-group states (`GroupState`, snake_case: pending/notified/resolved —
+  // `pending` shares the neutral entry above)
+  notified: 'info',
+  resolved: 'success',
+  // Recurring-action states. The status string is UI-derived (PascalCase); the
+  // snake_case aliases are kept too in case it is ever surfaced server-side.
   Active: 'success',
   Paused: 'warning',
   Completed: 'neutral',
-  // Swarm run statuses (lowercase, as the server emits them).
-  // `running`, `completed`, `failed`, `cancelled`, `timed_out` also appear
-  // in the chain-status block above and resolve to the same variants —
-  // listing them again documents the intent for future readers.
+  active: 'success',
+  paused: 'warning',
+  // Swarm run statuses (snake_case, as the server emits them). `running`,
+  // `completed`, `failed`, `cancelled`, `timed_out` reuse the chain entries.
   accepted: 'pending',
   adversarial: 'info',
   cancelling: 'warning',
 }
-
-// All chain-status keys reused by swarm runs (running, completed, failed,
-// cancelled, timed_out) resolve via the shared entries declared earlier.
 
 interface BadgeProps {
   variant?: keyof typeof variants

--- a/ui/src/pages/Actions.tsx
+++ b/ui/src/pages/Actions.tsx
@@ -20,7 +20,27 @@ import styles from './Actions.module.css'
 
 const col = createColumnHelper<AuditRecord>()
 
-const outcomeOptions = ['Executed', 'Failed', 'Suppressed', 'Deduplicated', 'Rerouted', 'Throttled', 'PendingApproval', 'ChainStarted', 'CircuitOpen', 'Scheduled', 'DryRun'].map((v) => ({ value: v, label: v }))
+// Values MUST be the snake_case strings the server stores (gateway
+// `outcome_tag`); the server filters by exact match, so PascalCase values
+// silently returned zero results. Labels are humanized for the dropdown.
+const outcomeOptions: { value: string; label: string }[] = [
+  { value: 'executed', label: 'Executed' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'suppressed', label: 'Suppressed' },
+  { value: 'deduplicated', label: 'Deduplicated' },
+  { value: 'rerouted', label: 'Rerouted' },
+  { value: 'throttled', label: 'Throttled' },
+  { value: 'pending_approval', label: 'Pending Approval' },
+  { value: 'chain_started', label: 'Chain Started' },
+  { value: 'circuit_open', label: 'Circuit Open' },
+  { value: 'scheduled', label: 'Scheduled' },
+  { value: 'dry_run', label: 'Dry Run' },
+  { value: 'state_changed', label: 'State Changed' },
+  { value: 'quota_exceeded', label: 'Quota Exceeded' },
+  { value: 'silenced', label: 'Silenced' },
+  { value: 'muted', label: 'Muted' },
+  { value: 'grouped', label: 'Grouped' },
+]
 
 // The server stamps `pending` on a compliance pre-execution intent record
 // (two-phase fail-closed). Show it as "Audit Intent" so operators don't read

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -125,10 +125,12 @@ interface StatCard {
 function buildStatCards(m: MetricsResponse): StatCard[] {
   const cards: StatCard[] = [
     { label: 'Dispatched', value: m.dispatched, link: '/audit' },
-    { label: 'Executed', value: m.executed, link: '/audit?outcome=Executed' },
-    { label: 'Failed', value: m.failed, link: '/audit?outcome=Failed' },
-    { label: 'Deduplicated', value: m.deduplicated, link: '/audit?outcome=Deduplicated' },
-    { label: 'Suppressed', value: m.suppressed, link: '/audit?outcome=Suppressed' },
+    // outcome filter uses the snake_case value the server stores, else the
+    // audit query matches nothing (the displayed label stays human-readable).
+    { label: 'Executed', value: m.executed, link: '/audit?outcome=executed' },
+    { label: 'Failed', value: m.failed, link: '/audit?outcome=failed' },
+    { label: 'Deduplicated', value: m.deduplicated, link: '/audit?outcome=deduplicated' },
+    { label: 'Suppressed', value: m.suppressed, link: '/audit?outcome=suppressed' },
     { label: 'Silenced', value: m.silenced ?? 0, link: '/silences' },
     { label: 'Muted', value: m.muted ?? 0, link: '/time-intervals' },
     { label: 'Pending Approval', value: m.pending_approval ?? 0, link: '/approvals' },


### PR DESCRIPTION
## The bug (survey theme — UI, verified)

The server stores action outcomes (and group states) as **snake_case** — `executed`, `state_changed`, `pending_approval`, … (the gateway's `outcome_tag`; `GroupState`'s `rename_all = "snake_case"`). But the UI used **PascalCase** in three places, so the strings never matched the data:

1. **`Badge.tsx`** — `outcomeVariant` was keyed `Executed`/`Suppressed`/… so `outcomeVariant['executed']` was `undefined` → **every outcome badge rendered neutral grey**. (Group-state keys had the same problem; there was even a `Completed: neutral` vs `completed: success` conflict.)
2. **`Actions.tsx`** — the outcome **filter** dropdown sent `Executed` etc. The server filters by exact match → it **returned zero results** for any outcome filter.
3. **`Dashboard.tsx`** — the Executed/Failed/Deduplicated/Suppressed **stat cards** linked to `/audit?outcome=Executed` etc., so clicking them filtered to nothing.

## The fix
- Badge keys → snake_case; added the missing `state_changed`, `quota_exceeded`, `recurring_created`, `waiting_parallel`, and group `notified`/`resolved`.
- Filter option **values** → the snake_case stored strings (labels stay human-readable, e.g. value `pending_approval` / label "Pending Approval").
- Dashboard stat-card outcome links → snake_case.
- Kept the UI-derived recurring `Active`/`Paused` labels (with snake aliases added for safety).
- Updated the `actions` + `dashboard` e2e specs to assert the snake_case `outcome=` param (real regression coverage).

## Verification
`npm run lint` (0 errors) and `npm run build` both pass; a repo-wide sweep confirms no remaining PascalCase `outcome=` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)