### PR TITLE
fix(compliance): select hash-chain tip by max sequence, not dispatched_at (CRITICAL)

### DIFF
--- a/crates/audit/audit/src/compliance.rs
+++ b/crates/audit/audit/src/compliance.rs
@@ -83,10 +83,18 @@ impl HashChainAuditStore {
         namespace: &str,
         tenant: &str,
     ) -> Result<Option<(String, u64)>, AuditError> {
+        // The tip is the record with the GREATEST sequence number, not the
+        // most recent `dispatched_at`. An intent and its outcome share a
+        // `dispatched_at`, so a `dispatched_at DESC` ordering can return the
+        // lower-sequence record of the pair, and the next write would then be
+        // assigned a colliding sequence number (Postgres rejects it and the
+        // dispatch fails closed; ClickHouse silently forks the chain). Order by
+        // sequence number descending and take the first.
         let query = AuditQuery {
             namespace: Some(namespace.to_string()),
             tenant: Some(tenant.to_string()),
             limit: Some(1),
+            sort_by_sequence_desc: true,
             ..AuditQuery::default()
         };
 
@@ -445,9 +453,25 @@ mod tests {
             if query.sort_by_sequence_asc {
                 // Ascending sequence order (used by chain verification).
                 filtered.sort_by_key(|r| r.sequence_number.unwrap_or(0));
+            } else if query.sort_by_sequence_desc {
+                // Hash-chain tip: greatest sequence number first.
+                filtered.sort_by(|a, b| {
+                    b.sequence_number
+                        .unwrap_or(0)
+                        .cmp(&a.sequence_number.unwrap_or(0))
+                        .then_with(|| b.id.cmp(&a.id))
+                });
             } else {
-                // Default: descending by sequence (mimics Postgres dispatched_at DESC).
-                filtered.sort_by(|a, b| b.sequence_number.cmp(&a.sequence_number));
+                // Default: `dispatched_at DESC, id DESC`, faithfully mirroring
+                // the real Postgres/ClickHouse backends. (This previously sorted
+                // by sequence_number DESC, which accidentally returned the
+                // correct tip and so MASKED the dispatched_at-ordering bug that
+                // `fetch_tip` now fixes via `sort_by_sequence_desc`.)
+                filtered.sort_by(|a, b| {
+                    b.dispatched_at
+                        .cmp(&a.dispatched_at)
+                        .then_with(|| b.id.cmp(&a.id))
+                });
             }
 
             let total = filtered.len() as u64;
@@ -551,6 +575,63 @@ mod tests {
         assert!(r.previous_hash.is_none(), "first record has no previous");
         assert!(r.record_hash.is_some(), "first record should have a hash");
         assert_eq!(r.sequence_number, Some(0));
+    }
+
+    #[tokio::test]
+    async fn hash_chain_tip_is_max_sequence_not_latest_dispatched_at() {
+        // Regression: the chain tip is the record with the GREATEST sequence
+        // number, not the most recent `dispatched_at`. An intent (seq N) and
+        // its outcome (seq N+1) share a `dispatched_at`, and the intent's id
+        // sorts AFTER the outcome's under `dispatched_at DESC, id DESC`
+        // ("<uuid>-intent" > "<uuid>"). A dispatched_at-ordered tip fetch
+        // therefore returns the intent (seq N), so the next write is assigned a
+        // COLLIDING seq N+1 — which, under the Postgres unique constraint
+        // simulated here, fails the dispatch closed after exhausting retries.
+        // `fetch_tip` now orders by `sequence_number DESC`, so it returns the
+        // outcome (the true tip) and the chain continues cleanly.
+        let inner = Arc::new(MemoryAudit::with_unique_constraint());
+        let store = HashChainAuditStore::new(Arc::clone(&inner) as Arc<dyn AuditStore>);
+
+        let ts = chrono::Utc::now();
+        // Action A: intent (id sorts high) then outcome (id sorts low), same ts.
+        let mut intent = make_record("act-a-intent", "ns", "t1");
+        intent.dispatched_at = ts;
+        intent.completed_at = ts;
+        store.record(intent).await.unwrap(); // seq 0
+
+        let mut outcome = make_record("act-a", "ns", "t1");
+        outcome.dispatched_at = ts;
+        outcome.completed_at = ts;
+        store.record(outcome).await.unwrap(); // seq 1
+
+        // Action B must continue from seq 1 (the outcome), not collide on it.
+        // With a dispatched_at-ordered tip this write fails closed.
+        let mut next = make_record("act-b-intent", "ns", "t1");
+        next.dispatched_at = ts;
+        next.completed_at = ts;
+        store
+            .record(next)
+            .await
+            .expect("next write must continue the chain, not collide on sequence_number");
+
+        let mut records = inner.raw_records();
+        records.sort_by_key(|r| r.sequence_number.unwrap_or(0));
+        let seqs: Vec<u64> = records
+            .iter()
+            .map(|r| r.sequence_number.unwrap_or(u64::MAX))
+            .collect();
+        assert_eq!(
+            seqs,
+            vec![0, 1, 2],
+            "sequence numbers must be contiguous with no collision"
+        );
+
+        let result = store.verify_chain("ns", "t1", None, None).await.unwrap();
+        assert!(
+            result.valid,
+            "hash chain must verify end-to-end: {result:?}"
+        );
+        assert_eq!(result.records_checked, 3);
     }
 
     #[tokio::test]

--- a/crates/audit/audit/src/record.rs
+++ b/crates/audit/audit/src/record.rs
@@ -225,6 +225,17 @@ pub struct AuditQuery {
     /// records in chain order with bounded memory.
     #[serde(default)]
     pub sort_by_sequence_asc: bool,
+    /// When true, sort by `sequence_number DESC` (greatest first). Used with
+    /// `limit = 1` to fetch the current hash-chain tip — the record with the
+    /// highest sequence number for a `(namespace, tenant)`. The previous tip
+    /// selection relied on the default `dispatched_at DESC` ordering, which
+    /// mis-ranks records that share a `dispatched_at` (an intent and its
+    /// outcome are written in the same millisecond), so the wrong tip could be
+    /// returned and the next sequence number would collide. Mutually exclusive
+    /// with `sort_by_sequence_asc` (which takes precedence); the tip fetch does
+    /// not paginate, so this is never combined with `cursor`.
+    #[serde(default)]
+    pub sort_by_sequence_desc: bool,
     /// Server-set tenant authorization scope. The set of tenant grant
     /// patterns the caller may read; backends restrict results to tenants
     /// covered hierarchically by one of these (see

--- a/crates/audit/clickhouse/src/store.rs
+++ b/crates/audit/clickhouse/src/store.rs
@@ -424,6 +424,9 @@ impl AuditStore for ClickHouseAuditStore {
         // Data query.
         let order_clause = if query.sort_by_sequence_asc {
             "ORDER BY sequence_number ASC, id ASC"
+        } else if query.sort_by_sequence_desc {
+            // Hash-chain tip selection: greatest sequence number first.
+            "ORDER BY sequence_number DESC, id DESC"
         } else {
             "ORDER BY dispatched_at DESC, id DESC"
         };

--- a/crates/audit/dynamodb/src/store.rs
+++ b/crates/audit/dynamodb/src/store.rs
@@ -368,49 +368,53 @@ impl AuditStore for DynamoDbAuditStore {
             if let (Some(ns), Some(t)) = (namespace, tenant) {
                 let ns_tenant = Self::ns_tenant(&ns, &t);
 
-                // Choose GSI based on sort order.
-                let (index_name, key_condition, mut expr_values) = if query.sort_by_sequence_asc {
-                    (
-                        "ns_tenant_sequence",
-                        "ns_tenant = :ns_tenant".to_owned(),
-                        HashMap::from([(
+                // Choose GSI based on sort order. Both the ascending (chain
+                // verification) and descending (hash-chain tip fetch) sequence
+                // orders use the sequence GSI; `scan_forward` below selects the
+                // direction (forward = asc, backward = desc/tip).
+                let (index_name, key_condition, mut expr_values) =
+                    if query.sort_by_sequence_asc || query.sort_by_sequence_desc {
+                        (
+                            "ns_tenant_sequence",
+                            "ns_tenant = :ns_tenant".to_owned(),
+                            HashMap::from([(
+                                ":ns_tenant".to_owned(),
+                                AttributeValue::S(ns_tenant.clone()),
+                            )]),
+                        )
+                    } else {
+                        let mut kc = "ns_tenant = :ns_tenant".to_owned();
+                        let mut ev = HashMap::from([(
                             ":ns_tenant".to_owned(),
                             AttributeValue::S(ns_tenant.clone()),
-                        )]),
-                    )
-                } else {
-                    let mut kc = "ns_tenant = :ns_tenant".to_owned();
-                    let mut ev = HashMap::from([(
-                        ":ns_tenant".to_owned(),
-                        AttributeValue::S(ns_tenant.clone()),
-                    )]);
+                        )]);
 
-                    // Add time range conditions on the SK.
-                    if let Some(ref from) = query.from {
-                        kc.push_str(" AND dispatched_at_ms >= :from_ms");
-                        ev.insert(
-                            ":from_ms".to_owned(),
-                            AttributeValue::N(from.timestamp_millis().to_string()),
-                        );
-                    }
-                    if let Some(ref to) = query.to {
-                        if query.from.is_some() {
-                            // Already have a range start, add end.
-                            kc = kc.replace(
-                                " AND dispatched_at_ms >= :from_ms",
-                                " AND dispatched_at_ms BETWEEN :from_ms AND :to_ms",
+                        // Add time range conditions on the SK.
+                        if let Some(ref from) = query.from {
+                            kc.push_str(" AND dispatched_at_ms >= :from_ms");
+                            ev.insert(
+                                ":from_ms".to_owned(),
+                                AttributeValue::N(from.timestamp_millis().to_string()),
                             );
-                        } else {
-                            kc.push_str(" AND dispatched_at_ms <= :to_ms");
                         }
-                        ev.insert(
-                            ":to_ms".to_owned(),
-                            AttributeValue::N(to.timestamp_millis().to_string()),
-                        );
-                    }
+                        if let Some(ref to) = query.to {
+                            if query.from.is_some() {
+                                // Already have a range start, add end.
+                                kc = kc.replace(
+                                    " AND dispatched_at_ms >= :from_ms",
+                                    " AND dispatched_at_ms BETWEEN :from_ms AND :to_ms",
+                                );
+                            } else {
+                                kc.push_str(" AND dispatched_at_ms <= :to_ms");
+                            }
+                            ev.insert(
+                                ":to_ms".to_owned(),
+                                AttributeValue::N(to.timestamp_millis().to_string()),
+                            );
+                        }
 
-                    ("ns_tenant_dispatched", kc, ev)
-                };
+                        ("ns_tenant_dispatched", kc, ev)
+                    };
 
                 // Merge filter values.
                 expr_values.extend(filter_values);

--- a/crates/audit/elasticsearch/src/store.rs
+++ b/crates/audit/elasticsearch/src/store.rs
@@ -276,6 +276,12 @@ impl AuditStore for ElasticsearchAuditStore {
                 { "sequence_number": { "order": "asc", "missing": "_last" } },
                 { "id": { "order": "asc" } }
             ])
+        } else if query.sort_by_sequence_desc {
+            // Hash-chain tip selection: greatest sequence number first.
+            serde_json::json!([
+                { "sequence_number": { "order": "desc", "missing": "_last" } },
+                { "id": { "order": "desc" } }
+            ])
         } else {
             serde_json::json!([
                 { "dispatched_at": "desc" },

--- a/crates/audit/memory/src/store.rs
+++ b/crates/audit/memory/src/store.rs
@@ -148,6 +148,14 @@ impl AuditStore for MemoryAuditStore {
                     .cmp(&b.sequence_number.unwrap_or(u64::MAX))
                     .then_with(|| a.id.cmp(&b.id))
             });
+        } else if query.sort_by_sequence_desc {
+            // Hash-chain tip selection: greatest sequence number first.
+            matching.sort_by(|a, b| {
+                b.sequence_number
+                    .unwrap_or(0)
+                    .cmp(&a.sequence_number.unwrap_or(0))
+                    .then_with(|| b.id.cmp(&a.id))
+            });
         } else {
             matching.sort_by(|a, b| {
                 b.dispatched_at

--- a/crates/audit/postgres/src/store.rs
+++ b/crates/audit/postgres/src/store.rs
@@ -284,6 +284,9 @@ impl AuditStore for PostgresAuditStore {
         // Data query.
         let order_clause = if query.sort_by_sequence_asc {
             "ORDER BY sequence_number ASC NULLS LAST, id ASC"
+        } else if query.sort_by_sequence_desc {
+            // Hash-chain tip selection: greatest sequence number first.
+            "ORDER BY sequence_number DESC NULLS LAST, id DESC"
         } else {
             "ORDER BY dispatched_at DESC, id DESC"
         };


### PR DESCRIPTION
## Severity: CRITICAL

Surfaced by the fresh multi-agent survey and reproduced empirically.

## Problem

The compliance hash-chain decorator (`HashChainAuditStore`) picks the chain **tip** — the record a new write links to (`previous_hash`) and derives its `sequence_number` from — with a `LIMIT 1` query that relied on each backend's **default `dispatched_at DESC` ordering** rather than the sequence number.

An intent record and its outcome record are written in the same millisecond, so they **share a `dispatched_at`**. The `id DESC` tiebreaker then ranks the intent (`"<uuid>-intent"`) above the outcome (`"<uuid>"`), so `fetch_tip` returns the **intent — the lower-sequence record of the pair.**

For the 2nd and every subsequent action in a `(namespace, tenant)` chain under SOC2/HIPAA compliance mode:

- **Postgres** → the next record gets a **colliding `sequence_number`**; the `UNIQUE(namespace, tenant, sequence_number)` index rejects it; the CAS loop re-fetches the *same stale tip* and retries the *same number*; after `MAX_CHAIN_RETRIES` the gateway returns `AuditWriteFailed` and **the action never executes** — a dispatch-path availability outage, exactly when fail-closed compliance is on.
- **ClickHouse** → no unique constraint, so the duplicate sequence is **silently accepted**, forking `previous_hash` and breaking tamper-evidence.

The existing tests passed only because the in-memory **test double sorted its default path by `sequence_number DESC`** (not `dispatched_at` like the real backends), accidentally returning the correct tip and masking the bug.

## Fix

- Add `AuditQuery::sort_by_sequence_desc`; `fetch_tip` sets it so the tip is the record with the **greatest sequence number**, regardless of timestamp.
- Implement the ordering across **all five backends**: postgres, clickhouse, elasticsearch, memory, dynamodb (the sequence GSI with a backward scan).
- Make the test double's default path sort by `dispatched_at DESC, id DESC` to **faithfully mirror the real backends** (so it no longer masks this class of bug) and honor the new flag.

## Regression test (empirically validated)

`hash_chain_tip_is_max_sequence_not_latest_dispatched_at` reproduces the exact scenario against the unique-constraint (Postgres) double:
- **Without the fix:** fails with `hash chain write failed after 5 retries ... duplicate sequence_number` (the production outage).
- **With the fix:** the chain continues (seqs `0,1,2`) and `verify_chain` passes.

I verified this by toggling the fix off/on.

## Checks
- `cargo clippy --workspace -- -D warnings` clean
- `cargo test -p acteon-audit` → 65 passed (+1); gateway 427
- `cargo check --all-targets` clean
- No SDK/UI surface (internal audit chaining); `sort_by_sequence_desc` is `#[serde(default)]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)