### PR TITLE
fix(authz): tenant-scope + role-gate the templates/profiles API

### DIFF
--- a/crates/server/src/api/templates.rs
+++ b/crates/server/src/api/templates.rs
@@ -20,6 +20,8 @@ use acteon_state::{KeyKind, StateKey};
 
 use super::AppState;
 use super::schemas::ErrorResponse;
+use crate::auth::identity::CallerIdentity;
+use crate::auth::role::Permission;
 
 // ---------------------------------------------------------------------------
 // Request / response types
@@ -345,6 +347,26 @@ fn validate_template_syntax(content: &str) -> Result<(), String> {
 }
 
 // ---------------------------------------------------------------------------
+// Authorization helpers
+// ---------------------------------------------------------------------------
+
+/// `403 Forbidden` for a caller whose grants don't cover `(namespace, tenant)`.
+fn tenant_forbidden(namespace: &str, tenant: &str) -> axum::response::Response {
+    error_response(
+        StatusCode::FORBIDDEN,
+        &format!("forbidden: no grant covers tenant={tenant} namespace={namespace}"),
+    )
+}
+
+/// `403 Forbidden` for a caller whose role lacks template-management rights.
+fn manage_forbidden() -> axum::response::Response {
+    error_response(
+        StatusCode::FORBIDDEN,
+        "insufficient permissions: templates manage requires admin or operator role",
+    )
+}
+
+// ---------------------------------------------------------------------------
 // Template handlers
 // ---------------------------------------------------------------------------
 
@@ -365,8 +387,15 @@ fn validate_template_syntax(content: &str) -> Result<(), String> {
 )]
 pub async fn create_template(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Json(req): Json<CreateTemplateRequest>,
 ) -> impl IntoResponse {
+    if !identity.role.has_permission(Permission::TemplatesManage) {
+        return manage_forbidden();
+    }
+    if !identity.can_manage_scope(&req.tenant, &req.namespace) {
+        return tenant_forbidden(&req.namespace, &req.tenant);
+    }
     if let Err(e) = validate_template_name(&req.name) {
         return error_response(StatusCode::BAD_REQUEST, &e);
     }
@@ -451,6 +480,7 @@ pub async fn create_template(
 )]
 pub async fn list_templates(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Query(params): Query<ListTemplatesParams>,
 ) -> impl IntoResponse {
     let gw = state.gateway.read().await;
@@ -469,6 +499,12 @@ pub async fn list_templates(
         let Ok(tpl) = serde_json::from_str::<Template>(&value) else {
             continue;
         };
+
+        // Tenant scoping: never surface templates the caller's grants don't
+        // cover, regardless of the requested namespace/tenant filter.
+        if !identity.can_manage_scope(&tpl.tenant, &tpl.namespace) {
+            continue;
+        }
 
         if let Some(ref ns) = params.namespace
             && tpl.namespace != *ns
@@ -519,17 +555,23 @@ pub async fn list_templates(
 )]
 pub async fn get_template(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
 
     match load_template(state_store.as_ref(), &id).await {
-        Ok(Some(tpl)) => (
-            StatusCode::OK,
-            Json(serde_json::json!(template_to_response(&tpl))),
-        )
-            .into_response(),
+        Ok(Some(tpl)) => {
+            if !identity.can_manage_scope(&tpl.tenant, &tpl.namespace) {
+                return tenant_forbidden(&tpl.namespace, &tpl.tenant);
+            }
+            (
+                StatusCode::OK,
+                Json(serde_json::json!(template_to_response(&tpl))),
+            )
+                .into_response()
+        }
         Ok(None) => error_response(StatusCode::NOT_FOUND, &format!("template not found: {id}")),
         Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e),
     }
@@ -553,9 +595,14 @@ pub async fn get_template(
 )]
 pub async fn update_template(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
     Json(req): Json<UpdateTemplateRequest>,
 ) -> impl IntoResponse {
+    if !identity.role.has_permission(Permission::TemplatesManage) {
+        return manage_forbidden();
+    }
+
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
 
@@ -566,6 +613,10 @@ pub async fn update_template(
         }
         Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e),
     };
+
+    if !identity.can_manage_scope(&tpl.tenant, &tpl.namespace) {
+        return tenant_forbidden(&tpl.namespace, &tpl.tenant);
+    }
 
     if let Some(ref content) = req.content {
         if let Err(e) = validate_template_content(content) {
@@ -623,8 +674,13 @@ pub async fn update_template(
 )]
 pub async fn delete_template(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
+    if !identity.role.has_permission(Permission::TemplatesManage) {
+        return manage_forbidden();
+    }
+
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
 
@@ -635,6 +691,10 @@ pub async fn delete_template(
         }
         Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e),
     };
+
+    if !identity.can_manage_scope(&tpl.tenant, &tpl.namespace) {
+        return tenant_forbidden(&tpl.namespace, &tpl.tenant);
+    }
 
     // Check if any profiles reference this template.
     let referencing: Vec<String> = gw
@@ -694,8 +754,15 @@ pub async fn delete_template(
 )]
 pub async fn create_profile(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Json(req): Json<CreateProfileRequest>,
 ) -> impl IntoResponse {
+    if !identity.role.has_permission(Permission::TemplatesManage) {
+        return manage_forbidden();
+    }
+    if !identity.can_manage_scope(&req.tenant, &req.namespace) {
+        return tenant_forbidden(&req.namespace, &req.tenant);
+    }
     if let Err(e) = validate_template_name(&req.name) {
         return error_response(StatusCode::BAD_REQUEST, &e);
     }
@@ -786,6 +853,7 @@ pub async fn create_profile(
 )]
 pub async fn list_profiles(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Query(params): Query<ListTemplatesParams>,
 ) -> impl IntoResponse {
     let gw = state.gateway.read().await;
@@ -806,6 +874,11 @@ pub async fn list_profiles(
         let Ok(prof) = serde_json::from_str::<TemplateProfile>(&value) else {
             continue;
         };
+
+        // Tenant scoping: never surface profiles outside the caller's grants.
+        if !identity.can_manage_scope(&prof.tenant, &prof.namespace) {
+            continue;
+        }
 
         if let Some(ref ns) = params.namespace
             && prof.namespace != *ns
@@ -853,17 +926,23 @@ pub async fn list_profiles(
 )]
 pub async fn get_profile(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
 
     match load_profile(state_store.as_ref(), &id).await {
-        Ok(Some(prof)) => (
-            StatusCode::OK,
-            Json(serde_json::json!(profile_to_response(&prof))),
-        )
-            .into_response(),
+        Ok(Some(prof)) => {
+            if !identity.can_manage_scope(&prof.tenant, &prof.namespace) {
+                return tenant_forbidden(&prof.namespace, &prof.tenant);
+            }
+            (
+                StatusCode::OK,
+                Json(serde_json::json!(profile_to_response(&prof))),
+            )
+                .into_response()
+        }
         Ok(None) => error_response(StatusCode::NOT_FOUND, &format!("profile not found: {id}")),
         Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e),
     }
@@ -887,9 +966,14 @@ pub async fn get_profile(
 )]
 pub async fn update_profile(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
     Json(req): Json<UpdateProfileRequest>,
 ) -> impl IntoResponse {
+    if !identity.role.has_permission(Permission::TemplatesManage) {
+        return manage_forbidden();
+    }
+
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
 
@@ -900,6 +984,10 @@ pub async fn update_profile(
         }
         Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e),
     };
+
+    if !identity.can_manage_scope(&prof.tenant, &prof.namespace) {
+        return tenant_forbidden(&prof.namespace, &prof.tenant);
+    }
 
     if let Some(ref fields) = req.fields {
         // Validate $ref templates exist.
@@ -961,8 +1049,13 @@ pub async fn update_profile(
 )]
 pub async fn delete_profile(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
+    if !identity.role.has_permission(Permission::TemplatesManage) {
+        return manage_forbidden();
+    }
+
     let gw = state.gateway.read().await;
     let state_store = gw.state_store();
 
@@ -973,6 +1066,10 @@ pub async fn delete_profile(
         }
         Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e),
     };
+
+    if !identity.can_manage_scope(&prof.tenant, &prof.namespace) {
+        return tenant_forbidden(&prof.namespace, &prof.tenant);
+    }
 
     let key = profile_state_key(&id);
     if let Err(e) = state_store.delete(&key).await {
@@ -1009,8 +1106,13 @@ pub async fn delete_profile(
 )]
 pub async fn render_preview(
     State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
     Json(req): Json<RenderPreviewRequest>,
 ) -> impl IntoResponse {
+    if !identity.can_manage_scope(&req.tenant, &req.namespace) {
+        return tenant_forbidden(&req.namespace, &req.tenant);
+    }
+
     let gw = state.gateway.read().await;
 
     let Some(profile) = gw.template_profile_by_scope(&req.namespace, &req.tenant, &req.profile)
@@ -1056,7 +1158,13 @@ pub async fn render_preview(
         (status = 500, description = "Reload failed", body = ErrorResponse),
     )
 )]
-pub async fn reload_static_templates(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn reload_static_templates(
+    State(state): State<AppState>,
+    axum::Extension(identity): axum::Extension<CallerIdentity>,
+) -> impl IntoResponse {
+    if !identity.role.has_permission(Permission::TemplatesManage) {
+        return manage_forbidden();
+    }
     let Some(handle) = state.static_templates.clone() else {
         return error_response(
             StatusCode::BAD_REQUEST,

--- a/crates/server/src/auth/role.rs
+++ b/crates/server/src/auth/role.rs
@@ -30,7 +30,8 @@ impl Role {
             | Permission::CircuitBreakerManage
             | Permission::PluginsManage
             | Permission::SilencesManage
-            | Permission::TimeIntervalsManage => matches!(self, Self::Admin | Self::Operator),
+            | Permission::TimeIntervalsManage
+            | Permission::TemplatesManage => matches!(self, Self::Admin | Self::Operator),
             Permission::AuditRead
             | Permission::RulesRead
             | Permission::RulesTest
@@ -64,4 +65,8 @@ pub enum Permission {
     SilencesManage,
     /// Create, update, or delete time intervals. Held by admin and operator.
     TimeIntervalsManage,
+    /// Create, update, delete, or reload payload templates and profiles.
+    /// Held by admin and operator. Reads (get/list/render preview) are open
+    /// to all roles but remain tenant-scoped.
+    TemplatesManage,
 }

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -165,12 +165,16 @@ fn sign_action(mut action: Action, key: &acteon_crypto::signing::ActionSigningKe
 /// `"test-raw-key"`. Callers authenticate by sending
 /// `Authorization: Bearer test-raw-key` on requests.
 fn build_test_state_with_auth(grants: Vec<Grant>) -> AppState {
+    build_test_state_with_auth_role("admin", grants)
+}
+
+fn build_test_state_with_auth_role(role: &str, grants: Vec<Grant>) -> AppState {
     let mut state = build_test_state(vec![]);
 
     let api_key_config = ApiKeyConfig {
         name: "test-key".to_string(),
         key_hash: SecretString::new(hash_api_key("test-raw-key")),
-        role: "admin".to_string(),
+        role: role.to_string(),
         grants,
     };
     let auth_config = AuthFileConfig {
@@ -3588,6 +3592,80 @@ async fn auth_post_status(app: axum::Router, uri: &str, body: serde_json::Value)
     .await
     .unwrap()
     .status()
+}
+
+fn templates_scope_grant() -> Grant {
+    Grant {
+        tenants: vec!["tenant-1".to_string()],
+        namespaces: vec!["notifications".to_string()],
+        providers: vec!["*".to_string()],
+        actions: vec!["*".to_string()],
+        agent_id: None,
+    }
+}
+
+fn create_template_body(namespace: &str, tenant: &str) -> serde_json::Value {
+    serde_json::json!({
+        "name": "tpl-test",
+        "namespace": namespace,
+        "tenant": tenant,
+        "content": "hello",
+    })
+}
+
+#[tokio::test]
+async fn tenant_authz_templates_create_in_scope_succeeds() {
+    let app = build_app(build_test_state_with_auth(vec![templates_scope_grant()]));
+    let status = auth_post_status(
+        app,
+        "/v1/templates",
+        create_template_body("notifications", "tenant-1"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+}
+
+#[tokio::test]
+async fn tenant_authz_templates_create_cross_tenant_forbidden() {
+    // Admin role, but grants only cover tenant-1 — writing a template for
+    // tenant-2 must be refused (the bug let any caller write any tenant's).
+    let app = build_app(build_test_state_with_auth(vec![templates_scope_grant()]));
+    let status = auth_post_status(
+        app,
+        "/v1/templates",
+        create_template_body("notifications", "tenant-2"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn tenant_authz_templates_create_viewer_role_forbidden() {
+    // Viewer lacks TemplatesManage even within its own grant scope.
+    let app = build_app(build_test_state_with_auth_role(
+        "viewer",
+        vec![templates_scope_grant()],
+    ));
+    let status = auth_post_status(
+        app,
+        "/v1/templates",
+        create_template_body("notifications", "tenant-1"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn tenant_authz_templates_render_cross_tenant_forbidden() {
+    let app = build_app(build_test_state_with_auth(vec![templates_scope_grant()]));
+    let body = serde_json::json!({
+        "namespace": "notifications",
+        "tenant": "tenant-2",
+        "profile": "p",
+        "payload": {},
+    });
+    let status = auth_post_status(app, "/v1/templates/render", body).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Severity: HIGH (cross-tenant isolation breach)

From the fresh survey. Second item in the **Server authz gaps + DoS panics** theme.

## Problem

The payload-templates control plane (`crates/server/src/api/templates.rs`) had **no authorization at all** — none of its 12 handlers took a `CallerIdentity`. Any authenticated caller, regardless of role or tenant grants, could:

- **create** a template/profile for **any** tenant (the handler trusted `req.namespace`/`req.tenant`),
- **list** — which returned **every tenant's** templates/profiles,
- **get / update / delete** any template/profile by id with no scope check,
- trigger a **global** static-template `reload`.

The #211 authz sweep covered chains, recurring, quotas, retention, swarm, dlq, events, and groups — but **missed templates**.

## Fix (matching the established convention)

- Add `Permission::TemplatesManage`, held by **admin + operator** (exactly like `SilencesManage`/`TimeIntervalsManage`).
- Every handler now takes `Extension<CallerIdentity>`:
  - **Mutations** (create/update/delete of templates *and* profiles, plus the global `reload`) require the `TemplatesManage` role permission → a **Viewer can no longer mutate** template state.
  - **Every read and write is tenant-scoped** via `can_manage_scope`: `create` and `render` check the request scope; `get`/`update`/`delete` check the **loaded resource's** scope; `list` post-filters to the caller's grants.

## Scope: no SDK/UI change

The endpoints are unchanged on the wire — out-of-scope or under-privileged callers simply receive `403` (clients already handle that).

## Tests (`api_tests.rs`)
- in-scope create → `201`
- admin writing **another** tenant → `403`
- **Viewer** writing its own tenant → `403` (role gate)
- cross-tenant render preview → `403`

Added a role-parameterized auth-state test helper.

## Checks
- `cargo clippy --workspace -- -D warnings` clean
- `cargo test -p acteon-server` → 284 lib + 92 api_tests (+4)
- `cargo check --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)