### PR TITLE
fix(api): reject unbounded durations instead of panicking (quota + silence)

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -106,9 +106,9 @@ pub use key::ActionKey;
 pub use outcome::{ActionError, ActionOutcome, ProviderResponse, ResponseStatus};
 pub use provider_health::{ListProviderHealthResponse, ProviderHealthStatus};
 pub use quota::{
-    MAX_POLICIES_PER_BUCKET, MAX_QUOTA_IDENTIFIER_LEN, OverageBehavior, QuotaIdentifierError,
-    QuotaPolicy, QuotaUsage, QuotaWindow, compute_window_boundaries, quota_counter_key,
-    validate_quota_scope_identifier,
+    MAX_POLICIES_PER_BUCKET, MAX_QUOTA_IDENTIFIER_LEN, MAX_WINDOW_SECONDS, OverageBehavior,
+    QuotaIdentifierError, QuotaPolicy, QuotaUsage, QuotaWindow, compute_window_boundaries,
+    quota_counter_key, validate_quota_scope_identifier,
 };
 pub use recurring::{
     CronValidationError, DEFAULT_MIN_INTERVAL_SECONDS, RecurringAction, RecurringActionTemplate,

--- a/crates/core/src/quota.rs
+++ b/crates/core/src/quota.rs
@@ -331,29 +331,43 @@ pub struct QuotaUsage {
     pub overage_behavior: OverageBehavior,
 }
 
+/// Upper bound on a quota window length, in seconds (~100 years).
+///
+/// Bounds the window so the boundary arithmetic in
+/// [`compute_window_boundaries`] cannot overflow the [`DateTime`] range and
+/// panic. The API layer rejects larger custom windows up front; the clamp in
+/// `compute_window_boundaries` is a defensive backstop for any value that
+/// reaches the core directly (e.g. a policy persisted before this bound).
+pub const MAX_WINDOW_SECONDS: u64 = 100 * 366 * 86_400;
+
 /// Compute the start of the current quota window and when it resets.
 ///
-/// Returns `(window_start, window_end)` based on the window type and current time.
-///
-/// # Panics
-///
-/// Panics if the window duration is zero (which should be prevented by
-/// validation at the API layer).
+/// Returns `(window_start, window_end)` based on the window type and current
+/// time. The window length is clamped to `[1, MAX_WINDOW_SECONDS]` so this
+/// never panics — a zero window (division by zero) or an astronomically large
+/// one (overflowing the `DateTime` range) is clamped rather than aborting the
+/// caller. The quota-usage endpoint must not be a panic/DoS surface.
 #[must_use]
 pub fn compute_window_boundaries(
     window: &QuotaWindow,
     now: &DateTime<Utc>,
 ) -> (DateTime<Utc>, DateTime<Utc>) {
-    let secs = window.duration_seconds();
-    assert!(secs > 0, "quota window duration must be greater than 0");
-    let duration = chrono::Duration::seconds(secs.cast_signed());
+    let window_secs = window
+        .duration_seconds()
+        .clamp(1, MAX_WINDOW_SECONDS)
+        .cast_signed();
+    let duration = chrono::Duration::seconds(window_secs);
     // Use epoch-aligned windows so all instances agree on boundaries.
     let epoch = DateTime::UNIX_EPOCH;
     let elapsed = now.signed_duration_since(epoch);
-    let window_secs = secs.cast_signed();
     let window_index = elapsed.num_seconds() / window_secs;
-    let window_start = epoch + chrono::Duration::seconds(window_index * window_secs);
-    let window_end = window_start + duration;
+    let start_offset = window_index.saturating_mul(window_secs);
+    let window_start = epoch
+        .checked_add_signed(chrono::Duration::seconds(start_offset))
+        .unwrap_or(epoch);
+    let window_end = window_start
+        .checked_add_signed(duration)
+        .unwrap_or(window_start);
     (window_start, window_end)
 }
 
@@ -437,6 +451,44 @@ mod tests {
             QuotaWindow::Custom { seconds: 7200 }.duration_seconds(),
             7200
         );
+    }
+
+    #[test]
+    fn compute_window_boundaries_never_panics_on_extreme_windows() {
+        let now = Utc::now();
+
+        // Astronomically large custom window: must clamp, not overflow/panic.
+        let (start, end) =
+            compute_window_boundaries(&QuotaWindow::Custom { seconds: u64::MAX }, &now);
+        assert!(end >= start, "window end must not precede start");
+        assert!(
+            start <= now,
+            "epoch-aligned start must not be in the future"
+        );
+
+        // Just over the cap clamps to the cap; just under is honoured exactly.
+        let (_, end_capped) = compute_window_boundaries(
+            &QuotaWindow::Custom {
+                seconds: MAX_WINDOW_SECONDS + 1,
+            },
+            &now,
+        );
+        let (_, end_at_cap) = compute_window_boundaries(
+            &QuotaWindow::Custom {
+                seconds: MAX_WINDOW_SECONDS,
+            },
+            &now,
+        );
+        assert_eq!(end_capped, end_at_cap);
+
+        // Zero window (e.g. a stale stored policy) clamps to 1s instead of a
+        // divide-by-zero panic.
+        let (z_start, z_end) = compute_window_boundaries(&QuotaWindow::Custom { seconds: 0 }, &now);
+        assert!(z_end > z_start);
+
+        // A normal window is unaffected by the clamp.
+        let (h_start, h_end) = compute_window_boundaries(&QuotaWindow::Hourly, &now);
+        assert_eq!((h_end - h_start).num_seconds(), 3_600);
     }
 
     #[test]
@@ -972,9 +1024,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "quota window duration must be greater than 0")]
-    fn compute_window_boundaries_panics_on_zero() {
+    fn compute_window_boundaries_clamps_zero_window() {
+        // A zero window used to panic (divide-by-zero); it now clamps to a 1s
+        // window so the usage endpoint stays available. Covered in detail by
+        // `compute_window_boundaries_never_panics_on_extreme_windows`.
         let now = Utc::now();
-        let _ = compute_window_boundaries(&QuotaWindow::Custom { seconds: 0 }, &now);
+        let (start, end) = compute_window_boundaries(&QuotaWindow::Custom { seconds: 0 }, &now);
+        assert!(end > start);
     }
 }

--- a/crates/server/src/api/quotas.rs
+++ b/crates/server/src/api/quotas.rs
@@ -13,8 +13,8 @@ use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
 use acteon_core::{
-    MAX_POLICIES_PER_BUCKET, OverageBehavior, QuotaPolicy, QuotaUsage, QuotaWindow,
-    compute_window_boundaries, quota_counter_key, validate_quota_scope_identifier,
+    MAX_POLICIES_PER_BUCKET, MAX_WINDOW_SECONDS, OverageBehavior, QuotaPolicy, QuotaUsage,
+    QuotaWindow, compute_window_boundaries, quota_counter_key, validate_quota_scope_identifier,
 };
 use acteon_state::{KeyKind, StateKey};
 
@@ -212,6 +212,10 @@ fn parse_window(s: &str) -> Result<QuotaWindow, String> {
             .and_then(|seconds| {
                 if seconds == 0 {
                     Err("invalid window: custom seconds must be greater than 0".to_string())
+                } else if seconds > MAX_WINDOW_SECONDS {
+                    Err(format!(
+                        "invalid window: custom seconds must not exceed {MAX_WINDOW_SECONDS}"
+                    ))
                 } else {
                     Ok(QuotaWindow::Custom { seconds })
                 }

--- a/crates/server/src/api/silences.rs
+++ b/crates/server/src/api/silences.rs
@@ -210,9 +210,22 @@ pub async fn create_silence(
     let ends_at = match (req.ends_at, req.duration_seconds) {
         (Some(end), _) => end,
         (None, Some(secs)) => {
-            #[allow(clippy::cast_possible_wrap)]
-            let secs = secs as i64;
-            starts_at + Duration::seconds(secs)
+            // Guard every step: a u64 that overflows i64, exceeds chrono's
+            // representable range, or pushes the end past the DateTime range
+            // must return 400 — never panic the handler (DoS surface).
+            let computed = i64::try_from(secs)
+                .ok()
+                .and_then(Duration::try_seconds)
+                .and_then(|d| starts_at.checked_add_signed(d));
+            match computed {
+                Some(end) => end,
+                None => {
+                    return error_response(
+                        StatusCode::BAD_REQUEST,
+                        "duration_seconds is too large",
+                    );
+                }
+            }
         }
         (None, None) => {
             return error_response(

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -3669,6 +3669,50 @@ async fn tenant_authz_templates_render_cross_tenant_forbidden() {
 }
 
 #[tokio::test]
+async fn silence_huge_duration_returns_400_not_panic() {
+    // An unbounded duration_seconds previously overflowed chrono and panicked
+    // the handler; it must now be rejected with 400.
+    let app = build_app(build_test_state_with_auth(vec![Grant {
+        tenants: vec!["*".to_string()],
+        namespaces: vec!["*".to_string()],
+        providers: vec!["*".to_string()],
+        actions: vec!["*".to_string()],
+        agent_id: None,
+    }]));
+    let body = serde_json::json!({
+        "namespace": "notifications",
+        "tenant": "tenant-1",
+        "matchers": [{ "name": "alertname", "value": "x" }],
+        "comment": "test",
+        "duration_seconds": u64::MAX,
+    });
+    let status = auth_post_status(app, "/v1/silences", body).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn quota_huge_custom_window_returns_400_not_panic() {
+    // A custom window larger than MAX_WINDOW_SECONDS must be rejected at
+    // create time rather than panicking later in the usage endpoint.
+    let app = build_app(build_test_state_with_auth(vec![Grant {
+        tenants: vec!["*".to_string()],
+        namespaces: vec!["*".to_string()],
+        providers: vec!["*".to_string()],
+        actions: vec!["*".to_string()],
+        agent_id: None,
+    }]));
+    let body = serde_json::json!({
+        "namespace": "notifications",
+        "tenant": "tenant-1",
+        "max_actions": 10,
+        "window": u64::MAX.to_string(),
+        "overage_behavior": "block",
+    });
+    let status = auth_post_status(app, "/v1/quotas", body).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn tenant_authz_chains_list_denies_cross_tenant() {
     let app = build_app(build_test_state_with_auth(vec![default_test_grant()]));
     let status = auth_get_status(app, "/v1/chains?namespace=notifications&tenant=tenant-2").await;


### PR DESCRIPTION
## Severity: MEDIUM (DoS / availability)

From the fresh survey. Third item in the **Server authz gaps + DoS panics** theme.

## Problem

Two endpoints could be **panicked (HTTP 500 / handler abort) by a single request** carrying an enormous duration:

- **`GET /v1/quotas/{id}/usage`** — a quota with a custom window of huge seconds reached `compute_window_boundaries`, where `chrono::Duration::seconds` and the `DateTime` additions overflowed and panicked. `parse_window` rejected `0` but had **no upper bound**.
- **`POST /v1/silences`** — `duration_seconds: u64` was cast to `i64` with a **wrapping `as`** (huge values wrapped negative) and added to a `DateTime` unchecked, overflowing and panicking.

## Fixes

- Add `MAX_WINDOW_SECONDS` (~100 years) and **clamp** the window length inside `compute_window_boundaries`, which now uses checked/saturating arithmetic and **can never panic** — a zero or astronomically large window is clamped, not aborted. Removed the `assert!` / `# Panics` contract. Normal windows are unaffected.
- `parse_window` now rejects custom windows above `MAX_WINDOW_SECONDS` with a `400` up front.
- The silence handler resolves `duration_seconds` via `i64::try_from` → `Duration::try_seconds` → `checked_add_signed`, returning `400` ("duration_seconds is too large") on any overflow.

## Tests
- `compute_window_boundaries_never_panics_on_extreme_windows` — `u64::MAX`, over-cap clamps to cap, zero clamps to 1s, normal Hourly window unchanged.
- api_tests: `POST /v1/silences` and `POST /v1/quotas` with `u64::MAX` durations return `400`, not `500`.
- Updated the former `should_panic` zero-window test to assert the new clamp behaviour.

## Checks
- `cargo clippy --workspace -- -D warnings` clean
- core 541 / server 284 + 94 api_tests
- `cargo check --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)