### PR TITLE
fix(authz): tenant-scope the rule playground evaluate endpoint

### DIFF
--- a/crates/server/src/api/rules.rs
+++ b/crates/server/src/api/rules.rs
@@ -374,6 +374,21 @@ pub async fn evaluate_rules(
         );
     }
 
+    // Tenant scoping: a caller may only evaluate rules against a
+    // (namespace, tenant) its grants cover — the trace would otherwise
+    // leak how another tenant's rules apply to a crafted action.
+    if !identity.can_manage_scope(&req.tenant, &req.namespace) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!(ErrorResponse {
+                error: format!(
+                    "forbidden: no grant covers tenant={} namespace={}",
+                    req.tenant, req.namespace
+                ),
+            })),
+        );
+    }
+
     let action = Action::new(
         req.namespace,
         req.tenant,

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -3713,6 +3713,36 @@ async fn quota_huge_custom_window_returns_400_not_panic() {
 }
 
 #[tokio::test]
+async fn tenant_authz_rule_playground_denies_cross_tenant() {
+    // Caller is granted tenant-1 only; evaluating rules against tenant-2 must
+    // be refused even though the role (admin) holds RulesTest.
+    let app = build_app(build_test_state_with_auth(vec![default_test_grant()]));
+    let body = serde_json::json!({
+        "namespace": "notifications",
+        "tenant": "tenant-2",
+        "provider": "email",
+        "action_type": "send_email",
+        "payload": {},
+    });
+    let status = auth_post_status(app, "/v1/rules/evaluate", body).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn tenant_authz_rule_playground_allows_in_scope() {
+    let app = build_app(build_test_state_with_auth(vec![default_test_grant()]));
+    let body = serde_json::json!({
+        "namespace": "notifications",
+        "tenant": "tenant-1",
+        "provider": "email",
+        "action_type": "send_email",
+        "payload": {},
+    });
+    let status = auth_post_status(app, "/v1/rules/evaluate", body).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
 async fn tenant_authz_chains_list_denies_cross_tenant() {
     let app = build_app(build_test_state_with_auth(vec![default_test_grant()]));
     let status = auth_get_status(app, "/v1/chains?namespace=notifications&tenant=tenant-2").await;


### PR DESCRIPTION
## Severity: LOW (cross-tenant info leak)

From the fresh survey. Final item in the **Server authz gaps + DoS panics** theme.

## Problem

`POST /v1/rules/evaluate` (the read-only rule-playground debugger) gated on the `RulesTest` role permission but **never checked that the caller's grants covered the supplied `namespace`/`tenant`**. A caller scoped to one tenant could evaluate rules against a crafted action in **another** tenant and read the detailed per-rule trace — leaking how that tenant's rules apply.

The #211 authz sweep covered the CRUD endpoints; this read-only debug endpoint (and templates, fixed in #228) were the misses.

## Fix

Add a `can_manage_scope(&req.tenant, &req.namespace)` check immediately after the role gate, returning `403` before the action is built.

## Tests
- cross-tenant evaluate → `403`
- in-scope evaluate → `200`

## Checks
- `cargo clippy --workspace -- -D warnings` clean
- `cargo test -p acteon-server` → 284 lib + 96 api_tests (+2)
- `cargo check --all-targets` clean

This completes the authz portion of the theme. Remaining survey item in this area — the `/verify` signature bugs (`verified`-overclaim + per-kid scope collapse) — will be a dedicated, adversarially-reviewed PR (security-sensitive crypto-scope changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)