### PR TITLE
fix(security): redact request URLs from provider transport errors

### DIFF
--- a/crates/integrations/discord/src/error.rs
+++ b/crates/integrations/discord/src/error.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 pub enum DiscordError {
     /// An HTTP-level transport error occurred.
     #[error("HTTP error: {0}")]
-    Http(#[from] reqwest::Error),
+    Http(reqwest::Error),
 
     /// The Discord API returned an error response.
     #[error("Discord API error: {0}")]
@@ -32,6 +32,15 @@ pub enum DiscordError {
     /// The provider received an HTTP 429 (Too Many Requests) response.
     #[error("rate limited by Discord")]
     RateLimited,
+}
+
+impl From<reqwest::Error> for DiscordError {
+    fn from(err: reqwest::Error) -> Self {
+        // Redact the request URL: for several providers it carries the bot
+        // token, webhook secret, or access token, which must never reach
+        // error messages, audit records, or the DLQ.
+        Self::Http(err.without_url())
+    }
 }
 
 impl From<DiscordError> for ProviderError {

--- a/crates/integrations/opsgenie/src/error.rs
+++ b/crates/integrations/opsgenie/src/error.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 pub enum OpsGenieError {
     /// An HTTP-level transport error occurred.
     #[error("HTTP error: {0}")]
-    Http(#[from] reqwest::Error),
+    Http(reqwest::Error),
 
     /// The `OpsGenie` API returned a **permanent** non-success response
     /// (a 4xx that is not a rate-limit or auth failure). These are
@@ -40,6 +40,15 @@ pub enum OpsGenieError {
     /// revoked API key.
     #[error("authentication failed: {0}")]
     Unauthorized(String),
+}
+
+impl From<reqwest::Error> for OpsGenieError {
+    fn from(err: reqwest::Error) -> Self {
+        // Redact the request URL: for several providers it carries the bot
+        // token, webhook secret, or access token, which must never reach
+        // error messages, audit records, or the DLQ.
+        Self::Http(err.without_url())
+    }
 }
 
 impl From<OpsGenieError> for ProviderError {

--- a/crates/integrations/pagerduty/src/error.rs
+++ b/crates/integrations/pagerduty/src/error.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 pub enum PagerDutyError {
     /// An HTTP-level transport error occurred.
     #[error("HTTP error: {0}")]
-    Http(#[from] reqwest::Error),
+    Http(reqwest::Error),
 
     /// The `PagerDuty` API returned a non-success response.
     #[error("PagerDuty API error: {0}")]
@@ -36,6 +36,15 @@ pub enum PagerDutyError {
     /// No `service_id` was provided and no default service is configured.
     #[error("no service_id in payload and no default service configured")]
     NoDefaultService,
+}
+
+impl From<reqwest::Error> for PagerDutyError {
+    fn from(err: reqwest::Error) -> Self {
+        // Redact the request URL: for several providers it carries the bot
+        // token, webhook secret, or access token, which must never reach
+        // error messages, audit records, or the DLQ.
+        Self::Http(err.without_url())
+    }
 }
 
 impl From<PagerDutyError> for ProviderError {

--- a/crates/integrations/pushover/src/error.rs
+++ b/crates/integrations/pushover/src/error.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 pub enum PushoverError {
     /// An HTTP-level transport error occurred.
     #[error("HTTP error: {0}")]
-    Http(#[from] reqwest::Error),
+    Http(reqwest::Error),
 
     /// The Pushover API returned a **permanent** non-success response
     /// (a 4xx that is not a rate-limit or auth failure).
@@ -47,6 +47,15 @@ pub enum PushoverError {
     /// (no default recipient, and the recipient map is not a single-entry map).
     #[error("no user_key in payload and no default recipient configured")]
     NoDefaultRecipient,
+}
+
+impl From<reqwest::Error> for PushoverError {
+    fn from(err: reqwest::Error) -> Self {
+        // Redact the request URL: for several providers it carries the bot
+        // token, webhook secret, or access token, which must never reach
+        // error messages, audit records, or the DLQ.
+        Self::Http(err.without_url())
+    }
 }
 
 impl From<PushoverError> for ProviderError {

--- a/crates/integrations/slack/src/error.rs
+++ b/crates/integrations/slack/src/error.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 pub enum SlackError {
     /// An HTTP-level transport error occurred.
     #[error("HTTP error: {0}")]
-    Http(#[from] reqwest::Error),
+    Http(reqwest::Error),
 
     /// The Slack API returned an error response (ok: false).
     #[error("Slack API error: {0}")]
@@ -32,6 +32,15 @@ pub enum SlackError {
     /// The provider received an HTTP 429 (Too Many Requests) response.
     #[error("rate limited by Slack")]
     RateLimited,
+}
+
+impl From<reqwest::Error> for SlackError {
+    fn from(err: reqwest::Error) -> Self {
+        // Redact the request URL: for several providers it carries the bot
+        // token, webhook secret, or access token, which must never reach
+        // error messages, audit records, or the DLQ.
+        Self::Http(err.without_url())
+    }
 }
 
 impl From<SlackError> for ProviderError {

--- a/crates/integrations/teams/src/error.rs
+++ b/crates/integrations/teams/src/error.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 pub enum TeamsError {
     /// An HTTP-level transport error occurred.
     #[error("HTTP error: {0}")]
-    Http(#[from] reqwest::Error),
+    Http(reqwest::Error),
 
     /// The Teams webhook returned an error response.
     #[error("Teams webhook error: {0}")]
@@ -28,6 +28,15 @@ pub enum TeamsError {
     /// `ProviderError::Connection` so the gateway retries instead of dropping.
     #[error("Teams transient error: {0}")]
     Transient(String),
+}
+
+impl From<reqwest::Error> for TeamsError {
+    fn from(err: reqwest::Error) -> Self {
+        // Redact the request URL: for several providers it carries the bot
+        // token, webhook secret, or access token, which must never reach
+        // error messages, audit records, or the DLQ.
+        Self::Http(err.without_url())
+    }
 }
 
 impl From<TeamsError> for ProviderError {

--- a/crates/integrations/telegram/src/error.rs
+++ b/crates/integrations/telegram/src/error.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 pub enum TelegramError {
     /// An HTTP-level transport error occurred.
     #[error("HTTP error: {0}")]
-    Http(#[from] reqwest::Error),
+    Http(reqwest::Error),
 
     /// The Telegram API returned a **permanent** non-success
     /// response (a 4xx that is not a rate-limit or auth failure).
@@ -53,6 +53,15 @@ pub enum TelegramError {
     /// single-entry map).
     #[error("no chat in payload and no default chat configured")]
     NoDefaultChat,
+}
+
+impl From<reqwest::Error> for TelegramError {
+    fn from(err: reqwest::Error) -> Self {
+        // Redact the request URL: for several providers it carries the bot
+        // token, webhook secret, or access token, which must never reach
+        // error messages, audit records, or the DLQ.
+        Self::Http(err.without_url())
+    }
 }
 
 impl From<TelegramError> for ProviderError {
@@ -137,6 +146,41 @@ mod tests {
         assert_eq!(
             TelegramError::UnknownChat("ops".into()).to_string(),
             "unknown Telegram chat: ops"
+        );
+    }
+
+    #[tokio::test]
+    async fn http_error_redacts_url() {
+        // A transport failure must not leak the request URL (which for Telegram
+        // carries the bot token in the path) into the converted ProviderError.
+        let marker = "REDACTME-9f8a7b6c";
+        let url = format!("http://127.0.0.1:1/bot{marker}/sendMessage");
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+            .unwrap();
+        let raw = client
+            .get(&url)
+            .send()
+            .await
+            .expect_err("connecting to 127.0.0.1:1 must fail");
+
+        // Precondition: the raw reqwest error DOES embed the URL/marker.
+        assert!(
+            raw.to_string().contains(marker),
+            "precondition: raw reqwest error should carry the URL"
+        );
+
+        // Routing it through `From` (which calls `without_url`) strips it.
+        let provider_err: ProviderError = TelegramError::from(raw).into();
+        let msg = provider_err.to_string();
+        assert!(
+            !msg.contains(marker),
+            "converted error leaked the URL secret: {msg}"
+        );
+        assert!(
+            !msg.contains("127.0.0.1"),
+            "converted error leaked the host: {msg}"
         );
     }
 }

--- a/crates/integrations/twilio/src/error.rs
+++ b/crates/integrations/twilio/src/error.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 pub enum TwilioError {
     /// An HTTP-level transport error occurred.
     #[error("HTTP error: {0}")]
-    Http(#[from] reqwest::Error),
+    Http(reqwest::Error),
 
     /// The Twilio API returned an error response.
     #[error("Twilio API error: {0}")]
@@ -32,6 +32,15 @@ pub enum TwilioError {
     /// The provider received an HTTP 429 (Too Many Requests) response.
     #[error("rate limited by Twilio")]
     RateLimited,
+}
+
+impl From<reqwest::Error> for TwilioError {
+    fn from(err: reqwest::Error) -> Self {
+        // Redact the request URL: for several providers it carries the bot
+        // token, webhook secret, or access token, which must never reach
+        // error messages, audit records, or the DLQ.
+        Self::Http(err.without_url())
+    }
 }
 
 impl From<TwilioError> for ProviderError {

--- a/crates/integrations/victorops/src/error.rs
+++ b/crates/integrations/victorops/src/error.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 pub enum VictorOpsError {
     /// An HTTP-level transport error occurred.
     #[error("HTTP error: {0}")]
-    Http(#[from] reqwest::Error),
+    Http(reqwest::Error),
 
     /// The `VictorOps` API returned a **permanent** non-success
     /// response (a 4xx that is not a rate-limit or auth failure).
@@ -54,6 +54,15 @@ pub enum VictorOpsError {
     /// routing-key map is not a single-entry map).
     #[error("no routing_key in payload and no default routing key configured")]
     NoDefaultRoutingKey,
+}
+
+impl From<reqwest::Error> for VictorOpsError {
+    fn from(err: reqwest::Error) -> Self {
+        // Redact the request URL: for several providers it carries the bot
+        // token, webhook secret, or access token, which must never reach
+        // error messages, audit records, or the DLQ.
+        Self::Http(err.without_url())
+    }
 }
 
 impl From<VictorOpsError> for ProviderError {

--- a/crates/integrations/webhook/src/error.rs
+++ b/crates/integrations/webhook/src/error.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 pub enum WebhookError {
     /// An HTTP-level transport error occurred.
     #[error("HTTP error: {0}")]
-    Http(#[from] reqwest::Error),
+    Http(reqwest::Error),
 
     /// The remote endpoint returned an unexpected status code.
     #[error("unexpected status {status}: {body}")]
@@ -26,6 +26,15 @@ pub enum WebhookError {
     /// HMAC signature computation failed.
     #[error("HMAC signing error: {0}")]
     SigningError(String),
+}
+
+impl From<reqwest::Error> for WebhookError {
+    fn from(err: reqwest::Error) -> Self {
+        // Redact the request URL: for several providers it carries the bot
+        // token, webhook secret, or access token, which must never reach
+        // error messages, audit records, or the DLQ.
+        Self::Http(err.without_url())
+    }
 }
 
 impl From<WebhookError> for ProviderError {

--- a/crates/integrations/webhook/src/provider.rs
+++ b/crates/integrations/webhook/src/provider.rs
@@ -218,7 +218,9 @@ impl Provider for WebhookProvider {
             if e.is_timeout() {
                 warn!("webhook request timed out");
             }
-            WebhookError::Http(e)
+            // Route through `from` so the URL (which may carry secrets in a
+            // user-supplied webhook URL) is stripped before it can be logged.
+            WebhookError::from(e)
         })?;
 
         self.interpret_response(response).await
@@ -276,7 +278,9 @@ impl Provider for WebhookProvider {
             if e.is_timeout() {
                 warn!("webhook request timed out");
             }
-            WebhookError::Http(e)
+            // Route through `from` so the URL (which may carry secrets in a
+            // user-supplied webhook URL) is stripped before it can be logged.
+            WebhookError::from(e)
         })?;
 
         self.interpret_response(response).await

--- a/crates/integrations/wechat/src/error.rs
+++ b/crates/integrations/wechat/src/error.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 pub enum WeChatError {
     /// An HTTP-level transport error occurred.
     #[error("HTTP error: {0}")]
-    Http(#[from] reqwest::Error),
+    Http(reqwest::Error),
 
     /// The `WeChat` API returned a **permanent** failure
     /// (`errcode != 0` that is neither rate-limit, auth, nor
@@ -66,6 +66,15 @@ pub enum WeChatError {
     /// `ProviderError` would be a provider bug.
     #[error("WeChat access token expired or invalid (internal retry signal)")]
     TokenExpired,
+}
+
+impl From<reqwest::Error> for WeChatError {
+    fn from(err: reqwest::Error) -> Self {
+        // Redact the request URL: for several providers it carries the bot
+        // token, webhook secret, or access token, which must never reach
+        // error messages, audit records, or the DLQ.
+        Self::Http(err.without_url())
+    }
 }
 
 impl From<WeChatError> for ProviderError {


### PR DESCRIPTION
## Severity: HIGH (credential leak to audit log + DLQ)

From the fresh survey. Part of the **secrets / mTLS / Redis** security theme.

## Problem

A `reqwest` transport failure — the routine timeout/connection-reset case these providers are built to **retry** — was stringified, **including the request URL**, into a retryable `ProviderError::Connection`, which the gateway writes to the **audit trail** and the **DLQ**.

For **Telegram / Discord / WeChat / VictorOps / Slack / Teams** the URL carries a live credential in its path or query (bot token, webhook secret, access token); for the generic **webhook** provider the user-supplied URL may carry secrets in query params. So a single transient failure leaked a **reusable credential** to sinks readable by anyone with audit or DLQ access — a strictly lower privilege than config access, and exactly what these crates' redacted-`Debug` hardening already exists to prevent.

## Fix

**Redact at ingestion.** Each provider's `Http(reqwest::Error)` variant loses its `#[from]`; a hand-written `From<reqwest::Error>` calls `reqwest::Error::without_url()` before storing the error. The URL is then gone from **every** downstream path — the variant's `Display`, `to_string()`, and the `ProviderError` conversion. Applied uniformly to **all 11** integration providers (the survey sampled four; the pattern was identical across the rest).

The webhook provider also built `WebhookError::Http(e)` directly in two `send().map_err` sites — both now route through `from`.

## Test

`telegram::error::http_error_redacts_url` — a real connection-refused request to `127.0.0.1:1` with a marker in the path. The **raw** reqwest error contains the marker; the **converted** `ProviderError` contains neither the marker nor the host.

## Checks
- `cargo clippy --workspace -- -D warnings` clean
- all 11 integration crates' tests pass (+1)
- `cargo check --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)