### PR TITLE
fix(mtls): pin to the provided CA only for outbound reqwest TLS

### DIFF
--- a/crates/crypto/src/tls.rs
+++ b/crates/crypto/src/tls.rs
@@ -232,7 +232,15 @@ pub fn build_reqwest_client(
         })?;
         let ca_cert = reqwest::Certificate::from_pem(&ca_pem)
             .map_err(|e| TlsError::ReqwestBuild(format!("invalid CA bundle: {e}")))?;
-        builder = builder.add_root_certificate(ca_cert);
+        // Pin to the provided CA *only*: drop the built-in public root set so a
+        // certificate signed by any other (publicly-trusted) CA is rejected.
+        // `add_root_certificate` otherwise merely ADDS to reqwest's default
+        // roots, which would let a MITM presenting any public-CA cert for the
+        // host succeed and defeat the pin. This matches the rustls
+        // `build_client_config` path, which trusts the pinned CA exclusively.
+        builder = builder
+            .tls_built_in_root_certs(false)
+            .add_root_certificate(ca_cert);
     }
 
     if let (Some(cert_path), Some(key_path)) = (client_cert_path, client_key_path) {


### PR DESCRIPTION
## Severity: HIGH (cert-pinning bypass / MITM)

From the fresh survey. Part of the **secrets / mTLS / Redis** security theme.

## Problem

`build_reqwest_client` added a pinned CA bundle via `reqwest::ClientBuilder::add_root_certificate`, which **augments** reqwest's default public root set rather than replacing it. So when an operator pinned a private CA for an outbound mTLS connection, the client still trusted **every public CA** — a man-in-the-middle presenting any publicly-trusted certificate for the target host would be accepted, **defeating the pin entirely**.

## Fix

Call `tls_built_in_root_certs(false)` when a CA bundle is supplied, so only the pinned CA is trusted. This matches the sibling rustls path (`build_client_config`), which already builds a fresh root store containing *either* the pinned CA *or* the webpki roots — never both.

## Testing note

Not unit-tested: verifying trust semantics requires a live public-CA host or an in-process TLS server + custom PKI, neither of which exists in the repo. The change is a one-line config fix mirroring the **verified-correct** rustls path (confirmed by inspection: its root store is mutually exclusive), and is covered by the build + existing construction tests.

## Checks
- `cargo clippy --workspace -- -D warnings` clean
- `cargo clippy -p acteon-crypto --features tls -- -D warnings` clean
- `cargo test -p acteon-crypto --features tls` → 37 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)