### PR TITLE
fix(redis): scan tolerates check_and_set keys + clear TTL on no-TTL overwrite

### DIFF
--- a/crates/state/redis/src/store.rs
+++ b/crates/state/redis/src/store.rs
@@ -175,6 +175,15 @@ impl StateStore for RedisStateStore {
                 .pexpire(&redis_key, ms)
                 .await
                 .map_err(|e| StateError::Backend(e.to_string()))?;
+        } else {
+            // Clear any pre-existing expiry: `HSET` preserves the old TTL, so
+            // without this a no-TTL overwrite of a key first written with a TTL
+            // would silently expire — diverging from the memory and Postgres
+            // backends, which make the overwrite permanent.
+            let () = conn
+                .persist(&redis_key)
+                .await
+                .map_err(|e| StateError::Backend(e.to_string()))?;
         }
 
         // Also remove any plain-string key so `get` reads consistently.
@@ -305,19 +314,22 @@ impl StateStore for RedisStateStore {
                 .map_err(|e| StateError::Backend(e.to_string()))?;
 
             for key in keys {
-                // Try to get value from hash first, then plain string
-                let val: Option<String> = conn
-                    .hget(&key, "v")
-                    .await
-                    .map_err(|e| StateError::Backend(e.to_string()))?;
-
-                let value = if let Some(v) = val {
-                    v
-                } else {
-                    // Try plain string key (without :h suffix)
-                    let plain_key = key.strip_suffix(":h").unwrap_or(&key);
+                // Dispatch on the key shape: `set` writes hashes (suffix
+                // `:h`), `check_and_set` writes plain strings. Issuing HGET
+                // against a string key fails the WHOLE scan with WRONGTYPE, so
+                // pick the matching read per key.
+                let value = if key.ends_with(":h") {
                     let v: Option<String> = conn
-                        .get(plain_key)
+                        .hget(&key, "v")
+                        .await
+                        .map_err(|e| StateError::Backend(e.to_string()))?;
+                    match v {
+                        Some(s) => s,
+                        None => continue,
+                    }
+                } else {
+                    let v: Option<String> = conn
+                        .get(&key)
                         .await
                         .map_err(|e| StateError::Backend(e.to_string()))?;
                     match v {
@@ -367,19 +379,22 @@ impl StateStore for RedisStateStore {
                 .map_err(|e| StateError::Backend(e.to_string()))?;
 
             for key in keys {
-                // Try to get value from hash first, then plain string
-                let val: Option<String> = conn
-                    .hget(&key, "v")
-                    .await
-                    .map_err(|e| StateError::Backend(e.to_string()))?;
-
-                let value = if let Some(v) = val {
-                    v
-                } else {
-                    // Try plain string key (without :h suffix)
-                    let plain_key = key.strip_suffix(":h").unwrap_or(&key);
+                // Dispatch on the key shape: `set` writes hashes (suffix
+                // `:h`), `check_and_set` writes plain strings. Issuing HGET
+                // against a string key fails the WHOLE scan with WRONGTYPE, so
+                // pick the matching read per key.
+                let value = if key.ends_with(":h") {
                     let v: Option<String> = conn
-                        .get(plain_key)
+                        .hget(&key, "v")
+                        .await
+                        .map_err(|e| StateError::Backend(e.to_string()))?;
+                    match v {
+                        Some(s) => s,
+                        None => continue,
+                    }
+                } else {
+                    let v: Option<String> = conn
+                        .get(&key)
                         .await
                         .map_err(|e| StateError::Backend(e.to_string()))?;
                     match v {

--- a/crates/state/state/src/testing.rs
+++ b/crates/state/state/src/testing.rs
@@ -25,8 +25,51 @@ pub async fn run_store_conformance_tests(store: &dyn StateStore) -> Result<(), S
     test_increment(store).await?;
     test_compare_and_swap(store).await?;
     test_ttl_set(store).await?;
+    test_scan_by_kind_includes_check_and_set(store).await?;
+    test_set_clears_ttl_on_overwrite(store).await?;
     test_timeout_index_reindex_replaces(store).await?;
     test_chain_ready_index_reindex_replaces(store).await?;
+    Ok(())
+}
+
+/// A key written via `check_and_set` must be visible to `scan_keys_by_kind`.
+/// On Redis, `check_and_set` stores a plain string while `set` stores a hash;
+/// the scan historically issued `HGET` against every matched key and failed
+/// the entire scan with `WRONGTYPE` as soon as one `check_and_set` key existed
+/// (breaking bus/A2A listing). Memory and Postgres always handled this.
+async fn test_scan_by_kind_includes_check_and_set(
+    store: &dyn StateStore,
+) -> Result<(), StateError> {
+    let key = test_key(KeyKind::State, "scan-cas-marker");
+    let created = store.check_and_set(&key, "scan-cas-value", None).await?;
+    assert!(created, "check_and_set on a fresh key should create it");
+
+    let results = store.scan_keys_by_kind(KeyKind::State).await?;
+    assert!(
+        results.iter().any(|(_, v)| v == "scan-cas-value"),
+        "scan_keys_by_kind must surface a check_and_set-created key, got {results:?}"
+    );
+    Ok(())
+}
+
+/// Overwriting a key that had a TTL with a no-TTL `set` must make it permanent.
+/// On Redis, `HSET` preserves the prior expiry, so the value would silently
+/// vanish when the original TTL elapsed — diverging from memory/Postgres.
+async fn test_set_clears_ttl_on_overwrite(store: &dyn StateStore) -> Result<(), StateError> {
+    let key = test_key(KeyKind::State, "ttl-clear-on-overwrite");
+    store
+        .set(&key, "ephemeral", Some(Duration::from_secs(1)))
+        .await?;
+    // Overwrite without a TTL — this must clear the expiry set above.
+    store.set(&key, "permanent", None).await?;
+    // Wait past the original TTL; if it wasn't cleared the key is now gone.
+    tokio::time::sleep(Duration::from_millis(1300)).await;
+    let val = store.get(&key).await?;
+    assert_eq!(
+        val.as_deref(),
+        Some("permanent"),
+        "a no-TTL overwrite must clear the prior TTL (key expired)"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Severity: HIGH + MEDIUM

From the fresh survey. Closes out the **secrets / mTLS / Redis** security theme. Both bugs stem from the Redis dual storage model — `set` writes a **hash** (suffix `:h`); `check_and_set` writes a **plain string**.

### 1. `scan_keys` / `scan_keys_by_kind` 500 on any `check_and_set` key (HIGH)

The scan issued `HGET` against **every** matched key. A `check_and_set`-created key is a plain string, so `HGET` returns a `WRONGTYPE` **error** (not nil) and the whole scan failed — making listing for the **agentic bus** (topics / subscriptions / approvals) and the **A2A task control plane** unusable under Redis the moment one such key existed. The string fallback below the `HGET` was never reached because the error short-circuited.

**Fix:** dispatch on the `:h` suffix — `HGET` for hashes, `GET` for strings — so a string key is never probed with `HGET`.

### 2. `set(key, value, None)` doesn't clear a prior TTL (MEDIUM, silent data loss)

`HSET` preserves the key's TTL, so a key first written **with** a TTL and later overwritten **without** one would silently expire — diverging from the memory and Postgres backends, which make the overwrite permanent.

**Fix:** `PERSIST` the key when no TTL is supplied.

## Tests

Both behaviours are now pinned by the **shared cross-backend conformance suite** (`acteon_state::testing`): `test_scan_by_kind_includes_check_and_set` and `test_set_clears_ttl_on_overwrite`.

- **Memory** passes both (verified locally) — confirms it was already correct.
- **Postgres** (`expires_at = EXCLUDED.expires_at` → NULL) and **DynamoDB** (`REMOVE expires_at`) already clear TTL and store keys uniformly, so they pass too — only Redis needed the fix (verified by reading their `set`).
- The Redis integration job exercises the suite against a live Redis.

## Checks
- `cargo clippy --workspace -- -D warnings` clean
- memory conformance (incl. 2 new tests) passes
- `cargo check --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)