### PR TITLE
fix(cloud): idempotency tokens + full pagination for AWS/GCP/PagerDuty

### DIFF
--- a/crates/aws/src/autoscaling.rs
+++ b/crates/aws/src/autoscaling.rs
@@ -202,23 +202,29 @@ impl AutoScalingProvider {
 
         debug!(group_names = ?payload.auto_scaling_group_names, "describing Auto Scaling Groups");
 
-        let mut request = self.client.describe_auto_scaling_groups();
-        if !payload.auto_scaling_group_names.is_empty() {
-            request = request
-                .set_auto_scaling_group_names(Some(payload.auto_scaling_group_names.clone()));
-        }
+        // Page through ALL groups: DescribeAutoScalingGroups caps each response
+        // (default 100) and returns a NextToken; ignoring it silently truncated
+        // the result to the first page.
+        let mut groups: Vec<serde_json::Value> = Vec::new();
+        let mut next_token: Option<String> = None;
+        loop {
+            let mut request = self.client.describe_auto_scaling_groups();
+            if !payload.auto_scaling_group_names.is_empty() {
+                request = request
+                    .set_auto_scaling_group_names(Some(payload.auto_scaling_group_names.clone()));
+            }
+            if let Some(ref token) = next_token {
+                request = request.next_token(token);
+            }
 
-        let result = request.send().await.map_err(|e| {
-            let err_str = e.to_string();
-            error!(error = %err_str, "describe_auto_scaling_groups failed");
-            let aws_err: ProviderError = classify_sdk_error(&err_str).into();
-            aws_err
-        })?;
+            let result = request.send().await.map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "describe_auto_scaling_groups failed");
+                let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+                aws_err
+            })?;
 
-        let groups: Vec<_> = result
-            .auto_scaling_groups()
-            .iter()
-            .map(|g| {
+            groups.extend(result.auto_scaling_groups().iter().map(|g| {
                 serde_json::json!({
                     "auto_scaling_group_name": g.auto_scaling_group_name(),
                     "min_size": g.min_size(),
@@ -227,8 +233,13 @@ impl AutoScalingProvider {
                     "instance_count": g.instances().len(),
                     "health_check_type": g.health_check_type().unwrap_or_default(),
                 })
-            })
-            .collect();
+            }));
+
+            match result.next_token() {
+                Some(token) if !token.is_empty() => next_token = Some(token.to_owned()),
+                _ => break,
+            }
+        }
 
         info!(count = groups.len(), "Auto Scaling Groups described");
 

--- a/crates/aws/src/ec2.rs
+++ b/crates/aws/src/ec2.rs
@@ -582,7 +582,12 @@ impl Ec2Provider {
                     })?,
             )
             .min_count(payload.min_count)
-            .max_count(payload.max_count);
+            .max_count(payload.max_count)
+            // Idempotency: derive the EC2 ClientToken from the action id so a
+            // gateway retry of the same action (a lost response, a timeout
+            // after AWS already committed) does not launch a SECOND set of
+            // instances. EC2 dedupes RunInstances on this token for 24h.
+            .client_token(action.id.to_string());
 
         if let Some(kn) = key_name {
             request = request.key_name(kn);
@@ -741,32 +746,49 @@ impl Ec2Provider {
 
         debug!(instance_ids = ?payload.instance_ids, "describing EC2 instances");
 
-        let mut request = self.client.describe_instances();
-        if !payload.instance_ids.is_empty() {
-            request = request.set_instance_ids(Some(payload.instance_ids.clone()));
+        // Page through ALL results: a single DescribeInstances returns at most
+        // ~1000 instances plus a NextToken; ignoring it silently truncated the
+        // result, so downstream logic (cleanup, inventory) only ever saw the
+        // first page.
+        let mut instances: Vec<serde_json::Value> = Vec::new();
+        let mut next_token: Option<String> = None;
+        loop {
+            let mut request = self.client.describe_instances();
+            if !payload.instance_ids.is_empty() {
+                request = request.set_instance_ids(Some(payload.instance_ids.clone()));
+            }
+            if let Some(ref token) = next_token {
+                request = request.next_token(token);
+            }
+
+            let result = request.send().await.map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "EC2 describe_instances failed");
+                let aws_err: ProviderError = classify_sdk_error(&err_str).into();
+                aws_err
+            })?;
+
+            instances.extend(
+                result
+                    .reservations()
+                    .iter()
+                    .flat_map(aws_sdk_ec2::types::Reservation::instances)
+                    .map(|i| {
+                        serde_json::json!({
+                            "instance_id": i.instance_id().unwrap_or_default(),
+                            "instance_type": i.instance_type().map_or("unknown", aws_sdk_ec2::types::InstanceType::as_str),
+                            "state": i.state().and_then(|s| s.name()).map_or("unknown", aws_sdk_ec2::types::InstanceStateName::as_str),
+                            "public_ip": i.public_ip_address().unwrap_or_default(),
+                            "private_ip": i.private_ip_address().unwrap_or_default(),
+                        })
+                    }),
+            );
+
+            match result.next_token() {
+                Some(token) if !token.is_empty() => next_token = Some(token.to_owned()),
+                _ => break,
+            }
         }
-
-        let result = request.send().await.map_err(|e| {
-            let err_str = e.to_string();
-            error!(error = %err_str, "EC2 describe_instances failed");
-            let aws_err: ProviderError = classify_sdk_error(&err_str).into();
-            aws_err
-        })?;
-
-        let instances: Vec<_> = result
-            .reservations()
-            .iter()
-            .flat_map(aws_sdk_ec2::types::Reservation::instances)
-            .map(|i| {
-                serde_json::json!({
-                    "instance_id": i.instance_id().unwrap_or_default(),
-                    "instance_type": i.instance_type().map_or("unknown", aws_sdk_ec2::types::InstanceType::as_str),
-                    "state": i.state().and_then(|s| s.name()).map_or("unknown", aws_sdk_ec2::types::InstanceStateName::as_str),
-                    "public_ip": i.public_ip_address().unwrap_or_default(),
-                    "private_ip": i.private_ip_address().unwrap_or_default(),
-                })
-            })
-            .collect();
 
         info!(count = instances.len(), "EC2 instances described");
 

--- a/crates/gcp/src/storage.rs
+++ b/crates/gcp/src/storage.rs
@@ -431,33 +431,50 @@ impl StorageProvider {
         let bucket_path = Self::bucket_path(bucket);
         debug!(bucket = %bucket, prefix = %prefix, "listing objects");
 
-        let mut request = self.storage_control.list_objects().set_parent(&bucket_path);
-        if !prefix.is_empty() {
-            request = request.set_prefix(&prefix);
-        }
-        if let Some(max) = payload.max_results {
-            request = request.set_page_size(max);
-        }
+        // Page through results: a single list response is capped and carries a
+        // `next_page_token`; dropping it silently truncated the listing to the
+        // first page. `max_results`, when set, is a TOTAL cap — accumulate
+        // across pages until it is reached or the listing is exhausted.
+        let max_results = payload.max_results.and_then(|m| usize::try_from(m).ok());
+        let mut objects: Vec<serde_json::Value> = Vec::new();
+        let mut page_token = String::new();
+        loop {
+            let mut request = self.storage_control.list_objects().set_parent(&bucket_path);
+            if !prefix.is_empty() {
+                request = request.set_prefix(&prefix);
+            }
+            if let Some(max) = payload.max_results {
+                request = request.set_page_size(max);
+            }
+            if !page_token.is_empty() {
+                request = request.set_page_token(&page_token);
+            }
 
-        let response = request.send().await.map_err(|e| {
-            let err_str = e.to_string();
-            error!(error = %err_str, "Cloud Storage list failed");
-            let gcp_err: ProviderError = classify_gcp_error(&err_str).into();
-            gcp_err
-        })?;
+            let response = request.send().await.map_err(|e| {
+                let err_str = e.to_string();
+                error!(error = %err_str, "Cloud Storage list failed");
+                let gcp_err: ProviderError = classify_gcp_error(&err_str).into();
+                gcp_err
+            })?;
 
-        let objects: Vec<_> = response
-            .objects
-            .into_iter()
-            .map(|obj| {
-                serde_json::json!({
+            let next = response.next_page_token.clone();
+            for obj in response.objects {
+                objects.push(serde_json::json!({
                     "name": obj.name,
                     "size": obj.size,
                     "content_type": obj.content_type,
                     "update_time": obj.update_time.map(|t| t.seconds()),
-                })
-            })
-            .collect();
+                }));
+                if max_results.is_some_and(|m| objects.len() >= m) {
+                    break;
+                }
+            }
+
+            if max_results.is_some_and(|m| objects.len() >= m) || next.is_empty() {
+                break;
+            }
+            page_token = next;
+        }
 
         info!(bucket = %bucket, count = objects.len(), "objects listed");
 

--- a/crates/integrations/pagerduty/src/provider.rs
+++ b/crates/integrations/pagerduty/src/provider.rs
@@ -107,7 +107,11 @@ impl PagerDutyProvider {
 
     /// Build a [`PagerDutyEvent`] from the deserialized action payload,
     /// applying config defaults where appropriate.
-    fn build_event(&self, payload: EventPayload) -> Result<PagerDutyEvent, PagerDutyError> {
+    fn build_event(
+        &self,
+        payload: EventPayload,
+        action_id: &str,
+    ) -> Result<PagerDutyEvent, PagerDutyError> {
         let routing_key = self
             .config
             .resolve_routing_key(payload.service_id.as_deref())?
@@ -121,6 +125,13 @@ impl PagerDutyProvider {
                     )
                 })?;
 
+                // Default the dedup_key to the action id when the caller didn't
+                // supply one, so a gateway retry of the same trigger collapses
+                // onto a single incident instead of paging the on-call once per
+                // attempt. Only triggers default it — acknowledge/resolve must
+                // reference the existing incident's key, which the caller owns.
+                let dedup_key = payload.dedup_key.or_else(|| Some(action_id.to_owned()));
+
                 let severity = payload
                     .severity
                     .unwrap_or_else(|| self.config.default_severity.clone());
@@ -133,7 +144,7 @@ impl PagerDutyProvider {
                 Ok(PagerDutyEvent {
                     routing_key,
                     event_action: "trigger".into(),
-                    dedup_key: payload.dedup_key,
+                    dedup_key,
                     payload: Some(PagerDutyPayload {
                         summary,
                         source,
@@ -182,7 +193,7 @@ impl Provider for PagerDutyProvider {
         let payload: EventPayload = serde_json::from_value(action.payload.clone())
             .map_err(|e| PagerDutyError::InvalidPayload(format!("failed to parse payload: {e}")))?;
 
-        let event = self.build_event(payload)?;
+        let event = self.build_event(payload, action.id.as_ref())?;
         let api_response = self.send_event(&event).await?;
 
         let body = serde_json::json!({
@@ -311,6 +322,37 @@ mod tests {
         let config = PagerDutyConfig::single_service("test-svc", "test-routing-key");
         let provider = PagerDutyProvider::new(config);
         assert_eq!(provider.name(), "pagerduty");
+    }
+
+    #[test]
+    fn trigger_defaults_dedup_key_to_action_id() {
+        let provider =
+            PagerDutyProvider::new(PagerDutyConfig::single_service("test-svc", "test-key"));
+        let payload: EventPayload = serde_json::from_value(serde_json::json!({
+            "event_action": "trigger",
+            "summary": "no dedup key supplied",
+        }))
+        .unwrap();
+        let event = provider.build_event(payload, "act-xyz").unwrap();
+        assert_eq!(
+            event.dedup_key.as_deref(),
+            Some("act-xyz"),
+            "a trigger without a dedup_key must default to the action id so retries collapse onto one incident"
+        );
+    }
+
+    #[test]
+    fn trigger_keeps_caller_supplied_dedup_key() {
+        let provider =
+            PagerDutyProvider::new(PagerDutyConfig::single_service("test-svc", "test-key"));
+        let payload: EventPayload = serde_json::from_value(serde_json::json!({
+            "event_action": "trigger",
+            "summary": "x",
+            "dedup_key": "caller-key",
+        }))
+        .unwrap();
+        let event = provider.build_event(payload, "act-xyz").unwrap();
+        assert_eq!(event.dedup_key.as_deref(), Some("caller-key"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Severity: HIGH ×2 + MEDIUM ×2 + LOW

From the fresh survey. The **cloud-provider idempotency & pagination** theme — silent duplication on retry and silently-truncated listings.

### Idempotency
- **EC2 `RunInstances` had no ClientToken (HIGH).** A gateway retry after a lost response (timeout / TLS reset *after* AWS committed) launched a **second** set of billable instances. Now the ClientToken is derived from `action.id`, so EC2 dedupes the launch for 24h — a retry of the same action is a no-op at AWS. (Other mutating providers in the crate already use dedup IDs; EC2 launch was the outlier.)
- **PagerDuty `trigger` without a `dedup_key` (LOW)** created a fresh incident on every retry, paging the on-call repeatedly. Default it to `action.id` so retries collapse onto one incident. `acknowledge`/`resolve` unchanged (they must reference the caller's existing incident key).

### Pagination (silent truncation)
- **EC2 `DescribeInstances` (MED)**, **AutoScaling `DescribeAutoScalingGroups` (MED)**, and **GCS `ListObjects` (HIGH)** ignored their `NextToken`/`next_page_token`, so anything past the first page (~1000 instances, 100 ASGs, 1000 objects) was silently dropped — cleanup/inventory logic saw a partial view. All three now loop until the page token is exhausted. For GCS, `max_results` is honoured as a **total cap across pages** (it was previously a per-page size that only returned one page).

## Tests

PagerDuty (which has an HTTP/mock harness): `trigger` defaults `dedup_key` to the action id; an explicit `dedup_key` is preserved.

The **AWS/GCP** changes are **build + clippy-verified** (incl. `cargo clippy -p acteon-aws --features full`): those crates mock no SDK client — existing tests cover payload deserialization only — so the pagination loops follow the standard SDK `NextToken` pattern without introducing a new stubbing harness.

## Checks
- `cargo clippy --workspace -- -D warnings` + `cargo clippy -p acteon-aws --features full -- -D warnings` clean
- aws 90 / gcp 48 / pagerduty 47 (+2) tests pass
- `cargo check --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)