### PR TITLE
fix(rules,wasm): numeric coercion in in/contains + UTF-8-safe truncation

### DIFF
--- a/crates/rules/rules/src/engine/eval.rs
+++ b/crates/rules/rules/src/engine/eval.rs
@@ -475,7 +475,12 @@ fn eval_contains(left: &Value, right: &Value) -> Result<Value, RuleError> {
         (Value::String(haystack), Value::String(needle)) => {
             Ok(Value::Bool(haystack.contains(needle.as_str())))
         }
-        (Value::List(list), needle) => Ok(Value::Bool(list.contains(needle))),
+        // Use the numeric-coercing `values_equal` (as `==` does) so a list of
+        // floats `contains` an int and vice versa; `Vec::contains` uses the
+        // exact derived `PartialEq` and would miss `[5.0] contains 5`.
+        (Value::List(list), needle) => Ok(Value::Bool(
+            list.iter().any(|item| values_equal(item, needle)),
+        )),
         _ => Err(RuleError::TypeError(format!(
             "contains: unsupported types {} and {}",
             left.type_name(),
@@ -528,7 +533,11 @@ fn eval_matches(left: &Value, right: &Value) -> Result<Value, RuleError> {
 /// Membership test: `value in collection`.
 fn eval_in(left: &Value, right: &Value) -> Result<Value, RuleError> {
     match right {
-        Value::List(list) => Ok(Value::Bool(list.contains(left))),
+        // Coerce numerics like `==` does (`5 in [5.0]` is true); `Vec::contains`
+        // uses the exact derived `PartialEq` and would miss it.
+        Value::List(list) => Ok(Value::Bool(
+            list.iter().any(|item| values_equal(left, item)),
+        )),
         Value::Map(map) => match left {
             Value::String(key) => Ok(Value::Bool(map.contains_key(key))),
             _ => Err(RuleError::TypeError(format!(
@@ -598,5 +607,30 @@ mod arithmetic_safety_tests {
         // overflowing constant can't panic the evaluator in a debug build.
         assert_eq!((i64::MIN).wrapping_sub(1), i64::MAX);
         assert_eq!((i64::MAX).wrapping_mul(2), -2);
+    }
+
+    #[test]
+    fn in_and_contains_coerce_numerics_like_eq() {
+        use Value::{Bool, Float, Int, List};
+        // `in`: int member vs float list and vice versa — must match, as `==`
+        // does (5 == 5.0 is true), where `Vec::contains` would not.
+        assert_eq!(
+            eval_in(&Int(5), &List(vec![Float(5.0)])).unwrap(),
+            Bool(true)
+        );
+        assert_eq!(
+            eval_in(&Float(5.0), &List(vec![Int(5)])).unwrap(),
+            Bool(true)
+        );
+        // `contains`: float list contains an int.
+        assert_eq!(
+            eval_contains(&List(vec![Float(5.0)]), &Int(5)).unwrap(),
+            Bool(true)
+        );
+        // A genuine non-member is still false.
+        assert_eq!(
+            eval_in(&Int(6), &List(vec![Float(5.0)])).unwrap(),
+            Bool(false)
+        );
     }
 }

--- a/crates/wasm-runtime/src/registry.rs
+++ b/crates/wasm-runtime/src/registry.rs
@@ -431,11 +431,15 @@ impl WasmPluginRegistry {
                         && let Ok(mut result) =
                             serde_json::from_str::<WasmInvocationResult>(result_str)
                     {
-                        // Truncate unreasonably long messages.
+                        // Truncate unreasonably long messages at a UTF-8 char
+                        // boundary so slicing a multi-byte character in half
+                        // can't panic (the plugin controls this string, so it
+                        // may be arbitrary UTF-8).
                         if let Some(ref msg) = result.message
                             && msg.len() > MAX_OUTPUT_JSON_BYTES
                         {
-                            result.message = Some(format!("{}... (truncated)", &msg[..1024]));
+                            let head = truncate_at_char_boundary(msg, 1024);
+                            result.message = Some(format!("{head}... (truncated)"));
                         }
                         return Ok(result);
                     }
@@ -544,9 +548,39 @@ impl WasmPluginRuntime for SharedWasmRegistry {
     }
 }
 
+/// Truncate `msg` to at most `max_bytes`, backing off to the nearest UTF-8
+/// character boundary at or below the cut so the returned slice never falls in
+/// the middle of a multi-byte character (which would panic).
+fn truncate_at_char_boundary(msg: &str, max_bytes: usize) -> &str {
+    let mut cut = max_bytes.min(msg.len());
+    while cut > 0 && !msg.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    &msg[..cut]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn truncate_at_char_boundary_never_splits_a_multibyte_char() {
+        // '€' is 3 bytes (U+20AC); 1024 is not a multiple of 3, so the raw
+        // `&msg[..1024]` would have panicked mid-character.
+        assert_ne!(1024 % 3, 0);
+        let msg = "€".repeat(500); // 1500 bytes
+        let head = truncate_at_char_boundary(&msg, 1024);
+        assert!(head.len() <= 1024);
+        assert!(msg.is_char_boundary(head.len()), "cut on a char boundary");
+        assert_eq!(head.len() % 3, 0, "only whole '€' characters retained");
+
+        // Short string is returned whole; ASCII cuts exactly.
+        assert_eq!(truncate_at_char_boundary("hi", 1024), "hi");
+        assert_eq!(
+            truncate_at_char_boundary(&"a".repeat(2000), 1024).len(),
+            1024
+        );
+    }
 
     fn test_config() -> WasmRuntimeConfig {
         WasmRuntimeConfig::default()


### PR DESCRIPTION
## Severity: MEDIUM + LOW

From the fresh survey. The **rules / WASM** theme — the last of the 21 findings.

### Rule engine: `in` / `contains` ignored numeric coercion (MED)

`eval_in` and `eval_contains` used `Vec::contains` — the exact derived `PartialEq` — while the `==` operator coerces int/float via `values_equal`. So `payload.code in [200, 404]` would **silently miss** when the payload value deserialized as a float (`200.0`) and the list as ints (or vice versa): a rule that reads as correct never matches. Both now compare with `values_equal`, so membership is consistent with `==` (`5 in [5.0]` is true).

### WASM runtime: message truncation could panic on a multi-byte char (LOW)

A plugin-returned message over the output cap was truncated with `&msg[..1024]` — a fixed **byte** offset. The plugin controls the string (arbitrary UTF-8), so if byte 1024 lands inside a multi-byte character the slice **panics**. Extracted `truncate_at_char_boundary`, which backs off to the nearest char boundary at or below the cut.

## Tests
- `in_and_contains_coerce_numerics_like_eq` — int/float membership both directions, plus a genuine non-member stays false.
- `truncate_at_char_boundary_never_splits_a_multibyte_char` — a string of 3-byte `€` where byte 1024 is mid-character (the old slice would have panicked); result lands on a boundary, ≤ 1024 bytes.

## Checks
- `cargo clippy -p acteon-rules -p acteon-wasm-runtime -- -D warnings` clean
- both crates' tests pass (+2)
- `cargo check --all-targets` clean

This completes the fresh-survey sweep — **all 21 findings addressed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)