### PR TITLE
feat(specs): extend TLA+ coverage — chain ordering, approval lifecycle, quota counter

### DIFF
--- a/docs/design/tla-plus-formal-verification.md
+++ b/docs/design/tla-plus-formal-verification.md
@@ -17,7 +17,7 @@ This document identifies **the highest-value areas** in Acteon where TLA+ modeli
 harden correctness, proposes concrete specifications, and provides an implementation
 roadmap.
 
-> **Implementation status (May 2026).** Five specs are implemented and pass the TLC
+> **Implementation status (May 2026).** Eight specs are implemented and pass the TLC
 > model checker on every run of `specs/tla/ci/run-tlc.sh` (wired into CI as the
 > `TLA+ Specs` job):
 >
@@ -28,14 +28,22 @@ roadmap.
 > | Compliance hash-chain | `HashChain.tla` | Contiguous audit chain — no duplicate sequence number, no fork (the PR #227 max-tip fix) |
 > | Recurring dispatch | `RecurringDispatch.tla` | ≤ 1 dispatch per occurrence under claim-TTL expiry (the PR #235 index re-arm) |
 > | Message bus | `MessageBus.tla` | Grouped notification emitted ≤ once per window across concurrent flushers (`flush_group` mutex) |
+> | Chain ordering (§4.4) | `ChainOrdering.tla` | Each chain step executed ≤ once and recorded in contiguous order, under concurrent `advance_chain` workers (isolates the fresh re-read CAS at gateway.rs:2986) |
+> | Approval lifecycle (§4.5) | `ApprovalLifecycle.tla` | Approval decided once; side-effect runs ≤ once and only if approved, only after the durable intent (the PR #225 intent-before-flip; gateway 3-state path) |
+> | Quota counter (§7.7) | `QuotaCounter.tla` | No counter drift (no lost increment) and no over-admission past the limit, under concurrent dispatchers (atomic check-and-increment + Block refund) |
 >
 > The realized layout deviates from the proposal below in one deliberate way: each spec
 > **inlines** its own lock / state-store state machine instead of sharing `common/`
 > modules, so each can be model-checked in isolation and the proof obligations stay local.
 > Each spec is adversarially validated — reverting the specific fix it models makes TLC
 > report the corresponding violation, so the spec catches the real bug rather than a
-> tautology. Specs for chain ordering, approval lifecycle, and quota counters remain
-> future work (Sections 4.4–4.5, 7.7).
+> tautology. The last three were each scoped to the layer they isolate: `ChainOrdering`
+> models the fresh re-read CAS (not the full lock + per-attempt dedup stack);
+> `ApprovalLifecycle` models the gateway 3-state path that PR #225 fixed (the separate
+> 5-state Kafka-bus approval machine in `core/bus_approval.rs` would warrant its own
+> spec); `QuotaCounter` assumes the Block-path refund always succeeds (the fail-open
+> rollback path is out of scope). The natural next targets are the Kafka-bus approval
+> machine and the multi-policy quota rollback.
 
 ---
 
@@ -523,13 +531,20 @@ specs/
     RecurringDispatch.cfg
     MessageBus.tla                   # grouped-notification notify-once delivery
     MessageBus.cfg
+    ChainOrdering.tla                # chain step at-most-once + in-order (§4.4)
+    ChainOrdering.cfg
+    ApprovalLifecycle.tla            # approval decided-once + intent-before-exec (§4.5, #225)
+    ApprovalLifecycle.cfg
+    QuotaCounter.tla                 # quota no-drift + no-over-admit (§7.7)
+    QuotaCounter.cfg
     Makefile                         # Automation: `make check-all`
     ci/
       run-tlc.sh                     # auto-discovers every *.cfg; used by CI
 ```
 
-Future specs (chain ordering, approval lifecycle, quota counters — Sections 4.4,
-4.5, 7.7) will follow the same inlined, self-contained convention.
+All eight specs follow the same inlined, self-contained convention. The next
+candidates are the Kafka-bus 5-state approval machine (`core/bus_approval.rs`,
+distinct from the gateway path modeled here) and the multi-policy quota rollback.
 
 ### 5.3 CI Integration
 

--- a/specs/tla/ApprovalLifecycle.cfg
+++ b/specs/tla/ApprovalLifecycle.cfg
@@ -1,0 +1,15 @@
+\* ApprovalLifecycle model-checking configuration (gateway approve/reject path)
+CONSTANTS
+    Approvers = {a1, a2}
+    Rejecters = {r1}
+    TTL = 2
+    MaxTime = 4
+    NOBODY = NOBODY
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    ExecuteOnceIfApproved
+    IntentBeforeExecute
+    DecidedOnce

--- a/specs/tla/ApprovalLifecycle.tla
+++ b/specs/tla/ApprovalLifecycle.tla
@@ -1,0 +1,205 @@
+-------------------------- MODULE ApprovalLifecycle ------------------------
+(*
+ * TLA+ specification of Acteon's human-in-the-loop (HITL) approval lifecycle —
+ * the gateway approve/reject path, which is what PR #225 hardened.
+ *
+ * Models crates/gateway/src/gateway.rs:
+ *   - execute_approval / execute_approval_inner (~5645..5841)
+ *   - reject_approval / reject_approval_inner   (~5847..5935)
+ * The persisted ApprovalRecord.status (gateway.rs:99) holds exactly one of
+ * "pending" | "approved" | "rejected" — there is NO persisted intermediate
+ * "approving" state and NO "expired" status. (The 5-state Approving/Expired
+ * machine in crates/core/src/bus_approval.rs is a DIFFERENT subsystem — the
+ * Kafka-envelope bus — and would warrant its own spec; this spec is the
+ * gateway path only.)
+ *
+ * Protocol. An approval is created Pending with a TTL. Approve and reject both
+ * race for ONE shared claim key ({id}:claim) via check_and_set — first writer
+ * wins, so approve and reject are mutually exclusive. Expiry is an authoritative
+ * read-side GATE (gateway.rs:5663 `now > expires_at => ApprovalNotFound`): once
+ * the TTL has elapsed a NEW claim is refused, but the row stays "pending" — no
+ * status is written. The winning claimant then runs its critical section:
+ *
+ *   APPROVE (the PR #225 ordering — each step is a distinct instruction):
+ *     claim ----------------------------------------> (claim held, still pending)
+ *     write durable pre-execution INTENT ------------> (intent_written)   [#225]
+ *     flip status pending -> approved ---------------> (only once intent durable)
+ *     run the side-effect, exactly once -------------> (executed)
+ *   The intent is recorded BEFORE the status flip and the side-effect, so a
+ *   transient audit/store outage between claim and flip leaves the row pending
+ *   and retryable — never executed-but-unaudited, never approved-but-stranded.
+ *
+ *   REJECT: claim and flip pending -> rejected. No intent, no side-effect.
+ *
+ * Verified (over every interleaving of concurrent approvers, a rejecter, and
+ * TTL expiry):
+ *   - DecidedOnce: the terminal status is owned by a claimant of the matching
+ *     role (approved => an approver holds the claim; rejected => a rejecter),
+ *     a recorded intent only ever exists on the approve path, and an executed
+ *     row is approved. No approve-after-reject, no reject-after-approve, no
+ *     cross-decision contamination.
+ *   - ExecuteOnceIfApproved: the side-effect fires at most once, and only while
+ *     the row is approved (never after a reject, never after an unclaimed
+ *     expiry, never twice).
+ *   - IntentBeforeExecute (PR #225): Execute is reachable only once the durable
+ *     pre-execution intent is recorded  (executed => intent_written).
+ *
+ * Negative check: revert the #225 ordering — drop the `intent_written = TRUE`
+ * precondition on FlipApproved and Execute and remove WriteIntent from Next, so
+ * the approver can flip and run the side-effect without first recording the
+ * intent. TLC then reaches executed = TRUE /\ intent_written = FALSE and reports
+ * IntentBeforeExecute violated.
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config ApprovalLifecycle.cfg ApprovalLifecycle.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    Approvers,  \* concurrent approve actors / replicas, e.g. {a1, a2}
+    Rejecters,  \* concurrent reject actors / replicas, e.g. {r1}
+    TTL,        \* approval time-to-live in ticks (read-side expiry gate)
+    MaxTime,    \* state-space / clock bound
+    NOBODY      \* sentinel: the decision claim is free
+
+\* Actors contending for the single shared claim key.
+Actors == Approvers \cup Rejecters
+
+VARIABLES
+    status,         \* "pending" | "approved" | "rejected"
+    intent_written, \* BOOLEAN: durable pre-execution intent recorded (approve path)
+    executed,       \* BOOLEAN: the side-effect ran
+    exec_count,     \* 0..3: number of Execute firings (catches double-exec)
+    claim,          \* Actors \cup {NOBODY}: holder of the shared decision claim
+    clock           \* 0..MaxTime: monotone tick clock; expiry gate at clock >= TTL
+
+vars == <<status, intent_written, executed, exec_count, claim, clock>>
+
+TypeOK ==
+    /\ status \in {"pending", "approved", "rejected"}
+    /\ intent_written \in BOOLEAN
+    /\ executed \in BOOLEAN
+    /\ exec_count \in 0..3
+    /\ claim \in Actors \cup {NOBODY}
+    /\ clock \in 0..MaxTime
+
+Init ==
+    /\ status = "pending"
+    /\ intent_written = FALSE
+    /\ executed = FALSE
+    /\ exec_count = 0
+    /\ claim = NOBODY
+    /\ clock = 0
+
+\* An approver wins the shared claim (check_and_set, first writer wins). The
+\* read-side expiry gate (clock < TTL) is the authoritative server-side check at
+\* gateway.rs:5663 — a NEW claim after the TTL is refused. The row stays
+\* "pending" while claimed; there is no persisted "approving" status.
+ClaimApprove(a) ==
+    /\ a \in Approvers
+    /\ claim = NOBODY
+    /\ status = "pending"
+    /\ clock < TTL
+    /\ claim' = a
+    /\ UNCHANGED <<status, intent_written, executed, exec_count, clock>>
+
+\* PR #225 phase 1: durably record the pre-execution INTENT, BEFORE the status
+\* flip and the side-effect. Runs under the claim while the row is still pending.
+\* (A failure here keeps the row pending and retryable.)
+WriteIntent(a) ==
+    /\ a \in Approvers
+    /\ claim = a
+    /\ status = "pending"
+    /\ intent_written = FALSE
+    /\ intent_written' = TRUE
+    /\ UNCHANGED <<status, executed, exec_count, claim, clock>>
+
+\* PR #225 phase 2: flip pending -> approved, but ONLY once the intent is
+\* durable. This precondition is the fix; reverting it is the negative check.
+FlipApproved(a) ==
+    /\ a \in Approvers
+    /\ claim = a
+    /\ status = "pending"
+    /\ intent_written = TRUE
+    /\ status' = "approved"
+    /\ UNCHANGED <<intent_written, executed, exec_count, claim, clock>>
+
+\* The side-effecting dispatch. Reachable ONLY from approved (so never after a
+\* reject or an unclaimed expiry) and ONLY with the intent durable; fires once.
+Execute(a) ==
+    /\ a \in Approvers
+    /\ claim = a
+    /\ status = "approved"
+    /\ intent_written = TRUE
+    /\ executed = FALSE
+    /\ executed' = TRUE
+    /\ exec_count' = exec_count + 1
+    /\ UNCHANGED <<status, intent_written, claim, clock>>
+
+\* A rejecter wins the same shared claim and flips pending -> rejected. No
+\* intent, no side-effect. Mutual exclusion with approve is via the claim.
+ClaimReject(r) ==
+    /\ r \in Rejecters
+    /\ claim = NOBODY
+    /\ status = "pending"
+    /\ clock < TTL
+    /\ claim' = r
+    /\ status' = "rejected"
+    /\ UNCHANGED <<intent_written, executed, exec_count, clock>>
+
+\* Time advances (monotone). Once clock >= TTL the read-side gate refuses new
+\* claims; a row never claimed by then stays pending forever (read-side expired).
+Tick ==
+    /\ clock < MaxTime
+    /\ clock' = clock + 1
+    /\ UNCHANGED <<status, intent_written, executed, exec_count, claim>>
+
+\* Recycle: open a FRESH approval window once the current one has settled —
+\* rejected, approved-and-executed, or expired-while-unclaimed (pending, no
+\* claim, past TTL). Keeps the system cycling (no benign terminal deadlock).
+Settled ==
+    \/ status = "rejected"
+    \/ (status = "approved" /\ executed = TRUE)
+    \/ (status = "pending" /\ claim = NOBODY /\ clock >= TTL)
+
+Recycle ==
+    /\ Settled
+    /\ status' = "pending"
+    /\ intent_written' = FALSE
+    /\ executed' = FALSE
+    /\ exec_count' = 0
+    /\ claim' = NOBODY
+    /\ clock' = 0
+
+Next ==
+    \/ \E a \in Approvers :
+         ClaimApprove(a) \/ WriteIntent(a) \/ FlipApproved(a) \/ Execute(a)
+    \/ \E r \in Rejecters : ClaimReject(r)
+    \/ Tick
+    \/ Recycle
+
+Spec == Init /\ [][Next]_vars
+
+\* =======================================================================
+\* SAFETY
+\* =======================================================================
+
+\* The side-effect fires at most once and only while the row is approved —
+\* never after a reject, never after an unclaimed expiry, never twice.
+ExecuteOnceIfApproved ==
+    /\ exec_count <= 1
+    /\ (executed => status = "approved")
+
+\* PR #225: the durable pre-execution intent precedes the side-effect.
+IntentBeforeExecute == executed => intent_written
+
+\* The terminal status is owned by a claimant of the matching role, an intent
+\* exists only on the approve path, and an executed row is approved — so no
+\* approve-after-reject, reject-after-approve, or cross-decision contamination.
+DecidedOnce ==
+    /\ (executed => status = "approved")
+    /\ (intent_written => claim \in Approvers)
+    /\ (status = "approved" => claim \in Approvers)
+    /\ (status = "rejected" => claim \in Rejecters)
+
+============================================================================

--- a/specs/tla/ChainOrdering.cfg
+++ b/specs/tla/ChainOrdering.cfg
@@ -1,0 +1,12 @@
+\* ChainOrdering model-checking configuration
+CONSTANTS
+    Workers = {a1, a2}
+    Steps = 3
+    NOBODY = NOBODY
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    StepAtMostOnce
+    InOrder

--- a/specs/tla/ChainOrdering.tla
+++ b/specs/tla/ChainOrdering.tla
@@ -1,0 +1,169 @@
+--------------------------- MODULE ChainOrdering ---------------------------
+(*
+ * TLA+ specification of Acteon's multi-step chain executor advancement.
+ *
+ * Models the protocol in crates/gateway/src/gateway.rs::advance_chain
+ * (around line 2544) and the FRESH re-read CAS idempotency guard at line 2986.
+ * The chain's runtime state (crates/core/src/chain.rs::ChainState) carries
+ *   current_step       : index of the step being executed,
+ *   step_results[i]    : Some(..) once step i has committed a result,
+ *   execution_path     : the committed steps in order.
+ * Steps run strictly sequentially 0,1,..,K-1; on the last step the chain
+ * transitions ChainStatus::Running -> Completed.
+ *
+ * N concurrent workers / gateway replicas may each call advance_chain on the
+ * SAME chain. A worker:
+ *   1. reads step_idx = chain_state.current_step (a snapshot, possibly stale);
+ *   2. executes step step_idx (dispatches the synthetic action);
+ *   3. before persisting, RE-READS fresh state and commits ONLY IF the step is
+ *      still unexecuted AND current_step is still step_idx — the CAS guard
+ *      `fresh.step_results[step_idx].is_some() || fresh.current_step != step_idx`
+ *      (line 2986). If either holds, another worker already advanced, so it
+ *      aborts and commits nothing.
+ *   4. on commit: records step_results[step_idx], bumps current_step to step_idx+1,
+ *      appends to execution_path. Running -> Completed on the final step.
+ *
+ * Execute and commit are modelled as SEPARATE steps so the re-read CAS guard is
+ * load-bearing (mirroring the read/write split in MessageBus.tla), not an
+ * artifact of step-atomicity: two workers can both read step_idx = i and both
+ * execute step i, but the CAS lets at most one of them commit it.
+ *
+ * SCOPE. advance_chain serializes commits with THREE layers: the chain:{id}
+ * distributed lock (gateway.rs:2554), a per-attempt dedup check_and_set
+ * (`chain-step:{chain_id}:{step}:a{n}`), and this fresh re-read CAS (line 2986).
+ * This spec isolates the LAST layer — the idempotency guard that must hold on
+ * the `!is_new` / crash-restart / lock-expiry path where the lock does not
+ * provide exclusion. It abstracts the lock and dedup CAS away (a conservative,
+ * stronger setting: it assumes the lock can fail to exclude). So a green run
+ * verifies the CAS's safety contribution, not the full three-layer stack.
+ * InOrder is asserted for LINEAR (sequential) chains; branching chains (where
+ * current_step can move non-sequentially) are intentionally out of scope.
+ *
+ * Verified (over every interleaving of concurrent workers / replicas):
+ *   - StepAtMostOnce: each step index is recorded at most once — exec_count[i] <= 1.
+ *   - InOrder (Monotonic + contiguous prefix): recorded steps are exactly the
+ *     contiguous prefix 0..current_step-1; current_step never skips or moves
+ *     backward; step i is never recorded before step i-1. No gap, no reorder.
+ *
+ * Negative check: drop the FRESH re-read CAS — let a worker commit step i based
+ * on its STALE local snapshot without re-checking current_step / step_results
+ * (replace the `step_results[i] = none /\ current_step = i` commit guard with
+ * the worker's own w_idx). Two workers then both commit step i and
+ * StepAtMostOnce is violated — exec_count[i] reaches 2.
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config ChainOrdering.cfg ChainOrdering.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    Workers,  \* concurrent chain advancers / gateway replicas, e.g. {a1, a2}
+    Steps,    \* number of steps in the chain (indices 0..Steps-1)
+    NOBODY    \* sentinel: step slot not yet recorded
+
+StepIdx == 0..(Steps - 1)
+
+VARIABLES
+    current_step,  \* 0..Steps : chain_state.current_step (= Steps when Completed)
+    recorded,      \* [StepIdx -> Workers \cup {NOBODY}] : committer of each step
+    exec_count,    \* [StepIdx -> 0..3] : times each step's result was recorded
+    completed,     \* BOOLEAN : ChainStatus has reached Completed
+    w_phase,       \* [Workers -> {"idle","executing","committing","done"}]
+    w_idx          \* [Workers -> 0..Steps] : the step_idx snapshot a worker read
+
+TypeOK ==
+    /\ current_step \in 0..Steps
+    /\ recorded \in [StepIdx -> Workers \cup {NOBODY}]
+    /\ exec_count \in [StepIdx -> 0..3]
+    /\ completed \in BOOLEAN
+    /\ w_phase \in [Workers -> {"idle", "executing", "committing", "done"}]
+    /\ w_idx \in [Workers -> 0..Steps]
+
+Init ==
+    /\ current_step = 0
+    /\ recorded = [s \in StepIdx |-> NOBODY]
+    /\ exec_count = [s \in StepIdx |-> 0]
+    /\ completed = FALSE
+    /\ w_phase = [w \in Workers |-> "idle"]
+    /\ w_idx = [w \in Workers |-> 0]
+
+\* advance_chain start: read step_idx = chain_state.current_step (line 2639).
+\* The snapshot is taken now; a concurrent worker may advance current_step
+\* before this worker reaches its commit, making the snapshot stale.
+Start(w) ==
+    /\ w_phase[w] = "idle"
+    /\ ~completed
+    /\ current_step < Steps
+    /\ w_idx' = [w_idx EXCEPT ![w] = current_step]
+    /\ w_phase' = [w_phase EXCEPT ![w] = "executing"]
+    /\ UNCHANGED <<current_step, recorded, exec_count, completed>>
+
+\* Execute step w_idx[w] (dispatch the synthetic action). This is the side-
+\* effecting work BEFORE the persist; two workers that both snapshotted the
+\* same index can both reach here. No chain state is mutated yet.
+Execute(w) ==
+    /\ w_phase[w] = "executing"
+    /\ w_phase' = [w_phase EXCEPT ![w] = "committing"]
+    /\ UNCHANGED <<current_step, recorded, exec_count, completed, w_idx>>
+
+\* Persist under the FRESH re-read CAS guard (line 2986). Re-read fresh state:
+\* commit ONLY IF step i is still unrecorded AND current_step is still i.
+\* On commit: record the result, bump current_step to i+1, (execution_path push),
+\* Running -> Completed on the final step. Otherwise abort — another worker
+\* already advanced this step — and commit nothing.
+Commit(w) ==
+    /\ w_phase[w] = "committing"
+    /\ LET i == w_idx[w] IN
+       IF recorded[i] = NOBODY /\ current_step = i
+       THEN \* CAS won: this worker commits step i exactly once.
+            /\ recorded' = [recorded EXCEPT ![i] = w]
+            /\ exec_count' = [exec_count EXCEPT ![i] = exec_count[i] + 1]
+            /\ current_step' = i + 1
+            /\ completed' = (i + 1 = Steps)
+            /\ w_phase' = [w_phase EXCEPT ![w] = "done"]
+            /\ UNCHANGED w_idx
+       ELSE \* CAS lost: stale snapshot, abort with no state change.
+            /\ w_phase' = [w_phase EXCEPT ![w] = "done"]
+            /\ UNCHANGED <<current_step, recorded, exec_count, completed, w_idx>>
+
+\* Worker returns; it may advance the chain again (next poll).
+Finish(w) ==
+    /\ w_phase[w] = "done"
+    /\ w_phase' = [w_phase EXCEPT ![w] = "idle"]
+    /\ UNCHANGED <<current_step, recorded, exec_count, completed, w_idx>>
+
+\* Recycle: once the chain Completed and no worker is in flight, start a fresh
+\* chain (or the next execution window) so the system CYCLES and there is no
+\* benign terminal deadlock under -deadlock.
+Recycle ==
+    /\ completed
+    /\ \A w \in Workers : w_phase[w] = "idle"
+    /\ current_step' = 0
+    /\ recorded' = [s \in StepIdx |-> NOBODY]
+    /\ exec_count' = [s \in StepIdx |-> 0]
+    /\ completed' = FALSE
+    /\ w_idx' = [w \in Workers |-> 0]
+    /\ UNCHANGED w_phase
+
+Next ==
+    \/ \E w \in Workers : Start(w) \/ Execute(w) \/ Commit(w) \/ Finish(w)
+    \/ Recycle
+
+vars == <<current_step, recorded, exec_count, completed, w_phase, w_idx>>
+Spec == Init /\ [][Next]_vars
+
+\* =======================================================================
+\* SAFETY
+\* =======================================================================
+
+\* Each step index is recorded (executed-and-committed) at most once, despite
+\* concurrent workers that snapshotted the same index and both executed it.
+StepAtMostOnce == \A i \in StepIdx : exec_count[i] <= 1
+
+\* The recorded steps are EXACTLY the contiguous prefix 0..current_step-1:
+\* step i is recorded iff i < current_step. This rules out gaps (step i+1
+\* recorded before step i), out-of-order commits, and a current_step that
+\* skips or moves backward relative to what has been recorded.
+InOrder == \A i \in StepIdx : (recorded[i] # NOBODY) <=> (i < current_step)
+
+============================================================================

--- a/specs/tla/Makefile
+++ b/specs/tla/Makefile
@@ -7,6 +7,9 @@
 #   make check-hashchain    # Run HashChain only
 #   make check-recurring    # Run RecurringDispatch only
 #   make check-bus          # Run MessageBus only
+#   make check-chain        # Run ChainOrdering only
+#   make check-approval     # Run ApprovalLifecycle only
+#   make check-quota        # Run QuotaCounter only
 #   make setup              # Download tla2tools.jar
 #   make clean              # Remove downloaded tools
 
@@ -14,7 +17,7 @@ SHELL := /bin/bash
 SPECS_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 CI_SCRIPT := $(SPECS_DIR)ci/run-tlc.sh
 
-.PHONY: check-all check-circuit check-dedup check-hashchain check-recurring check-bus setup clean help
+.PHONY: check-all check-circuit check-dedup check-hashchain check-recurring check-bus check-chain check-approval check-quota setup clean help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -37,6 +40,15 @@ check-recurring: ## Run TLC on RecurringDispatch spec
 
 check-bus: ## Run TLC on MessageBus spec
 	@$(CI_SCRIPT) MessageBus
+
+check-chain: ## Run TLC on ChainOrdering spec
+	@$(CI_SCRIPT) ChainOrdering
+
+check-approval: ## Run TLC on ApprovalLifecycle spec
+	@$(CI_SCRIPT) ApprovalLifecycle
+
+check-quota: ## Run TLC on QuotaCounter spec
+	@$(CI_SCRIPT) QuotaCounter
 
 setup: ## Download tla2tools.jar (requires curl or wget)
 	@$(CI_SCRIPT) __nonexistent__ 2>/dev/null || true

--- a/specs/tla/QuotaCounter.cfg
+++ b/specs/tla/QuotaCounter.cfg
@@ -1,0 +1,13 @@
+\* QuotaCounter model-checking configuration
+CONSTANTS
+    Dispatchers = {d1, d2}
+    Limit = 1
+    MaxCount = 3
+    NOBODY = NOBODY
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    NoDrift
+    NoOverAdmit

--- a/specs/tla/QuotaCounter.tla
+++ b/specs/tla/QuotaCounter.tla
@@ -1,0 +1,148 @@
+----------------------------- MODULE QuotaCounter -----------------------------
+(*
+ * TLA+ specification of Acteon's per-tenant usage quota counter under
+ * concurrent dispatch.
+ *
+ * Models crates/gateway/src/quota_enforcement.rs
+ * (check_quota / check_quota_inner ~line 70, increment_all_quota_counters
+ * ~line 248) together with the OverageBehavior::Block path in
+ * enforce_quota_policies. The state-store counter is the QuotaUsage.count in
+ * crates/core/src/quota.rs.
+ *
+ * Protocol. N concurrent dispatchers each admit one action under a single
+ * Block-mode quota policy with a fixed limit L. The enforcement step is an
+ * ATOMIC check-and-increment against the shared counter (the code's comment
+ * "Each policy increments its own counter first (atomic to avoid races)",
+ * line ~177, backed by state.increment(&key, 1, ttl) returning the
+ * post-increment value `new_count` / `used`):
+ *
+ *     let v = state.increment(key, +1);   // atomic fetch-add, observe v
+ *     if v <= L { admit }                 // within quota
+ *     else      { block; state.increment(key, -1); }  // refund the slot
+ *
+ * Per enforce_quota_policies (line ~205), when the winning policy is Block the
+ * counter touched in this call is ROLLED BACK so the blocked request does not
+ * consume a slot. This spec models that refund faithfully: a blocked
+ * dispatcher decrements the counter back, so the counter settles at exactly
+ * the number of ADMITTED actions.
+ *
+ * Verified (over every interleaving of concurrent dispatchers / replicas):
+ *   - NoDrift: the counter equals the number of admitted dispatchers — no two
+ *     concurrent atomic increments collapse into one. (Blocked dispatchers
+ *     refund, so they do not contribute to the settled counter.)
+ *   - NoOverAdmit: the number of ADMITTED actions never exceeds the limit L
+ *     (Block behavior).
+ *
+ * SCOPE. NoDrift assumes the Block-path refund ALWAYS succeeds. The real
+ * enforcement is fail-open (quota_enforcement.rs ~208-225): if the rollback
+ * increment fails on a state-store blip the counter can settle ABOVE the
+ * admitted count — that failure mode is deliberately out of scope here. This
+ * spec also models a single Block policy; the multi-policy "block wins -> roll
+ * back every counter incremented in this call" path is left to a future sibling.
+ *
+ * The fix anchored here is the ATOMICITY of check-and-increment. The Step
+ * action performs the fetch-add and the observation of the post-value as ONE
+ * indivisible action — exactly the guarantee state.increment provides.
+ *
+ * Negative check: split Step into a non-atomic read-then-write (read v from
+ * the shared counter, later write v+1) — modeled in the QuotaCounter_BUGGY
+ * scratch copy. Two dispatchers then read the same v and both write v+1, so
+ * one increment is lost (NoDrift violated: counter < admitted) AND both
+ * observe v+1 <= L and admit (NoOverAdmit violated: admitted > L when the slot
+ * they both claim is the last one).
+ *
+ * A WindowReset action (a fresh quota window resets the counter to 0) reopens
+ * the work so the system CYCLES — no benign terminal deadlock under -deadlock.
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config QuotaCounter.cfg QuotaCounter.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    Dispatchers,  \* concurrent dispatchers / gateway replicas, e.g. {d1, d2}
+    Limit,        \* L: max actions admitted per window (Block over this)
+    MaxCount,     \* state-space bound on the counter
+    NOBODY        \* sentinel: a dispatcher has not yet observed a value
+
+VARIABLES
+    counter,    \* the shared QuotaUsage.count for the current window
+    admitted,   \* set of Dispatchers whose action was admitted this window
+    blocked,    \* set of Dispatchers that hit the Block limit this window
+    d_phase,    \* [Dispatchers -> {"idle","done"}]: enforcement progress
+    d_obs       \* [Dispatchers -> NOBODY \cup (1..MaxCount)]: observed post-value
+
+TypeOK ==
+    /\ counter \in 0..MaxCount
+    /\ admitted \subseteq Dispatchers
+    /\ blocked \subseteq Dispatchers
+    /\ d_phase \in [Dispatchers -> {"idle", "done"}]
+    /\ d_obs \in [Dispatchers -> (1..MaxCount) \cup {NOBODY}]
+
+Init ==
+    /\ counter = 0
+    /\ admitted = {}
+    /\ blocked = {}
+    /\ d_phase = [d \in Dispatchers |-> "idle"]
+    /\ d_obs = [d \in Dispatchers |-> NOBODY]
+
+\* ATOMIC check-and-increment (state.increment(key, +1) returning the
+\* post-increment value). In ONE indivisible action the dispatcher fetch-adds
+\* the shared counter and observes the post-value v. If v <= Limit the action
+\* is admitted (the increment stands). Otherwise Block fires and the increment
+\* is refunded (counter decremented back) so the blocked request consumes no
+\* slot — this is the rollback in enforce_quota_policies. The atomicity here is
+\* the property under test: no other dispatcher can interleave between the
+\* fetch-add and the observation.
+Step(d) ==
+    /\ d_phase[d] = "idle"
+    /\ counter < MaxCount
+    /\ LET v == counter + 1 IN
+       IF v <= Limit
+       THEN \* Within quota: admit, increment stands.
+            /\ counter' = v
+            /\ admitted' = admitted \cup {d}
+            /\ blocked' = blocked
+            /\ d_obs' = [d_obs EXCEPT ![d] = v]
+       ELSE \* Over limit: Block, then refund the slot (net zero change).
+            /\ counter' = counter
+            /\ admitted' = admitted
+            /\ blocked' = blocked \cup {d}
+            /\ d_obs' = [d_obs EXCEPT ![d] = v]
+    /\ d_phase' = [d_phase EXCEPT ![d] = "done"]
+
+\* A fresh quota window opens (epoch-aligned window index rolls over, TTL'd
+\* counter resets). Clean boundary: every dispatcher has finished enforcing.
+\* Reopens the work so the system cycles — no terminal deadlock.
+WindowReset ==
+    /\ \A d \in Dispatchers : d_phase[d] = "done"
+    /\ counter' = 0
+    /\ admitted' = {}
+    /\ blocked' = {}
+    /\ d_phase' = [d \in Dispatchers |-> "idle"]
+    /\ d_obs' = [d \in Dispatchers |-> NOBODY]
+
+Next ==
+    \/ \E d \in Dispatchers : Step(d)
+    \/ WindowReset
+
+vars == <<counter, admitted, blocked, d_phase, d_obs>>
+Spec == Init /\ [][Next]_vars
+
+\* =======================================================================
+\* SAFETY
+\* =======================================================================
+
+\* No lost increment / no drift: the settled counter equals the number of
+\* dispatchers whose increment stands (the admitted set) — no two concurrent
+\* atomic increments collapse into one. Blocked dispatchers refund, so they do
+\* not contribute. With a non-atomic read-then-write this is violated because a
+\* lost update leaves counter < Cardinality(admitted).
+NoDrift == counter = Cardinality(admitted)
+
+\* No over-admission (Block): the number of admitted actions never exceeds the
+\* limit. A non-atomic split lets two dispatchers both observe the same
+\* sub-limit value and both admit past L, violating this.
+NoOverAdmit == Cardinality(admitted) <= Limit
+
+===============================================================================

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -23,12 +23,16 @@ for the full research document.
 | **Hash Chain** | `HashChain.tla` | `audit/compliance.rs` `HashChainAuditStore` (the PR #227 max-tip fix) | The committed audit chain is contiguous — no duplicate sequence number, no fork — for every interleaving of concurrent writers |
 | **Recurring Dispatch** | `RecurringDispatch.tla` | `background/workers/recurring.rs` claim + index re-arm (the PR #235 fix) | Each occurrence is dispatched **at most once**, even when a dispatch outlives the 60s claim TTL |
 | **Message Bus** | `MessageBus.tla` | `gateway/group_manager.rs` `flush_group` notify-once | A grouped notification is emitted onto the bus **at most once** per window, despite concurrent flush workers / replicas |
+| **Chain Ordering** | `ChainOrdering.tla` | `gateway.rs` `advance_chain` fresh re-read CAS (line 2986) | Each chain step is executed **at most once** and recorded **in contiguous order**, under concurrent `advance_chain` workers (isolates the idempotency-CAS layer) |
+| **Approval Lifecycle** | `ApprovalLifecycle.tla` | `gateway.rs` `execute_approval` / `reject_approval` (the PR #225 two-phase) | An approval is decided once; the side-effect runs **at most once and only if approved**, only after the durable intent is recorded (intent-before-execute) |
+| **Quota Counter** | `QuotaCounter.tla` | `gateway/quota_enforcement.rs` atomic check-and-increment + Block refund | **No counter drift** (no lost increment) and **no over-admission** past the limit, under concurrent dispatchers |
 
 Each spec is self-contained: it inlines its own lock / state-store state machine
 rather than sharing a module, so each can be model-checked independently.
 
 Each spec is also adversarially validated: reverting the specific fix it models
-(the max-tip read, the pre-dispatch re-arm, the flush mutex) makes TLC report the
+(the max-tip read, the pre-dispatch re-arm, the flush mutex, the step re-read CAS,
+the intent-before-flip ordering, the increment atomicity) makes TLC report the
 corresponding safety violation. The specs catch the real bug, not just a tautology.
 
 ## Quick Start
@@ -71,9 +75,9 @@ tla-specs:
     - run: make -C specs/tla check-all
 ```
 
-The CI configuration uses small model parameters (2 gateways/writers/flushers)
-for fast feedback (all five specs finish in a few seconds total). For nightly
-runs, increase the constants in the `.cfg` files for deeper coverage.
+The CI configuration uses small model parameters (2 of each principal) for fast
+feedback (all eight specs finish in a few seconds total). For nightly runs,
+increase the constants in the `.cfg` files for deeper coverage.
 
 ## Project Structure
 
@@ -89,6 +93,12 @@ specs/tla/
   RecurringDispatch.cfg
   MessageBus.tla           # Spec: grouped-notification notify-once delivery
   MessageBus.cfg
+  ChainOrdering.tla        # Spec: chain step at-most-once + in-order advance
+  ChainOrdering.cfg
+  ApprovalLifecycle.tla    # Spec: approval decided-once + intent-before-execute (#225)
+  ApprovalLifecycle.cfg
+  QuotaCounter.tla         # Spec: quota counter no-drift + no-over-admit
+  QuotaCounter.cfg
   ci/
     run-tlc.sh             # CI runner (auto-discovers every *.cfg)
   Makefile                 # Convenience targets


### PR DESCRIPTION
## What

Adds the three TLA+ specs the design doc flagged as future work — **§4.4 chain ordering, §4.5 approval lifecycle, §7.7 quota counter** — bringing the suite to **8 model-checked specs**. All pass TLC on every CI run and are adversarially validated (reverting the modeled fix makes TLC report the matching violation).

## Specs

| Spec | Models | Safety property | Negative check |
|------|--------|-----------------|----------------|
| `ChainOrdering` | `advance_chain` fresh re-read CAS (gateway.rs:2986) | each step executed ≤once + recorded in contiguous order, under concurrent workers | drop the CAS re-check → `StepAtMostOnce` violated (exec_count→2) |
| `ApprovalLifecycle` | gateway `execute_approval`/`reject_approval` (PR #225) | decided once; side-effect ≤once and only-if-approved, only after the durable intent | drop the intent precondition → `executed ∧ ¬intent_written`, `IntentBeforeExecute` violated |
| `QuotaCounter` | `quota_enforcement.rs` atomic check-and-increment + Block refund | no counter drift (no lost increment) + no over-admission past the limit | split into non-atomic read-then-write → `NoDrift`/`NoOverAdmit` violated |

## Faithfulness

Each spec was authored from the real Rust and cross-checked by an independent **faithfulness critic** against the implementation, not just an adversarial-nonvacuity check. That paid off: the first approval draft was a *chimera* mixing the gateway 3-state path with the separate Kafka-bus 5-state machine (`core/bus_approval.rs`) and invented an `"expired"` status that no code writes (real expiry is a read-side gate leaving the row `"pending"`). It was rewritten to model the gateway path faithfully — 3-state, one shared claim key for approve/reject mutual exclusion, read-side expiry gate, intent-before-flip.

Scope notes baked into each header: `ChainOrdering` isolates the CAS layer (above the lock + per-attempt dedup); `ApprovalLifecycle` is the gateway path (bus machine = future sibling); `QuotaCounter` assumes the refund succeeds (fail-open rollback out of scope).

Local: `Results: 8 passed, 0 failed`. README, Makefile, and the design-doc status table updated to 8 specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)