### PR TITLE
feat(specs): TLA+ specs for Kafka-bus approval + multi-policy quota rollback

### DIFF
--- a/docs/design/tla-plus-formal-verification.md
+++ b/docs/design/tla-plus-formal-verification.md
@@ -17,7 +17,7 @@ This document identifies **the highest-value areas** in Acteon where TLA+ modeli
 harden correctness, proposes concrete specifications, and provides an implementation
 roadmap.
 
-> **Implementation status (May 2026).** Eight specs are implemented and pass the TLC
+> **Implementation status (May 2026).** Ten specs are implemented and pass the TLC
 > model checker on every run of `specs/tla/ci/run-tlc.sh` (wired into CI as the
 > `TLA+ Specs` job):
 >
@@ -31,19 +31,22 @@ roadmap.
 > | Chain ordering (§4.4) | `ChainOrdering.tla` | Each chain step executed ≤ once and recorded in contiguous order, under concurrent `advance_chain` workers (isolates the fresh re-read CAS at gateway.rs:2986) |
 > | Approval lifecycle (§4.5) | `ApprovalLifecycle.tla` | Approval decided once; side-effect runs ≤ once and only if approved, only after the durable intent (the PR #225 intent-before-flip; gateway 3-state path) |
 > | Quota counter (§7.7) | `QuotaCounter.tla` | No counter drift (no lost increment) and no over-admission past the limit, under concurrent dispatchers (atomic check-and-increment + Block refund) |
+> | Bus approval | `BusApproval.tla` | Kafka pre-publish envelope produced ≤ once and only if approved — `Approving` committed before the produce, idempotent producer + reconciler (the Phase-10 two-phase fix; `core/bus_approval.rs` + `api/bus.rs`) |
+> | Multi-policy quota rollback | `MultiQuotaRollback.tla` | On a block, every counter incremented in the call is rolled back (all-or-nothing) — no partial leak on a non-blocking policy, no over-admit on any policy (`enforce_quota_policies`) |
 >
 > The realized layout deviates from the proposal below in one deliberate way: each spec
 > **inlines** its own lock / state-store state machine instead of sharing `common/`
 > modules, so each can be model-checked in isolation and the proof obligations stay local.
 > Each spec is adversarially validated — reverting the specific fix it models makes TLC
 > report the corresponding violation, so the spec catches the real bug rather than a
-> tautology. The last three were each scoped to the layer they isolate: `ChainOrdering`
-> models the fresh re-read CAS (not the full lock + per-attempt dedup stack);
-> `ApprovalLifecycle` models the gateway 3-state path that PR #225 fixed (the separate
-> 5-state Kafka-bus approval machine in `core/bus_approval.rs` would warrant its own
-> spec); `QuotaCounter` assumes the Block-path refund always succeeds (the fail-open
-> rollback path is out of scope). The natural next targets are the Kafka-bus approval
-> machine and the multi-policy quota rollback.
+> tautology. Each spec is scoped to the layer it isolates: `ChainOrdering` models the
+> fresh re-read CAS (not the full lock + per-attempt dedup stack); `ApprovalLifecycle`
+> models the gateway 3-state path that PR #225 fixed, while `BusApproval` covers the
+> separate 5-state Kafka-bus machine in `core/bus_approval.rs` (the Phase-10 two-phase
+> produce ordering); `QuotaCounter` verifies one counter's atomic check-and-increment,
+> while `MultiQuotaRollback` verifies the cross-policy all-or-nothing rollback on block.
+> `QuotaCounter`/`MultiQuotaRollback` both assume the Block-path refund succeeds (the
+> fail-open rollback that can leave ghost consumption is out of scope).
 
 ---
 
@@ -537,14 +540,18 @@ specs/
     ApprovalLifecycle.cfg
     QuotaCounter.tla                 # quota no-drift + no-over-admit (§7.7)
     QuotaCounter.cfg
+    BusApproval.tla                  # Kafka pre-publish approval, publish-once two-phase
+    BusApproval.cfg
+    MultiQuotaRollback.tla           # multi-policy quota all-or-nothing rollback on block
+    MultiQuotaRollback.cfg
     Makefile                         # Automation: `make check-all`
     ci/
       run-tlc.sh                     # auto-discovers every *.cfg; used by CI
 ```
 
-All eight specs follow the same inlined, self-contained convention. The next
-candidates are the Kafka-bus 5-state approval machine (`core/bus_approval.rs`,
-distinct from the gateway path modeled here) and the multi-policy quota rollback.
+All ten specs follow the same inlined, self-contained convention. Remaining
+candidates for future work: the A2A Task pause/resume state machine
+(`core/bus_task.rs`), and the chain DAG cancel-cascade across sub-chains.
 
 ### 5.3 CI Integration
 

--- a/specs/tla/BusApproval.cfg
+++ b/specs/tla/BusApproval.cfg
@@ -1,0 +1,15 @@
+\* BusApproval model-checking configuration (Kafka-bus pre-publish HITL, Phase 10)
+CONSTANTS
+    Operators = {o1, o2}
+    Reconcilers = {x1}
+    TTL = 2
+    MaxTime = 4
+    NOBODY = NOBODY
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    PublishAtMostOnce
+    PublishOnlyIfApproved
+    DecisionTerminal

--- a/specs/tla/BusApproval.tla
+++ b/specs/tla/BusApproval.tla
@@ -1,0 +1,218 @@
+----------------------------- MODULE BusApproval -----------------------------
+(*
+ * TLA+ specification of Acteon's Kafka-bus PRE-PUBLISH human-in-the-loop (HITL)
+ * approval — the Phase-10 two-phase 5-state machine. This is a DIFFERENT
+ * subsystem from the gateway HITL path in ApprovalLifecycle.tla: here a parked
+ * bus envelope is produced to Kafka only after an operator approves.
+ *
+ * Models:
+ *   - crates/core/src/bus_approval.rs : enum BusApprovalStatus
+ *     { Pending, Approving, Approved, Rejected, Expired } and is_terminal()
+ *     (Approved | Rejected | Expired terminal; Pending & Approving non-terminal).
+ *   - crates/server/src/api/bus.rs : approve_bus_approval (~8023..8262) and
+ *     reject_bus_approval (~8308..8374).
+ *   - crates/server/src/bus_reconciler.rs : retry_approving_row (~166..264),
+ *     the background reconciler for stuck Approving rows.
+ *
+ * Protocol (the Phase-10 two-phase fix). An operator approval is a TWO-PHASE
+ * commit around the Kafka produce:
+ *
+ *   approve, from Pending:
+ *     CAS Pending -> Approving      (committed FIRST, bus.rs:8079; stamps
+ *                                    decided_by — row is now ineligible for
+ *                                    reject)
+ *     backend.produce(envelope)     (fires WHILE Approving, bus.rs:8187)
+ *     CAS Approving -> Approved      (only after the produce succeeded,
+ *                                    bus.rs:8231; records produced offset)
+ *
+ *   The produce is IDEMPOTENT, so the reconciler (bus_reconciler.rs) retrying a
+ *   stuck Approving row re-produces with no duplicate Kafka record, then runs
+ *   the same Approving -> Approved CAS (a no-op if the row already left
+ *   Approving, bus.rs:239..243).
+ *
+ *   reject is reachable ONLY from Pending (bus.rs:8356 — "only Pending is
+ *   rejectable"; an Approving row's envelope is in flight). expire is likewise
+ *   only from Pending (TTL elapsed before any decision). Approved / Rejected /
+ *   Expired are terminal.
+ *
+ * The V1 (Phase 6c) bug this fixed (bus_approval.rs:54..60): Pending -> Approved
+ * in ONE step *after* the produce, so a successful produce + a failed CAS left
+ * the row looking Pending. Then (a) a reject could fire on an ALREADY-PUBLISHED
+ * envelope, and (b) a non-idempotent retry could DOUBLE-PUBLISH.
+ *
+ * Verified (over every interleaving of two concurrent operators, a reconciler,
+ * and TTL expiry):
+ *   - PublishAtMostOnce: the envelope is produced to Kafka at most once across
+ *     reconciler retries and crashes (idempotent producer) — publish_count <= 1.
+ *   - PublishOnlyIfApproved: a published row is on the approve path only
+ *     (published => status \in {approving, approved}); a rejected or expired row
+ *     is never published.
+ *   - DecisionTerminal: reject/expire are reachable only from Pending; once
+ *     Approving the row never becomes Rejected/Expired; Approved/Rejected/
+ *     Expired are terminal except for an explicit Recycle to a fresh window.
+ *
+ * SCOPE. Abstracts away: the per-row CAS version contention (cas_update's retry
+ * loop — modeled as an atomic guarded transition), the multi-tenant key shape,
+ * the conversation/topic resolution and schema re-validation at produce time,
+ * and the audit/index side-writes. It models a SINGLE approval row and treats
+ * "produce" as one idempotent boolean side-effect. Models the produce as
+ * always-eventually-succeeding (the failure path simply leaves the row
+ * Approving for the next retry, which this spec already covers).
+ *
+ * Negative check: revert to the V1 single-phase machine — produce while still
+ * Pending, flip Pending -> Approved AFTER the produce, and keep reject reachable
+ * from Pending. TLC then finds a published row that gets Rejected
+ * (PublishOnlyIfApproved violated) and, with a non-idempotent re-produce, a
+ * publish_count reaching 2 (PublishAtMostOnce violated).
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config BusApproval.cfg BusApproval.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    Operators,    \* concurrent operator approve actors / replicas, e.g. {o1, o2}
+    Reconcilers,  \* background reconciler workers retrying Approving, e.g. {x1}
+    TTL,          \* approval time-to-live in ticks (expiry gate)
+    MaxTime,      \* state-space / clock bound
+    NOBODY        \* sentinel: no actor is driving the in-flight approve
+
+\* Actors that can drive the approve produce + flip: operators and reconcilers.
+Approvers == Operators \cup Reconcilers
+
+VARIABLES
+    status,         \* "pending" | "approving" | "approved" | "rejected" | "expired"
+    published,      \* BOOLEAN: the parked envelope landed on Kafka
+    publish_count,  \* 0..3: number of distinct Kafka produces (idempotent => <= 1)
+    claim,          \* Approvers \cup {NOBODY}: who claimed the row into Approving
+    clock           \* 0..MaxTime: monotone tick clock; expiry gate at clock >= TTL
+
+vars == <<status, published, publish_count, claim, clock>>
+
+TypeOK ==
+    /\ status \in {"pending", "approving", "approved", "rejected", "expired"}
+    /\ published \in BOOLEAN
+    /\ publish_count \in 0..3
+    /\ claim \in Approvers \cup {NOBODY}
+    /\ clock \in 0..MaxTime
+
+Init ==
+    /\ status = "pending"
+    /\ published = FALSE
+    /\ publish_count = 0
+    /\ claim = NOBODY
+    /\ clock = 0
+
+\* PHASE 1 (bus.rs:8079). An operator wins the CAS Pending -> Approving, FIRST,
+\* before any produce. This stamps decided_by and makes the row ineligible for
+\* reject. The soft-expire read gate (bus.rs:8039 `expires_at < now`) refuses a
+\* claim once the TTL has elapsed — modeled as clock < TTL. cas_update's compare-
+\* and-swap makes this an atomic guarded transition: only one claimant wins.
+ClaimApproving(o) ==
+    /\ o \in Operators
+    /\ status = "pending"
+    /\ claim = NOBODY
+    /\ clock < TTL
+    /\ status' = "approving"
+    /\ claim' = o
+    /\ UNCHANGED <<published, publish_count, clock>>
+
+\* The Kafka produce (bus.rs:8187, bus_reconciler.rs:215). Fires WHILE the row is
+\* Approving, BEFORE the flip to Approved. The producer is IDEMPOTENT: the first
+\* produce sets published and increments the publish counter; a retry (reconciler
+\* re-produce, or a crashed-and-resumed approve) re-runs the produce as a NO-OP
+\* for the count. Any claimed Approver (operator or reconciler) may produce.
+Produce(p) ==
+    /\ p \in Approvers
+    /\ status = "approving"
+    /\ IF published
+       THEN \* Idempotent retry: re-produce is a no-op at the consumer dedup.
+            UNCHANGED <<published, publish_count>>
+       ELSE \* First produce: the envelope lands on Kafka exactly once.
+            /\ published' = TRUE
+            /\ publish_count' = publish_count + 1
+    /\ UNCHANGED <<status, claim, clock>>
+
+\* PHASE 2 (bus.rs:8231, bus_reconciler.rs:244). CAS Approving -> Approved, ONLY
+\* after the produce has landed (published = TRUE). Records the produced offset.
+\* A reconciler that finds the row already left Approving treats it as a no-op
+\* (bus.rs:239); here the guard status = "approving" gives the same effect.
+FlipApproved(p) ==
+    /\ p \in Approvers
+    /\ status = "approving"
+    /\ published = TRUE
+    /\ status' = "approved"
+    /\ claim' = NOBODY
+    /\ UNCHANGED <<published, publish_count, clock>>
+
+\* Reject (bus.rs:8356). Reachable ONLY from Pending — "only Pending is
+\* rejectable". Once Approving the envelope is in flight and reject is refused
+\* (409). No produce, no Kafka footprint.
+Reject(o) ==
+    /\ o \in Operators
+    /\ status = "pending"
+    /\ clock < TTL
+    /\ status' = "rejected"
+    /\ UNCHANGED <<published, publish_count, claim, clock>>
+
+\* Expire. TTL elapses before any decision: Pending -> Expired (same outcome as
+\* Rejected, distinguished for audit). Reachable only from Pending; an Approving
+\* row is past the decision point and is finalized by the reconciler instead.
+Expire ==
+    /\ status = "pending"
+    /\ clock >= TTL
+    /\ status' = "expired"
+    /\ UNCHANGED <<published, publish_count, claim, clock>>
+
+\* Time advances (monotone). Once clock >= TTL the expiry gate refuses new claims
+\* and reject, and Expire becomes enabled for a still-pending row.
+Tick ==
+    /\ clock < MaxTime
+    /\ clock' = clock + 1
+    /\ UNCHANGED <<status, published, publish_count, claim>>
+
+\* Recycle: open a FRESH approval window once the current one has settled into a
+\* terminal status. Keeps the system cycling — no benign terminal deadlock under
+\* -deadlock.
+Settled == status \in {"approved", "rejected", "expired"}
+
+Recycle ==
+    /\ Settled
+    /\ status' = "pending"
+    /\ published' = FALSE
+    /\ publish_count' = 0
+    /\ claim' = NOBODY
+    /\ clock' = 0
+
+Next ==
+    \/ \E o \in Operators : ClaimApproving(o) \/ Reject(o)
+    \/ \E p \in Approvers : Produce(p) \/ FlipApproved(p)
+    \/ Expire
+    \/ Tick
+    \/ Recycle
+
+Spec == Init /\ [][Next]_vars
+
+\* =======================================================================
+\* SAFETY
+\* =======================================================================
+
+\* The envelope is produced to Kafka AT MOST ONCE across reconciler retries and
+\* crashes — the idempotent producer. A non-idempotent re-produce (V1) reaches 2.
+PublishAtMostOnce == publish_count <= 1
+
+\* A published row is on the approve path ONLY: published implies the row is
+\* mid-approve (approving) or approved. A Rejected or Expired row is NEVER
+\* published. V1 (produce while still Pending, reject still allowed) violates
+\* this — a published row gets Rejected.
+PublishOnlyIfApproved == published => status \in {"approving", "approved"}
+
+\* Reject/expire are reachable only from Pending; once Approving the row never
+\* becomes Rejected/Expired; Approved is published-and-flipped. Encodes the
+\* one-way decision boundary the two-phase machine enforces.
+DecisionTerminal ==
+    /\ (status = "approved" => published)
+    /\ (status = "rejected" => ~published)
+    /\ (status = "expired" => ~published)
+
+============================================================================

--- a/specs/tla/Makefile
+++ b/specs/tla/Makefile
@@ -10,6 +10,8 @@
 #   make check-chain        # Run ChainOrdering only
 #   make check-approval     # Run ApprovalLifecycle only
 #   make check-quota        # Run QuotaCounter only
+#   make check-busapproval  # Run BusApproval only
+#   make check-multiquota   # Run MultiQuotaRollback only
 #   make setup              # Download tla2tools.jar
 #   make clean              # Remove downloaded tools
 
@@ -17,7 +19,7 @@ SHELL := /bin/bash
 SPECS_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 CI_SCRIPT := $(SPECS_DIR)ci/run-tlc.sh
 
-.PHONY: check-all check-circuit check-dedup check-hashchain check-recurring check-bus check-chain check-approval check-quota setup clean help
+.PHONY: check-all check-circuit check-dedup check-hashchain check-recurring check-bus check-chain check-approval check-quota check-busapproval check-multiquota setup clean help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -49,6 +51,12 @@ check-approval: ## Run TLC on ApprovalLifecycle spec
 
 check-quota: ## Run TLC on QuotaCounter spec
 	@$(CI_SCRIPT) QuotaCounter
+
+check-busapproval: ## Run TLC on BusApproval spec
+	@$(CI_SCRIPT) BusApproval
+
+check-multiquota: ## Run TLC on MultiQuotaRollback spec
+	@$(CI_SCRIPT) MultiQuotaRollback
 
 setup: ## Download tla2tools.jar (requires curl or wget)
 	@$(CI_SCRIPT) __nonexistent__ 2>/dev/null || true

--- a/specs/tla/MultiQuotaRollback.cfg
+++ b/specs/tla/MultiQuotaRollback.cfg
@@ -1,0 +1,14 @@
+\* MultiQuotaRollback model-checking configuration
+CONSTANTS
+    Dispatchers = {d1, d2}
+    La = 1
+    Lb = 2
+    MaxCount = 3
+    NOBODY = NOBODY
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    AllOrNothingOnBlock
+    NoOverAdmitAnyPolicy

--- a/specs/tla/MultiQuotaRollback.tla
+++ b/specs/tla/MultiQuotaRollback.tla
@@ -1,0 +1,183 @@
+--------------------------- MODULE MultiQuotaRollback ---------------------------
+(*
+ * TLA+ specification of Acteon's MULTI-policy quota enforcement — the
+ * CROSS-policy all-or-nothing rollback when one policy blocks. This is distinct
+ * from QuotaCounter.tla, which verifies a SINGLE counter's atomic
+ * check-and-increment. Here the focus is the interaction ACROSS several Block
+ * policies that share one dispatch.
+ *
+ * Models crates/gateway/src/quota_enforcement.rs:
+ *   - enforce_quota_policies      (~line 182)
+ *   - increment_all_quota_counters(~line 248)
+ *   - pick_winning_quota          (~line 359)
+ * and the OverageBehavior::Block path in crates/core/src/quota.rs
+ * (QuotaPolicy.max_actions / OverageBehavior::Block, ~line 62/145).
+ *
+ * Per the doc comment at quota_enforcement.rs:177 — "Each policy increments its
+ * own counter first (atomic to avoid races). If any block, every counter touched
+ * in this call is rolled back. Otherwise the strictest non-block outcome wins,
+ * with counters left advanced." So for ONE dispatch subject to M Block policies:
+ *
+ *     // increment_all_quota_counters: atomic fetch-add on EVERY counter,
+ *     // observing each post-increment value `used` (state.increment returns it):
+ *     for p in policies { used[p] = state.increment(key[p], +1); }
+ *
+ *     // pick_winning_quota: a policy is exceeded iff used[p] > limit[p]
+ *     // (the code's `inc.used <= inc.policy.max_actions` is "within quota").
+ *     if EXISTS p : used[p] > limit[p] {        // a Block policy is exceeded
+ *         // enforce_quota_policies (is_block branch, ~205): roll back EVERY
+ *         // counter incremented in THIS call, in parallel (-1 each), so the
+ *         // blocked dispatch consumes NO budget on ANY policy.
+ *         for p in policies { state.increment(key[p], -1); }   // BLOCK
+ *     } else {
+ *         // within every limit: ADMIT, all increments stand.
+ *     }
+ *
+ * The admit/block decision uses the per-dispatcher INCREMENT-TIME observed
+ * post-values (what state.increment returned), not a fresh re-read — this spec
+ * captures each post-value into d_obs[d] at increment time and decides on it.
+ *
+ * Protocol modeled. N concurrent dispatchers, each subject to the SAME set of
+ * M = 2 Block-mode policies (limits La, Lb). A dispatcher's enforcement is one
+ * indivisible Step: atomically fetch-add BOTH counters (the per-counter
+ * state.increment is itself atomic, and join_all gathers the post-values),
+ * observe both post-values, then decide on those observed values. If EITHER
+ * observed value exceeds its limit -> BLOCK and roll back BOTH increments (net
+ * zero on both counters). Otherwise ADMIT and both increments stand. A blocked
+ * dispatcher therefore contributes 0 to BOTH counters.
+ *
+ * Verified (over every interleaving of concurrent dispatchers across both
+ * shared counters):
+ *   - AllOrNothingOnBlock / NoPartialLeak: for each policy p the settled
+ *     counter equals the number of ADMITTED dispatchers (counter[p] =
+ *     Cardinality(admitted)). A blocked dispatcher leaves no stale +1 on ANY
+ *     policy — including a policy that did NOT itself exceed its limit.
+ *   - NoOverAdmitAnyPolicy: for each policy p, Cardinality(admitted) <= limit[p]
+ *     — a dispatch is admitted only when within EVERY policy's limit.
+ *
+ * SCOPE. This spec deliberately abstracts away: the fail-open paths (a real
+ * state.increment can fail and the helper then rolls back and fail-opens; the
+ * Block-path rollback is itself best-effort and can leave "ghost consumption"
+ * on a store blip — quota_enforcement.rs:208-225); the non-Block overage
+ * behaviors (Warn/Degrade/Notify) and the strictest-wins precedence; the
+ * provider/principal scope filtering and the policy-key construction. It models
+ * the happy-path counters as exact and both policies as Block, isolating the
+ * one property under test: cross-policy all-or-nothing rollback.
+ *
+ * The fix anchored here is rolling back EVERY counter incremented in this call
+ * (not just the blocking one). Negative check: change the BLOCK branch to roll
+ * back ONLY the policy that exceeded (leaving the non-blocking policy's +1 in
+ * place). A dispatcher blocked because policy A exceeded then leaves a stale +1
+ * on policy B, so counter[B] > Cardinality(admitted) and AllOrNothingOnBlock is
+ * violated (TLC reports counter[B] reaching admitted+1).
+ *
+ * A WindowReset action (fresh quota window: both counters reset to 0) reopens
+ * the work so the system CYCLES — no benign terminal deadlock under -deadlock.
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config MultiQuotaRollback.cfg MultiQuotaRollback.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    Dispatchers,  \* concurrent dispatchers / gateway replicas, e.g. {d1, d2}
+    La,           \* limit of policy "a" (Block over this; used <= La is within)
+    Lb,           \* limit of policy "b"
+    MaxCount,     \* state-space bound on each counter
+    NOBODY        \* sentinel: a dispatcher has not yet observed a value
+
+\* The two Block policies sharing every dispatch.
+Policies == {"a", "b"}
+
+\* Per-policy limit. (.cfg cannot hold a function literal, so this is an
+\* OPERATOR rather than a CONSTANT mapping.)
+Limit(p) == IF p = "a" THEN La ELSE Lb
+
+VARIABLES
+    counter,    \* [Policies -> 0..MaxCount]: the shared QuotaUsage.count per policy
+    admitted,   \* set of Dispatchers whose dispatch was admitted this window
+    blocked,    \* set of Dispatchers blocked (rolled back) this window
+    d_phase,    \* [Dispatchers -> {"idle","done"}]: enforcement progress
+    d_obs       \* [Dispatchers -> [Policies -> NOBODY \cup (1..MaxCount)]]:
+                \* per-policy post-increment value observed at increment time
+
+TypeOK ==
+    /\ counter \in [Policies -> 0..MaxCount]
+    /\ admitted \subseteq Dispatchers
+    /\ blocked \subseteq Dispatchers
+    /\ d_phase \in [Dispatchers -> {"idle", "done"}]
+    /\ d_obs \in [Dispatchers -> [Policies -> (1..MaxCount) \cup {NOBODY}]]
+
+Init ==
+    /\ counter = [p \in Policies |-> 0]
+    /\ admitted = {}
+    /\ blocked = {}
+    /\ d_phase = [d \in Dispatchers |-> "idle"]
+    /\ d_obs = [d \in Dispatchers |-> [p \in Policies |-> NOBODY]]
+
+\* One dispatcher's enforcement, as ONE indivisible Step. This models
+\* increment_all_quota_counters followed by pick_winning_quota and the is_block
+\* rollback in enforce_quota_policies. Each counter's fetch-add is atomic
+\* (state.increment); the post-values are observed here (d_obs) and the
+\* admit/block decision is made on THOSE observed values — not a fresh re-read.
+\*
+\*   post[p] = counter[p] + 1     for every policy p   (atomic fetch-add)
+\*   if EXISTS p : post[p] > Limit(p)   -> BLOCK: roll back EVERY counter
+\*                                         (net zero on both) -> blocked
+\*   else                               -> ADMIT: both increments stand -> admitted
+Step(d) ==
+    /\ d_phase[d] = "idle"
+    /\ \A p \in Policies : counter[p] < MaxCount
+    /\ LET post == [p \in Policies |-> counter[p] + 1] IN
+       IF \E p \in Policies : post[p] > Limit(p)
+       THEN \* At least one Block policy exceeded: BLOCK and roll back BOTH
+            \* counters (net zero change on every policy). The fix under test:
+            \* EVERY incremented counter is rolled back, not just the exceeder.
+            /\ counter' = counter
+            /\ admitted' = admitted
+            /\ blocked' = blocked \cup {d}
+            /\ d_obs' = [d_obs EXCEPT ![d] = post]
+       ELSE \* Within every limit: ADMIT, all increments stand.
+            /\ counter' = [p \in Policies |-> counter[p] + 1]
+            /\ admitted' = admitted \cup {d}
+            /\ blocked' = blocked
+            /\ d_obs' = [d_obs EXCEPT ![d] = post]
+    /\ d_phase' = [d_phase EXCEPT ![d] = "done"]
+
+\* A fresh quota window opens (epoch-aligned window index rolls over, TTL'd
+\* counters reset). Clean boundary: every dispatcher has finished enforcing.
+\* Reopens the work so the system cycles — no terminal deadlock.
+WindowReset ==
+    /\ \A d \in Dispatchers : d_phase[d] = "done"
+    /\ counter' = [p \in Policies |-> 0]
+    /\ admitted' = {}
+    /\ blocked' = {}
+    /\ d_phase' = [d \in Dispatchers |-> "idle"]
+    /\ d_obs' = [d \in Dispatchers |-> [p \in Policies |-> NOBODY]]
+
+Next ==
+    \/ \E d \in Dispatchers : Step(d)
+    \/ WindowReset
+
+vars == <<counter, admitted, blocked, d_phase, d_obs>>
+Spec == Init /\ [][Next]_vars
+
+\* =======================================================================
+\* SAFETY
+\* =======================================================================
+
+\* All-or-nothing on block / no partial leak: for EVERY policy the settled
+\* counter equals the number of admitted dispatchers. A blocked dispatcher
+\* contributes 0 to every counter — including a policy that did not itself
+\* exceed. With a buggy partial rollback (only the exceeding policy refunded),
+\* the non-blocking policy's counter exceeds the admitted count, violating this.
+AllOrNothingOnBlock ==
+    \A p \in Policies : counter[p] = Cardinality(admitted)
+
+\* No over-admission on any policy: the number of admitted dispatches never
+\* exceeds any policy's limit (a dispatch is admitted only when within EVERY
+\* policy's limit, blocked if ANY exceeds).
+NoOverAdmitAnyPolicy ==
+    \A p \in Policies : Cardinality(admitted) <= Limit(p)
+
+===============================================================================

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -26,14 +26,17 @@ for the full research document.
 | **Chain Ordering** | `ChainOrdering.tla` | `gateway.rs` `advance_chain` fresh re-read CAS (line 2986) | Each chain step is executed **at most once** and recorded **in contiguous order**, under concurrent `advance_chain` workers (isolates the idempotency-CAS layer) |
 | **Approval Lifecycle** | `ApprovalLifecycle.tla` | `gateway.rs` `execute_approval` / `reject_approval` (the PR #225 two-phase) | An approval is decided once; the side-effect runs **at most once and only if approved**, only after the durable intent is recorded (intent-before-execute) |
 | **Quota Counter** | `QuotaCounter.tla` | `gateway/quota_enforcement.rs` atomic check-and-increment + Block refund | **No counter drift** (no lost increment) and **no over-admission** past the limit, under concurrent dispatchers |
+| **Bus Approval** | `BusApproval.tla` | `core/bus_approval.rs` + `api/bus.rs` Kafka pre-publish two-phase (Phase-10) | The parked envelope is published **at most once** and **only if approved** — `Approving` is committed before the produce; idempotent producer + reconciler |
+| **Multi-Quota Rollback** | `MultiQuotaRollback.tla` | `gateway/quota_enforcement.rs` `enforce_quota_policies` block rollback | On a block, **every** counter touched is rolled back (all-or-nothing) — no partial leak on a non-blocking policy; no over-admit on any policy |
 
 Each spec is self-contained: it inlines its own lock / state-store state machine
 rather than sharing a module, so each can be model-checked independently.
 
 Each spec is also adversarially validated: reverting the specific fix it models
 (the max-tip read, the pre-dispatch re-arm, the flush mutex, the step re-read CAS,
-the intent-before-flip ordering, the increment atomicity) makes TLC report the
-corresponding safety violation. The specs catch the real bug, not just a tautology.
+the intent-before-flip ordering, the increment atomicity, the two-phase produce
+ordering, the all-or-nothing rollback) makes TLC report the corresponding safety
+violation. The specs catch the real bug, not just a tautology.
 
 ## Quick Start
 
@@ -76,7 +79,7 @@ tla-specs:
 ```
 
 The CI configuration uses small model parameters (2 of each principal) for fast
-feedback (all eight specs finish in a few seconds total). For nightly runs,
+feedback (all ten specs finish in a few seconds total). For nightly runs,
 increase the constants in the `.cfg` files for deeper coverage.
 
 ## Project Structure
@@ -99,6 +102,10 @@ specs/tla/
   ApprovalLifecycle.cfg
   QuotaCounter.tla         # Spec: quota counter no-drift + no-over-admit
   QuotaCounter.cfg
+  BusApproval.tla          # Spec: Kafka pre-publish approval, publish-once two-phase
+  BusApproval.cfg
+  MultiQuotaRollback.tla   # Spec: multi-policy quota all-or-nothing rollback on block
+  MultiQuotaRollback.cfg
   ci/
     run-tlc.sh             # CI runner (auto-discovers every *.cfg)
   Makefile                 # Convenience targets


### PR DESCRIPTION
## What

Extends the TLA+ suite to **10 model-checked specs**, covering the two protocols flagged as next targets. Both pass TLC on every CI run, are adversarially validated, **and** faithfulness-checked against the real Rust by an independent reviewer.

## Specs

| Spec | Models | Safety property | Negative check |
|------|--------|-----------------|----------------|
| `BusApproval` | `core/bus_approval.rs` + `api/bus.rs` Kafka pre-publish two-phase (Phase-10) | envelope produced ≤once and only-if-approved; `Approving` committed *before* produce; reject/expire only from `Pending` | revert to V1 single-phase (produce while Pending, flip after) → published row gets Rejected (`PublishOnlyIfApproved`) + non-idempotent re-produce → `publish_count=2` (`PublishAtMostOnce`) |
| `MultiQuotaRollback` | `quota_enforcement.rs` `enforce_quota_policies` block rollback | on a block, **every** counter touched is rolled back → `counter[p] = |admitted|` for every policy; no over-admit on any policy | refund only the exceeding policy → non-blocking counter over-counts the blocked dispatcher (`counter[b]=2 > |admitted|=1`), `AllOrNothingOnBlock` violated |

## Why these are distinct from existing specs

- `BusApproval` is the **Kafka bus** subsystem, separate from the gateway `ApprovalLifecycle` (#239). Its ordering is the *opposite*: the side-effect (produce) fires *in* `Approving`, *before* the flip to `Approved` — the V1 bug was a single-step Pending→Approved *after* produce, where a successful produce + failed CAS left the row rejectable/re-publishable. Idempotent producer + reconciler close the gap.
- `MultiQuotaRollback` verifies the **cross-policy** all-or-nothing rollback, where `QuotaCounter` (#239) verified a single counter's atomic check-and-increment.

## Faithfulness

Each spec was authored from the real Rust and cross-checked by an independent **faithfulness critic** (the pattern that caught a chimera in #239). For `BusApproval` the critic confirmed from the code that the produce fires in `Approving` *before* the `Approved` flip (bus.rs:8079→8187→8231) and that reject is refused for any non-`Pending` row; for `MultiQuotaRollback`, that a block rolls back *all* counters and the decision uses increment-time observed values. Both negative tests were also reproduced first-hand.

Local: `Results: 10 passed, 0 failed`. README, Makefile, and the design-doc status table updated to 10 specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)