### PR TITLE
feat(specs): TLA+ specs for A2A task transitions + chain cancel-cascade

### DIFF
--- a/docs/design/tla-plus-formal-verification.md
+++ b/docs/design/tla-plus-formal-verification.md
@@ -17,7 +17,7 @@ This document identifies **the highest-value areas** in Acteon where TLA+ modeli
 harden correctness, proposes concrete specifications, and provides an implementation
 roadmap.
 
-> **Implementation status (May 2026).** Ten specs are implemented and pass the TLC
+> **Implementation status (May 2026).** Twelve specs are implemented and pass the TLC
 > model checker on every run of `specs/tla/ci/run-tlc.sh` (wired into CI as the
 > `TLA+ Specs` job):
 >
@@ -33,6 +33,8 @@ roadmap.
 > | Quota counter (§7.7) | `QuotaCounter.tla` | No counter drift (no lost increment) and no over-admission past the limit, under concurrent dispatchers (atomic check-and-increment + Block refund) |
 > | Bus approval | `BusApproval.tla` | Kafka pre-publish envelope produced ≤ once and only if approved — `Approving` committed before the produce, idempotent producer + reconciler (the Phase-10 two-phase fix; `core/bus_approval.rs` + `api/bus.rs`) |
 > | Multi-policy quota rollback | `MultiQuotaRollback.tla` | On a block, every counter incremented in the call is rolled back (all-or-nothing) — no partial leak on a non-blocking policy, no over-admit on any policy (`enforce_quota_policies`) |
+> | A2A task transition | `A2aTaskTransition.tla` | Every committed A2A task transition is legal (`can_transition_to`) and terminal stays terminal, under concurrent optimistic version-CAS that re-validates against the fresh row (`core/bus_task.rs` + `task_engine.rs cas_mutate`) |
+> | Chain cancel-cascade | `ChainCancelCascade.tla` | A cancel cascades to every running descendant (no orphan) and a cancelled chain never resurrects — load-bearing on both the recursion and the WaitingSubChain completion coupling (`cancel_chain` + `advance_chain`) |
 >
 > The realized layout deviates from the proposal below in one deliberate way: each spec
 > **inlines** its own lock / state-store state machine instead of sharing `common/`
@@ -544,14 +546,18 @@ specs/
     BusApproval.cfg
     MultiQuotaRollback.tla           # multi-policy quota all-or-nothing rollback on block
     MultiQuotaRollback.cfg
+    A2aTaskTransition.tla            # A2A task version-CAS legal transitions
+    A2aTaskTransition.cfg
+    ChainCancelCascade.tla           # chain cancel-cascade, no orphan, no resurrection
+    ChainCancelCascade.cfg
     Makefile                         # Automation: `make check-all`
     ci/
       run-tlc.sh                     # auto-discovers every *.cfg; used by CI
 ```
 
-All ten specs follow the same inlined, self-contained convention. Remaining
-candidates for future work: the A2A Task pause/resume state machine
-(`core/bus_task.rs`), and the chain DAG cancel-cascade across sub-chains.
+All twelve specs follow the same inlined, self-contained convention. Remaining
+candidates for future work: the message-bus subscription fan-out / replay
+cursor, the DLQ redelivery dedup, and the retention reaper vs. live-write race.
 
 ### 5.3 CI Integration
 

--- a/specs/tla/A2aTaskTransition.cfg
+++ b/specs/tla/A2aTaskTransition.cfg
@@ -1,0 +1,18 @@
+\* A2aTaskTransition model-checking configuration
+\*
+\* Small parameters for CI (~seconds). The allowed-graph mapping is an
+\* operator (CanTransition) in the module, so no function literal is needed.
+
+CONSTANTS
+    Actors = {w1, w2}
+    MaxVer = 3
+    NOBODY = NOBODY
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    AllTransitionsLegal
+
+PROPERTIES
+    TerminalStaysTerminal

--- a/specs/tla/A2aTaskTransition.tla
+++ b/specs/tla/A2aTaskTransition.tla
@@ -1,0 +1,234 @@
+------------------------- MODULE A2aTaskTransition -------------------------
+(*
+ * TLA+ specification of Acteon's A2A Task state machine under concurrent
+ * optimistic-CAS transitions.
+ *
+ * Models:
+ *   - crates/core/src/bus_task.rs :: TaskState::can_transition_to — the exact
+ *     allowed graph, enforced by Task::transition_to (which errors on an
+ *     illegal transition, validating against the task's CURRENT state).
+ *   - crates/gateway/src/task_engine.rs :: cas_mutate (~line 808) and
+ *     transition_task (~line 327). The mutation is OPTIMISTIC version-CAS:
+ *         let (raw, version) = state.get_versioned(key)?;   // READ (state+version)
+ *         let mut task = deserialize(raw);
+ *         mutate(&mut task);            // task.transition_to(next) RE-VALIDATES
+ *                                       // can_transition_to against the FRESH
+ *                                       // loaded state, errors if illegal
+ *         compare_and_swap(key, version, serialize(task))?;  // COMMIT iff version
+ *                                                            // unchanged
+ *     On CasResult::Conflict the loop RE-READS and RE-APPLIES the closure
+ *     against the new fresh state (up to MAX_CAS_RETRY_ATTEMPTS).
+ *
+ * Protocol. A single Task row carries a `state` and a `version` counter.
+ * N concurrent actors each attempt a transition (a worker advancing
+ * Working -> Completed/Failed/interrupt; a user resuming an interrupt to
+ * Working; a canceller -> Canceled). Each actor:
+ *   1. READS (state, version) and picks an intended `next` that is legal
+ *      from the READ state.
+ *   2. COMMITS via version-CAS — the commit succeeds ONLY IF the version is
+ *      unchanged AND can_transition_to(current_state, next) holds against the
+ *      FRESH row (faithful to transition_to re-validating on the fresh load).
+ * On a version conflict the actor re-reads and retries. Because the version
+ * bumps on every committed transition, the loser of a race re-reads the
+ * winner's new state; its intended transition may now be illegal -> it is
+ * refused, never committed.
+ *
+ * The READ and the COMMIT are SEPARATE steps so the version-CAS is load-
+ * bearing (a stale read can survive a concurrent commit), mirroring the
+ * read/commit split in MessageBus.tla. With version-CAS, a stale committer
+ * loses the CAS and never overwrites the winner's state.
+ *
+ * Verified (over every interleaving of concurrent actors):
+ *   - AllTransitionsLegal: every COMMITTED transition obeys can_transition_to;
+ *     the `illegal_commit` flag (set TRUE if any commit moves from S to T with
+ *     ~can_transition_to(S,T)) stays FALSE.
+ *   - TerminalStaysTerminal: once the task is in a terminal state it never
+ *     changes state again (until an explicit Recycle replaces the row).
+ *
+ * Negative check: replace the version-CAS commit with a BLIND versionless
+ * write (drop the `version = read_version` guard AND re-validate against the
+ * STALE read state instead of the fresh row). A slow actor that read Working
+ * then commits AFTER a concurrent actor already drove the task to a terminal
+ * state overwrites that terminal state with an illegal transition out of it ->
+ * AllTransitionsLegal and TerminalStaysTerminal are both violated.
+ *
+ * SCOPE. Isolates the optimistic version-CAS + fresh re-validation layer of a
+ * single Task row. It abstracts away: the dispatch/per-key lock, the message
+ * dedup key, history/artifact mutations, the stale-task reaper, and chain
+ * linkage — those are separate concerns. `Recycle` models a fresh Task minted
+ * at the same key once the prior one is terminal, so the system CYCLES (no
+ * benign terminal deadlock under -deadlock).
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config A2aTaskTransition.cfg A2aTaskTransition.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    Actors,    \* concurrent transition attempts / gateway replicas, e.g. {w1, w2}
+    MaxVer,    \* state-space bound on the version counter
+    NOBODY     \* sentinel: actor holds no in-flight read (or no target picked)
+
+\* -----------------------------------------------------------------------
+\* The eight A2A task states (crates/core/src/bus_task.rs::TaskState).
+\* -----------------------------------------------------------------------
+Submitted     == "submitted"
+Working       == "working"
+Completed     == "completed"
+Failed        == "failed"
+Canceled      == "canceled"
+InputRequired == "input_required"
+AuthRequired  == "auth_required"
+Rejected      == "rejected"
+
+States == { Submitted, Working, Completed, Failed, Canceled,
+            InputRequired, AuthRequired, Rejected }
+
+Terminal == { Completed, Failed, Canceled, Rejected }
+
+\* TaskState::can_transition_to — the EXACT allowed graph from bus_task.rs.
+\* An operator (not a .cfg function literal) so the .cfg stays clean.
+CanTransition(s, t) ==
+    \/ /\ s = Submitted     /\ t \in { Working, Canceled, Failed, Rejected }
+    \/ /\ s = Working       /\ t \in { Completed, Failed, Canceled,
+                                       InputRequired, AuthRequired }
+    \/ /\ s \in { InputRequired, AuthRequired }
+       /\ t \in { Working, Canceled, Failed }
+    \* Terminal states have no outgoing transitions.
+
+\* -----------------------------------------------------------------------
+\* Variables
+\* -----------------------------------------------------------------------
+VARIABLES
+    task_state,      \* current persisted state of the single Task row
+    version,         \* optimistic-CAS version, bumped on every committed transition
+    illegal_commit,  \* BOOLEAN: TRUE iff any commit ever broke can_transition_to
+    a_phase,         \* [Actors -> {"idle","committing"}]
+    a_read_state,    \* [Actors -> States \cup {NOBODY}]: state observed at READ
+    a_read_ver,      \* [Actors -> 0..MaxVer]: version observed at READ
+    a_target         \* [Actors -> States \cup {NOBODY}]: intended next state
+
+TypeOK ==
+    /\ task_state \in States
+    /\ version \in 0..MaxVer
+    /\ illegal_commit \in BOOLEAN
+    /\ a_phase \in [Actors -> {"idle", "committing"}]
+    /\ a_read_state \in [Actors -> States \cup {NOBODY}]
+    /\ a_read_ver \in [Actors -> 0..MaxVer]
+    /\ a_target \in [Actors -> States \cup {NOBODY}]
+
+Init ==
+    /\ task_state = Submitted
+    /\ version = 0
+    /\ illegal_commit = FALSE
+    /\ a_phase = [a \in Actors |-> "idle"]
+    /\ a_read_state = [a \in Actors |-> NOBODY]
+    /\ a_read_ver = [a \in Actors |-> 0]
+    /\ a_target = [a \in Actors |-> NOBODY]
+
+\* -----------------------------------------------------------------------
+\* Actions
+\* -----------------------------------------------------------------------
+
+\* READ phase: get_versioned(key) -> (state, version), then pick an intended
+\* `next` that is LEGAL from the just-read state — what transition_task's
+\* caller chooses. The snapshot may be stale by the time the actor commits.
+\* A version conflict re-enters this action (re-read + re-apply), so a
+\* committing actor may also re-read here.
+Read(a, t) ==
+    /\ a_phase[a] = "idle"
+    /\ CanTransition(task_state, t)
+    /\ a_read_state' = [a_read_state EXCEPT ![a] = task_state]
+    /\ a_read_ver'   = [a_read_ver   EXCEPT ![a] = version]
+    /\ a_target'     = [a_target     EXCEPT ![a] = t]
+    /\ a_phase'      = [a_phase      EXCEPT ![a] = "committing"]
+    /\ UNCHANGED <<task_state, version, illegal_commit>>
+
+\* COMMIT phase: version-CAS. compare_and_swap(key, read_version, payload)
+\* succeeds ONLY IF the version is unchanged since the read. transition_to
+\* additionally RE-VALIDATES can_transition_to against the FRESH loaded row;
+\* with the version-CAS the fresh row IS the read row, so re-validation always
+\* holds on the winning path — modeled explicitly to keep the guard faithful.
+CommitWin(a) ==
+    /\ a_phase[a] = "committing"
+    /\ version < MaxVer                          \* bound the version counter (CI)
+    /\ a_read_ver[a] = version                  \* CAS: version unchanged
+    /\ CanTransition(task_state, a_target[a])    \* transition_to re-validation
+    /\ task_state' = a_target[a]
+    /\ version' = version + 1
+    \* Track any illegal committed move; with the guards above it stays FALSE.
+    /\ illegal_commit' =
+         (illegal_commit \/ ~CanTransition(task_state, a_target[a]))
+    /\ a_phase'      = [a_phase      EXCEPT ![a] = "idle"]
+    /\ a_read_state' = [a_read_state EXCEPT ![a] = NOBODY]
+    /\ a_target'     = [a_target     EXCEPT ![a] = NOBODY]
+    /\ UNCHANGED a_read_ver
+
+\* COMMIT conflict: a concurrent actor bumped the version since this actor's
+\* read (CasResult::Conflict). The actor abandons its stale attempt and
+\* returns to idle to re-read (the cas_mutate retry loop).
+CommitConflict(a) ==
+    /\ a_phase[a] = "committing"
+    /\ a_read_ver[a] # version                  \* CAS failed: version moved
+    /\ a_phase'      = [a_phase      EXCEPT ![a] = "idle"]
+    /\ a_read_state' = [a_read_state EXCEPT ![a] = NOBODY]
+    /\ a_target'     = [a_target     EXCEPT ![a] = NOBODY]
+    /\ UNCHANGED <<task_state, version, illegal_commit, a_read_ver>>
+
+\* Once the version counter saturates the bound, an actor mid-flight gives up
+\* (CAS attempts exhausted / no further progress representable). Keeps the
+\* state space finite without falsely deadlocking before Recycle can fire.
+GiveUp(a) ==
+    /\ a_phase[a] = "committing"
+    /\ version = MaxVer
+    /\ a_phase'      = [a_phase      EXCEPT ![a] = "idle"]
+    /\ a_read_state' = [a_read_state EXCEPT ![a] = NOBODY]
+    /\ a_target'     = [a_target     EXCEPT ![a] = NOBODY]
+    /\ UNCHANGED <<task_state, version, illegal_commit, a_read_ver>>
+
+\* Recycle: once the Task is terminal and no actor is mid-flight, a fresh Task
+\* is minted at the same key (Submitted, version reset). The system CYCLES so
+\* there is no benign terminal deadlock under -deadlock.
+Recycle ==
+    /\ task_state \in Terminal
+    /\ \A a \in Actors : a_phase[a] = "idle"
+    /\ task_state' = Submitted
+    /\ version' = 0
+    /\ a_read_state' = [a \in Actors |-> NOBODY]
+    /\ a_read_ver'   = [a \in Actors |-> 0]
+    /\ a_target'     = [a \in Actors |-> NOBODY]
+    /\ UNCHANGED <<illegal_commit, a_phase>>
+
+Next ==
+    \/ \E a \in Actors :
+        \/ \E t \in States : Read(a, t)
+        \/ CommitWin(a)
+        \/ CommitConflict(a)
+        \/ GiveUp(a)
+    \/ Recycle
+
+vars == <<task_state, version, illegal_commit,
+          a_phase, a_read_state, a_read_ver, a_target>>
+
+Spec == Init /\ [][Next]_vars
+
+\* =======================================================================
+\* SAFETY
+\* =======================================================================
+
+\* Every committed transition obeys can_transition_to. The flag is set TRUE
+\* by any commit that moves from S to T with ~CanTransition(S, T); it must
+\* stay FALSE under the version-CAS + fresh re-validation.
+AllTransitionsLegal == illegal_commit = FALSE
+
+\* Once the task is in a terminal state it makes no further transition: no
+\* actor mid-flight that read a non-terminal state can still win the CAS and
+\* overwrite the terminal row. (Recycle is the only path out, and it mints a
+\* brand-new task rather than transitioning the terminal one.) Encoded as a
+\* two-state action property: from any terminal state, the only allowed
+\* same-row change is a Recycle (version drops to 0).
+TerminalStaysTerminal ==
+    [][ (task_state \in Terminal /\ task_state' # task_state)
+        => (task_state' = Submitted /\ version' = 0) ]_vars
+
+============================================================================

--- a/specs/tla/ChainCancelCascade.cfg
+++ b/specs/tla/ChainCancelCascade.cfg
@@ -1,0 +1,20 @@
+\* Configuration for ChainCancelCascade.tla
+\*
+\* The four chain ids are bound as distinct model values. Chains and Root are
+\* DERIVED in the .tla from these, and the acyclic tree (child_chain_ids) is
+\* wired in the .tla Children operator (a .cfg cannot hold a function literal):
+\*     R -> {C1, C2},  C1 -> {G},  C2 -> {},  G -> {}
+\* Root (= R) is the chain whose cancellation seeds the recursive cascade.
+
+CONSTANTS
+    R = R
+    C1 = C1
+    C2 = C2
+    G = G
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    NoResurrection
+    NoOrphanedRunningDescendant

--- a/specs/tla/ChainCancelCascade.tla
+++ b/specs/tla/ChainCancelCascade.tla
@@ -1,0 +1,210 @@
+-------------------------- MODULE ChainCancelCascade ------------------------
+(*
+ * TLA+ specification of Acteon's recursive chain-cancellation cascade.
+ *
+ * Models crates/gateway/src/gateway.rs:
+ *   - fn cancel_chain   (~5461): acquires the per-chain lock "chain:{chain_id}",
+ *     guards on status \in {Running, WaitingSubChain, WaitingParallel}. A chain
+ *     already terminal (Completed/Failed/Cancelled/TimedOut) returns Err at the
+ *     guard (gateway.rs:5488..5499) and is LEFT untouched — crucially, this
+ *     return happens BEFORE the child-recursion loop (gateway.rs:5536), so the
+ *     cascade does NOT descend into an already-terminal chain's children. A
+ *     non-terminal chain is flipped -> Cancelled, persisted; the lock is
+ *     RELEASED, and only THEN does cancel_chain recurse over
+ *     chain_state.child_chain_ids (best-effort: a child already terminal returns
+ *     the same Err, caught and ignored — "may already be terminal").
+ *   - fn advance_chain  (~2544): under the SAME per-chain lock; its guard (~2574)
+ *     only advances status \in {Running, WaitingSubChain, WaitingParallel}, so a
+ *     Cancelled chain can never advance / complete (no resurrection). A chain
+ *     with a sub-chain step enters ChainStatus::WaitingSubChain (gateway.rs:2711)
+ *     and advances past that step ONLY once the child is observed terminal
+ *     (Completed 2735->2763; Failed/TimedOut/Cancelled 2784). So a parent reaches
+ *     a terminal status ONLY AFTER all of its children are already terminal.
+ *   - ChainState.child_chain_ids / parent_chain_id (crates/core/src/chain.rs).
+ *     The chain graph is an acyclic tree (validate_chain_graph enforces this at
+ *     build time), so the recursive cascade terminates.
+ *
+ * Protocol. A small FIXED acyclic tree of chains: root r with children c1, c2,
+ * and a grandchild g under c1. Each chain has a status, abstracted to
+ *   "running" | "completed" | "cancelled"
+ * where "completed" stands for any self-terminal outcome. Concurrent actions are
+ * serialized per-chain by the lock (cancel-vs-advance on ONE chain is mutually
+ * exclusive); the cascade itself runs WITHOUT the parent lock held.
+ *
+ *   Advance(c): a Running chain finishes on its own -> Completed, but ONLY once
+ *     all of its children are already terminal — the WaitingSubChain coupling
+ *     (gateway.rs:2711/2735/2763): a parent never completes ahead of its children.
+ *   CancelRoot: open a cancel of the root -> seed the cascade work-set with {r}.
+ *   CascadeStep(c): pop c from the work-set. If c is Running, flip it to Cancelled
+ *     and RECURSE — enqueue its children (cancel_chain proceeds past the guard
+ *     into the child loop). If c is already terminal, SKIP it and do NOT enqueue
+ *     its children (cancel_chain returns Err at the guard, before the child loop).
+ *   The work-set captures the recursion; it drains to {} when the cascade is done.
+ *
+ * Verified (over every interleaving of concurrent self-completion and the
+ * cancel cascade):
+ *   - NoResurrection: a Cancelled chain never becomes Running or Completed again
+ *     (advance refuses non-Running) — Cancelled is terminal.
+ *   - NoOrphanedRunningDescendant: once a cascade seeded from the cancelled root
+ *     has DRAINED (work-set empty after a cancel started), NO descendant of the
+ *     root is left Running. This holds for the RIGHT reason: a root cancelled
+ *     while Running cascades into its running descendants; a root that had already
+ *     Completed never recurses, but the WaitingSubChain coupling guarantees all of
+ *     its descendants were already terminal before it completed.
+ *
+ * Negative check: revert the RECURSION — in CascadeStep's running branch, do NOT
+ * enqueue the popped chain's children (cancel only the root). A child/grandchild
+ * left Running under the cancelled root then survives the drain, and TLC reports
+ * NoOrphanedRunningDescendant violated. (The completion coupling on Advance is
+ * likewise load-bearing: drop it and a parent can self-Complete with running
+ * children, which — since the faithful cascade does not recurse through a
+ * terminal chain — also orphans those children.)
+ *
+ * SCOPE. Abstracts the per-chain lock to per-chain action mutual exclusion (each
+ * chain's status transition is one atomic step, which the lock guarantees) and
+ * collapses the self-terminal ChainStatus values (Completed/Failed/TimedOut, plus
+ * the Waiting* live states) into "running"/"completed". The cancel guard's
+ * acceptance set, the cascade's Err-before-child-loop short-circuit, and the
+ * parent/child completion coupling are modeled faithfully. The on_cancel
+ * notification dispatch, audit/stream emission, and TTL are out of scope. The
+ * chain tree is fixed and acyclic (build-time invariant), so cascade termination
+ * is assumed, not proved here.
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config ChainCancelCascade.cfg ChainCancelCascade.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    R,   \* root chain id          (model value)
+    C1,  \* child of R             (model value)
+    C2,  \* child of R             (model value)
+    G    \* grandchild, child of C1 (model value)
+
+\* The four chain ids form the fixed tree. Chains and Root are DERIVED from the
+\* id constants so Children/Root compare against the SAME model values TLC binds
+\* (comparing a model value to a string literal would silently never match —
+\* which is why the tree edges are keyed on constants, not "r"/"c1" strings).
+Chains == {R, C1, C2, G}
+Root   == R
+
+\* ---------------------------------------------------------------------------
+\* The fixed acyclic chain tree (ChainState.child_chain_ids). Encoded as an
+\* OPERATOR (a .cfg function literal would be rejected by TLC):
+\*     R -> {C1, C2},  C1 -> {G},  C2 -> {},  G -> {}
+\* ---------------------------------------------------------------------------
+Children(c) ==
+    CASE c = R   -> {C1, C2}
+      [] c = C1  -> {G}
+      [] OTHER   -> {}
+
+\* Transitive descendants of c (the subtree under c, excluding c itself). The
+\* tree has depth 2, so two unrollings of Children cover every descendant.
+Descendants(c) ==
+    LET d1 == Children(c)
+        d2 == UNION { Children(x) : x \in d1 }
+    IN d1 \cup d2
+
+VARIABLES
+    status,        \* [Chains -> {"running","completed","cancelled"}]
+    work,          \* SUBSET Chains : the cascade work-set (chains awaiting cancel)
+    started,       \* BOOLEAN : a cancel cascade from Root has been initiated
+    was_cancelled  \* SUBSET Chains : history of chains ever set Cancelled this
+                   \*   window (reset on Recycle). Lets NoResurrection catch a
+                   \*   chain that left "cancelled" — the resurrection bug.
+
+vars == <<status, work, started, was_cancelled>>
+
+TypeOK ==
+    /\ status \in [Chains -> {"running", "completed", "cancelled"}]
+    /\ work \subseteq Chains
+    /\ started \in BOOLEAN
+    /\ was_cancelled \subseteq Chains
+
+Init ==
+    /\ status = [c \in Chains |-> "running"]
+    /\ work = {}
+    /\ started = FALSE
+    /\ was_cancelled = {}
+
+\* A Running chain finishes on its own -> Completed, but ONLY once every child is
+\* already terminal. This is the WaitingSubChain coupling (gateway.rs:2711/2735/
+\* 2763): a chain with sub-chain steps blocks in WaitingSubChain and advances past
+\* the step only after the child is observed terminal, so a parent never reaches a
+\* terminal status ahead of its children. advance_chain's status guard (~2574)
+\* also refuses any non-Running chain, so this never resurrects a Cancelled chain.
+\* Per-chain mutual exclusion (the lock) makes this one atomic step.
+Advance(c) ==
+    /\ status[c] = "running"
+    /\ \A ch \in Children(c) : status[ch] # "running"
+    /\ status' = [status EXCEPT ![c] = "completed"]
+    /\ UNCHANGED <<work, started, was_cancelled>>
+
+\* Initiate the cascade: seed the work-set with the Root. Modeled once per window
+\* (started gate) so the cascade has a well-defined drain point.
+CancelRoot ==
+    /\ ~started
+    /\ started' = TRUE
+    /\ work' = {Root}
+    /\ UNCHANGED <<status, was_cancelled>>
+
+\* One cascade step on chain c (cancel_chain's body). Pop c from the work-set:
+\*   - if c is Running: cancel_chain proceeds past the status guard, flips
+\*     c -> Cancelled (the write under the lock), then — after releasing the lock —
+\*     RECURSES into child_chain_ids, so enqueue c's children.
+\*   - if c is already terminal (completed/cancelled): cancel_chain returns Err at
+\*     the guard (gateway.rs:5496) BEFORE the child loop, so it does NOT recurse —
+\*     dequeue c and enqueue NOTHING. (Reverting the running-branch enqueue is the
+\*     negative check.)
+CascadeStep(c) ==
+    /\ c \in work
+    /\ IF status[c] = "running"
+       THEN /\ status' = [status EXCEPT ![c] = "cancelled"]
+            /\ was_cancelled' = was_cancelled \cup {c}
+            /\ work' = (work \ {c}) \cup Children(c)
+       ELSE /\ work' = work \ {c}
+            /\ UNCHANGED <<status, was_cancelled>>
+    /\ UNCHANGED started
+
+\* Recycle: once the cascade has been started and fully drained, reset to a fresh
+\* tree of Running chains so the system CYCLES (no benign terminal deadlock under
+\* -deadlock).
+Recycle ==
+    /\ started
+    /\ work = {}
+    /\ status' = [c \in Chains |-> "running"]
+    /\ work' = {}
+    /\ started' = FALSE
+    /\ was_cancelled' = {}
+
+Next ==
+    \/ \E c \in Chains : Advance(c)
+    \/ CancelRoot
+    \/ \E c \in work : CascadeStep(c)
+    \/ Recycle
+
+Spec == Init /\ [][Next]_vars
+
+\* =======================================================================
+\* SAFETY
+\* =======================================================================
+
+\* A Cancelled chain is terminal: advance_chain refuses non-Running chains, so
+\* once a chain has been set Cancelled (recorded in was_cancelled) it can never
+\* transition back to Running or Completed within the same window. was_cancelled
+\* is reset only by the explicit Recycle (a deliberately fresh tree), so any chain
+\* that left "cancelled" without a Recycle — i.e. is recorded cancelled yet now
+\* Running or Completed — is a resurrection and trips this invariant.
+NoResurrection ==
+    \A c \in was_cancelled : status[c] = "cancelled"
+
+\* Once a cascade seeded from Root has DRAINED (started /\ work = {}), no
+\* descendant of Root is left Running — the central guarantee of the recursive
+\* cascade combined with the parent/child completion coupling. A Running
+\* descendant here means either the recursion failed to reach it, or a parent
+\* completed ahead of a still-running child.
+NoOrphanedRunningDescendant ==
+    (started /\ work = {}) =>
+        \A d \in Descendants(Root) : status[d] # "running"
+
+============================================================================

--- a/specs/tla/Makefile
+++ b/specs/tla/Makefile
@@ -12,6 +12,8 @@
 #   make check-quota        # Run QuotaCounter only
 #   make check-busapproval  # Run BusApproval only
 #   make check-multiquota   # Run MultiQuotaRollback only
+#   make check-task         # Run A2aTaskTransition only
+#   make check-cancel       # Run ChainCancelCascade only
 #   make setup              # Download tla2tools.jar
 #   make clean              # Remove downloaded tools
 
@@ -19,7 +21,7 @@ SHELL := /bin/bash
 SPECS_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 CI_SCRIPT := $(SPECS_DIR)ci/run-tlc.sh
 
-.PHONY: check-all check-circuit check-dedup check-hashchain check-recurring check-bus check-chain check-approval check-quota check-busapproval check-multiquota setup clean help
+.PHONY: check-all check-circuit check-dedup check-hashchain check-recurring check-bus check-chain check-approval check-quota check-busapproval check-multiquota check-task check-cancel setup clean help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -57,6 +59,12 @@ check-busapproval: ## Run TLC on BusApproval spec
 
 check-multiquota: ## Run TLC on MultiQuotaRollback spec
 	@$(CI_SCRIPT) MultiQuotaRollback
+
+check-task: ## Run TLC on A2aTaskTransition spec
+	@$(CI_SCRIPT) A2aTaskTransition
+
+check-cancel: ## Run TLC on ChainCancelCascade spec
+	@$(CI_SCRIPT) ChainCancelCascade
 
 setup: ## Download tla2tools.jar (requires curl or wget)
 	@$(CI_SCRIPT) __nonexistent__ 2>/dev/null || true

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -28,6 +28,8 @@ for the full research document.
 | **Quota Counter** | `QuotaCounter.tla` | `gateway/quota_enforcement.rs` atomic check-and-increment + Block refund | **No counter drift** (no lost increment) and **no over-admission** past the limit, under concurrent dispatchers |
 | **Bus Approval** | `BusApproval.tla` | `core/bus_approval.rs` + `api/bus.rs` Kafka pre-publish two-phase (Phase-10) | The parked envelope is published **at most once** and **only if approved** — `Approving` is committed before the produce; idempotent producer + reconciler |
 | **Multi-Quota Rollback** | `MultiQuotaRollback.tla` | `gateway/quota_enforcement.rs` `enforce_quota_policies` block rollback | On a block, **every** counter touched is rolled back (all-or-nothing) — no partial leak on a non-blocking policy; no over-admit on any policy |
+| **A2A Task Transition** | `A2aTaskTransition.tla` | `core/bus_task.rs` `can_transition_to` + `task_engine.rs` `cas_mutate` | Every committed task transition is **legal** and **terminal stays terminal**, under concurrent optimistic version-CAS (re-validates against the fresh row) |
+| **Chain Cancel-Cascade** | `ChainCancelCascade.tla` | `gateway.rs` `cancel_chain` recursion + `advance_chain` guard | A cancel **cascades to every running descendant** (no orphan) and a **cancelled chain never resurrects** — relies on the recursion *and* the WaitingSubChain completion coupling |
 
 Each spec is self-contained: it inlines its own lock / state-store state machine
 rather than sharing a module, so each can be model-checked independently.
@@ -35,7 +37,8 @@ rather than sharing a module, so each can be model-checked independently.
 Each spec is also adversarially validated: reverting the specific fix it models
 (the max-tip read, the pre-dispatch re-arm, the flush mutex, the step re-read CAS,
 the intent-before-flip ordering, the increment atomicity, the two-phase produce
-ordering, the all-or-nothing rollback) makes TLC report the corresponding safety
+ordering, the all-or-nothing rollback, the version-CAS re-validation, the cancel
+recursion / completion coupling) makes TLC report the corresponding safety
 violation. The specs catch the real bug, not just a tautology.
 
 ## Quick Start
@@ -79,7 +82,7 @@ tla-specs:
 ```
 
 The CI configuration uses small model parameters (2 of each principal) for fast
-feedback (all ten specs finish in a few seconds total). For nightly runs,
+feedback (all twelve specs finish in a few seconds total). For nightly runs,
 increase the constants in the `.cfg` files for deeper coverage.
 
 ## Project Structure
@@ -106,6 +109,10 @@ specs/tla/
   BusApproval.cfg
   MultiQuotaRollback.tla   # Spec: multi-policy quota all-or-nothing rollback on block
   MultiQuotaRollback.cfg
+  A2aTaskTransition.tla    # Spec: A2A task version-CAS legal transitions
+  A2aTaskTransition.cfg
+  ChainCancelCascade.tla   # Spec: chain cancel-cascade, no orphan, no resurrection
+  ChainCancelCascade.cfg
   ci/
     run-tlc.sh             # CI runner (auto-discovers every *.cfg)
   Makefile                 # Convenience targets


### PR DESCRIPTION
## What

Extends the TLA+ suite to **12 model-checked specs**. Both pass TLC on every CI run, are adversarially validated, **and** faithfulness-checked against the real Rust.

## Specs

| Spec | Models | Safety property | Negative check |
|------|--------|-----------------|----------------|
| `A2aTaskTransition` | `core/bus_task.rs` `can_transition_to` + `task_engine.rs` `cas_mutate` | every committed transition is legal + terminal-stays-terminal, under optimistic version-CAS that re-validates on the fresh row | blind versionless write validated against the *stale* read → illegal transition over a terminal row (`AllTransitionsLegal`) |
| `ChainCancelCascade` | `gateway.rs` `cancel_chain` recursion + `advance_chain` guard | cancel cascades to every running descendant (no orphan) + no resurrection | revert the recursion **or** drop the completion coupling → `NoOrphanedRunningDescendant` (each independently) |

## Faithfulness — the cancel-cascade was rewritten

The faithfulness critic caught that the first `ChainCancelCascade` draft passed TLC **only because two unfaithful modeling errors cancelled out**:
1. the cascade descended through *terminal* nodes' children (real `cancel_chain` returns Err at the guard *before* the child loop on a terminal chain, gateway.rs:5496), and
2. `Advance` let a parent self-complete while children were still running.

I verified both against the code and rewrote the spec to model: (1) the cascade recurses into children **only** when the chain was running, and (2) the **WaitingSubChain completion coupling** (gateway.rs:2711/2735/2763) — a parent reaches terminal only after its children are terminal. I then proved each mechanism is **independently load-bearing**: reverting either one alone makes TLC violate `NoOrphanedRunningDescendant`. So the green result is genuine, not a coincidence of compensating errors.

`A2aTaskTransition` was solid as authored — the critic confirmed `can_transition_to` is encoded verbatim and the version-CAS re-validates against the fresh row (the load-bearing subtlety); I only removed a leftover scratch file.

Local: `Results: 12 passed, 0 failed`. README, Makefile, and the design-doc status table updated to 12 specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)