### PR TITLE
feat(specs): TLA+ specs for SSE replay, retention reaper, DLQ redelivery

### DIFF
--- a/docs/design/tla-plus-formal-verification.md
+++ b/docs/design/tla-plus-formal-verification.md
@@ -17,7 +17,7 @@ This document identifies **the highest-value areas** in Acteon where TLA+ modeli
 harden correctness, proposes concrete specifications, and provides an implementation
 roadmap.
 
-> **Implementation status (May 2026).** Twelve specs are implemented and pass the TLC
+> **Implementation status (May 2026).** Fifteen specs are implemented and pass the TLC
 > model checker on every run of `specs/tla/ci/run-tlc.sh` (wired into CI as the
 > `TLA+ Specs` job):
 >
@@ -35,6 +35,9 @@ roadmap.
 > | Multi-policy quota rollback | `MultiQuotaRollback.tla` | On a block, every counter incremented in the call is rolled back (all-or-nothing) — no partial leak on a non-blocking policy, no over-admit on any policy (`enforce_quota_policies`) |
 > | A2A task transition | `A2aTaskTransition.tla` | Every committed A2A task transition is legal (`can_transition_to`) and terminal stays terminal, under concurrent optimistic version-CAS that re-validates against the fresh row (`core/bus_task.rs` + `task_engine.rs cas_mutate`) |
 > | Chain cancel-cascade | `ChainCancelCascade.tla` | A cancel cascades to every running descendant (no orphan) and a cancelled chain never resurrects — load-bearing on both the recursion and the WaitingSubChain completion coupling (`cancel_chain` + `advance_chain`) |
+> | Stream replay | `StreamReplay.tla` | SSE reconnect (`Last-Event-ID`) delivers every event with no gap and no duplicate — subscribe-before-replay + the `last_replayed_id` cursor dedup, each independently load-bearing (`api/stream.rs`) |
+> | Retention reaper | `RetentionReaper.tla` | A record held or not-expired at scan time is never deleted — the `compliance_hold` skip and the expiry-check (honest about the real by-key-delete TOCTOU; invariants anchored on scan-time state) (`workers/retention.rs`) |
+> | DLQ redelivery | `DlqRedelivery.tla` | Every dead-letter entry is drained exactly once and never lost under concurrent push/drain — the `std::mem::take` take+clear atomicity (`executor/dlq.rs`) |
 >
 > The realized layout deviates from the proposal below in one deliberate way: each spec
 > **inlines** its own lock / state-store state machine instead of sharing `common/`
@@ -550,14 +553,20 @@ specs/
     A2aTaskTransition.cfg
     ChainCancelCascade.tla           # chain cancel-cascade, no orphan, no resurrection
     ChainCancelCascade.cfg
+    StreamReplay.tla                 # SSE reconnect replay, no gap, no duplicate
+    StreamReplay.cfg
+    RetentionReaper.tla              # reaper never deletes a held/live record
+    RetentionReaper.cfg
+    DlqRedelivery.tla                # DLQ drain exactly-once, no lost entry
+    DlqRedelivery.cfg
     Makefile                         # Automation: `make check-all`
     ci/
       run-tlc.sh                     # auto-discovers every *.cfg; used by CI
 ```
 
-All twelve specs follow the same inlined, self-contained convention. Remaining
-candidates for future work: the message-bus subscription fan-out / replay
-cursor, the DLQ redelivery dedup, and the retention reaper vs. live-write race.
+All fifteen specs follow the same inlined, self-contained convention. Remaining
+candidates for future work: the message dedup TTL window vs. replay, the
+encrypted-state key rotation, and the A2A reference-graph cycle defense.
 
 ### 5.3 CI Integration
 

--- a/specs/tla/DlqRedelivery.cfg
+++ b/specs/tla/DlqRedelivery.cfg
@@ -1,0 +1,12 @@
+\* DlqRedelivery model-checking configuration
+CONSTANTS
+    Entries = {e1, e2}
+    Drainers = {d1, d2}
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    RedeliveredAtMostOnce
+    NoLostEntry
+    QueuedConsistent

--- a/specs/tla/DlqRedelivery.tla
+++ b/specs/tla/DlqRedelivery.tla
@@ -1,0 +1,171 @@
+----------------------------- MODULE DlqRedelivery -----------------------------
+(*
+ * TLA+ specification of Acteon's dead-letter queue push/drain under concurrency.
+ *
+ * Models crates/executor/src/dlq.rs (DeadLetterQueue, the DeadLetterSink impl):
+ *   - push(action, error, attempts): locks the Mutex<Vec<DeadLetterEntry>> and
+ *     APPENDS one entry (dlq.rs:84). Called by send_to_dlq / push_to_dlq when an
+ *     action exhausts its retries (executor.rs:77/178/209/226).
+ *   - drain() -> Vec<DeadLetterEntry>: locks the SAME Mutex and runs
+ *     std::mem::take(&mut *guard) (dlq.rs:91-92) — it RETURNS all entries AND
+ *     EMPTIES the queue in a SINGLE critical section (the take reads out the Vec
+ *     and leaves Vec::new() behind, atomically, under one lock acquisition).
+ *     Confirmed by the tests drain_returns_all_entries_and_empties_queue (the Vec
+ *     is non-empty, then dlq.is_empty()) and push_increments_len.
+ *   drain() is consumed by an operator-facing path (POST /v1/dlq/drain, the CLI,
+ *   the MCP tool), which processes / resubmits each drained entry once; the
+ *   re-dispatch of a resubmitted entry then flows through the gateway dispatch
+ *   dedup, modeled separately in DispatchDedup.tla.
+ *
+ * The single load-bearing mechanism is the ATOMICITY of drain's take+clear:
+ * because std::mem::take reads out the Vec AND clears it in one Mutex critical
+ * section, no two drains can both observe the same entry, and no push can be lost
+ * "between" a drain's read and its clear. push and drain are each one critical
+ * section under the same Mutex, modeled here as one atomic TLA+ action apiece
+ * (TLA+ action atomicity is exactly the mutual exclusion the Mutex provides — so
+ * there is no separate lock variable to model; that would be dead state).
+ *
+ * Protocol. Producers PUSH failed entries (one append per call); one or more
+ * drainers DRAIN (take-all) and hand each drained entry to its consumer exactly
+ * once. A push either lands before a take (included in that drain) or after it
+ * (left queued for the next drain) — never dropped. A take empties the queue, so
+ * a second concurrent drain gets only the empty remainder.
+ *
+ * Verified (over every interleaving of concurrent producers and drainers):
+ *   - RedeliveredAtMostOnce: no entry is drained / redelivered more than once.
+ *     The atomic take empties the queue as it returns the batch, so two drains
+ *     never both return the same entry.
+ *   - NoLostEntry: when the system has quiesced (every entry pushed, nothing
+ *     queued, no drainer mid-flight), every pushed entry has been drained — a
+ *     push concurrent with a drain is never dropped.
+ *   - QueuedConsistent: a queued entry has been pushed and not yet drained; a
+ *     drained entry is not still queued (the take cleared it).
+ *
+ * Negative check: revert the ATOMIC take — split drain() into a READ step that
+ * snapshots the queued entries and hands them to the consumer WITHOUT clearing,
+ * and a separate CLEAR step (two critical sections instead of std::mem::take's
+ * one). The one atomicity break manifests two ways, confirming it is genuinely
+ * load-bearing:
+ *   - two drainers both READ the same queued entry before either CLEARs, so it is
+ *     redelivered twice -> RedeliveredAtMostOnce violated (rd_count[e] = 2); and
+ *   - a PUSH that lands between a drainer's READ and its CLEAR is wiped by the
+ *     unconditional clear -> NoLostEntry violated (the entry is stranded).
+ *
+ * SCOPE. Models a single DeadLetterQueue. Entries are an abstract finite set;
+ * their payload (action, error, attempts, timestamp) and FIFO order within the
+ * Vec are not modeled — only the set membership the safety properties depend on.
+ * The downstream re-dispatch dedup of each resubmitted entry is out of scope and
+ * lives in DispatchDedup.tla.
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config DlqRedelivery.cfg DlqRedelivery.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    Entries,   \* the distinct failed actions that may be pushed, e.g. {e1, e2}
+    Drainers   \* concurrent drainers / redelivery workers, e.g. {d1, d2}
+
+VARIABLES
+    pushed,       \* SUBSET Entries: entries appended to the queue at least once
+    queued,       \* SUBSET Entries: entries currently sitting in the Vec
+    redelivered,  \* SUBSET Entries: entries drained (taken) and handed to a consumer
+    rd_count,     \* [Entries -> 0..3]: times each entry has been drained
+    d_phase       \* [Drainers -> {"idle","redelivering"}]
+
+vars == <<pushed, queued, redelivered, rd_count, d_phase>>
+
+TypeOK ==
+    /\ pushed \subseteq Entries
+    /\ queued \subseteq Entries
+    /\ redelivered \subseteq Entries
+    /\ rd_count \in [Entries -> 0..3]
+    /\ d_phase \in [Drainers -> {"idle", "redelivering"}]
+
+Init ==
+    /\ pushed = {}
+    /\ queued = {}
+    /\ redelivered = {}
+    /\ rd_count = [e \in Entries |-> 0]
+    /\ d_phase = [d \in Drainers |-> "idle"]
+
+\* push(action, error, attempts): a producer locks the Mutex and APPENDS one
+\* entry (dlq.rs:84). Modeled as one atomic critical section. Each distinct failed
+\* action is pushed once per window — an entry is enqueued only if not already
+\* pushed (a re-failure after drain is a fresh window, modeled by Recycle).
+\* `pushed` records the enqueue; `queued` is the live Vec contents.
+Push(e) ==
+    /\ e \notin pushed
+    /\ queued' = queued \cup {e}
+    /\ pushed' = pushed \cup {e}
+    /\ UNCHANGED <<redelivered, rd_count, d_phase>>
+
+\* drain() -> Vec: a drainer locks the SAME Mutex and runs std::mem::take — it
+\* RETURNS all queued entries AND EMPTIES the queue in ONE critical section
+\* (dlq.rs:91-92). Modeled as a single atomic action: read the current `queued`
+\* snapshot, hand every entry in it to the consumer (mark redelivered, bump each
+\* entry's count), and clear `queued` — all in one indivisible step. Because the
+\* read-out and the clear are one atomic step, a drainer that runs next sees
+\* queued = {} and takes nothing, so no entry is drained twice.
+Drain(d) ==
+    /\ d_phase[d] = "idle"
+    /\ redelivered' = redelivered \cup queued
+    /\ rd_count' = [e \in Entries |->
+                       IF e \in queued THEN rd_count[e] + 1 ELSE rd_count[e]]
+    /\ queued' = {}
+    /\ d_phase' = [d_phase EXCEPT ![d] = "redelivering"]
+    /\ UNCHANGED pushed
+
+\* The drainer finishes handing off its taken batch and is ready to drain again.
+\* (The re-dispatch of each entry flows through the gateway dedup — DispatchDedup.
+\* tla — and is out of scope here.) Releases the worker back to idle.
+DrainDone(d) ==
+    /\ d_phase[d] = "redelivering"
+    /\ d_phase' = [d_phase EXCEPT ![d] = "idle"]
+    /\ UNCHANGED <<pushed, queued, redelivered, rd_count>>
+
+\* Recycle: once everything pushed has been drained, the queue is empty, and no
+\* drainer is mid-flight, reset the per-window history so the system CYCLES (fresh
+\* failures can be pushed again). No benign terminal deadlock under -deadlock.
+\* rd_count resets so the at-most-once bound is per-window.
+Recycle ==
+    /\ pushed # {}
+    /\ queued = {}
+    /\ pushed \subseteq redelivered
+    /\ \A d \in Drainers : d_phase[d] = "idle"
+    /\ pushed' = {}
+    /\ redelivered' = {}
+    /\ rd_count' = [e \in Entries |-> 0]
+    /\ UNCHANGED <<queued, d_phase>>
+
+Next ==
+    \/ \E e \in Entries : Push(e)
+    \/ \E d \in Drainers : Drain(d) \/ DrainDone(d)
+    \/ Recycle
+
+Spec == Init /\ [][Next]_vars
+
+\* =======================================================================
+\* SAFETY
+\* =======================================================================
+
+\* No entry is drained / redelivered more than once. The atomic take-under-the-
+\* Mutex empties the queue as it returns the batch, so two concurrent drains
+\* never both return the same entry.
+RedeliveredAtMostOnce == \A e \in Entries : rd_count[e] <= 1
+
+\* When the window has quiesced — nothing queued and no drainer mid-flight —
+\* every pushed entry has been drained. A push that races a drain is never
+\* dropped: the take and the (would-be) concurrent append cannot interleave
+\* within one critical section, so the entry lands in that drain or the next one.
+NoLostEntry ==
+    (queued = {} /\ \A d \in Drainers : d_phase[d] = "idle")
+        => (pushed \subseteq redelivered)
+
+\* A queued entry has been pushed and not yet drained; a drained entry is not
+\* still queued (the take cleared it).
+QueuedConsistent ==
+    /\ queued \subseteq pushed
+    /\ queued \cap redelivered = {}
+
+============================================================================

--- a/specs/tla/Makefile
+++ b/specs/tla/Makefile
@@ -14,6 +14,9 @@
 #   make check-multiquota   # Run MultiQuotaRollback only
 #   make check-task         # Run A2aTaskTransition only
 #   make check-cancel       # Run ChainCancelCascade only
+#   make check-replay       # Run StreamReplay only
+#   make check-reaper       # Run RetentionReaper only
+#   make check-dlq          # Run DlqRedelivery only
 #   make setup              # Download tla2tools.jar
 #   make clean              # Remove downloaded tools
 
@@ -21,7 +24,7 @@ SHELL := /bin/bash
 SPECS_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 CI_SCRIPT := $(SPECS_DIR)ci/run-tlc.sh
 
-.PHONY: check-all check-circuit check-dedup check-hashchain check-recurring check-bus check-chain check-approval check-quota check-busapproval check-multiquota check-task check-cancel setup clean help
+.PHONY: check-all check-circuit check-dedup check-hashchain check-recurring check-bus check-chain check-approval check-quota check-busapproval check-multiquota check-task check-cancel check-replay check-reaper check-dlq setup clean help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -65,6 +68,15 @@ check-task: ## Run TLC on A2aTaskTransition spec
 
 check-cancel: ## Run TLC on ChainCancelCascade spec
 	@$(CI_SCRIPT) ChainCancelCascade
+
+check-replay: ## Run TLC on StreamReplay spec
+	@$(CI_SCRIPT) StreamReplay
+
+check-reaper: ## Run TLC on RetentionReaper spec
+	@$(CI_SCRIPT) RetentionReaper
+
+check-dlq: ## Run TLC on DlqRedelivery spec
+	@$(CI_SCRIPT) DlqRedelivery
 
 setup: ## Download tla2tools.jar (requires curl or wget)
 	@$(CI_SCRIPT) __nonexistent__ 2>/dev/null || true

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -30,6 +30,9 @@ for the full research document.
 | **Multi-Quota Rollback** | `MultiQuotaRollback.tla` | `gateway/quota_enforcement.rs` `enforce_quota_policies` block rollback | On a block, **every** counter touched is rolled back (all-or-nothing) — no partial leak on a non-blocking policy; no over-admit on any policy |
 | **A2A Task Transition** | `A2aTaskTransition.tla` | `core/bus_task.rs` `can_transition_to` + `task_engine.rs` `cas_mutate` | Every committed task transition is **legal** and **terminal stays terminal**, under concurrent optimistic version-CAS (re-validates against the fresh row) |
 | **Chain Cancel-Cascade** | `ChainCancelCascade.tla` | `gateway.rs` `cancel_chain` recursion + `advance_chain` guard | A cancel **cascades to every running descendant** (no orphan) and a **cancelled chain never resurrects** — relies on the recursion *and* the WaitingSubChain completion coupling |
+| **Stream Replay** | `StreamReplay.tla` | `api/stream.rs` SSE reconnect (`Last-Event-ID` replay + live tail) | Across a reconnect, every event is delivered with **no gap and no duplicate** — relies on subscribe-before-replay *and* the `last_replayed_id` cursor dedup |
+| **Retention Reaper** | `RetentionReaper.tla` | `workers/retention.rs` `run_retention_reaper` scan→delete | A record **held or not-expired at scan time is never deleted** — the `compliance_hold` skip and the expiry-check, each independently load-bearing (honest about the by-key-delete TOCTOU) |
+| **DLQ Redelivery** | `DlqRedelivery.tla` | `executor/dlq.rs` `DeadLetterQueue` push/drain | Every DLQ entry is drained **exactly once and never lost** under concurrent push/drain — the `std::mem::take` take+clear atomicity |
 
 Each spec is self-contained: it inlines its own lock / state-store state machine
 rather than sharing a module, so each can be model-checked independently.
@@ -38,8 +41,9 @@ Each spec is also adversarially validated: reverting the specific fix it models
 (the max-tip read, the pre-dispatch re-arm, the flush mutex, the step re-read CAS,
 the intent-before-flip ordering, the increment atomicity, the two-phase produce
 ordering, the all-or-nothing rollback, the version-CAS re-validation, the cancel
-recursion / completion coupling) makes TLC report the corresponding safety
-violation. The specs catch the real bug, not just a tautology.
+recursion / completion coupling, the subscribe-before-replay / cursor dedup, the
+reaper hold-skip / expiry-check, the drain take+clear atomicity) makes TLC report
+the corresponding safety violation. The specs catch the real bug, not a tautology.
 
 ## Quick Start
 
@@ -82,7 +86,7 @@ tla-specs:
 ```
 
 The CI configuration uses small model parameters (2 of each principal) for fast
-feedback (all twelve specs finish in a few seconds total). For nightly runs,
+feedback (all fifteen specs finish in a few seconds total). For nightly runs,
 increase the constants in the `.cfg` files for deeper coverage.
 
 ## Project Structure
@@ -113,6 +117,12 @@ specs/tla/
   A2aTaskTransition.cfg
   ChainCancelCascade.tla   # Spec: chain cancel-cascade, no orphan, no resurrection
   ChainCancelCascade.cfg
+  StreamReplay.tla         # Spec: SSE reconnect replay, no gap, no duplicate
+  StreamReplay.cfg
+  RetentionReaper.tla      # Spec: reaper never deletes a held/live record
+  RetentionReaper.cfg
+  DlqRedelivery.tla        # Spec: DLQ drain exactly-once, no lost entry
+  DlqRedelivery.cfg
   ci/
     run-tlc.sh             # CI runner (auto-discovers every *.cfg)
   Makefile                 # Convenience targets

--- a/specs/tla/RetentionReaper.cfg
+++ b/specs/tla/RetentionReaper.cfg
@@ -1,0 +1,11 @@
+\* RetentionReaper model-checking configuration
+CONSTANTS
+    Records = {r1, r2}
+    NOBODY = NOBODY
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    NeverDeleteScanHeld
+    NeverDeleteScanLive

--- a/specs/tla/RetentionReaper.tla
+++ b/specs/tla/RetentionReaper.tla
@@ -1,0 +1,220 @@
+----------------------------- MODULE RetentionReaper -----------------------------
+(*
+ * TLA+ specification of Acteon's data-retention reaper racing live writes.
+ *
+ * Models crates/gateway/src/background/workers/retention.rs:
+ *   - run_retention_reaper (~16): loads the enabled RetentionPolicy rows, then
+ *     calls reap_chains_optimized / reap_events_optimized.
+ *   - reap_chains_optimized (~103) / reap_events_optimized (~196): each does ONE
+ *     scan_keys_by_kind(...) — a snapshot of (key, raw_value) pairs — then loops:
+ *         if policy.compliance_hold { skipped += 1; continue; }   // hold-skip
+ *         ...
+ *         let cutoff = now - ttl;
+ *         let ts = <parsed from the SCANNED raw_value>;            // age from snapshot
+ *         if ts < cutoff {                                         // expiry-check
+ *             self.state.delete(&state_key).await ...              // UNCONDITIONAL by-key
+ *         }
+ *     The delete decision (held? expired?) is computed from the value the reaper
+ *     SCANNED. The delete itself (crates/state/memory/src/store.rs:227,
+ *     trait crates/state/state/src/store.rs:53) is `delete(key)` — a plain
+ *     remove-by-key. It does NOT re-read the record and does NOT re-check
+ *     compliance_hold or the age at delete time. (gateway.rs:~1343 resolves the
+ *     audit TTL — compliance_hold => None => never expires — but that is the same
+ *     hold-skip decision, computed from the loaded policy, not re-checked on the
+ *     persisted record at delete.)
+ *
+ * Protocol. A small set of records, each with a current compliance hold flag and a
+ * current expiry flag (refreshed => not expired). The reaper processes each record
+ * as TWO separate steps so a concurrent live write can interleave between them:
+ *   Scan(r):   reads the record's CURRENT held/expired and freezes a per-record
+ *              verdict — delete IFF (NOT held AND expired), else keep — exactly the
+ *              continue/skip cascade above. It also records scan_held/scan_expired:
+ *              what was true the instant the reaper looked.
+ *   Delete(r): if the frozen verdict is "delete", removes the record by key,
+ *              UNCONDITIONALLY (the bare state.delete). No re-read, no re-check.
+ * Concurrent live writes (any time a record is present):
+ *   Refresh(r): a live write resets the record's age   -> expired := FALSE.
+ *   SetHold(r): a live write sets compliance_hold       -> held    := TRUE.
+ *   Age(r):     wall-clock passes the cutoff            -> expired := TRUE.
+ *
+ * Verified (over every interleaving of the two-step reaper and concurrent live
+ * writes), anchored on what the code ACTUALLY guarantees — the SCAN-TIME state,
+ * because the delete acts on the verdict frozen at the scan:
+ *   - NeverDeleteScanHeld: a record that was on compliance hold AT SCAN TIME is
+ *     never deleted (the `if policy.compliance_hold { continue }` skip).
+ *   - NeverDeleteScanLive: a record that was NOT expired AT SCAN TIME (e.g. just
+ *     refreshed before the reaper looked) is never deleted (the `if ts < cutoff`
+ *     expiry-check).
+ * These two guards are INDEPENDENT: each alone is load-bearing (see Negative).
+ *
+ * Negative check (each guard reverted SEPARATELY — each trips ONLY its own
+ * invariant, proving the two are independently load-bearing, not offsetting):
+ *   (1) Drop the hold-skip, KEEPING the expiry-check: in Scan let
+ *       verdict = "delete" iff `expired` (ignoring `held`). A record held at scan
+ *       is then deleted -> NeverDeleteScanHeld violated, while NeverDeleteScanLive
+ *       still holds (a not-expired record is still kept).
+ *   (2) Drop the expiry-check, KEEPING the hold-skip: in Scan let
+ *       verdict = "delete" iff `~held` (ignoring `expired`). A not-expired
+ *       (just-refreshed) unheld record is then deleted -> NeverDeleteScanLive
+ *       violated, while NeverDeleteScanHeld still holds (a held record is kept).
+ *
+ * SCOPE. Abstracts the policy/record hold and the TTL-vs-now comparison to per-
+ * record BOOLEAN flags (held, expired), the per-kind scan to a per-record Scan,
+ * and the store delete to remove-by-key. The terminal-status / resolved-state
+ * gating (only completed chains / resolved events are eligible) and the metrics
+ * are out of scope. IMPORTANT — the TOCTOU window is REAL and modeled faithfully:
+ * the code re-checks NOTHING at delete time, so a record that becomes held or gets
+ * refreshed AFTER the reaper scanned it but BEFORE the by-key delete fires IS
+ * still deleted. That is why the verified invariants are stated over scan-time
+ * state (scan_held/scan_expired), NOT current state — the current-state versions
+ * (NeverDeleteHeldNow / NeverDeleteLiveNow, defined below as documentation) do NOT
+ * hold and are deliberately NOT listed as INVARIANTS.
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config RetentionReaper.cfg RetentionReaper.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    Records,  \* the records under one retention policy, e.g. {r1, r2}
+    NOBODY    \* sentinel: no frozen verdict (record not yet scanned this pass)
+
+VARIABLES
+    held,         \* [Records -> BOOLEAN]  current compliance_hold on the record
+    expired,      \* [Records -> BOOLEAN]  current: record older than the TTL cutoff
+    present,      \* [Records -> BOOLEAN]  record still exists in the store
+    rphase,       \* [Records -> {"unscanned","scanned","done"}] reaper progress
+    verdict,      \* [Records -> {"delete","keep"} \cup {NOBODY}] frozen at Scan
+    scan_held,    \* [Records -> BOOLEAN]  held value the reaper OBSERVED at Scan
+    scan_expired, \* [Records -> BOOLEAN]  expired value the reaper OBSERVED at Scan
+    deleted       \* SUBSET Records: records the reaper has removed this pass
+
+vars == <<held, expired, present, rphase, verdict, scan_held, scan_expired, deleted>>
+
+TypeOK ==
+    /\ held \in [Records -> BOOLEAN]
+    /\ expired \in [Records -> BOOLEAN]
+    /\ present \in [Records -> BOOLEAN]
+    /\ rphase \in [Records -> {"unscanned", "scanned", "done"}]
+    /\ verdict \in [Records -> {"delete", "keep", NOBODY}]
+    /\ scan_held \in [Records -> BOOLEAN]
+    /\ scan_expired \in [Records -> BOOLEAN]
+    /\ deleted \subseteq Records
+
+Init ==
+    /\ held = [r \in Records |-> FALSE]
+    /\ expired = [r \in Records |-> FALSE]
+    /\ present = [r \in Records |-> TRUE]
+    /\ rphase = [r \in Records |-> "unscanned"]
+    /\ verdict = [r \in Records |-> NOBODY]
+    /\ scan_held = [r \in Records |-> FALSE]
+    /\ scan_expired = [r \in Records |-> FALSE]
+    /\ deleted = {}
+
+\* --------------------------------------------------------------------------
+\* Concurrent LIVE WRITES (may interleave between a record's Scan and Delete).
+\* --------------------------------------------------------------------------
+
+\* Wall-clock advances past the cutoff: the record becomes eligible by age. Only
+\* meaningful while the record exists. (Source of work + part of the recycle.)
+Age(r) ==
+    /\ present[r]
+    /\ ~expired[r]
+    /\ expired' = [expired EXCEPT ![r] = TRUE]
+    /\ UNCHANGED <<held, present, rphase, verdict, scan_held, scan_expired, deleted>>
+
+\* A live write touches the record and resets its age -> no longer expired.
+Refresh(r) ==
+    /\ present[r]
+    /\ expired[r]
+    /\ expired' = [expired EXCEPT ![r] = FALSE]
+    /\ UNCHANGED <<held, present, rphase, verdict, scan_held, scan_expired, deleted>>
+
+\* A live write places the record under compliance hold.
+SetHold(r) ==
+    /\ present[r]
+    /\ ~held[r]
+    /\ held' = [held EXCEPT ![r] = TRUE]
+    /\ UNCHANGED <<expired, present, rphase, verdict, scan_held, scan_expired, deleted>>
+
+\* --------------------------------------------------------------------------
+\* The REAPER — two separate steps per record.
+\* --------------------------------------------------------------------------
+
+\* Scan(r): read the record's CURRENT held/expired and freeze the verdict, exactly
+\* mirroring reap_*_optimized's per-record cascade:
+\*     if policy.compliance_hold { skip }       -> held  => keep
+\*     if !expired { continue }                 -> !expired => keep
+\*     else (expired & not held)                -> delete
+\* scan_held/scan_expired capture what was observed, for the scan-time invariants.
+Scan(r) ==
+    /\ present[r]
+    /\ rphase[r] = "unscanned"
+    /\ scan_held' = [scan_held EXCEPT ![r] = held[r]]
+    /\ scan_expired' = [scan_expired EXCEPT ![r] = expired[r]]
+    /\ verdict' = [verdict EXCEPT ![r] =
+                     IF (~held[r]) /\ expired[r] THEN "delete" ELSE "keep"]
+    /\ rphase' = [rphase EXCEPT ![r] = "scanned"]
+    /\ UNCHANGED <<held, expired, present, deleted>>
+
+\* Delete(r): act on the FROZEN verdict. The store delete is by key and
+\* UNCONDITIONAL — no re-read, no re-check of the now-current held/expired. A live
+\* SetHold/Refresh that landed since Scan is invisible here: the verdict still says
+\* "delete" and the record is removed anyway (the real TOCTOU window).
+Delete(r) ==
+    /\ rphase[r] = "scanned"
+    /\ IF verdict[r] = "delete" /\ present[r]
+       THEN /\ present' = [present EXCEPT ![r] = FALSE]
+            /\ deleted' = deleted \cup {r}
+       ELSE UNCHANGED <<present, deleted>>
+    /\ rphase' = [rphase EXCEPT ![r] = "done"]
+    /\ UNCHANGED <<held, expired, verdict, scan_held, scan_expired>>
+
+\* --------------------------------------------------------------------------
+\* Recycle: the reaper pass finished (every record scanned-and-acted). Reset to a
+\* fresh batch — surviving records start a new pass; deleted records are replaced
+\* by fresh ones — so the system CYCLES (no benign terminal deadlock under
+\* -deadlock). New records arrive un-held and un-expired (freshly written).
+\* --------------------------------------------------------------------------
+Recycle ==
+    /\ \A r \in Records : rphase[r] = "done"
+    /\ held' = [r \in Records |-> FALSE]
+    /\ expired' = [r \in Records |-> FALSE]
+    /\ present' = [r \in Records |-> TRUE]
+    /\ rphase' = [r \in Records |-> "unscanned"]
+    /\ verdict' = [r \in Records |-> NOBODY]
+    /\ scan_held' = [r \in Records |-> FALSE]
+    /\ scan_expired' = [r \in Records |-> FALSE]
+    /\ deleted' = {}
+
+Next ==
+    \/ \E r \in Records : Age(r) \/ Refresh(r) \/ SetHold(r)
+    \/ \E r \in Records : Scan(r) \/ Delete(r)
+    \/ Recycle
+
+Spec == Init /\ [][Next]_vars
+
+\* =======================================================================
+\* SAFETY — anchored on SCAN-TIME state (what the code observed), because the
+\* by-key delete acts on the verdict frozen at the scan and re-checks nothing.
+\* =======================================================================
+
+\* A record that was on compliance hold AT THE MOMENT THE REAPER SCANNED it is
+\* never deleted: the `if policy.compliance_hold { continue }` skip froze a "keep"
+\* verdict. (Drop that skip -> a scan-time-held record is deleted -> violated.)
+NeverDeleteScanHeld ==
+    \A r \in deleted : scan_held[r] = FALSE
+
+\* A record that was NOT expired AT SCAN TIME (e.g. a live write refreshed it before
+\* the reaper looked) is never deleted: the `if ts < cutoff` expiry-check froze a
+\* "keep" verdict. (Drop that check -> a scan-time-live record is deleted -> violated.)
+NeverDeleteScanLive ==
+    \A r \in deleted : scan_expired[r] = TRUE
+
+\* ---- Documentation only: the CURRENT-state versions. These do NOT hold (the
+\* ---- reaper re-checks nothing at delete time, so a record held/refreshed AFTER
+\* ---- the scan is still deleted) and are intentionally NOT listed as INVARIANTS.
+\* NeverDeleteHeldNow  == \A r \in deleted : held[r]    = FALSE
+\* NeverDeleteLiveNow  == \A r \in deleted : expired[r] = TRUE
+
+============================================================================

--- a/specs/tla/StreamReplay.cfg
+++ b/specs/tla/StreamReplay.cfg
@@ -1,0 +1,21 @@
+\* StreamReplay model-checking configuration
+\*
+\* MaxId bounds the monotone event log (kept small for fast CI).
+\* SubscribeBeforeQuery and CursorDedup are the two independently load-bearing
+\* fixes; both TRUE is the faithful spec. Flip one to FALSE in a scratch copy to
+\* run the negative check:
+\*   SubscribeBeforeQuery = FALSE -> NoGap violated (subscribe-after-query race)
+\*   CursorDedup          = FALSE -> NoDuplicate violated (replay/live overlap)
+\* NOBODY is the cursor/last_replayed_id "none" sentinel.
+CONSTANTS
+    MaxId = 3
+    SubscribeBeforeQuery = TRUE
+    CursorDedup = TRUE
+    NOBODY = NOBODY
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    NoGap
+    NoDuplicate

--- a/specs/tla/StreamReplay.tla
+++ b/specs/tla/StreamReplay.tla
@@ -1,0 +1,296 @@
+----------------------------- MODULE StreamReplay -----------------------------
+(*
+ * TLA+ specification of Acteon's SSE reconnect catch-up: Last-Event-ID replay
+ * stitched to the live broadcast tail with no gap and no duplicate.
+ *
+ * Models crates/server/src/api/stream.rs (the `stream` handler, ~148..230, and
+ * `replay_from_audit` ~235, `make_event_stream` ~352). A reconnecting client
+ * sends Last-Event-ID = k. The handler runs, IN THIS ORDER:
+ *   step 4 (~199): rx = stream_tx().subscribe()   -- subscribe to the live
+ *          broadcast channel BEFORE the audit query. From this instant the
+ *          broadcast buffers every event sent onto the channel.
+ *   step 5 (~211/235): replay_from_audit(audit, k, ...) -- query the audit store
+ *          for records from k's timestamp (clamped to MAX_REPLAY_WINDOW),
+ *          reverse to chronological, SKIP the record with id == k (the client
+ *          already has it), and return (replay_events, last_replayed_id).
+ *   step 6 (~218/352): make_event_stream(rx, ..., last_replayed_id) -- the live
+ *          tail, which SUPPRESSES (`&event.id <= last_id` -> None, ~369) any
+ *          event at or below last_replayed_id, then chains replay ++ live (~222).
+ *
+ * How a produced event reaches the two surfaces (gateway.rs:613..639 fixes the
+ * intra-event order): the gateway first WRITES the audit record (emit_audit_record
+ * ~625) and only THEN BROADCASTS the stream event (stream_tx.send ~639). So per
+ * event: audit-write happens-before broadcast. An event is in the REPLAY page iff
+ * its audit-write preceded the client's query; it is in the LIVE buffer iff its
+ * broadcast followed the client's subscribe.
+ *
+ * The subtle correctness, and why subscribe-BEFORE-query is load-bearing:
+ *   - subscribe first => any event broadcast after `now` is captured on rx and
+ *     delivered after the replay. An event whose audit-write lands DURING the
+ *     replay query (so it is NOT in the page) still had its broadcast after the
+ *     earlier subscribe, so the live tail catches it -> NoGap.
+ *   - the last_replayed_id cursor => an event present in BOTH the replay page and
+ *     the live buffer (audit-written before the query AND broadcast after the
+ *     subscribe) is emitted once via replay and SUPPRESSED on the live side
+ *     (id <= last_replayed_id) -> NoDuplicate.
+ * The two mechanisms are JOINTLY load-bearing and negative-tested separately.
+ *
+ * Verified (over every interleaving of the concurrent producer with the client's
+ * subscribe and query steps, for every reconnect cursor k):
+ *   - NoGap: once the client has switched to the live tail, every event with
+ *     id > k is delivered AT LEAST once (via replay or via live) -- nothing
+ *     between the cursor and the live stream is lost.
+ *   - NoDuplicate: no event id is delivered to the client more than once.
+ *
+ * Negative check (TWO independent fixes, each separately reverted):
+ *   (1) subscribe-before-replay: set SubscribeBeforeQuery = FALSE in the .cfg so
+ *       the subscribe happens AFTER the query (Query then Subscribe). An event
+ *       whose audit-write lands after the query (not in the page) and whose
+ *       broadcast lands before the late subscribe (not on rx) is in NEITHER
+ *       surface -> NoGap violated.
+ *   (2) cursor dedup: set CursorDedup = FALSE so the live tail does NOT suppress
+ *       events with id <= last_replayed_id. An event that is both in the replay
+ *       page and the live buffer is delivered twice -> NoDuplicate violated.
+ *
+ * SCOPE. Abstracts UUIDv7 ids to the integers 1..MaxId (monotone, lexicographic =
+ * numeric), the broadcast channel to a per-event "captured on rx" flag, and the
+ * audit store to a per-event "durably written" flag; the MAX_REPLAY_WINDOW clamp,
+ * tenant/query filtering, lagged backpressure, and keep-alive pings are out of
+ * scope. The intra-event audit-write-before-broadcast order, subscribe-before-
+ * query order, the id==k skip, and the last_replayed_id suppression are modeled
+ * faithfully.
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config StreamReplay.cfg StreamReplay.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    MaxId,                  \* highest event id the producer can append (e.g. 3)
+    SubscribeBeforeQuery,   \* TRUE = faithful (subscribe at step 4, before query)
+    CursorDedup,            \* TRUE = faithful (live tail suppresses id <= cursor)
+    NOBODY                  \* sentinel: cursor / Last-Event-ID not yet set
+
+Ids == 1..MaxId
+
+VARIABLES
+    appended,    \* SUBSET Ids: ids the producer has created (monotone next id)
+    written,     \* SUBSET Ids: ids whose audit record is durably written
+    broadcast,   \* SUBSET Ids: ids that have been sent onto the live channel
+    rxbuf,       \* SUBSET Ids: events captured on the client's broadcast rx
+                 \*   (an event lands here iff broadcast AFTER the subscribe)
+    cursor,      \* the reconnect Last-Event-ID k (a value in 0..MaxId; 0 = none)
+    subscribed,  \* BOOLEAN: client has taken rx = subscribe()  (step 4)
+    queried,     \* BOOLEAN: client has run replay_from_audit    (step 5)
+    last_repl,   \* last_replayed_id returned by replay (NOBODY until queried)
+    live,        \* BOOLEAN: client has switched to the live tail (step 6 done)
+    delivered    \* bag of ids delivered to the client, as [Ids -> Nat] multiset
+                 \*   (counts > 1 catch a duplicate delivery)
+
+vars == <<appended, written, broadcast, rxbuf, cursor, subscribed, queried,
+          last_repl, live, delivered>>
+
+\* k as an integer: 0 means "no Last-Event-ID set yet" (cursor = NOBODY).
+K == IF cursor = NOBODY THEN 0 ELSE cursor
+
+\* Highest id whose audit record was written by the time the query ran (= the
+\* set the replay page draws from). The replay returns ids in `written` with
+\* id > k, skipping id == k. We snapshot it at query time into `last_repl`.
+ReplaySet == { i \in written : i > K }
+
+TypeOK ==
+    /\ appended \subseteq Ids
+    /\ written \subseteq Ids
+    /\ broadcast \subseteq Ids
+    /\ rxbuf \subseteq Ids
+    /\ cursor \in (Ids \cup {NOBODY})
+    /\ subscribed \in BOOLEAN
+    /\ queried \in BOOLEAN
+    /\ last_repl \in (Ids \cup {NOBODY})
+    /\ live \in BOOLEAN
+    /\ delivered \in [Ids -> 0..2]
+
+Init ==
+    /\ appended = {}
+    /\ written = {}
+    /\ broadcast = {}
+    /\ rxbuf = {}
+    /\ cursor = NOBODY
+    /\ subscribed = FALSE
+    /\ queried = FALSE
+    /\ last_repl = NOBODY
+    /\ live = FALSE
+    /\ delivered = [i \in Ids |-> 0]
+
+\* ---------------------------------------------------------------------------
+\* Producer (concurrent with the reconnect). The lowest un-appended id is created
+\* next, so ids stay monotone. The three producer steps fire in the gateway's
+\* order: append -> write audit (queryable) -> broadcast (delivered live).
+\* ---------------------------------------------------------------------------
+
+\* Create the next event id (monotone). Just establishes the id exists.
+Append ==
+    /\ \E i \in Ids : i \notin appended /\ (\A j \in Ids : j < i => j \in appended)
+                   /\ appended' = appended \cup {i}
+    /\ UNCHANGED <<written, broadcast, rxbuf, cursor, subscribed, queried,
+                   last_repl, live, delivered>>
+
+\* gateway.rs:625 -- emit_audit_record: the event becomes durably queryable.
+\* Happens-before the broadcast of the SAME event.
+WriteAudit(i) ==
+    /\ i \in appended
+    /\ i \notin written
+    /\ written' = written \cup {i}
+    /\ UNCHANGED <<appended, broadcast, rxbuf, cursor, subscribed, queried,
+                   last_repl, live, delivered>>
+
+\* gateway.rs:639 -- stream_tx.send: broadcast onto the live channel. Per event,
+\* the audit write already happened (written guard). If the client has already
+\* subscribed, the event is captured on its rx buffer; otherwise it is missed by
+\* this subscriber (broadcast channels do not retroactively deliver).
+Broadcast(i) ==
+    /\ i \in written
+    /\ i \notin broadcast
+    /\ broadcast' = broadcast \cup {i}
+    /\ rxbuf' = IF subscribed THEN rxbuf \cup {i} ELSE rxbuf
+    /\ UNCHANGED <<appended, written, cursor, subscribed, queried,
+                   last_repl, live, delivered>>
+
+\* ---------------------------------------------------------------------------
+\* Client reconnect. The cursor k is chosen once (a previously-seen id, or 0). The
+\* two ordered handler steps -- subscribe (step 4) then query (step 5) -- may
+\* interleave with producer steps. SubscribeBeforeQuery gates their order: TRUE is
+\* the faithful subscribe-before-query; FALSE is the reverted (buggy) order.
+\* ---------------------------------------------------------------------------
+
+\* Choose the reconnect cursor k: any already-appended id (the client held it from
+\* a prior session) or 0 (NOBODY = fresh stream, no Last-Event-ID). Done once.
+SetCursor(k) ==
+    /\ cursor = NOBODY
+    /\ ~subscribed
+    /\ k \in appended
+    /\ cursor' = k
+    /\ UNCHANGED <<appended, written, broadcast, rxbuf, subscribed, queried,
+                   last_repl, live, delivered>>
+
+\* Step 4 (~199): rx = subscribe(). Faithful order requires the query has NOT run
+\* yet; the reverted order (SubscribeBeforeQuery = FALSE) requires it HAS.
+Subscribe ==
+    /\ ~subscribed
+    /\ IF SubscribeBeforeQuery THEN ~queried ELSE queried
+    /\ subscribed' = TRUE
+    /\ UNCHANGED <<appended, written, broadcast, rxbuf, cursor, queried,
+                   last_repl, live, delivered>>
+
+\* Step 5 (~211/235): replay_from_audit. Query the audit page = ids already
+\* written with id > k (skipping id == k, which the loop `continue`s). DELIVER the
+\* replay events now, and set last_replayed_id to the max id in the page (NOBODY if
+\* empty -- replay_from_audit returns the original last_event_id, but with an empty
+\* page nothing was suppressed, modeled as no cursor). Faithful order requires the
+\* subscribe already happened; reverted order requires it has not.
+Query ==
+    /\ ~queried
+    /\ IF SubscribeBeforeQuery THEN subscribed ELSE ~subscribed
+    /\ queried' = TRUE
+    /\ LET page == ReplaySet IN
+         /\ delivered' = [i \in Ids |-> IF i \in page THEN delivered[i] + 1
+                                                       ELSE delivered[i]]
+         /\ last_repl' = IF page = {} THEN NOBODY
+                                      ELSE CHOOSE m \in page : \A j \in page : j <= m
+    /\ UNCHANGED <<appended, written, broadcast, rxbuf, cursor, subscribed, live>>
+
+\* Step 6 (~218/352): switch to the live tail. Drain the rx buffer, applying the
+\* cursor dedup: with CursorDedup (faithful), suppress any buffered event with
+\* id <= last_replayed_id (it was already delivered by replay); without it (the
+\* reverted bug), deliver every buffered event, double-delivering the overlap.
+\* After this the stream is live: each subsequently-broadcast event is delivered
+\* on arrival (also under the cursor dedup) -- see DeliverLive.
+GoLive ==
+    /\ subscribed
+    /\ queried
+    /\ ~live
+    /\ live' = TRUE
+    /\ LET cut == IF last_repl = NOBODY THEN 0 ELSE last_repl
+           pass == IF CursorDedup THEN { i \in rxbuf : i > cut } ELSE rxbuf
+       IN delivered' = [i \in Ids |-> IF i \in pass THEN delivered[i] + 1
+                                                    ELSE delivered[i]]
+    /\ UNCHANGED <<appended, written, broadcast, rxbuf, cursor, subscribed,
+                   queried, last_repl>>
+
+\* Once live, an event broadcast AFTER GoLive arrives on the live tail and is
+\* delivered immediately, subject to the same cursor suppression. (Events buffered
+\* on rx BEFORE GoLive were already drained by GoLive; this is the post-switch
+\* steady state. We model a freshly-broadcast id that is on rx but not yet
+\* delivered as one that arrives now.)
+DeliverLive(i) ==
+    /\ live
+    /\ i \in rxbuf
+    /\ delivered[i] = 0
+    /\ LET cut == IF last_repl = NOBODY THEN 0 ELSE last_repl
+       IN IF (~CursorDedup) \/ i > cut
+          THEN delivered' = [delivered EXCEPT ![i] = delivered[i] + 1]
+          ELSE UNCHANGED delivered
+    /\ UNCHANGED <<appended, written, broadcast, rxbuf, cursor, subscribed,
+                   queried, last_repl, live>>
+
+\* ---------------------------------------------------------------------------
+\* Recycle: the client disconnects and reconnects afresh (a new catch-up window),
+\* so the system CYCLES (no benign terminal deadlock under -deadlock). A new
+\* session re-subscribes and re-queries against the same monotone log; the
+\* delivery bag and the per-session handler state reset.
+\* ---------------------------------------------------------------------------
+Recycle ==
+    /\ live
+    /\ subscribed' = FALSE
+    /\ queried' = FALSE
+    /\ live' = FALSE
+    /\ cursor' = NOBODY
+    /\ last_repl' = NOBODY
+    /\ rxbuf' = {}
+    /\ delivered' = [i \in Ids |-> 0]
+    /\ UNCHANGED <<appended, written, broadcast>>
+
+Next ==
+    \/ Append
+    \/ \E i \in Ids : WriteAudit(i)
+    \/ \E i \in Ids : Broadcast(i)
+    \/ \E k \in Ids : SetCursor(k)
+    \/ Subscribe
+    \/ Query
+    \/ GoLive
+    \/ \E i \in Ids : DeliverLive(i)
+    \/ Recycle
+
+Spec == Init /\ [][Next]_vars
+
+\* =======================================================================
+\* SAFETY
+\* =======================================================================
+
+\* Set of ids that genuinely existed at reconnect-relevant time and sit strictly
+\* above the cursor -- the ids the client must receive. An event "counts" once it
+\* has been broadcast (its live side fired); an event only appended/written but
+\* never broadcast is still in flight and not yet owed.
+OwedAfterLive == { i \in broadcast : i > K }
+
+\* The client is fully caught up: on the live tail, the producer is quiescent
+\* (everything appended has been broadcast), and the live tail has drained (no
+\* buffered owed event is still waiting for DeliverLive). Only at this fixpoint is
+\* it meaningful to demand that every owed event has arrived; before it, an owed
+\* event may legitimately still be in flight on the live tail.
+CaughtUp ==
+    /\ live
+    /\ broadcast = appended
+    /\ \A i \in OwedAfterLive : delivered[i] >= 1 \/ i \notin rxbuf
+
+\* NoGap: once the client is caught up, every owed event id > k has been delivered
+\* at least once -- via replay if it predated the live subscription, or via the
+\* live tail otherwise. Nothing between the cursor and the live stream is lost.
+NoGap ==
+    CaughtUp => \A i \in OwedAfterLive : delivered[i] >= 1
+
+\* NoDuplicate: no event id is ever delivered to the client more than once -- the
+\* last_replayed_id cursor dedups the replay/live boundary.
+NoDuplicate == \A i \in Ids : delivered[i] <= 1
+
+===============================================================================


### PR DESCRIPTION
## What

Extends the TLA+ suite to **15 model-checked specs**. All pass TLC on every CI run, are adversarially validated, **and** faithfulness-checked against the real Rust.

## Specs

| Spec | Models | Safety property | Negative check |
|------|--------|-----------------|----------------|
| `StreamReplay` | `api/stream.rs` SSE reconnect (`Last-Event-ID`) | every event delivered with **no gap and no duplicate** across a reconnect | subscribe-after-query → `NoGap`; drop cursor dedup → `NoDuplicate` (each via a `.cfg` flip) |
| `RetentionReaper` | `workers/retention.rs` `run_retention_reaper` | a record **held or not-expired at scan time is never deleted** | drop hold-skip → `NeverDeleteScanHeld`; drop expiry-check → `NeverDeleteScanLive` |
| `DlqRedelivery` | `executor/dlq.rs` `DeadLetterQueue` push/drain | every entry drained **exactly once and never lost** | split drain's take+clear → double-read (`RedeliveredAtMostOnce`) + push-lost (`NoLostEntry`) |

## Faithfulness

Each spec was authored from the real Rust and cross-checked by an independent **faithfulness critic**:

- `StreamReplay` and `RetentionReaper` were both solid as authored — the critics confirmed `StreamReplay` models subscribe-before-replay + the `last_replayed_id` cursor (both independently load-bearing), and that `RetentionReaper` is **honest about the real by-key-delete TOCTOU** (the reaper deletes unconditionally with no re-read), anchoring its invariants on scan-time state rather than inventing a re-check the code lacks.
- `DlqRedelivery` was **rewritten** after the critic found the first draft carried a decorative `lock` variable (never assigned to a non-sentinel value) and a false claim of a *second* load-bearing mechanism. The honest model has **one** mechanism — the atomicity of drain's `std::mem::take` (take+clear in one Mutex critical section) — demonstrated from two angles (double-read; push-between-lost). I verified both first-hand.

Local: `Results: 15 passed, 0 failed`. README, Makefile, and the design-doc status table updated to 15 specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)