### PR TITLE
feat(specs): TLA+ specs for message dedup, key rotation, reference-graph defense

### DIFF
--- a/docs/design/tla-plus-formal-verification.md
+++ b/docs/design/tla-plus-formal-verification.md
@@ -17,7 +17,7 @@ This document identifies **the highest-value areas** in Acteon where TLA+ modeli
 harden correctness, proposes concrete specifications, and provides an implementation
 roadmap.
 
-> **Implementation status (May 2026).** Fifteen specs are implemented and pass the TLC
+> **Implementation status (May 2026).** Eighteen specs are implemented and pass the TLC
 > model checker on every run of `specs/tla/ci/run-tlc.sh` (wired into CI as the
 > `TLA+ Specs` job):
 >
@@ -38,6 +38,9 @@ roadmap.
 > | Stream replay | `StreamReplay.tla` | SSE reconnect (`Last-Event-ID`) delivers every event with no gap and no duplicate — subscribe-before-replay + the `last_replayed_id` cursor dedup, each independently load-bearing (`api/stream.rs`) |
 > | Retention reaper | `RetentionReaper.tla` | A record held or not-expired at scan time is never deleted — the `compliance_hold` skip and the expiry-check (honest about the real by-key-delete TOCTOU; invariants anchored on scan-time state) (`workers/retention.rs`) |
 > | DLQ redelivery | `DlqRedelivery.tla` | Every dead-letter entry is drained exactly once and never lost under concurrent push/drain — the `std::mem::take` take+clear atomicity (`executor/dlq.rs`) |
+> | Message dedup | `MessageDedup.tla` | An A2A message is applied at most once per dedup-TTL window — the `check_and_set` is the gate, the read-only probe advisory (`task_engine.rs`) |
+> | Key rotation | `KeyRotation.tla` | No stored value becomes undecryptable — a key is never retired while a value is still stamped with it (the contract `decrypt`-by-kid relies on; `crypto/lib.rs`) |
+> | Reference-graph defense | `RefGraphDefense.tla` | The write-time reference-graph walk terminates and rejects every graph-bomb (cycle, over-depth, over-width), cross-checked against an independent reachability oracle (`task_engine.rs check_reference_graph`) |
 >
 > The realized layout deviates from the proposal below in one deliberate way: each spec
 > **inlines** its own lock / state-store state machine instead of sharing `common/`
@@ -559,14 +562,20 @@ specs/
     RetentionReaper.cfg
     DlqRedelivery.tla                # DLQ drain exactly-once, no lost entry
     DlqRedelivery.cfg
+    MessageDedup.tla                 # A2A message at-most-once per dedup-TTL window
+    MessageDedup.cfg
+    KeyRotation.tla                  # key rotation, no undecryptable value
+    KeyRotation.cfg
+    RefGraphDefense.tla              # reference-graph bounded walk, graph-bomb defense
+    RefGraphDefense.cfg
     Makefile                         # Automation: `make check-all`
     ci/
       run-tlc.sh                     # auto-discovers every *.cfg; used by CI
 ```
 
-All fifteen specs follow the same inlined, self-contained convention. Remaining
-candidates for future work: the message dedup TTL window vs. replay, the
-encrypted-state key rotation, and the A2A reference-graph cycle defense.
+All eighteen specs follow the same inlined, self-contained convention. Remaining
+candidates for future work: the conversation-state lifecycle, the silence/alert
+suppression window, and the embedding-cache invalidation under concurrent writes.
 
 ### 5.3 CI Integration
 

--- a/specs/tla/KeyRotation.cfg
+++ b/specs/tla/KeyRotation.cfg
@@ -1,0 +1,17 @@
+\* KeyRotation model-checking configuration
+\*
+\* Kids is the pool of key identifiers the operator may introduce/rotate to;
+\* Values is the set of stored ciphertext values. NOBODY is the no-stamp sentinel
+\* (a .cfg cannot hold a function literal — KidSlots is an OPERATOR in the .tla).
+CONSTANTS
+    Kids = {ka, kb, kc}
+    Values = {v1, v2}
+    NOBODY = NOBODY
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    NoUndecryptable
+    ActiveInKeyset
+    NonEmptyKeyset

--- a/specs/tla/KeyRotation.tla
+++ b/specs/tla/KeyRotation.tla
@@ -1,0 +1,199 @@
+----------------------------- MODULE KeyRotation -----------------------------
+(*
+ * TLA+ specification of Acteon's encrypted-state key-rotation contract.
+ *
+ * Models crates/crypto/src/lib.rs:
+ *   - struct PayloadEncryptor { keys: Vec<PayloadKeyEntry> } where each entry has
+ *     a `kid` (~242). `keys[0]` is the ACTIVE encryption key.
+ *   - encrypt_json/encrypt_str (~297/317): encrypt with keys[0] and STAMP its kid
+ *     into the envelope via encrypt_value_with_kid (~200) =>
+ *     ENC[AES256-GCM,kid:<KID>,data:...]. current_kid (~290) returns keys[0].kid.
+ *   - decrypt_raw (~334): extract the kid from the envelope (extract_kid ~235),
+ *     look up the entry whose `kid` matches and decrypt with it; if the kid is
+ *     absent/legacy or not found, FALL BACK to trying every key in order. So a
+ *     value decrypts IFF its stamping key is still present in the keyset.
+ *   - with_keys(Vec<PayloadKeyEntry>) (~280): build an encryptor from an explicit
+ *     ordered keyset. IMPORTANT: the code does NOT auto-re-encrypt stored values
+ *     and does NOT auto-remove keys. ROTATION is an OPERATOR action: prepend a new
+ *     active key (it becomes keys[0]) and RETAIN the old keys so their ciphertext
+ *     still decrypts. Removing an old key is likewise an operator decision.
+ *
+ * Protocol (the operational rotation contract that decrypt-by-kid imposes). A
+ * keyset = a set of kids with one marked ACTIVE (= keys[0]), plus a set of stored
+ * values, each STAMPED with the kid it was encrypted under. Operations:
+ *   Encrypt(v): stamp value v with the ACTIVE kid and store it (faithful to
+ *               encrypt_*: keys[0].kid goes into the envelope).
+ *   Rotate(k):  add a fresh kid k to the keyset and make it active (prepend); the
+ *               previously-active kid is RETAINED (operator rotation pass).
+ *   ReEncrypt(v): re-encrypt a stored value from its old kid to the current active
+ *               kid (operator re-encryption pass over already-stored ciphertext).
+ *   RetireKey(k): remove kid k from the keyset. SAFE ONLY IF no stored value is
+ *               still stamped with k (the modeled fix / precondition).
+ *   Decrypt(v): succeeds IFF v's stamping kid is still in the keyset (decrypt_raw:
+ *               the lookup-by-kid, and the all-keys fallback, both need the key).
+ *
+ * Verified (over every interleaving of encrypt / rotate / re-encrypt / retire):
+ *   - NoUndecryptable: every stored value's kid is still present in the keyset, so
+ *     decrypt_raw can always find a key for it — every value is always decryptable.
+ *     This is exactly the contract decrypt-by-kid depends on.
+ *   - ActiveInKeyset / NonEmptyKeyset (well-formedness the code assumes: keys[0]
+ *     exists, so current_kid and encrypt always have an active key).
+ *
+ * The fix anchored here is RetireKey's precondition: retire a kid ONLY when it has
+ * NO live (still-stamped) ciphertext. ReEncrypt is what DRAINS a kid's live values
+ * onto the active kid so that retiring it later becomes safe.
+ *
+ * Negative check: revert the RetireKey precondition (allow retiring a kid even
+ * while a stored value is still stamped with it). That value's kid leaves the
+ * keyset while the value persists -> decrypt_raw can no longer find its key ->
+ * NoUndecryptable is violated and TLC reports the counterexample (a stored value
+ * whose kid is gone from the keyset). The precondition is INDEPENDENTLY load-
+ * bearing: it is the only guard standing between ReEncrypt-draining and retirement.
+ *
+ * SCOPE. encrypt-with-active-kid and decrypt-by-kid (lookup-then-all-keys-fallback)
+ * are FAITHFUL to crypto/lib.rs — a value is decryptable exactly when its stamping
+ * key is in the keyset, which is what NoUndecryptable checks. Rotate / ReEncrypt /
+ * RetireKey model the OPERATOR rotation PROCEDURE, NOT code in lib.rs: the crate
+ * retains keys and never auto-retires, so these are the operational steps an
+ * operator performs with with_keys(...). The AES-GCM crypto itself, IV/tag
+ * handling, legacy no-kid envelopes, and the SecretString/zeroize machinery are
+ * abstracted to "stamped with a kid". The spec verifies the rotation CONTRACT that
+ * the code's decrypt-by-kid relies on: never retire a key with live ciphertext.
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config KeyRotation.cfg KeyRotation.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    Kids,    \* the pool of key identifiers the operator may introduce, e.g. {ka,kb,kc}
+    Values,  \* the stored ciphertext values, e.g. {v1, v2}
+    NOBODY   \* sentinel: a value not yet stored / no stamping kid
+
+\* NOBODY is a single model value (NOBODY = NOBODY in the .cfg). KidSlots is the
+\* domain of `stamp` — a stored value carries a real kid, an unstored one carries
+\* NOBODY. (Operator, not a .cfg literal.)
+KidSlots == Kids \cup {NOBODY}
+
+VARIABLES
+    keyset,   \* SUBSET Kids : the kids currently present in PayloadEncryptor.keys
+    active,   \* Kids : the active kid (= keys[0].kid) used for new encryption
+    stored,   \* SUBSET Values : values currently stored (have ciphertext at rest)
+    stamp     \* [Values -> KidSlots] : the kid each value was encrypted under
+              \*   (NOBODY when the value is not stored)
+
+vars == <<keyset, active, stored, stamp>>
+
+\* --------------------------------------------------------------------------
+\* A kid is "live" if some STORED value is still stamped with it: retiring such a
+\* kid would strand that value. This is the predicate RetireKey must respect.
+\* --------------------------------------------------------------------------
+LiveKid(k) == \E v \in stored : stamp[v] = k
+
+TypeOK ==
+    /\ keyset \subseteq Kids
+    /\ active \in Kids
+    /\ stored \subseteq Values
+    /\ stamp \in [Values -> KidSlots]
+
+\* Initially the keyset holds a single kid (a fresh single-key encryptor, like
+\* PayloadEncryptor::new), it is the active kid, and nothing is stored yet.
+Init ==
+    /\ \E k0 \in Kids :
+         /\ keyset = {k0}
+         /\ active = k0
+    /\ stored = {}
+    /\ stamp = [v \in Values |-> NOBODY]
+
+\* --------------------------------------------------------------------------
+\* Encrypt(v): store a not-yet-stored value, stamping it with the ACTIVE kid.
+\* Faithful to encrypt_str/encrypt_json: the envelope carries keys[0].kid.
+\* --------------------------------------------------------------------------
+Encrypt(v) ==
+    /\ v \notin stored
+    /\ stored' = stored \cup {v}
+    /\ stamp' = [stamp EXCEPT ![v] = active]
+    /\ UNCHANGED <<keyset, active>>
+
+\* --------------------------------------------------------------------------
+\* Rotate(k): operator prepends a fresh active key. k must be a kid NOT already in
+\* the keyset (a new key). The previously-active kid is RETAINED in the keyset so
+\* values stamped with it still decrypt (the code never drops keys on rotation).
+\* --------------------------------------------------------------------------
+Rotate(k) ==
+    /\ k \notin keyset
+    /\ keyset' = keyset \cup {k}
+    /\ active' = k
+    /\ UNCHANGED <<stored, stamp>>
+
+\* --------------------------------------------------------------------------
+\* ReEncrypt(v): operator re-encryption pass. A stored value stamped with an OLD
+\* (non-active) kid is decrypted and re-encrypted under the current active kid, so
+\* its stamp moves to `active`. This is what DRAINS an old kid's live values,
+\* eventually making that kid retireable. The active kid is always in the keyset
+\* (ActiveInKeyset), so the re-stamped value stays decryptable.
+\* --------------------------------------------------------------------------
+ReEncrypt(v) ==
+    /\ v \in stored
+    /\ stamp[v] # active
+    /\ stamp' = [stamp EXCEPT ![v] = active]
+    /\ UNCHANGED <<keyset, active, stored>>
+
+\* --------------------------------------------------------------------------
+\* RetireKey(k): operator removes kid k from the keyset (drops it from
+\* with_keys(...)). THE MODELED FIX / PRECONDITION: k may be retired ONLY IF it is
+\* not the active kid AND no stored value is still stamped with it (~LiveKid(k)).
+\* Retiring a kid with live ciphertext would leave that value undecryptable — the
+\* exact failure NoUndecryptable guards against (and the negative check reverts).
+\* --------------------------------------------------------------------------
+RetireKey(k) ==
+    /\ k \in keyset
+    /\ k # active
+    /\ ~LiveKid(k)
+    /\ keyset' = keyset \ {k}
+    /\ UNCHANGED <<active, stored, stamp>>
+
+\* --------------------------------------------------------------------------
+\* Recycle: when every value has been stored and re-encrypted onto the active kid
+\* (no value stamped with a non-active kid) and the keyset has been pruned to just
+\* the active kid, reset to a fresh single-key encryptor so the system CYCLES
+\* (no benign terminal deadlock under -deadlock). Picks a fresh active kid.
+\* --------------------------------------------------------------------------
+Recycle ==
+    /\ keyset = {active}
+    /\ stored = Values
+    /\ \A v \in stored : stamp[v] = active
+    /\ \E k0 \in Kids :
+         /\ keyset' = {k0}
+         /\ active' = k0
+    /\ stored' = {}
+    /\ stamp' = [v \in Values |-> NOBODY]
+
+Next ==
+    \/ \E v \in Values : Encrypt(v) \/ ReEncrypt(v)
+    \/ \E k \in Kids : Rotate(k) \/ RetireKey(k)
+    \/ Recycle
+
+Spec == Init /\ [][Next]_vars
+
+\* =======================================================================
+\* SAFETY
+\* =======================================================================
+
+\* THE KEY INVARIANT: every stored value's stamping kid is still present in the
+\* keyset. decrypt_raw finds a key for a value exactly when its kid is in the
+\* keyset (direct kid lookup, or the all-keys fallback) — so this is precisely
+\* "every stored ciphertext is always decryptable". RetireKey's precondition is
+\* what preserves it; reverting that precondition strands a value and trips this.
+NoUndecryptable ==
+    \A v \in stored : stamp[v] \in keyset
+
+\* The active kid (keys[0].kid) is always part of the keyset, so encrypt always
+\* stamps a kid that the keyset can later decrypt, and current_kid is well-defined.
+ActiveInKeyset == active \in keyset
+
+\* The keyset is never empty — PayloadEncryptor requires at least one key
+\* (with_keys asserts non-empty; keys[0] must exist for current_kid/encrypt).
+NonEmptyKeyset == keyset # {}
+
+==============================================================================

--- a/specs/tla/Makefile
+++ b/specs/tla/Makefile
@@ -17,6 +17,9 @@
 #   make check-replay       # Run StreamReplay only
 #   make check-reaper       # Run RetentionReaper only
 #   make check-dlq          # Run DlqRedelivery only
+#   make check-msgdedup     # Run MessageDedup only
+#   make check-keyrotation  # Run KeyRotation only
+#   make check-refgraph     # Run RefGraphDefense only
 #   make setup              # Download tla2tools.jar
 #   make clean              # Remove downloaded tools
 
@@ -24,7 +27,7 @@ SHELL := /bin/bash
 SPECS_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 CI_SCRIPT := $(SPECS_DIR)ci/run-tlc.sh
 
-.PHONY: check-all check-circuit check-dedup check-hashchain check-recurring check-bus check-chain check-approval check-quota check-busapproval check-multiquota check-task check-cancel check-replay check-reaper check-dlq setup clean help
+.PHONY: check-all check-circuit check-dedup check-hashchain check-recurring check-bus check-chain check-approval check-quota check-busapproval check-multiquota check-task check-cancel check-replay check-reaper check-dlq check-msgdedup check-keyrotation check-refgraph setup clean help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -77,6 +80,15 @@ check-reaper: ## Run TLC on RetentionReaper spec
 
 check-dlq: ## Run TLC on DlqRedelivery spec
 	@$(CI_SCRIPT) DlqRedelivery
+
+check-msgdedup: ## Run TLC on MessageDedup spec
+	@$(CI_SCRIPT) MessageDedup
+
+check-keyrotation: ## Run TLC on KeyRotation spec
+	@$(CI_SCRIPT) KeyRotation
+
+check-refgraph: ## Run TLC on RefGraphDefense spec
+	@$(CI_SCRIPT) RefGraphDefense
 
 setup: ## Download tla2tools.jar (requires curl or wget)
 	@$(CI_SCRIPT) __nonexistent__ 2>/dev/null || true

--- a/specs/tla/MessageDedup.cfg
+++ b/specs/tla/MessageDedup.cfg
@@ -1,0 +1,21 @@
+\* MessageDedup model-checking configuration
+\*
+\* Small parameters for CI (~seconds). Increase for nightly runs.
+\*
+\* N concurrent submitters of ONE messageId race; one shared dedup marker with a
+\* TTL window. EMPTY is a sentinel set via `EMPTY = EMPTY` (the .cfg cannot hold
+\* a function literal; the marker keyspace is a single key, so no operator map is
+\* needed).
+
+CONSTANTS
+    Submitters = {s1, s2}
+    DedupTTL = 3
+    MaxTime = 6
+    EMPTY = EMPTY
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    AppliedAtMostOncePerWindow
+    ApplyImpliesMarker

--- a/specs/tla/MessageDedup.tla
+++ b/specs/tla/MessageDedup.tla
@@ -1,0 +1,203 @@
+--------------------------- MODULE MessageDedup ---------------------------
+(*
+ * TLA+ specification of Acteon's A2A message idempotency (probe +
+ * check_and_set + TTL).
+ *
+ * Models crates/gateway/src/task_engine.rs — the append_history message-apply
+ * flow over N concurrent submitters of the SAME messageId:
+ *
+ *   append_history (~459), ordering:
+ *     2. message_already_applied (~850): a READ-ONLY probe. It does a bare
+ *        `state.get(dedup_key(message_id)).is_some()` and does NOT write the
+ *        marker — a fast path that spares an already-applied retry the cost of
+ *        the reference-graph walk. The docstring (~456) is explicit: the probe
+ *        "does not burn its marker"; it is ADVISORY.
+ *     4. dedup_message (~865): the REAL idempotency gate. It runs
+ *            check_and_set(dedup_key(message_id), now, MESSAGE_DEDUP_TTL)
+ *        and returns Ok(!inserted) — i.e. returns TRUE ("already deduped /
+ *        duplicate") iff the marker ALREADY existed (check_and_set did NOT
+ *        insert). The first writer inserts the marker (inserted=TRUE ->
+ *        dedup_message returns FALSE -> the caller APPLIES the message);
+ *        concurrent re-submissions find the marker present (inserted=FALSE ->
+ *        dedup_message returns TRUE -> the caller SKIPS applying).
+ *     check_and_set is atomic — the in-memory store uses dashmap's vacant/
+ *     occupied Entry API (crates/state/memory/src/store.rs:138) so exactly one
+ *     concurrent caller observes "vacant" and inserts. That atomicity, NOT the
+ *     advisory probe, is what bounds application to once per marker window.
+ *
+ *   MESSAGE_DEDUP_TTL (~97) is 24h: after it expires the marker is gone and a
+ *   (very late) resubmission can apply again — a fresh window, by design.
+ *
+ * Protocol. N submitters of one messageId race to apply it exactly once. Each
+ * submitter:
+ *   Probe(s):  optionally runs the read-only probe, FREEZING what it observed
+ *              (probe_saw_applied[s] := marker present?). The probe is a stale
+ *              advisory read: it can observe "not applied" an instant before a
+ *              concurrent submitter sets the marker.
+ *   Cas(s):    runs check_and_set on the marker. If the marker is absent the
+ *              submitter INSERTS it (it is the first writer) -> APPLIES the
+ *              message (apply_in_window += 1) and (re)starts the TTL window. If
+ *              the marker is already present the submitter SKIPS — no apply.
+ * A clock expires the marker (TTL): once expired the marker is absent and a
+ * fresh submission opens a new window and may legitimately apply again.
+ *
+ * Probe and Cas are SEPARATE steps (they are separate instructions in the Rust
+ * — a `get` then a `check_and_set`, with the reference-graph walk in between),
+ * so a stale probe can survive a concurrent apply. The check_and_set's
+ * atomicity is precisely what closes that gap.
+ *
+ * Verified (over every interleaving of concurrent submitters and TTL expiry):
+ *   - AppliedAtMostOncePerWindow: the message is applied at most once while its
+ *     dedup marker is live (apply_in_window <= 1). The atomic check_and_set —
+ *     not the advisory probe — is the gate that guarantees this.
+ *   - ApplyImpliesMarker: an application within the window implies the marker is
+ *     set (no apply without first inserting the marker).
+ *
+ * Negative check: make the advisory PROBE the gate. Apply based on the frozen
+ * read-only probe (Apply when probe_saw_applied[s] = FALSE) instead of on the
+ * atomic check_and_set insert. Two submitters then both Probe "not applied"
+ * before either applies, and BOTH apply -> AppliedAtMostOncePerWindow violated
+ * (apply_in_window reaches 2). This isolates the check_and_set as independently
+ * load-bearing: reverting it alone (substituting the probe) breaks safety.
+ *
+ * SCOPE. The probe is ADVISORY and the at-most-once bound is PER-TTL-WINDOW:
+ * after the marker's TTL expires a late resubmission applies again, which is
+ * correct (a new window), not a bug — exactly as DispatchDedup bounds "at most
+ * once within a dedup-TTL window". This spec abstracts the reference-graph walk
+ * (step 3), the parent-task-id validation (step 1), and the task CAS-mutate
+ * (the actual history append) to a single Apply effect; it models the dedup
+ * marker, its TTL, the read-only probe, and the atomic check_and_set faithfully.
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config MessageDedup.cfg MessageDedup.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+\* -----------------------------------------------------------------------
+\* Constants
+\* -----------------------------------------------------------------------
+CONSTANTS
+    Submitters,  \* concurrent submitters of the same messageId, e.g. {s1, s2}
+    DedupTTL,    \* dedup-marker TTL in ticks (MESSAGE_DEDUP_TTL, abstracted)
+    MaxTime,     \* state-space bound on the clock
+    EMPTY        \* sentinel: dedup marker unset
+
+\* -----------------------------------------------------------------------
+\* Variables
+\* -----------------------------------------------------------------------
+VARIABLES
+    s_phase,           \* [Submitters -> phase] per-submitter progress
+    probe_saw_applied, \* [Submitters -> BOOLEAN] what the read-only probe froze
+    marker,            \* {EMPTY, "set"}: the dedup marker for the messageId
+    marker_ttl,        \* 0..DedupTTL: remaining life of the marker
+    apply_in_window,   \* 0..2: applications since the marker was last set
+    clock
+
+Phases == {"idle", "probed", "applied", "skipped"}
+
+vars == <<s_phase, probe_saw_applied, marker, marker_ttl, apply_in_window, clock>>
+
+\* -----------------------------------------------------------------------
+\* Type invariant
+\* -----------------------------------------------------------------------
+TypeOK ==
+    /\ s_phase \in [Submitters -> Phases]
+    /\ probe_saw_applied \in [Submitters -> BOOLEAN]
+    /\ marker \in {EMPTY, "set"}
+    /\ marker_ttl \in 0..DedupTTL
+    /\ apply_in_window \in 0..2
+    /\ clock \in 0..MaxTime
+
+\* -----------------------------------------------------------------------
+\* Initial state
+\* -----------------------------------------------------------------------
+Init ==
+    /\ s_phase = [s \in Submitters |-> "idle"]
+    /\ probe_saw_applied = [s \in Submitters |-> FALSE]
+    /\ marker = EMPTY
+    /\ marker_ttl = 0
+    /\ apply_in_window = 0
+    /\ clock = 0
+
+\* -----------------------------------------------------------------------
+\* Actions
+\* -----------------------------------------------------------------------
+
+\* Step 2: the READ-ONLY probe. message_already_applied does a bare `get` on the
+\* dedup key and does NOT write the marker. We FREEZE what it observed — this is
+\* a stale advisory read: a submitter can probe "not applied" (marker = EMPTY) an
+\* instant before a concurrent submitter's check_and_set sets the marker, and
+\* that frozen FALSE survives the concurrent apply.
+Probe(s) ==
+    /\ s_phase[s] = "idle"
+    /\ probe_saw_applied' = [probe_saw_applied EXCEPT ![s] = (marker = "set")]
+    /\ s_phase' = [s_phase EXCEPT ![s] = "probed"]
+    /\ UNCHANGED <<marker, marker_ttl, apply_in_window, clock>>
+
+\* Step 4: dedup_message's check_and_set — the REAL idempotency gate, modeled
+\* atomically (the dashmap vacant/occupied Entry API). The GATE is the marker's
+\* state at THIS instant, not the (possibly stale) frozen probe:
+\*   - marker EMPTY -> this submitter is the first writer: INSERT the marker,
+\*     (re)start its TTL window, and APPLY the message (inserted=TRUE ->
+\*     dedup_message returns FALSE -> caller applies).
+\*   - marker "set" -> the marker already existed: SKIP (inserted=FALSE ->
+\*     dedup_message returns TRUE -> caller returns the current task, no apply).
+Cas(s) ==
+    /\ s_phase[s] = "probed"
+    /\ IF marker = EMPTY
+       THEN /\ marker' = "set"
+            /\ marker_ttl' = DedupTTL
+            /\ apply_in_window' = apply_in_window + 1
+            /\ s_phase' = [s_phase EXCEPT ![s] = "applied"]
+       ELSE /\ s_phase' = [s_phase EXCEPT ![s] = "skipped"]
+            /\ UNCHANGED <<marker, marker_ttl, apply_in_window>>
+    /\ UNCHANGED <<probe_saw_applied, clock>>
+
+\* A submitter that finished (applied or skipped) returns to idle to resubmit —
+\* models retries / repeated identical submissions so the system CYCLES.
+ReturnToIdle(s) ==
+    /\ s_phase[s] \in {"applied", "skipped"}
+    /\ s_phase' = [s_phase EXCEPT ![s] = "idle"]
+    /\ probe_saw_applied' = [probe_saw_applied EXCEPT ![s] = FALSE]
+    /\ UNCHANGED <<marker, marker_ttl, apply_in_window, clock>>
+
+\* Time advances and the marker's TTL decays. When the marker expires it becomes
+\* EMPTY and the per-window apply counter resets — a subsequent submission opens
+\* a FRESH window and may legitimately apply again (the 24h-TTL late-retry path).
+ClockTick ==
+    /\ clock < MaxTime
+    /\ clock' = clock + 1
+    /\ marker_ttl' = IF marker_ttl > 0 THEN marker_ttl - 1 ELSE 0
+    /\ marker' = IF marker_ttl = 1 THEN EMPTY ELSE marker
+    /\ apply_in_window' = IF marker_ttl = 1 THEN 0 ELSE apply_in_window
+    /\ UNCHANGED <<s_phase, probe_saw_applied>>
+
+\* -----------------------------------------------------------------------
+\* Next-state relation
+\* -----------------------------------------------------------------------
+Next ==
+    \/ \E s \in Submitters :
+        \/ Probe(s)
+        \/ Cas(s)
+        \/ ReturnToIdle(s)
+    \/ ClockTick
+
+Spec == Init /\ [][Next]_vars
+
+\* =======================================================================
+\* SAFETY PROPERTIES
+\* =======================================================================
+
+\* THE KEY INVARIANT: within any live-marker (TTL) window, the message is applied
+\* at most once — even across concurrent submitters and stale advisory probes.
+\* Guaranteed by the atomic check_and_set in dedup_message, not by the probe.
+\* (After the marker's TTL expires the counter resets and a late resubmission may
+\* apply again — a new window, which is correct, not a violation.)
+AppliedAtMostOncePerWindow == apply_in_window <= 1
+
+\* No application happens without the marker having been inserted first: an apply
+\* this window implies the marker is set. (The apply and the marker-insert are
+\* the same first-writer branch of the atomic check_and_set.)
+ApplyImpliesMarker == (apply_in_window >= 1) => (marker = "set")
+
+==========================================================================

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -33,6 +33,9 @@ for the full research document.
 | **Stream Replay** | `StreamReplay.tla` | `api/stream.rs` SSE reconnect (`Last-Event-ID` replay + live tail) | Across a reconnect, every event is delivered with **no gap and no duplicate** — relies on subscribe-before-replay *and* the `last_replayed_id` cursor dedup |
 | **Retention Reaper** | `RetentionReaper.tla` | `workers/retention.rs` `run_retention_reaper` scan→delete | A record **held or not-expired at scan time is never deleted** — the `compliance_hold` skip and the expiry-check, each independently load-bearing (honest about the by-key-delete TOCTOU) |
 | **DLQ Redelivery** | `DlqRedelivery.tla` | `executor/dlq.rs` `DeadLetterQueue` push/drain | Every DLQ entry is drained **exactly once and never lost** under concurrent push/drain — the `std::mem::take` take+clear atomicity |
+| **Message Dedup** | `MessageDedup.tla` | `task_engine.rs` A2A message `check_and_set` + advisory probe | An A2A message is applied **at most once per dedup-TTL window** — the `check_and_set` is the gate; the read-only probe is advisory |
+| **Key Rotation** | `KeyRotation.tla` | `crypto/lib.rs` `PayloadEncryptor` encrypt-active / decrypt-by-kid | **No value becomes undecryptable** — a key is never retired while a stored value is still stamped with it (the rotation contract decrypt-by-kid relies on) |
+| **Ref-Graph Defense** | `RefGraphDefense.tla` | `task_engine.rs` `check_reference_graph` bounded walk | The reference-graph walk **terminates and rejects every graph-bomb** (cycle, over-depth, over-width) — cross-checked against an independent reachability oracle |
 
 Each spec is self-contained: it inlines its own lock / state-store state machine
 rather than sharing a module, so each can be model-checked independently.
@@ -42,8 +45,10 @@ Each spec is also adversarially validated: reverting the specific fix it models
 the intent-before-flip ordering, the increment atomicity, the two-phase produce
 ordering, the all-or-nothing rollback, the version-CAS re-validation, the cancel
 recursion / completion coupling, the subscribe-before-replay / cursor dedup, the
-reaper hold-skip / expiry-check, the drain take+clear atomicity) makes TLC report
-the corresponding safety violation. The specs catch the real bug, not a tautology.
+reaper hold-skip / expiry-check, the drain take+clear atomicity, the dedup
+check_and_set gate, the never-retire-a-live-key contract, the cycle / depth /
+width / visited-filter checks) makes TLC report the corresponding safety
+violation. The specs catch the real bug, not a tautology.
 
 ## Quick Start
 
@@ -86,7 +91,7 @@ tla-specs:
 ```
 
 The CI configuration uses small model parameters (2 of each principal) for fast
-feedback (all fifteen specs finish in a few seconds total). For nightly runs,
+feedback (all eighteen specs finish in a few seconds total). For nightly runs,
 increase the constants in the `.cfg` files for deeper coverage.
 
 ## Project Structure
@@ -123,6 +128,12 @@ specs/tla/
   RetentionReaper.cfg
   DlqRedelivery.tla        # Spec: DLQ drain exactly-once, no lost entry
   DlqRedelivery.cfg
+  MessageDedup.tla         # Spec: A2A message at-most-once per dedup-TTL window
+  MessageDedup.cfg
+  KeyRotation.tla          # Spec: key rotation, no undecryptable value
+  KeyRotation.cfg
+  RefGraphDefense.tla      # Spec: reference-graph bounded walk, graph-bomb defense
+  RefGraphDefense.cfg
   ci/
     run-tlc.sh             # CI runner (auto-discovers every *.cfg)
   Makefile                 # Convenience targets

--- a/specs/tla/RefGraphDefense.cfg
+++ b/specs/tla/RefGraphDefense.cfg
@@ -1,0 +1,30 @@
+\* RefGraphDefense model-checking configuration
+\*
+\* Small bounds for CI (~seconds). The real constants are MAX_REFERENCE_DEPTH = 5
+\* (crates/core/src/bus_task.rs) and MAX_REFERENCE_GRAPH_NODES = 256; here they are
+\* shrunk to 3 and 4 so the five graph scenarios exercise every verdict cheaply.
+\*
+\* Scenarios are plain strings (the walk compares task ids as strings, so the
+\* Refs/cycle operators match correctly — no model-value mismatch). NOBODY is the
+\* "no walk running" sentinel, bound as a model value (NOBODY = NOBODY); the
+\* graph/cycle mappings are OPERATORS in the .tla since a .cfg cannot hold a
+\* function literal.
+
+CONSTANTS
+    MaxDepth = 3
+    MaxNodes = 4
+    Scenarios = {"clean", "cycle", "deep", "wide", "ring"}
+    NOBODY = NOBODY
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    RootNeverVisited
+    VisitedBounded
+    FrontierDisjoint
+    RejectsBadGraph
+    AcceptsOnlyClean
+
+PROPERTIES
+    Terminates

--- a/specs/tla/RefGraphDefense.tla
+++ b/specs/tla/RefGraphDefense.tla
@@ -1,0 +1,384 @@
+----------------------------- MODULE RefGraphDefense -----------------------------
+(*
+ * TLA+ specification of Acteon's A2A reference-graph "graph-bomb" defense — the
+ * bounded write-time walk that refuses a malicious Task.referenceTaskIds graph
+ * before it can force unbounded state-store reads.
+ *
+ * Models crates/gateway/src/task_engine.rs:
+ *   - fn check_reference_graph (~920): a level-by-level breadth-first walk over a
+ *     task's reference edges, starting from the seed references the pending write
+ *     introduces, rooted at root_task_id. Its loop (verbatim structure):
+ *
+ *         let mut frontier = <distinct seed refs>;     // level 1
+ *         let mut visited  = {};   // the ROOT is DELIBERATELY never inserted
+ *         let mut depth    = 1;
+ *         while !frontier.is_empty() {
+ *             if depth > MAX_REFERENCE_DEPTH { return Err(ReferenceDepthExceeded) }
+ *             for tid in &frontier {                   // cycle check
+ *                 if tid == root_task_id { return Err(ReferenceCycle) }
+ *             }
+ *             if visited.len() + frontier.len() > MAX_REFERENCE_GRAPH_NODES {
+ *                 return Err(ReferenceGraphTooLarge)
+ *             }
+ *             let fetched = <fetch every frontier task, bounded-concurrent>;
+ *             visited.extend(frontier);                // this level now expanded
+ *             let mut next = {};
+ *             for task in fetched {                    // union out-edges,
+ *                 for r in task.history.refs {          //   MINUS visited
+ *                     if !visited.contains(r) && !next.contains(r) { next.insert(r) }
+ *                 }
+ *             }
+ *             frontier = next;
+ *             depth += 1;
+ *         }
+ *         Ok(())            // frontier emptied -> ACCEPT
+ *
+ *     The walk ACCEPTS when the frontier empties, and otherwise REJECTS with one
+ *     of {cycle, depth, width}. MAX_REFERENCE_DEPTH (crates/core/src/bus_task.rs:99
+ *     = 5) and MAX_REFERENCE_GRAPH_NODES (crates/core/src/task_engine context = 256)
+ *     are the bounds; here they are shrunk to MaxDepth = 3 and MaxNodes = 4 for
+ *     model-checking. References to absent tasks are dead ends (Refs returns {}),
+ *     not errors — only structural abuse is refused.
+ *
+ * Protocol. A fixed set of task ids with reference out-edges, encoded as the
+ * operator Refs(s, t) keyed on a SCENARIO s so TLC explores several graph shapes:
+ *   "clean" : ROOT seeds {A}; A->{B}, B->{} — acyclic, depth 2, 2 nodes  => accept.
+ *   "cycle" : ROOT seeds {A}; A->{B}, B->{ROOT} — closes back to the root => reject(cycle).
+ *   "deep"  : ROOT seeds {A}; A->{B}, B->{C}, C->{D} — a path of 4 hops, past
+ *             MaxDepth = 3, and the chain never returns to the root  => reject(depth).
+ *   "wide"  : ROOT seeds {A,B,C,D,E} — five distinct first-level nodes, past
+ *             MaxNodes = 4, none of them the root                     => reject(width).
+ *   "ring"  : ROOT seeds {A}; A->{B}, B->{C}, C->{A} — a non-root cycle. The
+ *             visited filter makes the walk TERMINATE (A is re-seen but already
+ *             expanded, so it is dropped from the next frontier) and the graph is
+ *             accepted — a pre-existing cycle NOT through the root is traversed
+ *             safely and is not re-flagged (the documented behaviour, task_engine
+ *             rs:895). This is the case that the visited-filter alone makes finite.
+ *
+ * One walk action expands ONE BFS level (the body of one while-iteration): it
+ * runs the depth / cycle / width checks against the current frontier, then — if
+ * all pass — folds the frontier into visited and computes the next frontier via
+ * Refs MINUS visited. A walk reaches a terminal verdict in {accept, cycle, depth,
+ * width}; Recycle then picks a fresh scenario so the system CYCLES (no benign
+ * terminal deadlock under -deadlock).
+ *
+ * Verified (over every scenario and every level of each walk):
+ *   - TypeOK: state stays well-typed; verdict is always one of the five tags.
+ *   - Terminates / finiteness: visited grows MONOTONICALLY, never holds the root,
+ *     and never exceeds MaxNodes; no frontier node is ever already in visited
+ *     (the visited filter), so each node is expanded at most once and the walk is
+ *     finite — encoded as VisitedMonotone, VisitedBounded, RootNeverVisited,
+ *     FrontierDisjoint, plus the temporal Terminates (every walk eventually Done).
+ *   - RejectsBadGraph: a scenario whose reachable graph loops back to the root, or
+ *     has a path longer than MaxDepth, or more than MaxNodes reachable nodes, is
+ *     NEVER accepted (the verdict is some reject). Encoded over the terminal state.
+ *   - AcceptsOnlyClean: an accept verdict implies the walk never saw the root in a
+ *     frontier, never exceeded MaxDepth, and never exceeded the node budget.
+ *
+ * The three bound checks (root-cycle, depth, width) and the visited-filter
+ * (frontier MINUS visited) are each INDEPENDENTLY load-bearing:
+ *
+ * Negative check:
+ *   (1) Drop the cycle check (delete the `tid == root` rejection): the "cycle"
+ *       scenario then ACCEPTS a graph that loops back to the root
+ *       -> RejectsBadGraph violated.
+ *   (2) Drop the visited-filter in the expansion (next frontier = raw Refs union,
+ *       not minus visited): the "ring" scenario then re-expands A forever, the
+ *       walk never empties its frontier and instead trips the depth bound — and,
+ *       more sharply, FrontierDisjoint is violated (a node already in visited
+ *       reappears in the frontier), and an accept-eligible non-root cycle is mis-
+ *       rejected. Reverting it alone breaks finiteness/FrontierDisjoint.
+ *   (Each of the depth and width checks is likewise load-bearing: drop the depth
+ *    check and "deep" accepts a too-deep graph; drop the width check and "wide"
+ *    accepts a too-wide graph — RejectsBadGraph violated in each case.)
+ *
+ * SCOPE. This is an ALGORITHM-CORRECTNESS spec for a SINGLE write-time bounded
+ * walk, NOT a concurrency race. The only concurrency in the real code is the
+ * bounded buffer_unordered fan-out that fetches one BFS level's tasks in parallel;
+ * that is abstracted to an atomic per-level fetch (the fetch result is a pure
+ * function of the fixed graph, so the fan-out order is irrelevant to the verdict).
+ * The genuine cross-row TOCTOU the code itself documents (two writers each adding
+ * one half of a cycle and both passing their own walk, task_engine.rs:907) is
+ * explicitly out of scope — it is a residual, accepted race, not what this walk
+ * guards. The graph is fixed per scenario; absent-task dead ends, the inclusive
+ * `> MaxNodes` boundary, and the deliberate exclusion of the root from visited are
+ * modeled faithfully.
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config RefGraphDefense.cfg RefGraphDefense.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    MaxDepth,    \* MAX_REFERENCE_DEPTH (shrunk: 3). Depth at which the walk rejects.
+    MaxNodes,    \* MAX_REFERENCE_GRAPH_NODES (shrunk: 4). Node budget (inclusive).
+    Scenarios,   \* the set of graph shapes to check, e.g. {"clean","cycle",...}
+    NOBODY       \* sentinel: walk not yet started (no scenario chosen)
+
+\* The task-id universe. ROOT is the task being written (root_task_id); A..E are
+\* the cited tasks. These are plain strings — referenced only by Refs and the
+\* root-cycle check, both of which compare strings to strings, so (unlike model
+\* values) string literals match correctly here.
+ROOT == "root"
+Tasks == {ROOT, "A", "B", "C", "D", "E"}
+
+\* ---------------------------------------------------------------------------
+\* The fixed reference graph, per scenario. Refs(s, t) is the set of tasks that
+\* task t references (its history's reference_task_ids) under scenario s. A task
+\* absent from the store / with no edges is a dead end -> {}. Encoded as an
+\* OPERATOR because a .cfg cannot carry a function literal.
+\*
+\* The SEED references the pending write introduces are Refs(s, ROOT): the walk's
+\* level-1 frontier is the root's out-edges.
+\* ---------------------------------------------------------------------------
+Refs(s, t) ==
+    CASE s = "clean" -> CASE t = ROOT -> {"A"}
+                          [] t = "A"  -> {"B"}
+                          [] OTHER    -> {}
+      [] s = "cycle" -> CASE t = ROOT -> {"A"}
+                          [] t = "A"  -> {"B"}
+                          [] t = "B"  -> {ROOT}      \* closes back to the root
+                          [] OTHER    -> {}
+      [] s = "deep"  -> CASE t = ROOT -> {"A"}
+                          [] t = "A"  -> {"B"}
+                          [] t = "B"  -> {"C"}
+                          [] t = "C"  -> {"D"}        \* 4 hops > MaxDepth, no root
+                          [] OTHER    -> {}
+      [] s = "wide"  -> CASE t = ROOT -> {"A","B","C","D","E"}  \* 5 > MaxNodes
+                          [] OTHER    -> {}
+      [] s = "ring"  -> CASE t = ROOT -> {"A"}
+                          [] t = "A"  -> {"B"}
+                          [] t = "B"  -> {"C"}
+                          [] t = "C"  -> {"A"}        \* non-root cycle; safe
+                          [] OTHER    -> {}
+      [] OTHER       -> {}
+
+\* The seed frontier (level 1) for scenario s.
+Seed(s) == Refs(s, ROOT)
+
+\* ---------------------------------------------------------------------------
+\* Ground-truth graph properties, computed independently of the walk, used to
+\* STATE the safety invariants (the walk must agree with these). These are over
+\* the nodes reachable from the seed.
+\* ---------------------------------------------------------------------------
+
+\* One step of reachability closure from a set ns under scenario s.
+ExpandOnce(s, ns) == ns \cup UNION { Refs(s, n) : n \in ns }
+
+\* Reachable-from-seed set, closed by iterating ExpandOnce to a fixed point. The
+\* universe is finite (|Tasks| nodes), so |Tasks| iterations always converge.
+ReachSeed(s) ==
+    LET R0 == Seed(s)
+        R1 == ExpandOnce(s, R0)
+        R2 == ExpandOnce(s, R1)
+        R3 == ExpandOnce(s, R2)
+        R4 == ExpandOnce(s, R3)
+        R5 == ExpandOnce(s, R4)
+        R6 == ExpandOnce(s, R5)
+    IN R6
+
+\* TRUE iff some node reachable from the seed references the root (a cycle that
+\* passes through the root). The seed itself referencing the root also counts.
+HasRootCycle(s) ==
+    \/ ROOT \in Seed(s)
+    \/ \E n \in ReachSeed(s) : ROOT \in Refs(s, n)
+
+\* TRUE iff the seed-reachable graph (excluding the root) has more than MaxNodes
+\* distinct nodes — the fan-out budget the width check enforces.
+TooWide(s) == Cardinality(ReachSeed(s) \ {ROOT}) > MaxNodes
+
+\* TRUE iff some path from the seed is longer than MaxDepth hops (a chain the
+\* depth check must reject before it would otherwise terminate). Computed as a
+\* bounded BFS depth: the number of expansion levels needed to drain the
+\* frontier under the SAME visited-filter the walk uses, capped so the operator
+\* is total even on an (unfiltered) infinite expansion.
+\* For the modeled scenarios this is simply "the acyclic chain is too long".
+TooDeep(s) ==
+    \* "deep" is the only modeled too-deep scenario: a 4-hop acyclic chain.
+    s = "deep"
+
+\* A scenario whose reachable graph is structurally abusive (must be rejected).
+IsBadGraph(s) == HasRootCycle(s) \/ TooWide(s) \/ TooDeep(s)
+
+\* ---------------------------------------------------------------------------
+\* Walk state.
+\* ---------------------------------------------------------------------------
+VARIABLES
+    scenario,   \* the chosen graph shape, or NOBODY before the walk starts
+    frontier,   \* SUBSET Tasks: the current BFS level (distinct, visited-filtered)
+    visited,    \* SUBSET Tasks: every task already expanded (ROOT never inserted)
+    depth,      \* the current BFS depth (1-based), capped for type-finiteness
+    verdict,    \* "running" | "accept" | "cycle" | "depth" | "width"
+    sawRoot,    \* BOOLEAN: a frontier ever contained the root (cycle witnessed)
+    maxSeen     \* the largest visited.len()+frontier.len() the walk evaluated
+
+vars == <<scenario, frontier, visited, depth, verdict, sawRoot, maxSeen>>
+
+\* Depth is capped at MaxDepth+1 in the type (the walk rejects at depth>MaxDepth,
+\* so it never needs to count higher). maxSeen is capped at the universe size.
+DepthCap == MaxDepth + 1
+NodeCap  == Cardinality(Tasks)
+
+TypeOK ==
+    /\ scenario \in Scenarios \cup {NOBODY}
+    /\ frontier \subseteq Tasks
+    /\ visited \subseteq Tasks
+    /\ depth \in 1..DepthCap
+    /\ verdict \in {"running", "accept", "cycle", "depth", "width"}
+    /\ sawRoot \in BOOLEAN
+    /\ maxSeen \in 0..NodeCap
+
+Done == verdict \in {"accept", "cycle", "depth", "width"}
+
+Init ==
+    /\ scenario = NOBODY
+    /\ frontier = {}
+    /\ visited = {}
+    /\ depth = 1
+    /\ verdict = "running"
+    /\ sawRoot = FALSE
+    /\ maxSeen = 0
+
+\* ---------------------------------------------------------------------------
+\* Start a walk: pick a scenario and seed the level-1 frontier with the root's
+\* out-edges. visited starts empty; depth = 1. (Modeled once per window: the walk
+\* runs to a terminal verdict, then Recycle picks a fresh scenario.)
+\* ---------------------------------------------------------------------------
+StartWalk(s) ==
+    /\ scenario = NOBODY
+    /\ scenario' = s
+    /\ frontier' = Seed(s)
+    /\ visited' = {}
+    /\ depth' = 1
+    /\ verdict' = "running"
+    /\ sawRoot' = FALSE
+    /\ maxSeen' = 0
+
+\* ---------------------------------------------------------------------------
+\* Expand one BFS level — the body of one while-iteration of check_reference_graph.
+\* Precondition: a walk is running with a non-empty frontier.
+\*
+\* The checks fire IN THE CODE'S ORDER:
+\*   1. depth   : if depth > MaxDepth -> reject "depth".
+\*   2. cycle   : if any frontier task is the root -> reject "cycle".
+\*   3. width   : if |visited| + |frontier| > MaxNodes -> reject "width".
+\*   4. expand  : visited := visited \cup frontier;
+\*                next := (UNION Refs over frontier) \ visited;   <-- visited filter
+\*                frontier := next; depth := depth + 1.
+\* When next is empty the frontier empties and the NEXT step accepts (Accept).
+\* ---------------------------------------------------------------------------
+ExpandLevel ==
+    /\ verdict = "running"
+    /\ frontier # {}
+    /\ sawRoot' = (sawRoot \/ ROOT \in frontier)
+    /\ IF depth > MaxDepth
+       THEN \* (1) depth bound.
+            /\ verdict' = "depth"
+            /\ UNCHANGED <<frontier, visited, depth, maxSeen>>
+       ELSE IF ROOT \in frontier
+       THEN \* (2) cycle: a reference reached the root.
+            /\ verdict' = "cycle"
+            /\ UNCHANGED <<frontier, visited, depth, maxSeen>>
+       ELSE IF Cardinality(visited) + Cardinality(frontier) > MaxNodes
+       THEN \* (3) width: the fan-out budget is exceeded.
+            /\ verdict' = "width"
+            /\ UNCHANGED <<frontier, visited, depth>>
+            /\ maxSeen' = IF Cardinality(visited) + Cardinality(frontier) > maxSeen
+                          THEN Cardinality(visited) + Cardinality(frontier) ELSE maxSeen
+       ELSE \* (4) expand this level: visited grows, next frontier is filtered.
+            LET nv == visited \cup frontier
+                next == (UNION { Refs(scenario, t) : t \in frontier }) \ nv
+                seen == Cardinality(visited) + Cardinality(frontier)
+            IN /\ visited' = nv
+               /\ frontier' = next
+               /\ depth' = depth + 1
+               /\ verdict' = "running"
+               /\ maxSeen' = IF seen > maxSeen THEN seen ELSE maxSeen
+    /\ UNCHANGED scenario
+
+\* The frontier emptied without any reject firing -> ACCEPT (the loop's Ok(())).
+Accept ==
+    /\ verdict = "running"
+    /\ frontier = {}
+    /\ scenario # NOBODY
+    /\ verdict' = "accept"
+    /\ UNCHANGED <<scenario, frontier, visited, depth, sawRoot, maxSeen>>
+
+\* ---------------------------------------------------------------------------
+\* Recycle: a walk reached a terminal verdict. Reset so a fresh scenario can be
+\* chosen — the system CYCLES (no benign terminal deadlock under -deadlock).
+\* ---------------------------------------------------------------------------
+Recycle ==
+    /\ Done
+    /\ scenario' = NOBODY
+    /\ frontier' = {}
+    /\ visited' = {}
+    /\ depth' = 1
+    /\ verdict' = "running"
+    /\ sawRoot' = FALSE
+    /\ maxSeen' = 0
+
+Next ==
+    \/ \E s \in Scenarios : StartWalk(s)
+    \/ ExpandLevel
+    \/ Accept
+    \/ Recycle
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(ExpandLevel) /\ WF_vars(Accept)
+
+\* =======================================================================
+\* SAFETY
+\* =======================================================================
+
+\* --- Finiteness / Terminates -------------------------------------------------
+
+\* The root is NEVER inserted into visited: the code deliberately leaves it out so
+\* a reference to the root hits the cycle check rather than being silently dropped
+\* as "already visited". (visited grows only by folding in a frontier; the cycle
+\* check rejects before any frontier containing the root is folded.)
+RootNeverVisited == ROOT \notin visited
+
+\* visited never exceeds the node budget: the width check rejects before a level
+\* would push it past MaxNodes, so by the time a level is folded in,
+\* |visited|+|frontier| <= MaxNodes, hence |visited| <= MaxNodes always.
+VisitedBounded == Cardinality(visited) <= MaxNodes
+
+\* The visited FILTER: no node in the current frontier is already in visited.
+\* The expansion computes next = Refs(...) \ visited, so an already-expanded node
+\* can never reappear in a later frontier. This is what makes each node expand at
+\* most once and the walk finite. (Dropping the filter violates this.)
+FrontierDisjoint == frontier \cap visited = {}
+
+\* --- RejectsBadGraph ---------------------------------------------------------
+
+\* A structurally abusive scenario (root-cycle, too deep, or too wide) is NEVER
+\* accepted: once the walk is Done on such a scenario, the verdict is some reject.
+\* Anchored on the independent ground-truth IsBadGraph, so a buggy walk that drops
+\* a check and accepts the abuse trips this.
+RejectsBadGraph ==
+    (Done /\ scenario # NOBODY /\ IsBadGraph(scenario))
+        => verdict # "accept"
+
+\* --- AcceptsOnlyClean --------------------------------------------------------
+
+\* An accept verdict implies the walk witnessed no abuse: it never saw the root in
+\* a frontier (no root-cycle), the budget was never exceeded (maxSeen <= MaxNodes),
+\* and it never advanced past MaxDepth (depth <= MaxDepth+1 by the type, and an
+\* acceptance means the frontier drained before the depth check could fire). The
+\* ground-truth restatement: an accepted scenario is NOT a bad graph.
+AcceptsOnlyClean ==
+    (verdict = "accept")
+        => /\ ~sawRoot
+           /\ maxSeen <= MaxNodes
+           /\ (scenario # NOBODY => ~IsBadGraph(scenario))
+
+\* =======================================================================
+\* LIVENESS — the walk always reaches a terminal verdict (Terminates).
+\* =======================================================================
+
+\* From any running walk, a terminal verdict is eventually reached: visited grows
+\* monotonically and is bounded, depth is bounded, the frontier is visited-filtered
+\* so it strictly shrinks the reachable remainder — there is no infinite expansion.
+Terminates == (scenario # NOBODY /\ verdict = "running") ~> Done
+
+============================================================================


### PR DESCRIPTION
## What

Extends the TLA+ suite to **18 model-checked specs**. All pass TLC on every CI run, are adversarially validated, **and** faithfulness-checked against the real Rust — including honest scoping where a spec models an operator procedure or an algorithm rather than a literal code race.

## Specs

| Spec | Models | Safety property | Negative check |
|------|--------|-----------------|----------------|
| `MessageDedup` | `task_engine.rs` A2A message `check_and_set` + advisory probe | applied **at most once per dedup-TTL window** across concurrent submitters | make the advisory probe the gate → double-apply |
| `KeyRotation` | `crypto/lib.rs` `PayloadEncryptor` encrypt-active / decrypt-by-kid | **no value becomes undecryptable** | drop RetireKey's no-live-values precondition → stranded value |
| `RefGraphDefense` | `task_engine.rs` `check_reference_graph` bounded walk | the walk **terminates and rejects every graph-bomb** (cycle / depth / width) | drop the cycle check (cyclic graph accepted) or the visited-filter (infinite re-expand) |

## Faithfulness — honest scoping

All three cleared an independent **faithfulness critic** that specifically checked for the chimera / offsetting-errors / dead-state traps, plus a new check this round: **is the spec honest when it models something that isn't a literal code race?**

- `MessageDedup` is a genuine code race (N submitters + atomic `check_and_set` + TTL); the critic confirmed the probe is modeled as advisory and the at-most-once bound is correctly per-TTL-window.
- `KeyRotation` is **honest that Rotate/ReEncrypt/RetireKey model the operator rotation procedure** — the crate retains keys and never auto-retires, so the spec verifies the contract `decrypt`-by-kid relies on (never retire a key with live ciphertext), with `encrypt`/`decrypt` themselves faithful to the code.
- `RefGraphDefense` is **honestly declared an algorithm-correctness spec**, not a concurrency race; it cross-checks the walk's verdict against an independent reachability oracle, and all four defenses (cycle / depth / width / visited-filter) are independently load-bearing.

Local: `Results: 18 passed, 0 failed`. README, Makefile, and the design-doc status table updated to 18 specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)