### PR TITLE
feat(specs): TLA+ specs for distributed lock, stale-task reaper, group ingest-flush

### DIFF
--- a/docs/design/tla-plus-formal-verification.md
+++ b/docs/design/tla-plus-formal-verification.md
@@ -17,7 +17,7 @@ This document identifies **the highest-value areas** in Acteon where TLA+ modeli
 harden correctness, proposes concrete specifications, and provides an implementation
 roadmap.
 
-> **Implementation status (May 2026).** Twenty-one specs are implemented and pass the TLC
+> **Implementation status (May 2026).** Twenty-four specs are implemented and pass the TLC
 > model checker on every run of `specs/tla/ci/run-tlc.sh` (wired into CI as the
 > `TLA+ Specs` job):
 >
@@ -44,6 +44,9 @@ roadmap.
 > | Conversation lifecycle | `ConversationLifecycle.tla` | Linear no-skip lifecycle (never Active→Archived without Resolved) and no message accepted after Archive, under concurrent version-CAS transitions + posts (`bus_conversation.rs` + `api/bus.rs`) |
 > | Silence window | `SilenceWindow.tla` | An action is suppressed iff a matching silence is active at dispatch time — the half-open `[starts_at, ends_at)` boundary + expiry, checked against an independent window oracle (`core/silence.rs is_active_at`) |
 > | Embedding single-flight | `EmbeddingSingleFlight.tla` | Concurrent misses for the same key coalesce into one provider call (thundering-herd protection) and all callers return the same value (`embedding/cache.rs` moka `try_get_with`) |
+> | Distributed lock | `DistributedLock.tla` | Mutual exclusion + owner-fenced release (a stale holder never frees the new holder's lock) + TTL lease — the `SET NX PX` + owner-checked-delete primitive every other spec assumes (`state/lock.rs` + `redis/lock.rs`) |
+> | Stale-task reaper | `StaleTaskReaper.tla` | The reaper never fails a task that heartbeated after its scan — the fresh `is_stale_at` re-check on the CAS-loaded row (`task_engine.rs fail_if_stale`, modeled scan→load→commit so the fresh re-check is load-bearing) |
+> | Group ingest-flush | `GroupIngestFlush.tla` | A late event for a Notified group re-arms it to Pending so no ingested event is stranded unnotified (`group_manager.rs add_to_group`; distinct from the `MessageBus` notify-once) |
 >
 > The realized layout deviates from the proposal below in one deliberate way: each spec
 > **inlines** its own lock / state-store state machine instead of sharing `common/`
@@ -577,14 +580,22 @@ specs/
     SilenceWindow.cfg
     EmbeddingSingleFlight.tla        # embedding cache single-flight (thundering herd)
     EmbeddingSingleFlight.cfg
+    DistributedLock.tla              # lock mutual exclusion + owner-fenced release + TTL
+    DistributedLock.cfg
+    StaleTaskReaper.tla              # reaper fresh-staleness re-check (no reap-after-heartbeat)
+    StaleTaskReaper.cfg
+    GroupIngestFlush.tla             # group ingest re-arm, no stranded event
+    GroupIngestFlush.cfg
     Makefile                         # Automation: `make check-all`
     ci/
       run-tlc.sh                     # auto-discovers every *.cfg; used by CI
 ```
 
-All twenty-one specs follow the same inlined, self-contained convention. Remaining
-candidates for future work: the group-flush dedup vs. concurrent ingest, the
-provider circuit-breaker probe under load, and the snapshot/restore consistency.
+All twenty-four specs follow the same inlined, self-contained convention. This
+covers the genuinely concurrency-critical surface of the system; the earlier
+"circuit-breaker probe under load" candidate is already covered by
+`CircuitBreaker.tla` (which models the full failure-threshold state machine), and
+"snapshot/restore" is config-DTO serialization rather than a concurrency protocol.
 
 ### 5.3 CI Integration
 

--- a/specs/tla/DistributedLock.cfg
+++ b/specs/tla/DistributedLock.cfg
@@ -1,0 +1,19 @@
+\* DistributedLock model-checking configuration
+\*
+\* Small parameters for CI (~seconds). Three contenders so the stale-releaser
+\* race (one stale, one new holder in its critical section, one third acquirer)
+\* is reachable. NOBODY is the free-key sentinel — an operator-free .cfg literal.
+
+CONSTANTS
+    Contenders = {c1, c2, c3}
+    TTL = 2
+    MaxToken = 4
+    NOBODY = NOBODY
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    MutualExclusion
+    HolderMatchesLock
+    OwnerFencedRelease

--- a/specs/tla/DistributedLock.tla
+++ b/specs/tla/DistributedLock.tla
@@ -1,0 +1,278 @@
+----------------------------- MODULE DistributedLock -----------------------------
+(*
+ * TLA+ specification of Acteon's distributed lock primitive — the foundational
+ * mutual-exclusion + owner-fencing lease that EVERY other spec assumes.
+ *
+ * Models:
+ *   - crates/state/state/src/lock.rs :: trait DistributedLock { try_acquire,
+ *     acquire } and trait LockGuard { release }.
+ *   - crates/state/redis/src/lock.rs + crates/state/redis/src/scripts.rs :: the
+ *     Redis impl. try_acquire runs `SET key <owner-uuid> NX PX <ttl_ms>` (NX =
+ *     set only if absent; PX = millisecond TTL auto-expiry). A FRESH owner UUID
+ *     is minted per acquisition and stored as the value (LOCK_ACQUIRE). release()
+ *     runs the LOCK_RELEASE Lua script:
+ *         local owner = redis.call('GET', KEYS[1])
+ *         if owner == ARGV[1] then redis.call('DEL', KEYS[1]); return 1 end
+ *         return 0
+ *     a COMPARE-AND-DELETE on the owner token — it deletes the key ONLY IF the
+ *     stored value still equals THIS guard's token. The TTL means the key
+ *     auto-expires (the lease) if the holder never releases.
+ *   - crates/state/memory/src/lock.rs :: the in-memory impl mirrors this — an
+ *     owner-tagged entry with `expires_at`, and release() does
+ *     `remove_if(name, |_, e| e.owner == self.owner)` (owner-checked delete).
+ *
+ * Protocol. A single lock key. N contenders each move idle -> InCS (in the
+ * critical section, lease live) -> PendingRelease (left the critical section,
+ * about to call release; the lease MAY have lapsed in the meantime) -> idle.
+ *   - TryAcquire: succeeds, becoming the holder with a FRESH owner token + a
+ *     TTL, ONLY IF the key is free; enters the critical section.
+ *   - LeaveCS: finish the protected work and leave the critical section (still
+ *     about to release). The lease may expire only AFTER this — modeling the
+ *     documented precondition "the lock TTL is longer than the critical section"
+ *     (redis/lock.rs ~line 35): a live holder's lease does not lapse mid-CS.
+ *   - Release: deletes the key ONLY IF the stored owner token still equals this
+ *     contender's token (the Lua compare-and-delete).
+ * A clock expires the lease (TTL) once the holder has LEFT its critical section
+ * (it abandoned/finished without releasing yet, or crashed): the expired lock
+ * becomes free, and another contender can acquire it (with a NEW owner token).
+ * A contender whose lease EXPIRED is "stale" and may still attempt to release —
+ * the owner-token compare-and-delete must make that a no-op on the NEW holder's
+ * lock. This stale-releaser race is the owner-fencing case under test.
+ *
+ * The OWNER-TOKEN check on release (compare-and-delete on the UUID) is the
+ * load-bearing fix. A contender carries the token it acquired with; the lock
+ * carries the token of its CURRENT holder. Release frees the lock ONLY when the
+ * releaser's token equals the lock's current token. Tokens are modeled as a
+ * monotonic counter so every acquisition gets a distinct, fresh value — faithful
+ * to the per-acquisition UUID, and so a stale token can never collide with a
+ * later holder's token.
+ *
+ * Verified (over every interleaving of concurrent contenders, releases, and TTL
+ * expiry):
+ *   - MutualExclusion: at most one contender is in its critical section at any
+ *     time. The invariant counts contenders whose phase is "holding" — an
+ *     INDEPENDENT ground-truth oracle, NOT the lock_owner/token bookkeeping the
+ *     implementation mutates, so a buggy release that displaces a holder is
+ *     caught rather than self-masked.
+ *   - HolderMatchesLock: a contender in its critical section holds a token equal
+ *     to the lock's current owner token (the holder is not silently displaced).
+ *   - OwnerFencedRelease: the holder is never displaced from the lock except by
+ *     its OWN release or a TTL expiry — a stale releaser's compare-and-delete
+ *     never frees a re-acquired lock owned by someone else. Checked via an
+ *     independent ground-truth witness (bad_free) that no release frees a lock
+ *     owned by a different token.
+ *
+ * Negative check: replace the owner-token compare-and-delete in Release with a
+ * BLIND unconditional delete (drop the `cont_token[c] = lock_owner` guard, free
+ * the key regardless of token). A STALE contender in PendingRelease — whose lease
+ * expired and the lock was re-acquired by ANOTHER contender now in its critical
+ * section — then frees the NEW holder's lock; a THIRD contender acquires
+ * concurrently while the displaced holder is STILL in its critical section, so
+ * two contenders sit in the critical section at once -> MutualExclusion (count
+ * "InCS" >= 2) is violated. With the token check, the stale release returns 0
+ * (no-op) and the race is impossible.
+ *
+ * SCOPE. The `SET NX PX` acquire and the `GET / compare-and-DEL` Lua release are
+ * each modeled as a SINGLE atomic TLA action — faithful to Redis executing them
+ * atomically (NX is atomic; the Lua script runs atomically server-side). This
+ * spec verifies the single-instance mutual-exclusion + owner-fencing contract.
+ * ABSTRACTED: the acquire() timeout/poll-retry wait loop (try_acquire is the
+ * primitive under test), extend()/is_held(), the PostgreSQL advisory-lock and
+ * DynamoDB conditional-write backends, the connection pool, and the exact Lua
+ * text. The documented Redis Cluster/Sentinel failover hole (async replication
+ * losing a just-written key) is OUT OF SCOPE — this models the single-instance
+ * guarantee the code claims to provide. The TTL is a logical tick counter.
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config DistributedLock.cfg DistributedLock.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    Contenders,  \* concurrent lock contenders / replicas, e.g. {c1, c2, c3}
+    TTL,         \* lease TTL in ticks (PX milliseconds in production)
+    MaxToken,    \* state-space bound on the monotonic owner-token counter
+    NOBODY       \* sentinel: lock key is free (absent in Redis), token 0
+
+VARIABLES
+    lock_owner,   \* owner TOKEN currently stored at the key, or NOBODY if free
+    lock_ttl,     \* 0..TTL: remaining lease ticks; 0 means free/expired
+    next_token,   \* 1..MaxToken: next fresh owner token to mint on acquire
+    cont_phase,   \* [Contenders -> {"idle","incs","pending_release"}]
+                  \*   "incs"            = inside the critical section, lease live
+                  \*   "pending_release" = left the critical section, about to call
+                  \*                       release (lease may have lapsed by now)
+    cont_token,   \* [Contenders -> 0..MaxToken]: token this contender last acquired
+                  \*   with (0 = never acquired / released). Compared against
+                  \*   lock_owner on release (the compare-and-delete) and used to
+                  \*   detect staleness (token # lock_owner after a re-acquire).
+    bad_free      \* BOOLEAN witness: TRUE iff some Release ever freed the lock
+                  \*   while the releaser's token did NOT equal the lock's owner
+                  \*   token — i.e. a non-owner displaced the current holder. The
+                  \*   compare-and-delete keeps it FALSE; the blind-delete bug
+                  \*   sets it. An INDEPENDENT ground-truth oracle (cf.
+                  \*   illegal_commit in A2aTaskTransition.tla), read only by the
+                  \*   OwnerFencedRelease invariant — never by any guard — so a
+                  \*   buggy impl cannot self-mask the check.
+
+vars == <<lock_owner, lock_ttl, next_token, cont_phase, cont_token, bad_free>>
+
+TypeOK ==
+    /\ lock_owner \in (1..MaxToken) \cup {NOBODY}
+    /\ lock_ttl \in 0..TTL
+    /\ next_token \in 1..(MaxToken + 1)
+    /\ cont_phase \in [Contenders -> {"idle", "incs", "pending_release"}]
+    /\ cont_token \in [Contenders -> 0..MaxToken]
+    /\ bad_free \in BOOLEAN
+
+Init ==
+    /\ lock_owner = NOBODY
+    /\ lock_ttl = 0
+    /\ next_token = 1
+    /\ cont_phase = [c \in Contenders |-> "idle"]
+    /\ cont_token = [c \in Contenders |-> 0]
+    /\ bad_free = FALSE
+
+\* -----------------------------------------------------------------------
+\* TryAcquire: SET key <fresh-owner> NX PX ttl. Succeeds ONLY IF the key is
+\* free (NX): lock_owner = NOBODY (absent or just expired). Mints a FRESH owner
+\* token (distinct monotonic value), stores it at the key with a full TTL, and
+\* the contender enters its critical section as the holder.
+\* Bounded by MaxToken so the token counter stays finite for TLC.
+\* -----------------------------------------------------------------------
+TryAcquire(c) ==
+    /\ cont_phase[c] = "idle"
+    /\ lock_owner = NOBODY                 \* NX: set only if key absent/free
+    /\ next_token <= MaxToken              \* bound the monotonic token (CI)
+    /\ lock_owner' = next_token            \* store the fresh owner token
+    /\ lock_ttl' = TTL                     \* PX: full lease
+    /\ next_token' = next_token + 1        \* next acquisition gets a new token
+    /\ cont_token' = [cont_token EXCEPT ![c] = next_token]
+    /\ cont_phase' = [cont_phase EXCEPT ![c] = "incs"]
+    /\ UNCHANGED bad_free
+
+\* -----------------------------------------------------------------------
+\* LeaveCS: finish the protected work and leave the critical section. The
+\* contender is now in pending_release (about to call release) and STILL "owns"
+\* the lock token, but its lease may lapse before it releases. Separating this
+\* from Release means the lease can only expire AFTER the contender has left the
+\* critical section — faithful to the documented precondition that the TTL is
+\* longer than the critical section (a live in-CS holder's lease never lapses
+\* mid-section; the lease exists to reclaim a holder that finished/crashed
+\* without releasing).
+\* -----------------------------------------------------------------------
+LeaveCS(c) ==
+    /\ cont_phase[c] = "incs"
+    /\ cont_phase' = [cont_phase EXCEPT ![c] = "pending_release"]
+    /\ UNCHANGED <<lock_owner, lock_ttl, next_token, cont_token, bad_free>>
+
+\* -----------------------------------------------------------------------
+\* Release: the LOCK_RELEASE Lua compare-and-delete. GET the stored owner; DEL
+\* the key ONLY IF it still equals THIS contender's token. A contender may call
+\* release even while STALE (its lease expired and another contender re-acquired):
+\* the token mismatch then makes the DEL a NO-OP on the new holder's lock — the
+\* owner-fencing guarantee. Either way the contender leaves its critical section
+\* (the guard is dropped / returns).
+\*
+\* The fix anchored by the negative test is the `cont_token[c] = lock_owner`
+\* guard on the actual free: dropping it (unconditional DEL) lets a stale
+\* releaser free the new holder's lock.
+\* -----------------------------------------------------------------------
+Release(c) ==
+    /\ cont_phase[c] = "pending_release"
+    /\ IF cont_token[c] = lock_owner       \* compare-and-delete on the owner token
+       THEN /\ lock_owner' = NOBODY        \* token matches -> DEL the key (free it)
+            /\ lock_ttl' = 0
+       ELSE /\ UNCHANGED <<lock_owner, lock_ttl>>   \* stale: no-op, new holder kept
+    /\ cont_phase' = [cont_phase EXCEPT ![c] = "idle"]
+    /\ cont_token' = [cont_token EXCEPT ![c] = 0]   \* guard dropped
+    \* WITNESS (independent of the guard above): record if this release FREED a
+    \* lock whose CURRENT owner token was someone else's — a non-owner displacing
+    \* the holder. Computed from ground truth (the key went free though our token
+    \* didn't own it), so the blind-delete bug trips it while the correct
+    \* compare-and-delete leaves lock_owner untouched and keeps bad_free FALSE.
+    /\ bad_free' =
+         (bad_free \/ (lock_owner # NOBODY
+                        /\ cont_token[c] # lock_owner
+                        /\ lock_owner' = NOBODY))
+    /\ UNCHANGED next_token
+
+\* -----------------------------------------------------------------------
+\* TtlExpire: the PX lease elapses. A tick decrements the remaining TTL; when it
+\* hits 0 the key auto-expires and the lock becomes free (lock_owner = NOBODY) —
+\* exactly Redis dropping the key, or the in-memory `is_expired()` eviction. The
+\* lease only counts down once NO contender is still inside its critical section
+\* (faithful to "the TTL is longer than the critical section"): the lease reclaims
+\* a holder that finished/crashed in pending_release without releasing. Such a
+\* holder becomes STALE — its cont_token no longer matches the now-free, possibly
+\* re-acquired lock — yet may still call release. This is the stale-releaser race
+\* the owner-token check must fence.
+\* -----------------------------------------------------------------------
+TtlExpire ==
+    /\ lock_ttl > 0
+    /\ \A c \in Contenders : cont_phase[c] # "incs"   \* lease > critical section
+    /\ lock_ttl' = lock_ttl - 1
+    /\ IF lock_ttl - 1 = 0
+       THEN lock_owner' = NOBODY           \* key auto-expired -> free
+       ELSE UNCHANGED lock_owner
+    /\ UNCHANGED <<next_token, cont_phase, cont_token, bad_free>>
+
+\* -----------------------------------------------------------------------
+\* Recycle: once the token counter saturates and no contender is mid-critical-
+\* section and the key is free, reset the monotonic token so the system CYCLES
+\* (no benign terminal deadlock under -deadlock). Models the lock name being
+\* reused indefinitely; the fresh-token invariant within one sweep already
+\* exercised every race.
+\* -----------------------------------------------------------------------
+Recycle ==
+    /\ next_token > MaxToken
+    /\ lock_owner = NOBODY
+    /\ \A c \in Contenders : cont_phase[c] = "idle"
+    /\ next_token' = 1
+    /\ cont_token' = [c \in Contenders |-> 0]
+    /\ UNCHANGED <<lock_owner, lock_ttl, cont_phase, bad_free>>
+
+Next ==
+    \/ \E c \in Contenders : TryAcquire(c) \/ LeaveCS(c) \/ Release(c)
+    \/ TtlExpire
+    \/ Recycle
+
+Spec == Init /\ [][Next]_vars
+
+\* =======================================================================
+\* SAFETY
+\* =======================================================================
+
+\* GROUND-TRUTH ORACLE: the set of contenders actually in their critical section,
+\* derived purely from cont_phase — INDEPENDENT of lock_owner / cont_token, the
+\* bookkeeping the implementation reads and mutates. Stating MutualExclusion
+\* against this set (not against "the lock has one owner") means a buggy release
+\* that displaces a live holder is CAUGHT, not self-masked by the invariant
+\* referencing the same compare-and-delete the implementation uses.
+HoldersInCS == { c \in Contenders : cont_phase[c] = "incs" }
+
+\* MUTUAL EXCLUSION: at most one contender is in its critical section at any
+\* instant. This is the core lock contract every other spec assumes.
+MutualExclusion == Cardinality(HoldersInCS) <= 1
+
+\* A contender in its critical section holds the token currently stored at the
+\* key: it has not been silently displaced by another contender's release. While
+\* a contender is in its critical section the lease is live and has NOT been
+\* re-acquired by anyone else, so its token must equal lock_owner. (After it
+\* leaves CS into pending_release the lease may lapse and the lock be re-acquired,
+\* making it stale — that case is handled by the owner-token check on release.)
+HolderMatchesLock ==
+    \A c \in Contenders :
+        (cont_phase[c] = "incs") => (cont_token[c] = lock_owner)
+
+\* OWNER-FENCED RELEASE: a Release only frees the lock if the releaser's token
+\* equals the lock's CURRENT owner token — so a stale contender (lease expired,
+\* lock re-acquired by someone else) NEVER frees the new holder's lock. The
+\* bad_free witness is set TRUE the instant ANY release frees a lock owned by a
+\* different token; under the owner-token compare-and-delete that is impossible,
+\* so it stays FALSE. The witness is INDEPENDENT ground truth (it is computed from
+\* "the key went free though our token didn't own it", not from the guard the impl
+\* uses), so a buggy blind-delete trips it rather than self-masking it.
+OwnerFencedRelease == bad_free = FALSE
+
+============================================================================

--- a/specs/tla/GroupIngestFlush.cfg
+++ b/specs/tla/GroupIngestFlush.cfg
@@ -1,0 +1,10 @@
+\* GroupIngestFlush model-checking configuration
+CONSTANTS
+    MaxEvents = 3
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    NoStrandedEvent
+    QuiesceNotifiesAll

--- a/specs/tla/GroupIngestFlush.tla
+++ b/specs/tla/GroupIngestFlush.tla
@@ -1,0 +1,182 @@
+--------------------------- MODULE GroupIngestFlush ---------------------------
+(*
+ * TLA+ specification of Acteon's event-group INGEST path racing the FLUSH —
+ * specifically the Notified -> Pending RE-ARM on a late ingest, which keeps a
+ * newly-ingested event from being stranded in an already-flushed group.
+ *
+ * Models:
+ *   - crates/gateway/src/group_manager.rs :: GroupManager::add_to_group (~132).
+ *     The in-memory branch (under the groups write-lock) has three cases:
+ *       * NEW group        -> create Pending, notify_at = now + group_wait, add event.
+ *       * EXISTING PENDING  -> add the event; notify_at is UNCHANGED (the debounce
+ *                              window is NOT extended by a later event).
+ *       * EXISTING NOTIFIED -> the group transitions BACK to Pending (line 184:
+ *                              `group.state = GroupState::Pending`), notify_at is
+ *                              RE-ARMED to now + group_interval (line 187), THEN the
+ *                              event is added (line 192). A late event RE-OPENS the
+ *                              already-flushed group for a fresh notification.
+ *   - crates/gateway/src/group_manager.rs :: get_ready_groups (~332): a group is
+ *     flushable when notify_at <= now AND state = Pending (Notified is only re-
+ *     flushable for persistent groups via the repeat interval; the ingest re-arm
+ *     models the path that returns a group to Pending so get_ready_groups picks it
+ *     up again). flush_group (modeled in MessageBus.tla) flips a ready Pending
+ *     group -> Notified; the events it then carried become notified.
+ *   - crates/core/src/group.rs :: GroupState { Pending | Notified | Resolved } and
+ *     EventGroup { state, events, notify_at }.
+ *
+ * Protocol (single group, events as counters). Events are INGESTED over time and
+ * the group is Pending or Notified:
+ *   - Ingest: add an event (count it as ingested-and-not-yet-notified). If the
+ *     group is Notified, RE-ARM it back to Pending (the late-event reopen). If
+ *     Pending, just add (window unchanged).
+ *   - BecomeReady: the notify_at deadline passes while Pending (group flushable).
+ *   - Flush (Pending AND ready): group -> Notified; every event currently in the
+ *     group (the not-yet-notified ones) becomes notified.
+ * A pending-but-not-yet-notified event must always keep the group on a path to be
+ * flushed — i.e. the group must be (or return to) Pending so get_ready_groups can
+ * flush it.
+ *
+ * The RE-ARM (Notified -> Pending on ingest into a Notified group) is the load-
+ * bearing mechanism the negative test reverts.
+ *
+ * Verified (over every interleaving of ingest, deadline-expiry and flush):
+ *   - NoStrandedEvent: an event ingested but not yet notified implies the group
+ *     is Pending (and thus on a path get_ready_groups will flush). The re-arm is
+ *     exactly what prevents a late ingest from sitting in a Notified group that
+ *     get_ready_groups never flushes again.
+ *   - QuiesceNotifiesAll: when no event is in flight unnotified, the group has
+ *     left Pending iff there is nothing left to notify — i.e. a Notified group has
+ *     zero unnotified events (everything ingested got notified).
+ *
+ * Negative check: revert the re-arm — make Ingest into a NOTIFIED group leave the
+ * group Notified (drop `state' = "pending"` / `ready' = FALSE`) while still
+ * counting the new event as unnotified. The new event is then stranded:
+ * unnotified > 0 while state = "notified", which get_ready_groups never flushes ->
+ * NoStrandedEvent is violated. Confirmed: the BUGGY variant reports the violation;
+ * the real spec is green.
+ *
+ * The invariant is anchored on GROUND-TRUTH counters (unnotified, the integer
+ * count of ingested-not-yet-notified events) and the raw `state`, NOT on any
+ * operator the Ingest/Flush actions also use to make their decision — so a buggy
+ * re-arm cannot mutate the check into agreeing with itself (no self-masking).
+ *
+ * SCOPE. Single group. notify_at is ABSTRACTED to a `ready` boolean (the
+ * get_ready_groups flush precondition: notify_at <= now while Pending) rather than
+ * a concrete clock; the group_wait vs group_interval distinction (both just set a
+ * future notify_at) collapses to "ready becomes false again on re-arm". Events are
+ * COUNTERS (ingested / notified / unnotified), not payloads — max_group_size FIFO
+ * drop, fingerprint dedup, persistence/recovery, encryption, and the persistent
+ * repeat-interval re-fire of a Notified group are out of scope; this spec isolates
+ * the ingest/flush state-machine race and the late-ingest re-arm. The Resolved
+ * terminal state is omitted (the modeled lifecycle cycles Pending<->Notified).
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config GroupIngestFlush.cfg GroupIngestFlush.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    MaxEvents  \* state-space bound on total ingested events per cycle (small, e.g. 3)
+
+ASSUME MaxEvents \in 1..5
+
+VARIABLES
+    state,       \* "pending" | "notified": the EventGroup.state
+    ready,       \* BOOLEAN: notify_at <= now while Pending (flush precondition)
+    ingested,    \* 0..MaxEvents: total events ingested this cycle
+    notified,    \* 0..MaxEvents: events that have been carried through a flush
+    unnotified   \* 0..MaxEvents: ingested events not yet notified (ground-truth)
+
+vars == <<state, ready, ingested, notified, unnotified>>
+
+TypeOK ==
+    /\ state \in {"pending", "notified"}
+    /\ ready \in BOOLEAN
+    /\ ingested \in 0..MaxEvents
+    /\ notified \in 0..MaxEvents
+    /\ unnotified \in 0..MaxEvents
+    /\ ingested = notified + unnotified   \* the counters partition every ingested event
+
+Init ==
+    /\ state = "pending"
+    /\ ready = FALSE
+    /\ ingested = 0
+    /\ notified = 0
+    /\ unnotified = 0
+
+\* Ingest an event (add_to_group). Always counts the event as ingested-and-not-yet-
+\* notified. The state handling mirrors add_to_group's three cases collapsed onto a
+\* single group:
+\*   - NOTIFIED group: RE-ARM back to Pending (group.state = Pending), and reset the
+\*     flush deadline (notify_at = now + interval => not yet ready). THIS is the fix.
+\*   - PENDING group: just add; notify_at (and hence `ready`) is unchanged.
+Ingest ==
+    /\ ingested < MaxEvents
+    /\ ingested' = ingested + 1
+    /\ unnotified' = unnotified + 1
+    /\ IF state = "notified"
+       THEN /\ state' = "pending"   \* Notified -> Pending re-arm (group_manager.rs:184)
+            /\ ready' = FALSE        \* notify_at = now + interval (group_manager.rs:187)
+       ELSE /\ UNCHANGED state       \* Pending: add only, window unchanged
+            /\ UNCHANGED ready
+    /\ UNCHANGED notified
+
+\* The notify_at deadline passes while the group is Pending: get_ready_groups now
+\* returns this group (notify_at <= now AND state = Pending).
+BecomeReady ==
+    /\ state = "pending"
+    /\ ready = FALSE
+    /\ ready' = TRUE
+    /\ UNCHANGED <<state, ingested, notified, unnotified>>
+
+\* Flush a ready Pending group (flush_group): state -> Notified, and every event
+\* currently held (the unnotified ones) is delivered by the notification.
+Flush ==
+    /\ state = "pending"
+    /\ ready = TRUE
+    /\ state' = "notified"
+    /\ ready' = FALSE
+    /\ notified' = notified + unnotified
+    /\ unnotified' = 0
+    /\ UNCHANGED ingested
+
+\* Recycle: a quiesced, fully-notified group resets so the system CYCLES (the group
+\* key is reused for a fresh batching window). Only fires when nothing is pending
+\* unnotified and the group has been flushed at least once — a clean boundary.
+Recycle ==
+    /\ state = "notified"
+    /\ unnotified = 0
+    /\ ingested > 0
+    /\ state' = "pending"
+    /\ ready' = FALSE
+    /\ ingested' = 0
+    /\ notified' = 0
+    /\ unnotified' = 0
+
+Next ==
+    \/ Ingest
+    \/ BecomeReady
+    \/ Flush
+    \/ Recycle
+
+Spec == Init /\ [][Next]_vars
+
+\* =======================================================================
+\* SAFETY
+\* =======================================================================
+
+\* GROUND-TRUTH oracle, independent of the Ingest/Flush decision logic: any event
+\* ingested but not yet notified implies the group is Pending — and therefore on a
+\* path that get_ready_groups (Pending /\ notify_at <= now) will eventually flush.
+\* The Notified -> Pending re-arm on a late ingest is exactly what keeps this true;
+\* without it, a late event sits unnotified in a Notified group that
+\* get_ready_groups never re-flushes (the strand the negative test exhibits).
+NoStrandedEvent == (unnotified > 0) => (state = "pending")
+
+\* When the group has quiesced (no unnotified event in flight) and has been
+\* notified, every ingested event was delivered — notified accounts for all of
+\* them. Ties the abstract state to the concrete delivery count, independent of
+\* the re-arm: a Notified group with nothing pending has notified == ingested.
+QuiesceNotifiesAll == (state = "notified" /\ unnotified = 0) => (notified = ingested)
+
+============================================================================

--- a/specs/tla/Makefile
+++ b/specs/tla/Makefile
@@ -23,6 +23,9 @@
 #   make check-conv         # Run ConversationLifecycle only
 #   make check-silence      # Run SilenceWindow only
 #   make check-singleflight # Run EmbeddingSingleFlight only
+#   make check-lock         # Run DistributedLock only
+#   make check-staletask    # Run StaleTaskReaper only
+#   make check-groupflush   # Run GroupIngestFlush only
 #   make setup              # Download tla2tools.jar
 #   make clean              # Remove downloaded tools
 
@@ -30,7 +33,7 @@ SHELL := /bin/bash
 SPECS_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 CI_SCRIPT := $(SPECS_DIR)ci/run-tlc.sh
 
-.PHONY: check-all check-circuit check-dedup check-hashchain check-recurring check-bus check-chain check-approval check-quota check-busapproval check-multiquota check-task check-cancel check-replay check-reaper check-dlq check-msgdedup check-keyrotation check-refgraph check-conv check-silence check-singleflight setup clean help
+.PHONY: check-all check-circuit check-dedup check-hashchain check-recurring check-bus check-chain check-approval check-quota check-busapproval check-multiquota check-task check-cancel check-replay check-reaper check-dlq check-msgdedup check-keyrotation check-refgraph check-conv check-silence check-singleflight check-lock check-staletask check-groupflush setup clean help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -101,6 +104,15 @@ check-silence: ## Run TLC on SilenceWindow spec
 
 check-singleflight: ## Run TLC on EmbeddingSingleFlight spec
 	@$(CI_SCRIPT) EmbeddingSingleFlight
+
+check-lock: ## Run TLC on DistributedLock spec
+	@$(CI_SCRIPT) DistributedLock
+
+check-staletask: ## Run TLC on StaleTaskReaper spec
+	@$(CI_SCRIPT) StaleTaskReaper
+
+check-groupflush: ## Run TLC on GroupIngestFlush spec
+	@$(CI_SCRIPT) GroupIngestFlush
 
 setup: ## Download tla2tools.jar (requires curl or wget)
 	@$(CI_SCRIPT) __nonexistent__ 2>/dev/null || true

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -39,6 +39,9 @@ for the full research document.
 | **Conversation Lifecycle** | `ConversationLifecycle.tla` | `bus_conversation.rs` `apply_transition` + `accepts_messages` | Linear no-skip lifecycle (never Active→Archived without Resolved) and **no message accepted after Archive**, under concurrent version-CAS transitions + posts |
 | **Silence Window** | `SilenceWindow.tla` | `core/silence.rs` `is_active_at` half-open window | An action is suppressed **iff a matching silence is active at dispatch time** — the half-open `[starts_at, ends_at)` boundary + expiry, checked against an independent window oracle |
 | **Embedding Single-Flight** | `EmbeddingSingleFlight.tla` | `embedding/cache.rs` moka `try_get_with` coalescing | Concurrent misses for the same key **coalesce into one provider call** (thundering-herd protection) and all callers return the same value |
+| **Distributed Lock** | `DistributedLock.tla` | `state/lock.rs` + `redis/lock.rs` `SET NX PX` + owner-checked release | **Mutual exclusion** + **owner-fenced release** (a stale holder never frees the new holder's lock) + TTL lease — the primitive every other spec assumes |
+| **Stale-Task Reaper** | `StaleTaskReaper.tla` | `task_engine.rs` `fail_if_stale` scan→load→commit | The reaper **never fails a task that heartbeated** after its scan — the fresh `is_stale_at` re-check on the CAS-loaded row |
+| **Group Ingest-Flush** | `GroupIngestFlush.tla` | `group_manager.rs` `add_to_group` Notified→Pending re-arm | A late event for a Notified group **re-arms it to Pending** so **no ingested event is stranded** unnotified |
 
 Each spec is self-contained: it inlines its own lock / state-store state machine
 rather than sharing a module, so each can be model-checked independently.
@@ -51,7 +54,8 @@ recursion / completion coupling, the subscribe-before-replay / cursor dedup, the
 reaper hold-skip / expiry-check, the drain take+clear atomicity, the dedup
 check_and_set gate, the never-retire-a-live-key contract, the cycle / depth /
 width / visited-filter checks, the no-skip-archive / fresh-accepts re-check, the
-half-open window bound, the single-flight claim) makes TLC report the
+half-open window bound, the single-flight claim, the owner-fenced release, the
+fresh staleness re-check, the Notified→Pending re-arm) makes TLC report the
 corresponding safety violation. The specs catch the real bug, not a tautology.
 
 ## Quick Start
@@ -95,7 +99,7 @@ tla-specs:
 ```
 
 The CI configuration uses small model parameters (2 of each principal) for fast
-feedback (all twenty-one specs finish in a few seconds total). For nightly runs,
+feedback (all twenty-four specs finish in a few seconds total). For nightly runs,
 increase the constants in the `.cfg` files for deeper coverage.
 
 ## Project Structure
@@ -144,6 +148,12 @@ specs/tla/
   SilenceWindow.cfg
   EmbeddingSingleFlight.tla # Spec: embedding cache single-flight (thundering herd)
   EmbeddingSingleFlight.cfg
+  DistributedLock.tla      # Spec: lock mutual exclusion + owner-fenced release + TTL
+  DistributedLock.cfg
+  StaleTaskReaper.tla      # Spec: reaper fresh-staleness re-check (no reap-after-heartbeat)
+  StaleTaskReaper.cfg
+  GroupIngestFlush.tla     # Spec: group ingest re-arm, no stranded event
+  GroupIngestFlush.cfg
   ci/
     run-tlc.sh             # CI runner (auto-discovers every *.cfg)
   Makefile                 # Convenience targets

--- a/specs/tla/StaleTaskReaper.cfg
+++ b/specs/tla/StaleTaskReaper.cfg
@@ -1,0 +1,16 @@
+\* StaleTaskReaper model-checking configuration
+\*
+\* Small parameters for CI (~seconds). The staleness predicate is_stale_at is an
+\* operator (IsStaleAt) in the module, so no function literal is needed here.
+
+CONSTANTS
+    Producers = {p1, p2}
+    MaxVer = 3
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    NoReapHeartbeated
+    ReapOnlyStale
+    ReapAtMostOnce

--- a/specs/tla/StaleTaskReaper.tla
+++ b/specs/tla/StaleTaskReaper.tla
@@ -1,0 +1,256 @@
+------------------------- MODULE StaleTaskReaper -------------------------
+(*
+ * TLA+ specification of Acteon's A2A stale-task reaper's FRESH-staleness
+ * re-check — the reaper-vs-heartbeat race.
+ *
+ * Models:
+ *   - crates/gateway/src/background/workers/stale_task.rs : the reaper worker
+ *     SCANS for tasks past their working_ttl, then for each candidate calls
+ *     fail_if_stale. The scan and fail_if_stale are SEPARATE reads — a producer
+ *     can heartbeat in between.
+ *   - crates/gateway/src/task_engine.rs :: fail_if_stale (~383), a CAS loop:
+ *         let (raw, version) = state.get_versioned(key)?;   // (re-)LOAD row+version
+ *         let mut task = deserialize(raw);
+ *         if !task.is_stale_at(now) { return Ok(None); }     // FRESH re-check on the
+ *                                                            // loaded row
+ *         task.transition_to(Failed, reason);
+ *         compare_and_swap(key, version, payload)?;          // commit iff version eq
+ *     On Conflict the loop re-reads and re-evaluates. Doc (verbatim): "The
+ *     staleness re-check runs against the *fresh* CAS-loaded row, so a task a
+ *     producer just heartbeated is never failed out from under it."
+ *   - crates/core/src/bus_task.rs :: Task::is_stale_at (~925): a NON-TERMINAL
+ *     task past its working_ttl without progress. Terminal tasks are NEVER stale.
+ *
+ * Why the FRESH re-check is the load-bearing mechanism (not just the version-CAS).
+ * The reaper decides to attempt a reap from its OUTER SCAN (which saw the row
+ * stale). fail_if_stale then does its OWN get_versioned + is_stale_at re-check.
+ * A heartbeat that lands BETWEEN the scan and that load makes the loaded row
+ * already-fresh: its version is the post-heartbeat version, so the version-CAS
+ * would PASS — only the fresh is_stale_at re-check (re-read on the loaded row)
+ * refuses the reap. The version-CAS is the complementary gate for a heartbeat
+ * that lands between the load and the commit. This spec models all three steps
+ * (Scan, Load, Commit) so the fresh re-check is genuinely load-bearing.
+ *
+ * Protocol. A single task row carries state ("working" | "done"), a `stale`
+ * boolean (is_stale_at on a non-terminal row), and a CAS `version`. A PRODUCER
+ * may Heartbeat (clears stale, bumps version) or Complete (-> terminal, bumps
+ * version). The REAPER runs in THREE steps:
+ *   ReaperScan  — the worker's scan flags this row as a stale candidate (it
+ *                 currently looks stale). No version is captured here.
+ *   ReaperLoad  — fail_if_stale's get_versioned: capture the row's version NOW.
+ *   ReaperCommit— commit Failed IFF, at the commit instant, the FRESH row is
+ *                 still stale-non-terminal (is_stale_at re-check) AND the version
+ *                 is unchanged since the load (version-CAS).
+ *
+ * Verified (over every interleaving of producer heartbeat/complete, the clock
+ * setting staleness, and the reaper scan/load/commit):
+ *   - NoReapHeartbeated: the reaper never commits Failed against a row that, at
+ *     the commit instant, is NOT stale (heartbeated, or terminal). Checked by an
+ *     INDEPENDENT ground-truth flag `reaped_live`, computed from the FRESH
+ *     task_state/stale at commit — NOT from the reaper's own guard — so a buggy
+ *     guard cannot self-mask the violation. Must stay FALSE.
+ *   - ReapOnlyStale: a committed Failed implies the prior row was non-terminal
+ *     and stale (no terminal row is ever re-failed) — `reap_from_terminal` stays
+ *     FALSE.
+ *   - ReapAtMostOnce: at most one reaper Failed-commit per occurrence.
+ *
+ * Negative check: drop the FRESH is_stale_at re-check at ReaperCommit — commit
+ * Failed on the scan's candidacy as long as the version is unchanged since the
+ * load (version-CAS only). A producer that Heartbeats (clears stale, bumps
+ * version) BETWEEN the scan and the load then presents a fresh row whose version
+ * the load captures, so the version-CAS passes; without the fresh re-check the
+ * reaper fails this live, just-heartbeated row -> reaped_live flips TRUE ->
+ * NoReapHeartbeated violated. (The same revert lets a Completed terminal row be
+ * re-failed -> ReapOnlyStale / ReapAtMostOnce violated.)
+ *
+ * SCOPE. Isolates the reaper-vs-heartbeat race for a SINGLE task row. Staleness
+ * is a boolean a Heartbeat clears and the clock can set (the working_ttl_ms /
+ * last_progress_at arithmetic is abstracted). Abstracts the audit/stream
+ * emission, the per-key dispatch lock, the MAX_CAS_RETRY_ATTEMPTS bound (the
+ * loser re-reads), and the legal-transition graph (Failed is always legal from
+ * non-terminal, covered by A2aTaskTransition). The version-CAS is faithfully
+ * present (the complementary gate for the load->commit window) but in this
+ * single-row abstraction the FRESH re-check is the independently load-bearing
+ * mechanism. `Recycle` mints a fresh working task once terminal, so the system
+ * CYCLES (no benign terminal deadlock under -deadlock).
+ *
+ * Run with:
+ *   java -jar tla2tools.jar -config StaleTaskReaper.cfg StaleTaskReaper.tla
+ *)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    Producers,   \* concurrent producers heartbeating/completing, e.g. {p1, p2}
+    MaxVer       \* state-space bound on the version counter
+
+Working == "working"
+Done    == "done"
+States  == { Working, Done }
+
+\* is_stale_at(now) ground truth on the FRESH row (bus_task.rs:925): a NON-TERMINAL
+\* row past its TTL without progress. Terminal rows are never stale. The SINGLE
+\* staleness oracle; both the (correct) reaper guard and the invariant's
+\* independent flag read it off the FRESH task_state/stale.
+IsStaleAt(st, isStale) == (st = Working) /\ isStale
+
+VARIABLES
+    task_state,         \* persisted row state: Working | Done
+    stale,              \* BOOLEAN: row past TTL without progress (non-terminal)
+    version,            \* optimistic-CAS version, bumped on every committed write
+    reaped_live,        \* BOOLEAN ground-truth oracle: a Failed-commit landed on a NOT-stale row
+    reap_count,         \* 0..3: reaper Failed-commits for the CURRENT occurrence
+    reap_from_terminal, \* BOOLEAN: a reaper Failed-commit fired on a terminal row
+    r_phase,            \* reaper: "idle" | "scanned" | "committing"
+    r_load_ver          \* 0..MaxVer: version captured at ReaperLoad (get_versioned)
+
+vars == <<task_state, stale, version, reaped_live, reap_count,
+          reap_from_terminal, r_phase, r_load_ver>>
+
+TypeOK ==
+    /\ task_state \in States
+    /\ stale \in BOOLEAN
+    /\ version \in 0..MaxVer
+    /\ reaped_live \in BOOLEAN
+    /\ reap_count \in 0..3
+    /\ reap_from_terminal \in BOOLEAN
+    /\ r_phase \in {"idle", "scanned", "committing"}
+    /\ r_load_ver \in 0..MaxVer
+
+Init ==
+    /\ task_state = Working
+    /\ stale = FALSE
+    /\ version = 0
+    /\ reaped_live = FALSE
+    /\ reap_count = 0
+    /\ reap_from_terminal = FALSE
+    /\ r_phase = "idle"
+    /\ r_load_ver = 0
+
+\* -----------------------------------------------------------------------
+\* PRODUCER actions (the heartbeat / completion side of the race)
+\* -----------------------------------------------------------------------
+
+\* The working_ttl elapses with no progress: is_stale_at flips TRUE. Only a
+\* non-terminal row can become stale. Does NOT bump the version (staleness is
+\* derived on read, not a persisted write).
+ClockStale ==
+    /\ task_state = Working
+    /\ ~stale
+    /\ stale' = TRUE
+    /\ UNCHANGED <<task_state, version, reaped_live, reap_count,
+                   reap_from_terminal, r_phase, r_load_ver>>
+
+\* Producer records progress (the heartbeat): clears staleness, bumps the version.
+\* This is what must NEVER be reaped out from under the producer.
+Heartbeat(p) ==
+    /\ task_state = Working
+    /\ version < MaxVer
+    /\ stale' = FALSE
+    /\ version' = version + 1
+    /\ UNCHANGED <<task_state, reaped_live, reap_count, reap_from_terminal,
+                   r_phase, r_load_ver>>
+
+\* Producer drives the task to a terminal state: bumps the version; a terminal
+\* row is never stale.
+Complete(p) ==
+    /\ task_state = Working
+    /\ version < MaxVer
+    /\ task_state' = Done
+    /\ stale' = FALSE
+    /\ version' = version + 1
+    /\ UNCHANGED <<reaped_live, reap_count, reap_from_terminal, r_phase, r_load_ver>>
+
+\* -----------------------------------------------------------------------
+\* REAPER actions (the worker scan, then fail_if_stale modeled as Load + Commit)
+\* -----------------------------------------------------------------------
+
+\* ReaperScan: the worker's scan flags this row as a stale candidate (it looks
+\* stale right now). The candidacy decision is made HERE; no version is captured.
+\* A heartbeat may land between this scan and the get_versioned load below.
+ReaperScan ==
+    /\ r_phase = "idle"
+    /\ IsStaleAt(task_state, stale)
+    /\ r_phase' = "scanned"
+    /\ UNCHANGED <<task_state, stale, version, reaped_live, reap_count,
+                   reap_from_terminal, r_load_ver>>
+
+\* ReaperLoad: fail_if_stale's get_versioned — capture the row's CURRENT version.
+\* (If a heartbeat landed since the scan, this captures the post-heartbeat
+\* version, so the version-CAS below would pass — only the fresh re-check saves it.)
+ReaperLoad ==
+    /\ r_phase = "scanned"
+    /\ r_load_ver' = version
+    /\ r_phase' = "committing"
+    /\ UNCHANGED <<task_state, stale, version, reaped_live, reap_count,
+                   reap_from_terminal>>
+
+\* ReaperCommit: the CAS commit of fail_if_stale.
+\*   - FRESH re-check: is_stale_at re-evaluated against the CURRENT row
+\*     (`if !task.is_stale_at(now) return Ok(None)`). THE load-bearing guard.
+\*   - version-CAS: commit only if the version is unchanged since ReaperLoad.
+\* reaped_live / reap_from_terminal are recorded from the FRESH task_state/stale
+\* at the commit instant, INDEPENDENT of the reaper's own guard.
+ReaperCommit ==
+    /\ r_phase = "committing"
+    \* `version < MaxVer` bounds the CI counter (saturated -> no-write branch,
+    \* modeling MAX_CAS_RETRY_ATTEMPTS exhaustion). NOT a faithfulness guard.
+    /\ IF (version < MaxVer) /\ (r_load_ver = version) /\ IsStaleAt(task_state, stale)
+       THEN /\ task_state' = Done
+            /\ stale' = FALSE
+            /\ version' = version + 1
+            /\ reap_count' = reap_count + 1
+            \* Independent ground truth: did this Failed land on a NOT-stale row?
+            \* (terminal or progressed). With the correct guard, impossible.
+            /\ reaped_live' = (reaped_live \/ ~IsStaleAt(task_state, stale))
+            /\ reap_from_terminal' = (reap_from_terminal \/ (task_state = Done))
+       ELSE UNCHANGED <<task_state, stale, version, reap_count,
+                        reaped_live, reap_from_terminal>>
+    /\ r_phase' = "idle"
+    /\ r_load_ver' = 0
+
+\* -----------------------------------------------------------------------
+\* Recycle: mint a fresh working task at the same key once the reaper is idle and
+\* EITHER the row is terminal OR the version counter saturated the CI bound while
+\* still Working. The system CYCLES so there is no benign terminal deadlock.
+\* -----------------------------------------------------------------------
+Recycle ==
+    /\ r_phase = "idle"
+    /\ (task_state = Done) \/ (version = MaxVer)
+    /\ task_state' = Working
+    /\ stale' = FALSE
+    /\ version' = 0
+    /\ reap_count' = 0
+    /\ reap_from_terminal' = FALSE
+    /\ r_load_ver' = 0
+    /\ UNCHANGED <<reaped_live, r_phase>>
+
+Next ==
+    \/ ClockStale
+    \/ \E p \in Producers : Heartbeat(p) \/ Complete(p)
+    \/ ReaperScan
+    \/ ReaperLoad
+    \/ ReaperCommit
+    \/ Recycle
+
+Spec == Init /\ [][Next]_vars
+
+\* =======================================================================
+\* SAFETY
+\* =======================================================================
+
+\* The reaper NEVER fails a row that was not stale at the commit instant — a row
+\* that heartbeated (cleared stale) or reached terminal between the scan and the
+\* commit is refused by the fresh is_stale_at re-check. `reaped_live` is the
+\* INDEPENDENT oracle (read off the fresh task_state/stale at commit, not the
+\* reaper guard), so a buggy guard cannot self-mask this. Must stay FALSE.
+NoReapHeartbeated == reaped_live = FALSE
+
+\* A committed Failed reap only ever fires on a genuinely-stale, NON-TERMINAL row:
+\* a terminal row is never (re-)failed by the reaper.
+ReapOnlyStale == reap_from_terminal = FALSE
+
+\* At most one reaper Failed-commit per occurrence: once terminal the reaper makes
+\* no further Failed write.
+ReapAtMostOnce == reap_count <= 1
+
+============================================================================


### PR DESCRIPTION
## What

Extends the TLA+ suite to **24 model-checked specs**, covering the remaining genuinely concurrency-critical, *uncovered* protocols. All pass TLC on every CI run, are adversarially validated, **and** faithfulness-checked against the real Rust.

## Specs

| Spec | Models | Safety property | Negative check |
|------|--------|-----------------|----------------|
| `DistributedLock` | `state/lock.rs` + `redis/lock.rs` `SET NX PX` + owner-checked-delete | **mutual exclusion** + **owner-fenced release** + TTL lease | blind unconditional delete → a stale releaser frees someone else's lock → all 3 invariants break |
| `StaleTaskReaper` | `task_engine.rs` `fail_if_stale` scan→load→commit | the reaper **never fails a task that heartbeated** after its scan | drop the fresh `is_stale_at` re-check (version-CAS only) → a live row is failed |
| `GroupIngestFlush` | `group_manager.rs` `add_to_group` Notified→Pending re-arm | a late event **re-arms a Notified group** so **no event is stranded** | drop the re-arm → event stuck in a Notified group never re-flushed |

## Honesty about the candidate list

Two of the originally-named "remaining candidates" were **dropped after scouting** rather than shipped as filler:
- **"Circuit-breaker probe under load"** — already covered by `CircuitBreaker.tla` (which models the full `consecutive_failures`/`FailureThreshold` 3-state machine). A second spec would be a duplicate.
- **"Snapshot/restore consistency"** — `config/snapshot.rs` is 706 lines of config **DTO structs** (admin-API serialization + secret redaction), not a concurrency protocol.

Rather than pad the count, I substituted two higher-value protocols the suite never modeled: the **distributed lock primitive itself** (every other spec *assumes* it; none verified its owner-fencing) and the **stale-task reaper**.

## Faithfulness note — `StaleTaskReaper` was strengthened

The first draft was single-read, so the version-CAS subsumed the fresh re-check (every heartbeat bumps the version → CAS catches it) — making the "fresh re-check is load-bearing" claim untrue, and the spec indistinct from `A2aTaskTransition`. I rewrote it to model the reaper's real **two-level structure** (outer scan, *then* `get_versioned`), so a heartbeat landing between scan and load is caught *only* by the fresh `is_stale_at` re-check — exactly the code's documented mechanism. The negative (version-CAS only) now genuinely violates `NoReapHeartbeated`; I reproduced all the negatives first-hand.

Local: `Results: 24 passed, 0 failed`. README, Makefile, and the design-doc status table updated to 24 specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)