### PR TITLE
perf(recurring): maintain a durable recurring_active counter instead of a per-tick scan (#118)

### DIFF
--- a/crates/gateway/src/background/mod.rs
+++ b/crates/gateway/src/background/mod.rs
@@ -241,6 +241,10 @@ pub struct BackgroundProcessor {
     pub(crate) payload_encryptor: Option<Arc<PayloadEncryptor>>,
     /// Gateway metrics for tracking background tasks.
     pub(crate) metrics: Arc<GatewayMetrics>,
+    /// Monotonic counter of recurring ticks, used to decide when to
+    /// reconcile the `recurring_active` gauge against a full scan rather
+    /// than reading the maintained durable counter (issue #118).
+    pub(crate) recurring_tick_count: std::sync::atomic::AtomicU64,
     /// In-memory copy of retention policies for the reaper.
     pub(crate) retention_policies: HashMap<String, acteon_core::RetentionPolicy>,
     /// Optional gateway reference for template sync.
@@ -271,6 +275,7 @@ impl BackgroundProcessor {
             group_manager,
             state,
             metrics,
+            recurring_tick_count: std::sync::atomic::AtomicU64::new(0),
             state_machines,
             shutdown_rx,
             group_flush_tx: None,
@@ -1295,6 +1300,112 @@ mod tests {
 
         let _ = shutdown_tx.send(()).await;
         let _ = tokio::time::timeout(Duration::from_secs(1), handle).await;
+    }
+
+    async fn read_recurring_counter(state: &dyn StateStore) -> i64 {
+        state
+            .get(&acteon_state::recurring_active_counter_key())
+            .await
+            .unwrap()
+            .map_or(0, |v| v.parse().unwrap())
+    }
+
+    #[tokio::test]
+    async fn recurring_active_counter_tracks_membership_churn() {
+        let state: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+        let future = (Utc::now() + chrono::Duration::hours(1)).timestamp_millis();
+        let pk = |id: &str| StateKey::new("ns", "t", KeyKind::PendingRecurring, id);
+
+        // Insert five distinct entries (as CRUD create would).
+        for id in ["a", "b", "c", "d", "e"] {
+            acteon_state::set_pending_recurring(state.as_ref(), &pk(id), future)
+                .await
+                .unwrap();
+        }
+        assert_eq!(read_recurring_counter(state.as_ref()).await, 5);
+
+        // Re-arming existing entries (worker/consumer post-dispatch) must NOT
+        // change the count.
+        for id in ["a", "b", "c", "d", "e"] {
+            acteon_state::set_pending_recurring(state.as_ref(), &pk(id), future + 1)
+                .await
+                .unwrap();
+        }
+        assert_eq!(read_recurring_counter(state.as_ref()).await, 5);
+
+        // Remove two (delete/pause); removing an absent key is a no-op.
+        acteon_state::remove_pending_recurring(state.as_ref(), &pk("a"))
+            .await
+            .unwrap();
+        acteon_state::remove_pending_recurring(state.as_ref(), &pk("b"))
+            .await
+            .unwrap();
+        acteon_state::remove_pending_recurring(state.as_ref(), &pk("a"))
+            .await
+            .unwrap();
+        acteon_state::remove_pending_recurring(state.as_ref(), &pk("missing"))
+            .await
+            .unwrap();
+        assert_eq!(read_recurring_counter(state.as_ref()).await, 3);
+
+        // Counter equals ground truth.
+        let scanned = state
+            .scan_keys_by_kind(KeyKind::PendingRecurring)
+            .await
+            .unwrap()
+            .len();
+        assert_eq!(scanned, 3);
+    }
+
+    #[tokio::test]
+    async fn recurring_active_gauge_reads_counter_without_scanning() {
+        let group_manager = Arc::new(GroupManager::new());
+        let state: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+        let metrics = Arc::new(GatewayMetrics::default());
+        let future = (Utc::now() + chrono::Duration::hours(1)).timestamp_millis();
+        let pk = |id: &str| StateKey::new("ns", "t", KeyKind::PendingRecurring, id);
+
+        // Seed three via the maintained helpers.
+        for id in ["a", "b", "c"] {
+            acteon_state::set_pending_recurring(state.as_ref(), &pk(id), future)
+                .await
+                .unwrap();
+        }
+
+        let (rec_tx, _rec_rx) = mpsc::channel(10);
+        let (processor, _shutdown_tx) = BackgroundProcessorBuilder::new()
+            .metrics(Arc::clone(&metrics))
+            .config(BackgroundConfig {
+                enable_recurring_actions: true,
+                recurring_check_interval: Duration::from_millis(50),
+                ..BackgroundConfig::default()
+            })
+            .group_manager(group_manager)
+            .state(Arc::clone(&state))
+            .recurring_action_channel(rec_tx)
+            .build()
+            .unwrap();
+
+        // Tick 0 → reconcile path: full scan, seeds counter + gauge to truth.
+        processor.refresh_recurring_active_gauge().await;
+        assert_eq!(metrics.snapshot().recurring_active, 3);
+        assert_eq!(read_recurring_counter(state.as_ref()).await, 3);
+
+        // Churn WITHOUT a scan: add two, remove one → durable counter = 4.
+        acteon_state::set_pending_recurring(state.as_ref(), &pk("d"), future)
+            .await
+            .unwrap();
+        acteon_state::set_pending_recurring(state.as_ref(), &pk("e"), future)
+            .await
+            .unwrap();
+        acteon_state::remove_pending_recurring(state.as_ref(), &pk("a"))
+            .await
+            .unwrap();
+        assert_eq!(read_recurring_counter(state.as_ref()).await, 4);
+
+        // Tick 1 → steady-state path: reads the counter (no scan) → gauge = 4.
+        processor.refresh_recurring_active_gauge().await;
+        assert_eq!(metrics.snapshot().recurring_active, 4);
     }
 
     #[tokio::test]

--- a/crates/gateway/src/background/workers/recurring.rs
+++ b/crates/gateway/src/background/workers/recurring.rs
@@ -1,27 +1,77 @@
+use std::sync::atomic::Ordering;
+
 use chrono::Utc;
 use tracing::{debug, info, warn};
 
-use acteon_state::{KeyKind, StateKey};
+use acteon_state::{KeyKind, StateKey, recurring_active_counter_key};
 
 use super::super::{BackgroundProcessor, RecurringActionDueEvent};
 
+/// Number of recurring ticks between full reconciliation scans of the
+/// pending-recurring index. On every other tick the `recurring_active` gauge is
+/// refreshed from an O(1) read of the durable counter
+/// (`recurring_active_counter_key`), which is maintained incrementally on each
+/// index mutation. This removes the per-tick `scan_keys_by_kind` that, on
+/// `DynamoDB`, was an unbounded full-table `Scan` whose RCU cost scaled with the
+/// entire keyspace rather than the recurring workload (issue #118).
+///
+/// Tick 0 always reconciles, so the counter is seeded from ground truth at
+/// startup; the periodic re-scan thereafter self-heals any drift left by a
+/// crash between an index write and its counter bump. At the default 60s tick
+/// this reconciles roughly hourly — ~1.6% of the previous scan volume.
+const RECURRING_RECONCILE_EVERY_N_TICKS: u64 = 60;
+
 impl BackgroundProcessor {
-    /// Refresh the `recurring_active` gauge by counting entries in the
-    /// pending-recurring index. Called once per recurring tick before
-    /// dispatching due actions, so the gauge reflects the steady-state
-    /// number of scheduled recurring actions even when no dispatches
-    /// are happening.
+    /// Refresh the `recurring_active` gauge. Called once per recurring tick
+    /// before dispatching due actions, so the gauge reflects the steady-state
+    /// number of scheduled recurring actions even when nothing is due.
+    ///
+    /// Most ticks read the maintained durable counter (O(1) on every backend).
+    /// Every [`RECURRING_RECONCILE_EVERY_N_TICKS`] ticks (and at startup) it
+    /// falls back to an authoritative full scan, which also resets the counter
+    /// to ground truth.
     pub(crate) async fn refresh_recurring_active_gauge(&self) {
-        match self
-            .state
-            .scan_keys_by_kind(KeyKind::PendingRecurring)
-            .await
-        {
-            Ok(entries) => {
-                self.metrics.set_recurring_active(entries.len() as u64);
+        let tick = self.recurring_tick_count.fetch_add(1, Ordering::Relaxed);
+        // `is_multiple_of` is true for tick 0, so the very first tick reconciles
+        // (seeds the counter from a full scan) and then every Nth tick after.
+        let reconcile = tick.is_multiple_of(RECURRING_RECONCILE_EVERY_N_TICKS);
+
+        if reconcile {
+            match self
+                .state
+                .scan_keys_by_kind(KeyKind::PendingRecurring)
+                .await
+            {
+                Ok(entries) => {
+                    let count = entries.len();
+                    // Reset the durable counter to the scanned truth so future
+                    // O(1) reads stay accurate.
+                    let _ = self
+                        .state
+                        .set(&recurring_active_counter_key(), &count.to_string(), None)
+                        .await;
+                    self.metrics
+                        .set_recurring_active(u64::try_from(count).unwrap_or(u64::MAX));
+                }
+                Err(e) => {
+                    debug!(error = %e, "failed to reconcile recurring_active gauge");
+                }
             }
+            return;
+        }
+
+        match self.state.get(&recurring_active_counter_key()).await {
+            Ok(Some(v)) => {
+                if let Ok(n) = v.parse::<i64>() {
+                    self.metrics
+                        .set_recurring_active(u64::try_from(n.max(0)).unwrap_or(0));
+                }
+            }
+            // Counter not yet materialized (no recurring action ever created).
+            // Leave the gauge at its prior value; the next reconcile seeds it.
+            Ok(None) => {}
             Err(e) => {
-                debug!(error = %e, "failed to refresh recurring_active gauge");
+                debug!(error = %e, "failed to read recurring_active counter");
             }
         }
     }
@@ -118,8 +168,7 @@ impl BackgroundProcessor {
                 // Already deleted, clean up pending key.
                 let pending_key =
                     StateKey::new(namespace, tenant, KeyKind::PendingRecurring, recurring_id);
-                self.state.delete(&pending_key).await?;
-                self.state.remove_timeout_index(&pending_key).await?;
+                acteon_state::remove_pending_recurring(self.state.as_ref(), &pending_key).await?;
                 continue;
             };
 
@@ -162,8 +211,7 @@ impl BackgroundProcessor {
                 // Remove from pending index so it won't be re-polled.
                 let pending_key =
                     StateKey::new(namespace, tenant, KeyKind::PendingRecurring, recurring_id);
-                self.state.delete(&pending_key).await?;
-                self.state.remove_timeout_index(&pending_key).await?;
+                acteon_state::remove_pending_recurring(self.state.as_ref(), &pending_key).await?;
                 self.metrics.increment_recurring_skipped();
                 skipped += 1;
                 continue;
@@ -221,16 +269,19 @@ impl BackgroundProcessor {
                             .is_none_or(|max| recurring.execution_count + 1 < max)
                 });
             if let Some(next) = rearm_to {
-                let next_ms = next.timestamp_millis();
-                self.state
-                    .set(&pending_key, &next_ms.to_string(), None)
-                    .await?;
-                self.state.index_timeout(&pending_key, next_ms).await?;
+                // Re-arming an entry that is already in the index leaves the
+                // active count unchanged (the helper only counts true
+                // insertions).
+                acteon_state::set_pending_recurring(
+                    self.state.as_ref(),
+                    &pending_key,
+                    next.timestamp_millis(),
+                )
+                .await?;
             } else {
                 // No further occurrence (exhausted, past ends_at, at max, or
                 // unparsable) — drop it from the index.
-                self.state.delete(&pending_key).await?;
-                self.state.remove_timeout_index(&pending_key).await?;
+                acteon_state::remove_pending_recurring(self.state.as_ref(), &pending_key).await?;
             }
 
             info!(

--- a/crates/gateway/src/metrics.rs
+++ b/crates/gateway/src/metrics.rs
@@ -62,8 +62,10 @@ pub struct GatewayMetrics {
     /// Recurring actions skipped (disabled, expired, etc.).
     pub recurring_skipped: AtomicU64,
     /// Recurring actions currently scheduled and eligible for dispatch.
-    /// Refreshed once per `recurring_check_interval` tick by counting
-    /// the pending-recurring index.
+    /// Backed by a durable counter maintained on every pending-recurring
+    /// index mutation, so each tick refreshes this gauge with an O(1) read
+    /// instead of scanning the index (a periodic reconciliation scan
+    /// self-heals drift). See issue #118.
     pub recurring_active: AtomicU64,
     /// Actions blocked by tenant quota.
     pub quota_exceeded: AtomicU64,

--- a/crates/server/src/api/recurring.rs
+++ b/crates/server/src/api/recurring.rs
@@ -392,13 +392,9 @@ async fn index_pending(
             KeyKind::PendingRecurring,
             &rec.id,
         );
-        // Store the next execution timestamp as the value.
-        state_store
-            .set(&pending_key, &next.timestamp_millis().to_string(), None)
-            .await
-            .map_err(|e| e.to_string())?;
-        state_store
-            .index_timeout(&pending_key, next.timestamp_millis())
+        // Delegates to the shared helper so the durable `recurring_active`
+        // counter stays in sync (issue #118).
+        acteon_state::set_pending_recurring(state_store, &pending_key, next.timestamp_millis())
             .await
             .map_err(|e| e.to_string())?;
     }
@@ -413,9 +409,9 @@ async fn remove_pending(
     id: &str,
 ) -> Result<(), String> {
     let pending_key = StateKey::new(namespace, tenant, KeyKind::PendingRecurring, id);
-    // Best-effort removal; ignore errors if key doesn't exist.
-    let _ = state_store.remove_timeout_index(&pending_key).await;
-    let _ = state_store.delete(&pending_key).await;
+    // Best-effort removal; ignore errors if the key doesn't exist. Keeps the
+    // durable `recurring_active` counter in sync (issue #118).
+    let _ = acteon_state::remove_pending_recurring(state_store, &pending_key).await;
     Ok(())
 }
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -2246,15 +2246,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 &event.recurring_id,
                             );
 
+                            // Route through the shared helpers so the durable
+                            // `recurring_active` counter stays in sync with the
+                            // index (issue #118). Best-effort: a failed counter
+                            // bump self-heals on the next reconciliation scan.
                             if let Some(next_at) = rec.next_execution_at {
-                                let next_ms = next_at.timestamp_millis();
-                                let _ = recurring_store
-                                    .set(&pending_key, &next_ms.to_string(), None)
-                                    .await;
-                                let _ = recurring_store.index_timeout(&pending_key, next_ms).await;
+                                let _ = acteon_state::set_pending_recurring(
+                                    recurring_store.as_ref(),
+                                    &pending_key,
+                                    next_at.timestamp_millis(),
+                                )
+                                .await;
                             } else {
-                                let _ = recurring_store.delete(&pending_key).await;
-                                let _ = recurring_store.remove_timeout_index(&pending_key).await;
+                                let _ = acteon_state::remove_pending_recurring(
+                                    recurring_store.as_ref(),
+                                    &pending_key,
+                                )
+                                .await;
                             }
                         }
                     }

--- a/crates/state/state/src/lib.rs
+++ b/crates/state/state/src/lib.rs
@@ -1,10 +1,14 @@
 pub mod error;
 pub mod key;
 pub mod lock;
+pub mod recurring;
 pub mod store;
 pub mod testing;
 
 pub use error::StateError;
 pub use key::{KeyKind, StateKey};
 pub use lock::{DistributedLock, LockGuard};
+pub use recurring::{
+    recurring_active_counter_key, remove_pending_recurring, set_pending_recurring,
+};
 pub use store::{CasResult, StateStore};

--- a/crates/state/state/src/recurring.rs
+++ b/crates/state/state/src/recurring.rs
@@ -1,0 +1,92 @@
+//! Pending-recurring index maintenance with a durable active-count counter.
+//!
+//! The `recurring_active` gauge used to be refreshed every background tick by
+//! a full `scan_keys_by_kind(PendingRecurring)` — on `DynamoDB` an unbounded
+//! full-table `Scan` whose RCU cost scales with the *entire* keyspace, not the
+//! recurring workload (issue #118). To avoid that per-tick scan, every mutation
+//! of the pending-recurring index goes through the helpers here, which keep a
+//! single globally-shared durable counter in sync. The worker then refreshes
+//! the gauge from an O(1) read of that counter, reconciling against a full
+//! scan only occasionally to self-heal drift.
+//!
+//! The counter is maintained by *set-membership transitions*, not by raw
+//! operation counts:
+//! - [`set_pending_recurring`] bumps the counter `+1` only when the entry was
+//!   newly added (absent → present), detected with one O(1) `get`. Re-arming an
+//!   already-pending entry to its next occurrence leaves the count unchanged.
+//! - [`remove_pending_recurring`] decrements `-1` only when the entry actually
+//!   existed (present → absent), using the boolean returned by `delete`.
+//!
+//! Applied uniformly at every site that touches the index (server CRUD, the
+//! post-dispatch consumer, and the worker's re-arm/drop paths), this stays
+//! correct even across the worker→consumer double-mutation of the same key
+//! around a single dispatch. Counter bumps are best-effort: a failed bump (or a
+//! crash between the index write and the bump) self-heals on the next
+//! reconciliation scan, so it never fails the underlying index operation.
+
+use crate::key::{KeyKind, StateKey};
+use crate::{StateError, StateStore};
+
+/// Canonical key for the durable, globally-shared counter that tracks the
+/// number of active `PendingRecurring` index entries across all namespaces and
+/// tenants. The fixed `_system`/`_global` addressing keeps it outside any real
+/// tenant keyspace and outside the `PendingRecurring` kind, so it is never
+/// counted by `scan_keys_by_kind(PendingRecurring)`.
+#[must_use]
+pub fn recurring_active_counter_key() -> StateKey {
+    StateKey::new(
+        "_system",
+        "_global",
+        KeyKind::Custom("recurring_active_count".to_owned()),
+        "all",
+    )
+}
+
+/// Add or re-arm a `PendingRecurring` index entry at `next_ms`, keeping the
+/// durable active-count counter in sync. Increments the counter only on a true
+/// insertion (absent → present). See the module docs for the rationale.
+///
+/// # Errors
+/// Returns the underlying [`StateError`] if the `set` or timeout-index write
+/// fails. The counter bump is best-effort and never surfaces as an error.
+pub async fn set_pending_recurring(
+    state: &dyn StateStore,
+    pending_key: &StateKey,
+    next_ms: i64,
+) -> Result<(), StateError> {
+    let was_absent = state.get(pending_key).await?.is_none();
+    state.set(pending_key, &next_ms.to_string(), None).await?;
+    state.index_timeout(pending_key, next_ms).await?;
+    if was_absent {
+        let _ = state
+            .increment(&recurring_active_counter_key(), 1, None)
+            .await;
+    }
+    Ok(())
+}
+
+/// Remove a `PendingRecurring` index entry, keeping the durable active-count
+/// counter in sync. Decrements the counter only when the entry actually existed
+/// (present → absent), using `delete`'s returned boolean.
+///
+/// # Errors
+/// Returns the underlying [`StateError`] if the `delete` fails. The
+/// timeout-index removal and counter bump are best-effort.
+pub async fn remove_pending_recurring(
+    state: &dyn StateStore,
+    pending_key: &StateKey,
+) -> Result<(), StateError> {
+    let existed = state.delete(pending_key).await?;
+    let _ = state.remove_timeout_index(pending_key).await;
+    if existed {
+        let _ = state
+            .increment(&recurring_active_counter_key(), -1, None)
+            .await;
+    }
+    Ok(())
+}
+
+// Unit/integration tests for these helpers live in `acteon-gateway`
+// (crates/gateway/src/background/mod.rs), which has access to a concrete
+// `MemoryStateStore`. `acteon-state` cannot depend on `acteon-state-memory`
+// here without a build cycle.

--- a/docs/book/features/recurring-actions.md
+++ b/docs/book/features/recurring-actions.md
@@ -599,7 +599,7 @@ via `GET /metrics/prometheus` (and as JSON at `GET /metrics`):
 | `acteon_recurring_dispatched_total` | counter | Every successful recurring occurrence dispatched through the gateway |
 | `acteon_recurring_errors_total` | counter | Dispatch failures — cron parse error, state store unavailable, claim refused for a genuine reason, etc. |
 | `acteon_recurring_skipped_total` | counter | Occurrences skipped because another replica claimed them first (normal behavior under the CAS claim pattern — **not** an error signal) |
-| `acteon_recurring_active` | gauge | Recurring actions currently scheduled and eligible for dispatch. Refreshed once per `recurring_check_interval` tick by counting the pending-recurring index. |
+| `acteon_recurring_active` | gauge | Recurring actions currently scheduled and eligible for dispatch. Maintained as a durable counter that is incremented/decremented as pending-recurring index entries are added and removed, so each tick refreshes the gauge with an O(1) read instead of scanning the index. A full reconciliation scan runs about once an hour to self-heal any drift. |
 
 **Grafana.** The bundled `acteon-overview` dashboard has a
 "Recurring Actions" row with stat panels for active count and
@@ -614,7 +614,7 @@ rate(acteon_recurring_errors_total[5m]) > 0.1
 
 A drop in dispatch rate when recurring actions are configured
 often means the background processor is wedged — the claim TTL
-(120s) expired without progress. Compare the dispatched rate
+(60s) expired without progress. Compare the dispatched rate
 against `acteon_recurring_active` to spot a stuck worker without
 hitting `GET /v1/recurring`:
 


### PR DESCRIPTION
## Summary

Closes #118.

The `recurring_active` gauge was refreshed **every** recurring tick (default 60s) by `scan_keys_by_kind(PendingRecurring)`. On DynamoDB that is an unbounded full-table `Scan` with a post-read `FilterExpression` — its RCU cost scales with the *entire* state table (audit/event/chain/quota all share one physical table), **not** with the recurring workload. The scan also ran *before* the "any actions due?" early return, so it executed even with zero recurring actions: a per-minute death-scan that can dominate a large table's RCU budget.

This replaces it with a **durable, globally-shared counter** maintained incrementally on every pending-recurring index mutation. The worker refreshes the gauge with an O(1) read each tick and only falls back to a full scan ~hourly to self-heal drift.

## What changed

- **`crates/state/state/src/recurring.rs`** *(new)* — `recurring_active_counter_key()` + `set_pending_recurring` / `remove_pending_recurring` helpers. Counting is by **set-membership transition**: `+1` only on a true insert (detected with one O(1) `get`), `-1` only when `delete` reports the key existed. This is uniform across all 7 mutation sites and stays correct even across the worker→consumer double-mutation of the same key around a single dispatch.
- **Worker** (`background/workers/recurring.rs`) — gauge reads the O(1) counter each tick; full scan only every 60 ticks (~hourly) and at startup (seeds the counter + self-heals). All three worker mutation sites routed through the helpers.
- **Server CRUD** (`api/recurring.rs`) + **post-dispatch consumer** (`main.rs`) — routed through the same helpers so create/pause/delete/re-index keep the counter in sync.
- **`background/mod.rs`** — `recurring_tick_count` field + 2 new tests.
- Docs / metric comments updated; also fixed the stale **"120s" claim-TTL** mention → 60s (the discrepancy noted in #121).

## Why a durable counter (not a process-local `AtomicU64`)

The issue suggested a process-local `AtomicU64` as the v1. That is **not HA-correct**: a create served by replica X and the delete served by replica Y never reconcile, so per-replica counts diverge and can go negative. A durable counter via `StateStore::increment` (implemented on all five backends) is globally correct with O(1) reads on every backend; the periodic reconciliation scan covers any crash-window drift.

## Acceptance criteria (#118)

- [x] No `scan_keys_by_kind(PendingRecurring)` in the steady-state tick path
- [x] Gauge converges under create/delete/disable/re-enable churn — new tests `recurring_active_counter_tracks_membership_churn` and `recurring_active_gauge_reads_counter_without_scanning`
- [x] DynamoDB RCU in steady state ≈ gauge-disabled (only an ~hourly reconcile remains, ~1.6% of before)

## Testing

`cargo fmt --all` · `cargo clippy --workspace --no-deps -D warnings` · `cargo check --all-targets` · `cargo test --workspace --lib --bins --tests` — all green. All five state backends compile. No API/wire changes, so polyglot SDKs are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)