### PR TITLE
feat(metrics): add recurring_events_emitted worker counter for in-flight depth (#122)

### DIFF
--- a/crates/gateway/src/background/workers/recurring.rs
+++ b/crates/gateway/src/background/workers/recurring.rs
@@ -303,6 +303,11 @@ impl BackgroundProcessor {
                 warn!("recurring action event channel closed");
                 return Ok(());
             }
+            // The worker has successfully handed this occurrence to the
+            // consumer; the consumer increments `recurring_dispatched` once the
+            // action actually fires. The gap between the two is the in-flight /
+            // stuck depth (issue #122).
+            self.metrics.increment_recurring_events_emitted();
             dispatched += 1;
         }
 

--- a/crates/gateway/src/metrics.rs
+++ b/crates/gateway/src/metrics.rs
@@ -57,6 +57,13 @@ pub struct GatewayMetrics {
     pub scheduled: AtomicU64,
     /// Recurring actions dispatched successfully.
     pub recurring_dispatched: AtomicU64,
+    /// Recurring occurrences the worker successfully handed off to the
+    /// dispatch consumer, incremented right after the channel send.
+    /// `recurring_events_emitted - recurring_dispatched` is the number of
+    /// occurrences in flight or stuck between the worker and the consumer,
+    /// and a flat `recurring_events_emitted` while actions are scheduled
+    /// signals a wedged worker. See issue #122.
+    pub recurring_events_emitted: AtomicU64,
     /// Recurring action dispatch errors.
     pub recurring_errors: AtomicU64,
     /// Recurring actions skipped (disabled, expired, etc.).
@@ -227,6 +234,14 @@ impl GatewayMetrics {
         self.recurring_dispatched.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Increment the counter of recurring occurrences the worker has handed
+    /// off to the dispatch consumer (called right after the channel send
+    /// succeeds). See issue #122.
+    pub fn increment_recurring_events_emitted(&self) {
+        self.recurring_events_emitted
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
     /// Increment the recurring errors counter.
     pub fn increment_recurring_errors(&self) {
         self.recurring_errors.fetch_add(1, Ordering::Relaxed);
@@ -379,6 +394,7 @@ impl GatewayMetrics {
             circuit_fallbacks: self.circuit_fallbacks.load(Ordering::Relaxed),
             scheduled: self.scheduled.load(Ordering::Relaxed),
             recurring_dispatched: self.recurring_dispatched.load(Ordering::Relaxed),
+            recurring_events_emitted: self.recurring_events_emitted.load(Ordering::Relaxed),
             recurring_errors: self.recurring_errors.load(Ordering::Relaxed),
             recurring_skipped: self.recurring_skipped.load(Ordering::Relaxed),
             recurring_active: self.recurring_active.load(Ordering::Relaxed),
@@ -451,6 +467,8 @@ pub struct MetricsSnapshot {
     pub scheduled: u64,
     /// Recurring actions dispatched successfully.
     pub recurring_dispatched: u64,
+    /// Recurring occurrences the worker handed off to the dispatch consumer.
+    pub recurring_events_emitted: u64,
     /// Recurring action dispatch errors.
     pub recurring_errors: u64,
     /// Recurring actions skipped (disabled, expired, etc.).
@@ -841,6 +859,7 @@ mod tests {
         assert_eq!(snap.circuit_fallbacks, 0);
         assert_eq!(snap.scheduled, 0);
         assert_eq!(snap.recurring_dispatched, 0);
+        assert_eq!(snap.recurring_events_emitted, 0);
         assert_eq!(snap.recurring_errors, 0);
         assert_eq!(snap.recurring_skipped, 0);
         assert_eq!(snap.recurring_active, 0);
@@ -888,6 +907,7 @@ mod tests {
         m.increment_circuit_fallbacks();
         m.increment_scheduled();
         m.increment_recurring_dispatched();
+        m.increment_recurring_events_emitted();
         m.increment_recurring_errors();
         m.increment_recurring_skipped();
         m.set_recurring_active(7);
@@ -931,6 +951,7 @@ mod tests {
         assert_eq!(snap.circuit_fallbacks, 1);
         assert_eq!(snap.scheduled, 1);
         assert_eq!(snap.recurring_dispatched, 1);
+        assert_eq!(snap.recurring_events_emitted, 1);
         assert_eq!(snap.recurring_errors, 1);
         assert_eq!(snap.recurring_skipped, 1);
         assert_eq!(snap.recurring_active, 7);

--- a/crates/server/src/api/health.rs
+++ b/crates/server/src/api/health.rs
@@ -45,6 +45,7 @@ fn build_metrics_response(
         circuit_fallbacks: snap.circuit_fallbacks,
         scheduled: snap.scheduled,
         recurring_dispatched: snap.recurring_dispatched,
+        recurring_events_emitted: snap.recurring_events_emitted,
         recurring_errors: snap.recurring_errors,
         recurring_skipped: snap.recurring_skipped,
         recurring_active: snap.recurring_active,

--- a/crates/server/src/api/prometheus.rs
+++ b/crates/server/src/api/prometheus.rs
@@ -265,6 +265,12 @@ fn render_snapshot(snap: &MetricsSnapshot) -> String {
     );
     write_counter(
         &mut buf,
+        "acteon_recurring_events_emitted_total",
+        "Recurring occurrences the worker handed off to the dispatch consumer.",
+        snap.recurring_events_emitted,
+    );
+    write_counter(
+        &mut buf,
         "acteon_recurring_errors_total",
         "Recurring action dispatch errors.",
         snap.recurring_errors,
@@ -612,6 +618,7 @@ mod tests {
             circuit_fallbacks: 0,
             scheduled: 0,
             recurring_dispatched: 0,
+            recurring_events_emitted: 0,
             recurring_errors: 0,
             recurring_skipped: 0,
             recurring_active: 0,
@@ -660,6 +667,7 @@ mod tests {
             circuit_fallbacks: 1,
             scheduled: 7,
             recurring_dispatched: 4,
+            recurring_events_emitted: 6,
             recurring_errors: 1,
             recurring_skipped: 2,
             recurring_active: 9,
@@ -873,6 +881,7 @@ mod tests {
         "acteon_circuit_transitions_total",
         "acteon_circuit_fallbacks_total",
         "acteon_recurring_dispatched_total",
+        "acteon_recurring_events_emitted_total",
         "acteon_recurring_errors_total",
         "acteon_recurring_skipped_total",
         "acteon_quota_exceeded_total",
@@ -965,6 +974,7 @@ mod tests {
         assert!(output.contains("acteon_circuit_transitions_total 3"));
         assert!(output.contains("acteon_circuit_fallbacks_total 1"));
         assert!(output.contains("acteon_recurring_dispatched_total 4"));
+        assert!(output.contains("acteon_recurring_events_emitted_total 6"));
         assert!(output.contains("acteon_recurring_errors_total 1"));
         assert!(output.contains("acteon_recurring_skipped_total 2"));
         assert!(output.contains("acteon_recurring_active 9"));
@@ -1222,12 +1232,12 @@ mod tests {
             assert!(output.contains(name), "Missing provider metric: {name}");
         }
 
-        // 42 counters + 1 gauge from the snapshot + 8 provider families = 51.
+        // 43 counters + 1 gauge from the snapshot + 8 provider families = 52.
         let type_lines: Vec<&str> = output
             .lines()
             .filter(|l| l.starts_with("# TYPE "))
             .collect();
-        assert_eq!(type_lines.len(), 51, "Expected 51 TYPE declarations");
+        assert_eq!(type_lines.len(), 52, "Expected 52 TYPE declarations");
     }
 
     #[test]
@@ -1243,8 +1253,8 @@ mod tests {
             .collect();
         assert_eq!(
             type_lines.len(),
-            43,
-            "Expected 43 TYPE declarations without providers (42 counters + 1 gauge)"
+            44,
+            "Expected 44 TYPE declarations without providers (43 counters + 1 gauge)"
         );
     }
 

--- a/crates/server/src/api/schemas.rs
+++ b/crates/server/src/api/schemas.rs
@@ -83,6 +83,12 @@ pub struct MetricsResponse {
     /// Recurring actions dispatched successfully.
     #[schema(example = 0)]
     pub recurring_dispatched: u64,
+    /// Recurring occurrences the worker handed off to the dispatch consumer.
+    /// `recurring_events_emitted - recurring_dispatched` is the in-flight /
+    /// stuck depth between worker and consumer.
+    #[schema(example = 0)]
+    #[serde(default)]
+    pub recurring_events_emitted: u64,
     /// Recurring action dispatch errors.
     #[schema(example = 0)]
     pub recurring_errors: u64,

--- a/deploy/grafana/dashboards/acteon-overview.json
+++ b/deploy/grafana/dashboards/acteon-overview.json
@@ -316,9 +316,10 @@
       "id": 19,
       "options": { "colorMode": "background", "graphMode": "area", "textMode": "value_and_name", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "title": "Recurring Actions Active",
-      "description": "Recurring actions currently scheduled and eligible for dispatch. Refreshed once per recurring_check_interval tick.",
+      "description": "Active = recurring actions currently scheduled and eligible for dispatch. In-flight = occurrences the worker handed off but the consumer has not dispatched yet (emitted − dispatched); a persistently rising In-flight means a backed-up worker→consumer channel or a slow/stuck consumer.",
       "targets": [
-        { "expr": "acteon_recurring_active", "legendFormat": "Active", "refId": "A" }
+        { "expr": "acteon_recurring_active", "legendFormat": "Active", "refId": "A" },
+        { "expr": "acteon_recurring_events_emitted_total - acteon_recurring_dispatched_total", "legendFormat": "In-flight", "refId": "B" }
       ],
       "type": "stat"
     },
@@ -335,6 +336,7 @@
       "title": "Recurring Action Totals",
       "targets": [
         { "expr": "acteon_recurring_dispatched_total", "legendFormat": "Dispatched", "refId": "A" },
+        { "expr": "acteon_recurring_events_emitted_total", "legendFormat": "Emitted", "refId": "D" },
         { "expr": "acteon_recurring_errors_total", "legendFormat": "Errors", "refId": "B" },
         { "expr": "acteon_recurring_skipped_total", "legendFormat": "Skipped", "refId": "C" }
       ],

--- a/docs/book/features/grafana-dashboards.md
+++ b/docs/book/features/grafana-dashboards.md
@@ -97,7 +97,8 @@ All metrics use the `acteon_` prefix. Counters are monotonically increasing from
 
 | Metric | Type | Description |
 |--------|------|-------------|
-| `acteon_recurring_dispatched_total` | counter | Recurring actions dispatched |
+| `acteon_recurring_dispatched_total` | counter | Recurring actions dispatched (by the consumer, once fired) |
+| `acteon_recurring_events_emitted_total` | counter | Recurring occurrences handed off by the worker; `emitted - dispatched` = in-flight depth |
 | `acteon_recurring_errors_total` | counter | Recurring action dispatch errors |
 | `acteon_recurring_skipped_total` | counter | Recurring actions skipped |
 | `acteon_recurring_active` | gauge | Recurring actions currently scheduled and eligible for dispatch |

--- a/docs/book/features/recurring-actions.md
+++ b/docs/book/features/recurring-actions.md
@@ -596,7 +596,8 @@ via `GET /metrics/prometheus` (and as JSON at `GET /metrics`):
 
 | Metric | Type | Counted on |
 |---|---|---|
-| `acteon_recurring_dispatched_total` | counter | Every successful recurring occurrence dispatched through the gateway |
+| `acteon_recurring_dispatched_total` | counter | Every successful recurring occurrence dispatched through the gateway (incremented by the consumer once the action fires) |
+| `acteon_recurring_events_emitted_total` | counter | Every recurring occurrence the **worker** hands off to the dispatch consumer. `emitted - dispatched` is the in-flight/stuck depth; a flat `emitted` while actions are scheduled signals a wedged worker |
 | `acteon_recurring_errors_total` | counter | Dispatch failures — cron parse error, state store unavailable, claim refused for a genuine reason, etc. |
 | `acteon_recurring_skipped_total` | counter | Occurrences skipped because another replica claimed them first (normal behavior under the CAS claim pattern — **not** an error signal) |
 | `acteon_recurring_active` | gauge | Recurring actions currently scheduled and eligible for dispatch. Maintained as a durable counter that is incremented/decremented as pending-recurring index entries are added and removed, so each tick refreshes the gauge with an O(1) read instead of scanning the index. A full reconciliation scan runs about once an hour to self-heal any drift. |
@@ -620,6 +621,15 @@ hitting `GET /v1/recurring`:
 
 ```promql
 acteon_recurring_active > 0 and rate(acteon_recurring_dispatched_total[5m]) == 0
+```
+
+A growing gap between what the worker emits and what the consumer
+dispatches points specifically at a backed-up worker→consumer
+channel or a slow/stuck consumer (as opposed to a wedged worker,
+which stops emitting). Alert when the in-flight depth stays high:
+
+```promql
+acteon_recurring_events_emitted_total - acteon_recurring_dispatched_total > 50
 ```
 
 **Do not alert on `acteon_recurring_skipped_total`**: it fires

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -22,6 +22,7 @@ export interface MetricsResponse {
   llm_guardrail_denied?: number
   llm_guardrail_errors?: number
   recurring_dispatched?: number
+  recurring_events_emitted?: number
   recurring_errors?: number
   recurring_skipped?: number
   recurring_active?: number


### PR DESCRIPTION
## Summary

Closes #122.

The recurring lifecycle counters were split across two components: the **worker** owned `recurring_skipped`/`recurring_errors`, while the **server consumer** owned `recurring_dispatched` (incremented only once the action actually fires). Nothing recorded *"the worker successfully handed an occurrence to the consumer"*, which made three operator questions awkward to answer:

1. How long is the gap between claim and dispatch?
2. Is the worker→consumer channel backed up, or is a provider just slow?
3. Is the worker wedged? (A stuck worker stops emitting while the consumer can still drain a backlog, so `dispatched` looks healthy.)

This adds `recurring_events_emitted`, incremented by the worker **immediately after the channel send succeeds**. `recurring_events_emitted - recurring_dispatched` is the in-flight / stuck depth.

## What changed

- **`gateway/metrics.rs`** — new `recurring_events_emitted` `AtomicU64` + `increment_recurring_events_emitted()` + snapshot field (+ tests).
- **`gateway/background/workers/recurring.rs`** — increment right after the successful `tx.send(event)`, before `dispatched += 1`.
- **`server/api/prometheus.rs`** — exports `acteon_recurring_events_emitted_total` (+ updated fixtures and the TYPE-count assertions).
- **`server/api/schemas.rs` + `server/api/health.rs`** — JSON `/metrics` DTO.
- **`ui/src/types/index.ts`** — metrics type.
- **`deploy/grafana/dashboards/acteon-overview.json`** — "Emitted" series on the Totals stat panel and an "In-flight (emitted − dispatched)" series on the Active stat panel (also fixed that panel's stale description).
- **Docs** — metrics tables in `recurring-actions.md` + `grafana-dashboards.md`, and a new in-flight-depth alerting promql.

`recurring_dispatched` is unchanged in the consumer, so existing dashboards don't break. No SDK changes — `/metrics` isn't modeled in the polyglot clients (consistent with #118).

## Testing

`cargo fmt --all` · `cargo clippy --workspace --no-deps -D warnings` · `cargo check --all-targets` · `cargo test --workspace --lib --bins --tests` · `cd ui && npm run lint && npm run build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)