### PR TITLE
perf(gateway): version-gate the template/silence/time-interval cache sync

### DIFF
--- a/crates/gateway/src/background/mod.rs
+++ b/crates/gateway/src/background/mod.rs
@@ -461,9 +461,12 @@ impl BackgroundProcessor {
                         error!(error = %e, "error running stale-task reaper");
                     }
                 }
-                // TODO(template-sync): Replace with reactive invalidation
-                // (Redis pub/sub, PostgreSQL CDC, DynamoDB Streams).
-                // See `Gateway::sync_templates_from_store` for details.
+                // Template/silence/time-interval sync ticks are gated by a
+                // per-domain sync-version counter (see `acteon_state::sync_version`),
+                // so a tick with no changes is an O(1) counter read rather than a
+                // full-keyspace scan. A true push mechanism (Redis pub/sub,
+                // Postgres LISTEN/NOTIFY, DynamoDB Streams) remains possible future
+                // work to drop propagation latency below the poll interval.
                 _ = template_sync_interval.tick(), if self.config.enable_template_sync => {
                     if let Some(ref gw) = self.gateway {
                         let gw = gw.read().await;
@@ -500,7 +503,7 @@ impl BackgroundProcessor {
                 _ = time_interval_sync_interval.tick(), if self.config.enable_time_interval_sync => {
                     if let Some(ref gw) = self.gateway {
                         let gw = gw.read().await;
-                        match gw.load_time_intervals_from_state_store().await {
+                        match gw.sync_time_intervals_from_store().await {
                             Ok(count) => {
                                 debug!(count, "time interval sync completed");
                             }

--- a/crates/gateway/src/builder.rs
+++ b/crates/gateway/src/builder.rs
@@ -875,6 +875,7 @@ impl GatewayBuilder {
             )?),
             max_inline_bytes: self.max_inline_bytes,
             max_attachments_per_action: self.max_attachments_per_action,
+            sync_versions: crate::sync_state::SyncVersionTracker::default(),
         })
     }
 }

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -268,6 +268,10 @@ pub struct Gateway {
     pub(crate) max_inline_bytes: u64,
     /// Maximum number of attachments per action.
     pub(crate) max_attachments_per_action: usize,
+    /// Tracks the last cache-sync version observed per domain so the periodic
+    /// template/silence/time-interval sync workers can skip the expensive
+    /// full-keyspace scan when nothing has changed.
+    pub(crate) sync_versions: crate::sync_state::SyncVersionTracker,
 }
 
 impl std::fmt::Debug for Gateway {

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -11,6 +11,7 @@ pub mod group_manager;
 pub mod metrics;
 mod quota_enforcement;
 mod silence_enforcement;
+pub(crate) mod sync_state;
 pub mod task_chain_bridge;
 pub mod task_engine;
 pub mod template_engine;

--- a/crates/gateway/src/silence_enforcement.rs
+++ b/crates/gateway/src/silence_enforcement.rs
@@ -268,7 +268,23 @@ impl Gateway {
     ///
     /// Returns an error only if the underlying state store scan fails.
     pub async fn sync_silences_from_store(&self) -> Result<usize, GatewayError> {
-        self.load_silences_from_state_store().await
+        let version = acteon_state::read_sync_version(
+            self.state.as_ref(),
+            acteon_state::SyncDomain::Silences,
+        )
+        .await
+        .unwrap_or(0);
+        if !self
+            .sync_versions
+            .should_sync(acteon_state::SyncDomain::Silences, version)
+        {
+            // Unchanged since the last sync — skip the full keyspace scan.
+            return Ok(self.silence_cache_size());
+        }
+        let loaded = self.load_silences_from_state_store().await?;
+        self.sync_versions
+            .record(acteon_state::SyncDomain::Silences, version);
+        Ok(loaded)
     }
 
     /// Persist a silence to the state store.
@@ -287,7 +303,15 @@ impl Gateway {
         self.state
             .set(&key, &value, None)
             .await
-            .map_err(GatewayError::from)
+            .map_err(GatewayError::from)?;
+        // Data committed; bump the sync version so peer nodes refresh their
+        // silence caches (issue: poll→reactive sync). Best-effort.
+        let _ = acteon_state::bump_sync_version(
+            self.state.as_ref(),
+            acteon_state::SyncDomain::Silences,
+        )
+        .await;
+        Ok(())
     }
 
     /// Delete a silence from the state store by ID.
@@ -298,6 +322,11 @@ impl Gateway {
     pub async fn delete_silence(&self, silence_id: &str) -> Result<(), GatewayError> {
         let key = silence_state_key(silence_id);
         self.state.delete(&key).await.map_err(GatewayError::from)?;
+        let _ = acteon_state::bump_sync_version(
+            self.state.as_ref(),
+            acteon_state::SyncDomain::Silences,
+        )
+        .await;
         Ok(())
     }
 
@@ -585,5 +614,49 @@ mod tests {
         let loaded = gw.load_silences_from_state_store().await.unwrap();
         assert_eq!(loaded, 0);
         assert_eq!(gw.silence_cache_size(), 0);
+    }
+
+    #[tokio::test]
+    async fn sync_skips_scan_until_version_changes() {
+        let (gw, store) = build_test_gateway().await;
+
+        // First sync seeds the gate against an empty store (version 0).
+        assert_eq!(gw.sync_silences_from_store().await.unwrap(), 0);
+
+        // A silence written directly to the store WITHOUT bumping the version
+        // (e.g. an out-of-band write) is invisible to the gated sync: the
+        // version is unchanged, so the scan is skipped and the cache stays at 0.
+        store
+            .set(
+                &StateKey::new("_system", "_silences", KeyKind::Silence, "raw-one"),
+                &silence_json("raw-one", "warning"),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            gw.sync_silences_from_store().await.unwrap(),
+            0,
+            "gate must skip the scan while the version is unchanged"
+        );
+        assert_eq!(gw.silence_cache_size(), 0);
+
+        // Persisting through the gateway bumps the version, so the next sync
+        // re-scans and now loads BOTH the persisted silence and the earlier
+        // out-of-band one.
+        let mut s = silence_for(
+            vec![SilenceMatcher::new("severity", "warning", MatchOp::Equal).unwrap()],
+            1,
+            1,
+        );
+        s.id = "persisted-one".to_owned();
+        gw.persist_silence(&s).await.unwrap();
+
+        assert_eq!(
+            gw.sync_silences_from_store().await.unwrap(),
+            2,
+            "a version bump must force a full re-scan that picks up every silence"
+        );
+        assert_eq!(gw.silence_cache_size(), 2);
     }
 }

--- a/crates/gateway/src/sync_state.rs
+++ b/crates/gateway/src/sync_state.rs
@@ -1,0 +1,125 @@
+//! Per-node tracking of the last cache-sync version observed for each
+//! [`SyncDomain`], so the periodic background sync workers can skip the
+//! expensive `scan_keys_by_kind` rebuild when nothing has changed.
+//!
+//! See [`acteon_state::sync_version`] for the durable counter side. This struct
+//! is the in-process companion: it remembers the version a node last fully
+//! synced and decides, each tick, whether a fresh scan is warranted.
+
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+
+use acteon_state::SyncDomain;
+
+/// How many sync ticks between forced full-reconcile scans, regardless of the
+/// version gate. This self-heals the rare case of a version bump lost to a
+/// transient state-store error after its data write committed: a stale node
+/// converges within at most this many ticks instead of waiting for the next
+/// mutating write. At the default intervals that is ~10 min for silences (10s
+/// ticks) and ~30 min for templates/time intervals (30s ticks).
+const SYNC_RECONCILE_EVERY_N_TICKS: u64 = 60;
+
+/// Per-domain sync bookkeeping for one gateway instance.
+#[derive(Debug, Default)]
+pub(crate) struct SyncVersionTracker {
+    templates: Slot,
+    silences: Slot,
+    time_intervals: Slot,
+}
+
+#[derive(Debug)]
+struct Slot {
+    /// Store version this node last fully synced. Initialised to `-1` (an
+    /// impossible store value, since versions are `>= 0`) so the first sync
+    /// always runs and loads any data already present.
+    last_version: AtomicI64,
+    /// Monotonic count of sync attempts, driving the periodic reconcile.
+    ticks: AtomicU64,
+}
+
+impl Default for Slot {
+    fn default() -> Self {
+        Self {
+            last_version: AtomicI64::new(-1),
+            ticks: AtomicU64::new(0),
+        }
+    }
+}
+
+impl SyncVersionTracker {
+    fn slot(&self, domain: SyncDomain) -> &Slot {
+        match domain {
+            SyncDomain::Templates => &self.templates,
+            SyncDomain::Silences => &self.silences,
+            SyncDomain::TimeIntervals => &self.time_intervals,
+        }
+    }
+
+    /// Decide whether a full scan+rebuild should run this tick for `domain`,
+    /// given the `current_version` just read from the store. Returns `true`
+    /// when the version differs from the last fully-synced one, or a periodic
+    /// reconcile is due. Always `true` on the first call (last version `-1`,
+    /// tick `0` is a multiple of the reconcile interval). Advances the tick
+    /// counter as a side effect, so call exactly once per sync attempt.
+    pub(crate) fn should_sync(&self, domain: SyncDomain, current_version: i64) -> bool {
+        let slot = self.slot(domain);
+        let tick = slot.ticks.fetch_add(1, Ordering::Relaxed);
+        current_version != slot.last_version.load(Ordering::Relaxed)
+            || tick.is_multiple_of(SYNC_RECONCILE_EVERY_N_TICKS)
+    }
+
+    /// Record the store version observed by a completed full sync.
+    pub(crate) fn record(&self, domain: SyncDomain, version: i64) {
+        self.slot(domain)
+            .last_version
+            .store(version, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_call_always_syncs_then_gates_on_version() {
+        let t = SyncVersionTracker::default();
+        // First call: forced (last = -1, tick 0).
+        assert!(t.should_sync(SyncDomain::Silences, 0));
+        t.record(SyncDomain::Silences, 0);
+        // Unchanged version, not a reconcile tick → skip.
+        assert!(!t.should_sync(SyncDomain::Silences, 0));
+        // Version advanced by a peer write → sync.
+        assert!(t.should_sync(SyncDomain::Silences, 1));
+        t.record(SyncDomain::Silences, 1);
+        assert!(!t.should_sync(SyncDomain::Silences, 1));
+    }
+
+    #[test]
+    fn domains_are_independent() {
+        let t = SyncVersionTracker::default();
+        assert!(t.should_sync(SyncDomain::Templates, 0));
+        t.record(SyncDomain::Templates, 0);
+        assert!(!t.should_sync(SyncDomain::Templates, 0));
+        // A different domain still forces its own first sync.
+        assert!(t.should_sync(SyncDomain::TimeIntervals, 0));
+    }
+
+    #[test]
+    fn periodic_reconcile_fires_even_without_version_change() {
+        let t = SyncVersionTracker::default();
+        // Consume the forced first tick.
+        assert!(t.should_sync(SyncDomain::Templates, 5));
+        t.record(SyncDomain::Templates, 5);
+        let mut forced = 0;
+        // Over a full reconcile period with no version change, at least one
+        // forced scan must occur.
+        for _ in 0..SYNC_RECONCILE_EVERY_N_TICKS {
+            if t.should_sync(SyncDomain::Templates, 5) {
+                forced += 1;
+            }
+        }
+        assert!(
+            forced >= 1,
+            "expected a periodic reconcile within the window"
+        );
+    }
+}

--- a/crates/gateway/src/template_management.rs
+++ b/crates/gateway/src/template_management.rs
@@ -153,27 +153,41 @@ impl Gateway {
     /// Used by the background sync task to keep multi-node deployments
     /// consistent. Returns the total number of items synced.
     ///
-    // TODO(template-sync): Replace this poll-based sync with a reactive,
-    // backend-specific invalidation mechanism for near-zero-latency
-    // propagation across nodes:
-    //
-    //   - **Redis**: Subscribe to a pub/sub channel; the API layer publishes
-    //     an invalidation message on template create/update/delete. Each node
-    //     listens and calls `sync_templates_from_store()` (or applies a
-    //     targeted delta) on receipt.
-    //
-    //   - **PostgreSQL**: Use Change Data Capture (CDC) via logical replication
-    //     or LISTEN/NOTIFY on the template tables. A background listener
-    //     converts WAL events into in-memory map updates.
-    //
-    //   - **DynamoDB**: Enable DynamoDB Streams on the template items table.
-    //     A background consumer reads stream shards and applies inserts,
-    //     modifications, and deletions to the in-memory maps.
-    //
-    // Until then, the current approach polls at `template_sync_interval`
-    // (default 30 s), giving eventual consistency with a bounded staleness
-    // window equal to the poll interval.
+    // The poll still happens at `template_sync_interval` (default 30 s), but a
+    // sync-version gate (see `acteon_state::sync_version`) makes the common
+    // "nothing changed" tick an O(1) counter read instead of a full-keyspace
+    // scan: template CRUD bumps the `Templates` version, and this sync only
+    // rescans when the version moved (or on a periodic reconcile). A true
+    // push mechanism (Redis pub/sub, Postgres LISTEN/NOTIFY, DynamoDB Streams)
+    // would further cut propagation latency below the poll interval, but the
+    // gate already removes the per-tick full-keyspace scan that dominated cost.
     pub async fn sync_templates_from_store(&self) -> Result<usize, GatewayError> {
+        let version = acteon_state::read_sync_version(
+            self.state.as_ref(),
+            acteon_state::SyncDomain::Templates,
+        )
+        .await
+        .unwrap_or(0);
+        if !self
+            .sync_versions
+            .should_sync(acteon_state::SyncDomain::Templates, version)
+        {
+            // Unchanged since the last sync — skip the scan, report cache size.
+            let cached = self
+                .templates
+                .read()
+                .values()
+                .map(HashMap::len)
+                .sum::<usize>()
+                + self
+                    .template_profiles
+                    .read()
+                    .values()
+                    .map(HashMap::len)
+                    .sum::<usize>();
+            return Ok(cached);
+        }
+
         let mut new_templates: HashMap<(String, String), HashMap<String, acteon_core::Template>> =
             HashMap::new();
         let mut new_profiles: HashMap<
@@ -219,6 +233,8 @@ impl Gateway {
         *self.templates.write() = new_templates;
         *self.template_profiles.write() = new_profiles;
 
+        self.sync_versions
+            .record(acteon_state::SyncDomain::Templates, version);
         Ok(count)
     }
 }

--- a/crates/gateway/src/time_interval_management.rs
+++ b/crates/gateway/src/time_interval_management.rs
@@ -233,7 +233,15 @@ impl Gateway {
         self.state
             .set(&key, &value, None)
             .await
-            .map_err(GatewayError::from)
+            .map_err(GatewayError::from)?;
+        // Data committed; bump the sync version so peer nodes refresh their
+        // time-interval caches (issue: poll→reactive sync). Best-effort.
+        let _ = acteon_state::bump_sync_version(
+            self.state.as_ref(),
+            acteon_state::SyncDomain::TimeIntervals,
+        )
+        .await;
+        Ok(())
     }
 
     /// Delete a time interval from the state store.
@@ -250,6 +258,11 @@ impl Gateway {
         let id = time_interval_cache_id(namespace, tenant, name);
         let key = time_interval_state_key(&id);
         self.state.delete(&key).await.map_err(GatewayError::from)?;
+        let _ = acteon_state::bump_sync_version(
+            self.state.as_ref(),
+            acteon_state::SyncDomain::TimeIntervals,
+        )
+        .await;
         Ok(())
     }
 
@@ -332,6 +345,36 @@ impl Gateway {
             loaded += 1;
         }
         *self.time_intervals.write() = new_cache;
+        Ok(loaded)
+    }
+
+    /// Periodic sync entry point for the background processor: refresh the
+    /// time-interval cache from the state store, but only when the
+    /// `TimeIntervals` sync version has changed since the last sync (or a
+    /// periodic reconcile is due). This avoids the per-tick full-keyspace scan
+    /// that [`load_time_intervals_from_state_store`](Self::load_time_intervals_from_state_store)
+    /// performs on every node (issue: poll→reactive sync). The `load_` method
+    /// stays ungated for one-shot/startup use.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error only if the underlying scan fails.
+    pub async fn sync_time_intervals_from_store(&self) -> Result<usize, GatewayError> {
+        let version = acteon_state::read_sync_version(
+            self.state.as_ref(),
+            acteon_state::SyncDomain::TimeIntervals,
+        )
+        .await
+        .unwrap_or(0);
+        if !self
+            .sync_versions
+            .should_sync(acteon_state::SyncDomain::TimeIntervals, version)
+        {
+            return Ok(self.time_interval_cache_size());
+        }
+        let loaded = self.load_time_intervals_from_state_store().await?;
+        self.sync_versions
+            .record(acteon_state::SyncDomain::TimeIntervals, version);
         Ok(loaded)
     }
 }

--- a/crates/server/src/api/templates.rs
+++ b/crates/server/src/api/templates.rs
@@ -456,6 +456,11 @@ pub async fn create_template(
     if let Err(e) = state_store.set(&idx_key, &id, None).await {
         return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string());
     }
+    // Data committed; bump the sync version so peer nodes refresh (issue:
+    // poll→reactive sync). Best-effort — a lost bump self-heals on reconcile.
+    let _ =
+        acteon_state::bump_sync_version(state_store.as_ref(), acteon_state::SyncDomain::Templates)
+            .await;
     drop(gw);
 
     let gw = state.gateway.read().await;
@@ -648,6 +653,9 @@ pub async fn update_template(
     if let Err(e) = state_store.set(&key, &data, None).await {
         return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string());
     }
+    let _ =
+        acteon_state::bump_sync_version(state_store.as_ref(), acteon_state::SyncDomain::Templates)
+            .await;
     drop(gw);
 
     let gw = state.gateway.read().await;
@@ -725,6 +733,9 @@ pub async fn delete_template(
     }
     let idx_key = template_index_key(&tpl.namespace, &tpl.tenant, &tpl.name);
     let _ = state_store.delete(&idx_key).await;
+    let _ =
+        acteon_state::bump_sync_version(state_store.as_ref(), acteon_state::SyncDomain::Templates)
+            .await;
     drop(gw);
 
     let gw = state.gateway.read().await;
@@ -829,6 +840,9 @@ pub async fn create_profile(
     if let Err(e) = state_store.set(&idx_key, &id, None).await {
         return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string());
     }
+    let _ =
+        acteon_state::bump_sync_version(state_store.as_ref(), acteon_state::SyncDomain::Templates)
+            .await;
     drop(gw);
 
     let gw = state.gateway.read().await;
@@ -1024,6 +1038,9 @@ pub async fn update_profile(
     if let Err(e) = state_store.set(&key, &data, None).await {
         return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string());
     }
+    let _ =
+        acteon_state::bump_sync_version(state_store.as_ref(), acteon_state::SyncDomain::Templates)
+            .await;
     drop(gw);
 
     let gw = state.gateway.read().await;
@@ -1077,6 +1094,9 @@ pub async fn delete_profile(
     }
     let idx_key = profile_index_key(&prof.namespace, &prof.tenant, &prof.name);
     let _ = state_store.delete(&idx_key).await;
+    let _ =
+        acteon_state::bump_sync_version(state_store.as_ref(), acteon_state::SyncDomain::Templates)
+            .await;
     drop(gw);
 
     let gw = state.gateway.read().await;

--- a/crates/state/state/src/lib.rs
+++ b/crates/state/state/src/lib.rs
@@ -3,6 +3,7 @@ pub mod key;
 pub mod lock;
 pub mod recurring;
 pub mod store;
+pub mod sync_version;
 pub mod testing;
 
 pub use error::StateError;
@@ -12,3 +13,4 @@ pub use recurring::{
     recurring_active_counter_key, remove_pending_recurring, set_pending_recurring,
 };
 pub use store::{CasResult, StateStore};
+pub use sync_version::{SyncDomain, bump_sync_version, read_sync_version, sync_version_key};

--- a/crates/state/state/src/sync_version.rs
+++ b/crates/state/state/src/sync_version.rs
@@ -1,0 +1,91 @@
+//! Cache-sync version counters for cheap change detection.
+//!
+//! Several gateway caches (payload templates, silences, time intervals) are
+//! kept consistent across HA nodes by a periodic background sync that calls
+//! `scan_keys_by_kind` and rebuilds the in-memory map. On Redis that scan is a
+//! full-keyspace `SCAN`, on Postgres/DynamoDB a full-table read — O(total
+//! keyspace), paid by every node on every tick even when nothing changed.
+//!
+//! These resources are admin-managed and change rarely relative to the sync
+//! interval, so instead of scanning every tick we keep a single monotonic
+//! version counter per domain, bumped on every mutating write. A node reads
+//! that counter (an O(1) `get`) each tick and only performs the expensive
+//! scan+rebuild when the version differs from the one it last synced.
+//!
+//! ## Ordering contract
+//!
+//! Callers MUST complete the data write (the `set`/`delete` of the resource)
+//! **before** calling [`bump_sync_version`]. That ordering guarantees that any
+//! node which observes a given version has the corresponding data visible to
+//! its subsequent scan, so recording the observed version can never skip an
+//! unseen change. Bumps are otherwise best-effort: a lost bump (e.g. a
+//! transient store error after the data write) is self-healed by the sync's
+//! periodic full-reconcile fallback.
+
+use crate::key::{KeyKind, StateKey};
+use crate::{StateError, StateStore};
+
+/// A gateway cache whose freshness is gated by a sync-version counter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SyncDomain {
+    /// Payload templates and template profiles (`Template` + `TemplateProfile`).
+    Templates,
+    /// Notification silences (`Silence`).
+    Silences,
+    /// Named time intervals (`TimeInterval`).
+    TimeIntervals,
+}
+
+impl SyncDomain {
+    /// Stable identifier embedded in the counter key. Changing these strings
+    /// resets every node's view (harmless — the next sync re-scans).
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Templates => "templates",
+            Self::Silences => "silences",
+            Self::TimeIntervals => "time_intervals",
+        }
+    }
+}
+
+/// Canonical key for a domain's sync-version counter. Addressed under
+/// `_system`/`_global` so it sits outside any tenant keyspace and outside the
+/// scanned resource kinds.
+#[must_use]
+pub fn sync_version_key(domain: SyncDomain) -> StateKey {
+    StateKey::new(
+        "_system",
+        "_global",
+        KeyKind::Custom(format!("sync_version:{}", domain.as_str())),
+        "v",
+    )
+}
+
+/// Bump a domain's sync version after a mutating write. Call this only once the
+/// data write has committed (see the module ordering contract).
+///
+/// # Errors
+/// Returns the underlying [`StateError`] if the counter increment fails.
+pub async fn bump_sync_version(
+    state: &dyn StateStore,
+    domain: SyncDomain,
+) -> Result<i64, StateError> {
+    state.increment(&sync_version_key(domain), 1, None).await
+}
+
+/// Read a domain's current sync version, treating a missing counter as `0`
+/// (no mutating write has happened yet).
+///
+/// # Errors
+/// Returns the underlying [`StateError`] if the read fails.
+pub async fn read_sync_version(
+    state: &dyn StateStore,
+    domain: SyncDomain,
+) -> Result<i64, StateError> {
+    Ok(state
+        .get(&sync_version_key(domain))
+        .await?
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(0))
+}

--- a/docs/book/features/silences.md
+++ b/docs/book/features/silences.md
@@ -236,6 +236,13 @@ operator creates a silence via one instance, the change is visible on
 that instance immediately and propagates to peer instances via a
 background sync task that rebuilds the cache from the state store.
 
+Each silence write bumps a durable sync-version counter, and the
+background task only rebuilds the cache when that counter has changed
+since its last sync (with a periodic full reconcile as a safety net).
+So a quiet system pays an O(1) version check per tick instead of a
+full state-store scan — the expensive rebuild happens only when a
+silence actually changed.
+
 | Setting | Default | Description |
 |---|---|---|
 | `background.enable_silence_sync` | `true` | Enable periodic silence cache refresh from the state store |


### PR DESCRIPTION
## Summary

Each gateway node refreshes its **template**, **silence**, and **time-interval** caches by calling `scan_keys_by_kind` on a fixed interval (10–30s) and rebuilding the in-memory map. On Redis that scan is a **full-keyspace `SCAN`**; on Postgres/DynamoDB a full-table read — O(total keyspace), paid by *every* node on *every* tick even when nothing changed. With N nodes × 3 resource types this is a steady stream of full keyspace scans whose cost scales with the entire state store, not the (small, admin-managed) resource set.

This gates the rebuild on a **durable per-domain version counter**, so the steady-state "nothing changed" tick becomes a single O(1) counter read instead of a full scan + rebuild.

## How it works

- **`acteon-state::sync_version`** — `SyncDomain` (`Templates`/`Silences`/`TimeIntervals`), a per-domain counter key, and `bump_sync_version` / `read_sync_version`.
- Every mutating write bumps the counter **after** the data write commits. **Ordering contract:** a node that observes a given version is guaranteed the corresponding data is visible to its subsequent scan, so recording the observed version can never skip an unseen change.
- **`SyncVersionTracker`** (gateway) remembers the version each node last fully synced; the periodic sync reads the counter and only rescans when it moved. Initialised to `-1` so the **first** sync always loads pre-existing data. A periodic full reconcile (every 60 ticks) self-heals any bump lost to a transient store error.
- Bumps wired into the gateway persist/delete chokepoints (`persist_silence`/`delete_silence`/`persist_time_interval`/`delete_time_interval`) and the 6 template/profile CRUD handlers.

## Scope

Templates+profiles, silences, time intervals — the low-churn, admin-managed caches. **Group sync is intentionally left as-is:** groups mutate on nearly every action ingest, so a version gate would bump constantly and provide no benefit.

A true push mechanism (Redis pub/sub, Postgres `LISTEN/NOTIFY`, DynamoDB Streams) remains possible future work to drop propagation latency *below* the poll interval, but the gate already removes the per-tick full-keyspace scan that dominated cost. The stale `TODO(template-sync)` comments are updated to reflect this.

## Testing

- `SyncVersionTracker` unit tests: forced first sync, version gating, periodic reconcile, domain independence.
- End-to-end silence test: the gated sync skips the scan while the version is unchanged (an out-of-band write stays invisible), then a `persist_silence` bump forces a full re-scan that picks up every silence.
- `cargo fmt` · `clippy --workspace -D warnings` · `check --all-targets` · `test --workspace --lib --bins --tests` — all green.

No SDK changes — internal sync mechanism, no API/wire surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)