### PR TITLE
feat(swarm): implement run cancellation via a fail-closed per-run quota

### DIFF
--- a/crates/swarm/src/acteon/quota_manager.rs
+++ b/crates/swarm/src/acteon/quota_manager.rs
@@ -78,3 +78,101 @@ pub async fn delete_run_quota(config: &SwarmConfig, quota_id: &str) -> Result<()
         )))
     }
 }
+
+/// Cancel a swarm run by installing a zero-budget, fail-closed quota on its
+/// tenant (`swarm-{run_id}`).
+///
+/// Once the gateway's quota cache refreshes (bounded by its TTL, ~60s), the
+/// `PreToolUse` gate denies every gated action — command execution, file
+/// writes, web access, sub-agent spawns — for the run, so in-flight agents
+/// wind down and no new gated work is admitted. Read-only tool use and the
+/// orchestrator process itself are not force-killed; this is a graceful,
+/// cross-process cancel via the existing safety gate, not a SIGKILL.
+///
+/// The quota create endpoint rejects `max_actions == 0`, so this creates the
+/// policy at `1` and then clamps it to `0` via update — the update is the
+/// authoritative block. It is idempotent: a repeat cancel sees the create
+/// conflict (HTTP 409) and simply re-applies the clamp.
+///
+/// # Errors
+///
+/// Returns an error if Acteon is unreachable or rejects the create/update, so
+/// the CLI surfaces a non-zero exit rather than silently appearing to succeed.
+pub async fn block_run(config: &SwarmConfig, run_id: &str) -> Result<(), SwarmError> {
+    let client = reqwest::Client::new();
+    let quota_id = format!("swarm-{run_id}");
+    let tenant = format!("swarm-{run_id}");
+    let api_key = config.acteon.api_key.as_deref();
+
+    // 1) Ensure a quota exists for the run tenant. `create_quota` rejects
+    //    max_actions == 0, so seed at 1; an existing policy (409) is fine.
+    let create_body = serde_json::json!({
+        "id": quota_id,
+        "namespace": config.acteon.namespace,
+        "tenant": tenant,
+        "max_actions": 1,
+        "window_seconds": 60,
+        "overage_behavior": "block",
+        "enabled": true,
+        "description": format!("Cancellation block for swarm run {run_id}"),
+    });
+    let create_url = format!("{}/v1/quotas", config.acteon.endpoint);
+    let mut req = client.post(&create_url).json(&create_body);
+    if let Some(key) = api_key {
+        req = req.header("Authorization", format!("Bearer {key}"));
+    }
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| SwarmError::Acteon(format!("cancel: failed to reach Acteon: {e}")))?;
+    let status = resp.status();
+    if !status.is_success() && status != reqwest::StatusCode::CONFLICT {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(SwarmError::Acteon(format!(
+            "cancel: failed to create blocking quota: HTTP {status}: {body}"
+        )));
+    }
+
+    // 2) Clamp the budget to zero — the authoritative block.
+    let update_url = format!("{}/v1/quotas/{quota_id}", config.acteon.endpoint);
+    let mut req = client
+        .put(&update_url)
+        .json(&serde_json::json!({ "max_actions": 0 }));
+    if let Some(key) = api_key {
+        req = req.header("Authorization", format!("Bearer {key}"));
+    }
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| SwarmError::Acteon(format!("cancel: failed to reach Acteon: {e}")))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(SwarmError::Acteon(format!(
+            "cancel: failed to apply blocking quota: HTTP {status}: {body}"
+        )));
+    }
+
+    tracing::info!(quota_id = %quota_id, "installed cancellation block quota");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SwarmConfig;
+
+    /// `block_run` must surface an error (never silently succeed) when the
+    /// Acteon gateway is unreachable — port 1 is reserved and refuses
+    /// connections deterministically.
+    #[tokio::test]
+    async fn block_run_errors_when_acteon_unreachable() {
+        let mut config = SwarmConfig::default();
+        config.acteon.endpoint = "http://127.0.0.1:1".to_string();
+        let result = block_run(&config, "test-run").await;
+        assert!(
+            matches!(result, Err(SwarmError::Acteon(_))),
+            "expected an Acteon error, got {result:?}"
+        );
+    }
+}

--- a/crates/swarm/src/config.rs
+++ b/crates/swarm/src/config.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use crate::error::SwarmError;
 
 /// Top-level swarm configuration, typically loaded from `swarm.toml`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SwarmConfig {
     /// Acteon gateway connection settings.
     #[serde(default)]

--- a/crates/swarm/src/main.rs
+++ b/crates/swarm/src/main.rs
@@ -145,7 +145,7 @@ async fn main() -> Result<()> {
             cmd_status(&config, &args.run).await?;
         }
         Commands::Cancel(args) => {
-            cmd_cancel(&config, &args.run);
+            cmd_cancel(&config, &args.run).await?;
         }
     }
 
@@ -391,7 +391,16 @@ async fn cmd_status(config: &SwarmConfig, run_id: &str) -> Result<()> {
     Ok(())
 }
 
-fn cmd_cancel(_config: &SwarmConfig, run_id: &str) {
-    // TODO: Implement cancel via Acteon API + kill agent processes.
-    warn!(run_id = %run_id, "cancel not yet implemented");
+async fn cmd_cancel(config: &SwarmConfig, run_id: &str) -> Result<()> {
+    info!(run_id = %run_id, "cancelling swarm run");
+    acteon_swarm::acteon::quota_manager::block_run(config, run_id).await?;
+    info!(
+        run_id = %run_id,
+        "cancellation requested — Acteon will deny this run's gated actions \
+         (command execution, file writes, web access, sub-agent spawns) within the \
+         gateway quota-cache TTL (~60s). In-flight agents wind down as their tool \
+         calls are blocked; read-only work and the orchestrator process are not \
+         force-killed."
+    );
+    Ok(())
 }

--- a/crates/swarm/src/orchestrator/adversarial.rs
+++ b/crates/swarm/src/orchestrator/adversarial.rs
@@ -411,6 +411,7 @@ async fn spawn_single_recovery_agent(
         &system_prompt,
         &allowed_tools,
         ctx.hooks_binary,
+        &run.id,
     )
     .await
     {

--- a/crates/swarm/src/orchestrator/agent_spawner.rs
+++ b/crates/swarm/src/orchestrator/agent_spawner.rs
@@ -55,6 +55,7 @@ pub async fn spawn_agent(
     system_prompt: &str,
     allowed_tools: &[String],
     hooks_binary: &Path,
+    run_id: &str,
 ) -> Result<Child, SwarmError> {
     let workspace = &session.workspace;
     let engine = config.defaults.engine;
@@ -64,10 +65,18 @@ pub async fn spawn_agent(
         setup_workspace_hooks(workspace, hooks_binary, config, &session.id).await?;
     }
 
+    // Per-run tenant isolation: the PreToolUse gate reads ACTEON_NAMESPACE /
+    // ACTEON_TENANT from the inherited environment, so every gated action for
+    // this run is dispatched (and audited) under `swarm-{run_id}`. This is what
+    // makes `cmd_status` and `cmd_cancel` able to target a single run — without
+    // it the gate falls back to the shared `swarm-default` tenant.
+    let tenant = format!("swarm-{run_id}");
     let swarm_env = [
         ("ACTEON_URL", config.acteon.endpoint.as_str()),
+        ("ACTEON_NAMESPACE", config.acteon.namespace.as_str()),
+        ("ACTEON_TENANT", tenant.as_str()),
         ("ACTEON_AGENT_ROLE", session.role.as_str()),
-        ("SWARM_RUN_ID", session.task_id.as_str()),
+        ("SWARM_RUN_ID", run_id),
         ("SWARM_TASK_ID", session.task_id.as_str()),
         ("SWARM_SUBTASK_ID", session.subtask_id.as_str()),
         ("SWARM_AGENT_ID", session.id.as_str()),

--- a/crates/swarm/src/orchestrator/engine.rs
+++ b/crates/swarm/src/orchestrator/engine.rs
@@ -417,6 +417,7 @@ async fn execute_task_isolated(ctx: SharedContext, task: SwarmTask, role: AgentR
             &system_prompt,
             allowed_tools,
             &ctx.hooks_binary,
+            &ctx.run_id,
         )
         .await
         {

--- a/docs/book/features/agent-swarm.md
+++ b/docs/book/features/agent-swarm.md
@@ -309,6 +309,23 @@ acteon-swarm status --run <run-id>
 acteon-swarm cancel --run <run-id>
 ```
 
+#### How cancel works
+
+Each run's agents dispatch their gated actions under a per-run tenant
+(`swarm-{run-id}`), set via `ACTEON_NAMESPACE`/`ACTEON_TENANT` in the agent
+environment. `cancel` installs a **zero-budget, fail-closed quota** on that
+tenant through the Acteon API. Once the gateway's quota cache refreshes
+(bounded by its TTL, ~60s), the `PreToolUse` gate denies every gated action —
+command execution, file writes, web access, and sub-agent spawns — for the
+run. In-flight agents wind down as their tool calls are blocked.
+
+This is a **graceful, cross-process cancel** through the existing safety gate,
+not a `SIGKILL`: read-only tool use still completes, and the orchestrator
+process is not force-killed (it finishes its current plan with all gated work
+denied). `cancel` exits non-zero if it cannot reach Acteon, so a failed
+cancellation is never reported as success. Hard process termination (a per-run
+PID registry) and orchestrator-side early-stop are possible future additions.
+
 ### Environment Variables
 
 | Variable | Description | Default |


### PR DESCRIPTION
## Summary

`acteon-swarm cancel --run <id>` was a **no-op** — it logged "cancel not yet implemented" and exited 0, silently appearing to succeed while the run kept going.

Implementing a real cancel surfaced that the per-run isolation it depends on was never wired:

- The PreToolUse gate reads `ACTEON_NAMESPACE`/`ACTEON_TENANT` from the environment, but the agent spawner never set them — so **every** run's gated actions dispatched under the shared `swarm-default` tenant.
- `create_run_quota` was dead code; no per-run quota ever existed.
- `cmd_status` already queried the intended `swarm-{run_id}` tenant, which therefore never saw any traffic.

## Changes

- **Spawner** (`agent_spawner.rs`): set `ACTEON_NAMESPACE` + `ACTEON_TENANT=swarm-{run_id}` in the agent env (inherited by the gate hook), and fix `SWARM_RUN_ID` (it was set to the *task* id). `spawn_agent` now takes the run id; both call sites (engine, adversarial recovery) pass it. This isolates each run's actions per tenant — the prerequisite for targeting one run, and it makes `cmd_status` actually work too.
- **`quota_manager::block_run`**: installs a zero-budget, fail-closed quota on the run tenant. The create endpoint rejects `max_actions == 0`, so it seeds at 1 then clamps to 0 via update (the authoritative block); idempotent on a 409.
- **`cmd_cancel`**: now `async` and returns `Result` — calls `block_run`, reports the graceful semantics, and exits non-zero if Acteon is unreachable so a failed cancellation is never reported as success.
- Derive `Default` on `SwarmConfig` (all fields already impl `Default`).
- Docs: a "How cancel works" section.

## Semantics (honest)

A **graceful, cross-process cancel** through the existing safety gate — not a `SIGKILL`. Within the gateway quota-cache TTL (~60s), every gated action (command execution, file writes, web access, sub-agent spawns) for the run is denied, so in-flight agents wind down. Read-only tool use still completes and the orchestrator process is not force-killed (it finishes its current plan with all gated work denied). Hard process termination (a per-run PID registry) and orchestrator-side early-stop are noted as future work.

## Testing

- `block_run` surfaces an error when Acteon is unreachable (fail-loud) — the core regression fix.
- `cargo fmt` · `clippy --workspace -D warnings` · `check --all-targets` · `test --workspace --lib --bins --tests` — all green (91 swarm tests).

`acteon-swarm` is an internal orchestrator binary with no polyglot SDK surface, so no SDK changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)