### PR TITLE
Store pinned chain definitions once per version instead of per execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,15 @@ jobs:
         rust: [stable, "1.88"]
     steps:
       - uses: actions/checkout@v4
+      # This job builds the full workspace with debug info plus the cloud
+      # provider feature matrices; the runner's default free space is no
+      # longer enough and the linker dies with SIGBUS at 0 MB free.
+      # Reclaim ~25 GB by dropping preinstalled toolchains we never use.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          df -h /
       - name: Install librdkafka build deps
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
       - uses: dtolnay/rust-toolchain@master

--- a/crates/core/src/chain.rs
+++ b/crates/core/src/chain.rs
@@ -1261,11 +1261,12 @@ pub struct ChainState {
     /// Version of the chain definition this execution pinned at start.
     #[serde(default = "default_chain_version")]
     pub chain_version: u64,
-    /// Full snapshot of the chain definition taken when the execution
-    /// started. The execution advances against this snapshot, so editing the
-    /// definition never changes in-flight executions. `None` for executions
-    /// created before versioning support (they fall back to the live
-    /// definition).
+    /// Legacy: a full snapshot of the chain definition embedded in the
+    /// execution. New executions leave this `None` and resolve their pinned
+    /// definition from the shared `chain_def_pinned` store by
+    /// `(chain_name, chain_version)` instead — embedding the definition
+    /// multiplied every chain-state persist by its size. Still honored on
+    /// read for executions persisted by older builds.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config_snapshot: Option<Box<ChainConfig>>,
     /// User-defined, queryable key-value attributes for visibility

--- a/crates/gateway/src/builder.rs
+++ b/crates/gateway/src/builder.rs
@@ -853,6 +853,7 @@ impl GatewayBuilder {
             llm_fail_open: self.llm_fail_open,
             chains: parking_lot::RwLock::new(self.chains),
             chain_step_indices: parking_lot::RwLock::new(chain_step_indices),
+            pinned_config_cache: parking_lot::RwLock::new(std::collections::HashMap::new()),
             completed_chain_ttl: self.completed_chain_ttl,
             embedding: self.embedding,
             default_timezone,

--- a/crates/gateway/src/execution.rs
+++ b/crates/gateway/src/execution.rs
@@ -25,6 +25,16 @@ pub(crate) const EXEC_HISTORY_KIND: &str = "exec_history";
 pub(crate) const EXEC_HISTORY_SEQ_KIND: &str = "exec_history_seq";
 /// State-store kind for buffered chain signals.
 pub(crate) const CHAIN_SIGNAL_KIND: &str = "chain_signal";
+/// State-store kind for pinned (immutable) chain definitions, keyed
+/// `{name}@{version}` within a namespace/tenant. Written once when the
+/// first execution pins a version; every execution of that version
+/// resolves it from here instead of embedding a snapshot per execution.
+pub(crate) const PINNED_CHAIN_DEF_KIND: &str = "chain_def_pinned";
+
+/// Size cap for the process-local pinned-definition cache; reaching it
+/// clears the cache (entries are immutable and re-loadable, so eviction
+/// correctness is trivial).
+const PINNED_CONFIG_CACHE_CAP: usize = 256;
 
 /// How long a buffered (not-yet-consumed) signal is retained.
 const SIGNAL_BUFFER_TTL: Duration = Duration::from_secs(7 * 24 * 3600);
@@ -189,6 +199,82 @@ impl Gateway {
         }
         events.sort_by_key(|e| e.event_id);
         Ok(ExecutionHistory { events })
+    }
+
+    /// Persist the definition an execution pins at start. Write-once per
+    /// `{name}@{version}`: definitions are immutable per version, so a
+    /// concurrent start of the same version is a no-op.
+    ///
+    /// Pinned definitions are never expired: an execution may sleep for
+    /// months and must still resolve the version it started with.
+    pub(crate) async fn pin_chain_definition(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        config: &acteon_core::ChainConfig,
+    ) -> Result<(), GatewayError> {
+        let key = StateKey::new(
+            namespace,
+            tenant,
+            KeyKind::Custom(PINNED_CHAIN_DEF_KIND.into()),
+            format!("{}@{}", config.name, config.version),
+        );
+        let json = serde_json::to_string(config).map_err(|e| {
+            GatewayError::ChainError(format!("failed to serialize chain definition: {e}"))
+        })?;
+        let stored = self.encrypt_state_value(&json)?;
+        self.state.check_and_set(&key, &stored, None).await?;
+        Ok(())
+    }
+
+    /// Resolve the definition an execution runs against, in order:
+    /// process-local cache → pinned-definition store → the legacy snapshot
+    /// embedded in pre-store executions → the live registry (pre-pinning
+    /// executions only).
+    pub async fn execution_config(
+        &self,
+        chain_state: &ChainState,
+    ) -> Result<Option<acteon_core::ChainConfig>, GatewayError> {
+        // Legacy executions (created before the pinned store) carry the
+        // snapshot inline; honor it verbatim.
+        if let Some(snapshot) = chain_state.config_snapshot.as_deref() {
+            return Ok(Some(snapshot.clone()));
+        }
+
+        let cache_key = (
+            chain_state.namespace.clone(),
+            chain_state.tenant.clone(),
+            chain_state.chain_name.clone(),
+            chain_state.chain_version,
+        );
+        if let Some(config) = self.pinned_config_cache.read().get(&cache_key) {
+            return Ok(Some((**config).clone()));
+        }
+
+        let key = StateKey::new(
+            chain_state.namespace.as_str(),
+            chain_state.tenant.as_str(),
+            KeyKind::Custom(PINNED_CHAIN_DEF_KIND.into()),
+            format!("{}@{}", chain_state.chain_name, chain_state.chain_version),
+        );
+        if let Some(raw) = self.state.get(&key).await? {
+            let json = self.decrypt_state_value(&raw)?;
+            let config: acteon_core::ChainConfig = serde_json::from_str(&json).map_err(|e| {
+                GatewayError::ChainError(format!(
+                    "failed to deserialize pinned chain definition: {e}"
+                ))
+            })?;
+            let mut cache = self.pinned_config_cache.write();
+            if cache.len() >= PINNED_CONFIG_CACHE_CAP {
+                cache.clear();
+            }
+            cache.insert(cache_key, std::sync::Arc::new(config.clone()));
+            return Ok(Some(config));
+        }
+
+        // Pre-pinning executions (no snapshot, no store entry): fall back
+        // to the live registry, matching their original behavior.
+        Ok(self.chains.read().get(&chain_state.chain_name).cloned())
     }
 
     /// Deliver an external signal to a chain execution.
@@ -458,17 +544,12 @@ impl Gateway {
                 .await?
                 .ok_or_else(|| GatewayError::ChainError(format!("chain not found: {chain_id}")))?;
 
-            let chain_config = chain_state
-                .config_snapshot
-                .as_deref()
-                .cloned()
-                .or_else(|| self.chains.read().get(&chain_state.chain_name).cloned())
-                .ok_or_else(|| {
-                    GatewayError::ChainError(format!(
-                        "chain configuration not found: {}",
-                        chain_state.chain_name
-                    ))
-                })?;
+            let chain_config = self.execution_config(&chain_state).await?.ok_or_else(|| {
+                GatewayError::ChainError(format!(
+                    "chain configuration not found: {}",
+                    chain_state.chain_name
+                ))
+            })?;
 
             let target_idx = chain_config
                 .steps

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -178,6 +178,10 @@ impl Drop for DispatchLockGuard {
     }
 }
 
+/// Cache map for pinned chain definitions, keyed by
+/// namespace + tenant + chain name + version.
+pub(crate) type PinnedConfigCache = HashMap<(String, String, String, u64), Arc<ChainConfig>>;
+
 /// The central gateway that orchestrates the action dispatch pipeline.
 ///
 /// The dispatch pipeline for each action:
@@ -212,6 +216,10 @@ pub struct Gateway {
     /// gateway construction time (and updated via runtime CRUD) to avoid
     /// repeated `HashMap` allocations during chain advancement.
     pub(crate) chain_step_indices: parking_lot::RwLock<HashMap<String, HashMap<String, usize>>>,
+    /// Process-local cache of pinned (immutable) chain definitions, keyed
+    /// `(namespace, tenant, name, version)`. Entries never invalidate —
+    /// a pinned definition cannot change — but the cache is size-capped.
+    pub(crate) pinned_config_cache: parking_lot::RwLock<PinnedConfigCache>,
     pub(crate) completed_chain_ttl: Option<Duration>,
     pub(crate) embedding: Option<Arc<dyn acteon_rules::EmbeddingEvalSupport>>,
     pub(crate) default_timezone: Option<chrono_tz::Tz>,
@@ -2515,7 +2523,10 @@ impl Gateway {
             step_history: vec![Vec::new(); total_steps],
             caller: caller.cloned(),
             chain_version: chain_config.version,
-            config_snapshot: Some(Box::new(chain_config.clone())),
+            // Pinned definitions live in the shared store (written once
+            // per version below) — embedding them per execution multiplied
+            // every chain-state persist by the definition size.
+            config_snapshot: None,
             search_attributes: action
                 .metadata
                 .labels
@@ -2524,6 +2535,15 @@ impl Gateway {
                 .collect(),
             wait_state: None,
         };
+
+        // Pin the definition before any state is persisted: an execution
+        // must never exist without its version being resolvable.
+        self.pin_chain_definition(
+            action.namespace.as_str(),
+            action.tenant.as_str(),
+            &chain_config,
+        )
+        .await?;
 
         self.append_execution_history(
             action.namespace.as_str(),
@@ -2673,20 +2693,15 @@ impl Gateway {
             return Ok(());
         }
 
-        // Use the definition snapshot pinned at execution start so that
-        // editing a chain never changes in-flight executions. Executions
-        // created before versioning support fall back to the live registry.
-        let chain_config = chain_state
-            .config_snapshot
-            .as_deref()
-            .cloned()
-            .or_else(|| self.chains.read().get(&chain_state.chain_name).cloned())
-            .ok_or_else(|| {
-                GatewayError::ChainError(format!(
-                    "chain configuration not found: {}",
-                    chain_state.chain_name
-                ))
-            })?;
+        // Resolve the definition pinned at execution start (pinned store /
+        // legacy embedded snapshot / pre-pinning registry fallback) so that
+        // editing a chain never changes in-flight executions.
+        let chain_config = self.execution_config(&chain_state).await?.ok_or_else(|| {
+            GatewayError::ChainError(format!(
+                "chain configuration not found: {}",
+                chain_state.chain_name
+            ))
+        })?;
 
         // Compute the step index map from the effective (pinned) config —
         // the registry cache may reflect a newer definition version.
@@ -5481,10 +5496,13 @@ impl Gateway {
             // Sub-chains inherit the originating caller for audit attribution.
             caller: parent.caller.clone(),
             chain_version: sub_config.version,
-            config_snapshot: Some(Box::new(sub_config.clone())),
+            config_snapshot: None,
             search_attributes: parent.search_attributes.clone(),
             wait_state: None,
         };
+
+        self.pin_chain_definition(&parent.namespace, &parent.tenant, &sub_config)
+            .await?;
 
         self.append_execution_history(
             &parent.namespace,
@@ -5624,11 +5642,20 @@ impl Gateway {
                 )));
             }
 
-            let chain_config = self.chains.read().get(chain_name).cloned().ok_or_else(|| {
-                GatewayError::ChainError(format!(
-                    "chain configuration not found for DAG: {chain_name}"
-                ))
-            })?;
+            // Instance DAGs render the definition the execution actually
+            // runs against; definition DAGs use the live registry.
+            let pinned = match chain_state {
+                Some(state) => self.execution_config(state).await?,
+                None => None,
+            };
+            let chain_config = match pinned {
+                Some(config) => config,
+                None => self.chains.read().get(chain_name).cloned().ok_or_else(|| {
+                    GatewayError::ChainError(format!(
+                        "chain configuration not found for DAG: {chain_name}"
+                    ))
+                })?,
+            };
 
             let mut nodes = Vec::new();
             let mut edges = Vec::new();
@@ -6468,13 +6495,9 @@ impl Gateway {
 
         // Dispatch a cancel notification through the gateway pipeline.
         // Resolve the notification target from the execution's pinned
-        // definition snapshot — the live registry may have been edited or
-        // deleted since this execution started.
-        let chain_config = chain_state
-            .config_snapshot
-            .as_deref()
-            .cloned()
-            .or_else(|| self.chains.read().get(&chain_state.chain_name).cloned());
+        // definition — the live registry may have been edited or deleted
+        // since this execution started.
+        let chain_config = self.execution_config(&chain_state).await.ok().flatten();
         let (notify_provider, notify_action_type) = chain_config
             .as_ref()
             .and_then(|c| c.on_cancel.as_ref())

--- a/crates/gateway/src/task_queue.rs
+++ b/crates/gateway/src/task_queue.rs
@@ -757,17 +757,12 @@ impl Gateway {
                 return Ok(());
             }
 
-            let chain_config = chain_state
-                .config_snapshot
-                .as_deref()
-                .cloned()
-                .or_else(|| self.chains.read().get(&chain_state.chain_name).cloned())
-                .ok_or_else(|| {
-                    GatewayError::ChainError(format!(
-                        "chain configuration not found: {}",
-                        chain_state.chain_name
-                    ))
-                })?;
+            let chain_config = self.execution_config(&chain_state).await?.ok_or_else(|| {
+                GatewayError::ChainError(format!(
+                    "chain configuration not found: {}",
+                    chain_state.chain_name
+                ))
+            })?;
             if step_idx >= chain_config.steps.len() {
                 return Ok(());
             }

--- a/crates/gateway/tests/durable_executions.rs
+++ b/crates/gateway/tests/durable_executions.rs
@@ -447,6 +447,11 @@ async fn inflight_execution_pins_definition_version() {
     assert_eq!(state.chain_version, 1);
     assert_eq!(state.total_steps, 2);
     assert_eq!(state.execution_path, vec!["one", "two"]);
+    // The definition lives in the pinned store, not embedded per execution.
+    assert!(
+        state.config_snapshot.is_none(),
+        "new executions must not embed the definition snapshot"
+    );
 
     // A new execution uses the replaced (v2) definition.
     let new_chain_id = start_chain(&gateway).await;

--- a/crates/server/src/api/chains.rs
+++ b/crates/server/src/api/chains.rs
@@ -284,11 +284,7 @@ pub async fn get_chain(
     {
         Ok(Some(chain_state)) => {
             // Try to load the chain config for retry metadata.
-            let chain_config = chain_state
-                .config_snapshot
-                .as_deref()
-                .cloned()
-                .or_else(|| gw.chain_config(&chain_state.chain_name));
+            let chain_config = gw.execution_config(&chain_state).await.ok().flatten();
 
             // Build per-step status from the chain config and results.
             let steps: Vec<ChainStepStatus> = (0..chain_state.total_steps)
@@ -955,11 +951,7 @@ pub async fn get_chain_history(
         .await
     {
         Ok(Some(chain_state)) => {
-            let chain_config = chain_state
-                .config_snapshot
-                .as_deref()
-                .cloned()
-                .or_else(|| gw.chain_config(&chain_state.chain_name));
+            let chain_config = gw.execution_config(&chain_state).await.ok().flatten();
 
             let steps: Vec<StepHistoryEntry> = (0..chain_state.total_steps)
                 .map(|i| {

--- a/docs/book/features/durable-executions.md
+++ b/docs/book/features/durable-executions.md
@@ -86,10 +86,15 @@ Semantics:
 ## Definition versioning
 
 Chain definitions carry a `version` that bumps on every update
-(`PUT /v1/chains/definitions/{name}`). Every execution pins a full snapshot
-of the definition it started with and advances against that snapshot — so
-deploying a new chain version never changes the behavior of in-flight
-executions. New executions pick up the latest version.
+(`PUT /v1/chains/definitions/{name}`). Every execution pins the definition
+version it started with: the definition is stored once per
+`{name}@{version}` in the state store (immutable, written on first use) and
+every consumer — advancement, worker resume, reset, cancel notifications,
+and the detail/history/DAG endpoints — resolves it from there. Deploying a
+new chain version therefore never changes the behavior of in-flight
+executions; new executions pick up the latest version. Deleting a
+definition that other definitions still reference as a sub-chain is
+rejected.
 
 ## Visibility & search attributes
 


### PR DESCRIPTION
Follow-up to #250, closing two items deliberately deferred from its adversarial review: **efficiency finding 10b** (the embedded `config_snapshot` re-serialized on every chain-state persist) and the remaining **pinning seam from finding 7** (the per-execution DAG endpoint rendering the live definition).

## What changed

- **Pinned-definition store**: when an execution starts (chains and sub-chains), its definition is written once to a shared, immutable store keyed `{name}@{version}` (`KeyKind::Custom("chain_def_pinned")`, write-once via `check_and_set`, no TTL — an execution may sleep for months and must still resolve its version). `ChainState` no longer embeds the snapshot.
- **Single resolution path**: new `Gateway::execution_config(&ChainState)` resolves, in order: a size-capped process-local cache (definitions are immutable per version, so entries never invalidate) → the pinned store → the legacy embedded snapshot (back-compat for executions persisted by older builds) → the live registry (pre-versioning executions only). All consumers now go through it: `advance_chain`, worker-task resume, `reset_execution`, `cancel_chain`'s `on_cancel` target, the `GET /v1/chains/{id}` and `/history` endpoints, and — newly pinned — the per-execution **DAG endpoint** (instance DAGs now render the definition the execution actually runs against; definition DAGs keep using the live registry).

## Why it matters

Every `persist_chain_state` call (~40 sites, several per step: advancement, retries, wait transitions, resumes) previously rewrote the full definition through serialize + encrypt, and every state read paid the inverse — a 50 KB definition on a 20-step chain wrote >1 MB of redundant definition bytes per execution and inflated every `list_executions` row. Per-step persists are now proportional to actual execution state.

## Compatibility

- Executions persisted by older builds (embedded snapshot) are honored verbatim — the snapshot takes precedence in resolution.
- Pre-versioning executions (no snapshot, no store entry) fall back to the live registry, matching their original behavior.
- `ChainState.config_snapshot` stays in the schema as a read-only legacy field (serde default), so old state deserializes unchanged.

## Verification

- The existing pinning regression test (`inflight_execution_pins_definition_version`) now exercises the store path and gained an assertion that new executions persist with `config_snapshot: None`; all 35 durable-execution/queue/workflow integration tests pass.
- `cargo fmt`, clippy on stable **and** 1.88, `cargo test --workspace --lib --bins --tests`, `cargo check --all-targets` — all green.
- Docs: the versioning section in `docs/book/features/durable-executions.md` updated to describe the shared store.

## Out of scope (remaining #250 follow-ups)

Slim workflow continuation payloads, the `StepKind` tagged-enum refactor, cross-SDK contract fixtures, and gateway-level overlap enforcement — each still pending as its own change. (Pinned-definition garbage collection for fully-retired versions is also future work; entries are small and one-per-version.)

https://claude.ai/code/session_01T41GGbkbHtKcPtRFhxZ8DV

---
_Generated by [Claude Code](https://claude.ai/code/session_01T41GGbkbHtKcPtRFhxZ8DV)_