### PR TITLE
Dispatch chain steps through a tagged StepKind enum

### DIFF
--- a/crates/core/src/chain.rs
+++ b/crates/core/src/chain.rs
@@ -246,6 +246,48 @@ pub struct WorkerStepConfig {
     pub max_attempts: Option<u32>,
 }
 
+/// The kind of work a chain step performs — a borrowed, tagged view over
+/// the mutually-exclusive step-kind fields of [`ChainStepConfig`].
+///
+/// The step configuration keeps its flat, optional-field wire shape (so
+/// TOML/YAML/JSON definitions and persisted snapshots are unchanged), but
+/// engine code should dispatch through [`ChainStepConfig::kind`] instead of
+/// probing the individual `Option` fields: the precedence between kinds is
+/// then defined in exactly one place, and a future step kind extends this
+/// enum — turning every dispatch site into a compile error instead of a
+/// silent fall-through to provider dispatch.
+#[derive(Debug, Clone, Copy)]
+pub enum StepKind<'a> {
+    /// Dispatch a synthetic action to an in-process provider.
+    Provider,
+    /// Invoke another chain by name and wait for it to complete.
+    SubChain(&'a str),
+    /// Fan out to concurrent sub-steps.
+    Parallel(&'a ParallelStepGroup),
+    /// Pause on a durable timer.
+    Timer(&'a TimerStepConfig),
+    /// Pause until an external signal is delivered.
+    Signal(&'a SignalStepConfig),
+    /// Execute on an external worker queue.
+    Worker(&'a WorkerStepConfig),
+}
+
+impl StepKind<'_> {
+    /// Stable lowercase label for this kind, matching the field names used
+    /// in chain definitions (and in validation error messages).
+    #[must_use]
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Provider => "provider",
+            Self::SubChain(_) => "sub_chain",
+            Self::Parallel(_) => "parallel",
+            Self::Timer(_) => "timer",
+            Self::Signal(_) => "wait_for_signal",
+            Self::Worker(_) => "worker",
+        }
+    }
+}
+
 /// What a paused chain execution is waiting on.
 ///
 /// Set while the chain is in one of the waiting statuses
@@ -618,7 +660,35 @@ impl ChainStepConfig {
         step
     }
 
+    /// The canonical kind of this step, for engine dispatch.
+    ///
+    /// A valid step sets at most one kind ([`ChainConfig::validate`] rejects
+    /// combinations). For defense in depth against an invalid config that
+    /// slipped past validation, the precedence here mirrors the engine's
+    /// historical dispatch order: timer, wait-for-signal, worker, sub-chain,
+    /// parallel, then provider.
+    #[must_use]
+    pub fn kind(&self) -> StepKind<'_> {
+        if let Some(ref timer) = self.timer {
+            StepKind::Timer(timer)
+        } else if let Some(ref signal) = self.wait_for_signal {
+            StepKind::Signal(signal)
+        } else if let Some(ref worker) = self.worker {
+            StepKind::Worker(worker)
+        } else if let Some(ref sub_chain) = self.sub_chain {
+            StepKind::SubChain(sub_chain)
+        } else if let Some(ref parallel) = self.parallel {
+            StepKind::Parallel(parallel)
+        } else {
+            StepKind::Provider
+        }
+    }
+
     /// Returns `true` if this step invokes a sub-chain.
+    ///
+    /// Note: the `is_*` helpers probe the individual fields (so
+    /// [`ChainConfig::validate`] can detect steps that illegally set several
+    /// kinds); dispatch code should match on [`Self::kind`] instead.
     #[must_use]
     pub fn is_sub_chain(&self) -> bool {
         self.sub_chain.is_some()
@@ -984,28 +1054,28 @@ impl ChainConfig {
                     ));
                 }
             }
-            // Retry on wait steps is meaningless (nothing to retry).
-            if step.retry.is_some() && (step.is_timer() || step.is_wait_for_signal()) {
-                errors.push(format!(
-                    "step `{}` has a retry policy on a timer/wait_for_signal step; retry is only supported on provider and worker steps",
-                    step.name
-                ));
-            }
         }
 
-        // Reject retry policies on sub-chain and parallel parent steps.
+        // Retry is only meaningful where the engine re-executes the work
+        // itself: provider and worker steps.
         for step in &self.steps {
-            if step.retry.is_some() && step.is_sub_chain() {
-                errors.push(format!(
+            if step.retry.is_none() {
+                continue;
+            }
+            match step.kind() {
+                StepKind::Timer(_) | StepKind::Signal(_) => errors.push(format!(
+                    "step `{}` has a retry policy on a timer/wait_for_signal step; retry is only supported on provider and worker steps",
+                    step.name
+                )),
+                StepKind::SubChain(_) => errors.push(format!(
                     "step `{}` has a retry policy on a sub-chain step; retry is only supported on provider steps",
                     step.name
-                ));
-            }
-            if step.retry.is_some() && step.is_parallel() {
-                errors.push(format!(
+                )),
+                StepKind::Parallel(_) => errors.push(format!(
                     "step `{}` has a retry policy on a parallel step; retry is only supported on provider steps",
                     step.name
-                ));
+                )),
+                StepKind::Provider | StepKind::Worker(_) => {}
             }
         }
 
@@ -2368,6 +2438,124 @@ mod tests {
         let step =
             ChainStepConfig::new("test", "p", "t", serde_json::json!({})).with_parallel(group);
         assert!(step.is_parallel());
+    }
+
+    #[test]
+    fn step_kind_matches_each_constructor() {
+        let provider = ChainStepConfig::new("a", "email", "send", serde_json::json!({}));
+        assert!(matches!(provider.kind(), StepKind::Provider));
+
+        let sub = ChainStepConfig::new_sub_chain("b", "child");
+        assert!(matches!(sub.kind(), StepKind::SubChain("child")));
+
+        let group = ParallelStepGroup {
+            steps: vec![ChainStepConfig::new("x", "p", "t", serde_json::json!({}))],
+            join: ParallelJoinPolicy::All,
+            on_failure: ParallelFailurePolicy::FailFast,
+            timeout_seconds: None,
+            max_concurrency: None,
+        };
+        let parallel = ChainStepConfig::new_parallel("c", group);
+        assert!(matches!(parallel.kind(), StepKind::Parallel(g) if g.steps.len() == 1));
+
+        let timer = ChainStepConfig::new_timer(
+            "d",
+            TimerStepConfig {
+                duration_seconds: Some(60),
+                until: None,
+            },
+        );
+        assert!(matches!(
+            timer.kind(),
+            StepKind::Timer(t) if t.duration_seconds == Some(60)
+        ));
+
+        let signal = ChainStepConfig::new_wait_for_signal(
+            "e",
+            SignalStepConfig {
+                signal_name: "approved".into(),
+                timeout_seconds: None,
+                on_timeout: None,
+            },
+        );
+        assert!(matches!(
+            signal.kind(),
+            StepKind::Signal(s) if s.signal_name == "approved"
+        ));
+
+        let worker = ChainStepConfig::new_worker(
+            "f",
+            WorkerStepConfig {
+                queue: "builds".into(),
+                action_type: None,
+                timeout_seconds: None,
+                max_attempts: None,
+            },
+            serde_json::json!({}),
+        );
+        assert!(matches!(
+            worker.kind(),
+            StepKind::Worker(w) if w.queue == "builds"
+        ));
+    }
+
+    #[test]
+    fn step_kind_precedence_on_invalid_multi_kind_step() {
+        // An (invalid) step setting several kinds resolves by the documented
+        // precedence — timer wins over worker, worker over sub_chain.
+        let mut step = ChainStepConfig::new_sub_chain("multi", "child");
+        step.worker = Some(WorkerStepConfig {
+            queue: "q".into(),
+            action_type: None,
+            timeout_seconds: None,
+            max_attempts: None,
+        });
+        assert!(matches!(step.kind(), StepKind::Worker(_)));
+        step.timer = Some(TimerStepConfig {
+            duration_seconds: Some(1),
+            until: None,
+        });
+        assert!(matches!(step.kind(), StepKind::Timer(_)));
+        // validate() still sees every field set on the invalid step.
+        let config = ChainConfig::new("c").with_step(step);
+        assert!(
+            config
+                .validate()
+                .iter()
+                .any(|e| e.contains("multiple step kinds"))
+        );
+    }
+
+    #[test]
+    fn step_kind_labels_match_definition_field_names() {
+        let group = ParallelStepGroup {
+            steps: vec![],
+            join: ParallelJoinPolicy::All,
+            on_failure: ParallelFailurePolicy::FailFast,
+            timeout_seconds: None,
+            max_concurrency: None,
+        };
+        let timer = TimerStepConfig {
+            duration_seconds: Some(1),
+            until: None,
+        };
+        let signal = SignalStepConfig {
+            signal_name: "s".into(),
+            timeout_seconds: None,
+            on_timeout: None,
+        };
+        let worker = WorkerStepConfig {
+            queue: "q".into(),
+            action_type: None,
+            timeout_seconds: None,
+            max_attempts: None,
+        };
+        assert_eq!(StepKind::Provider.label(), "provider");
+        assert_eq!(StepKind::SubChain("c").label(), "sub_chain");
+        assert_eq!(StepKind::Parallel(&group).label(), "parallel");
+        assert_eq!(StepKind::Timer(&timer).label(), "timer");
+        assert_eq!(StepKind::Signal(&signal).label(), "wait_for_signal");
+        assert_eq!(StepKind::Worker(&worker).label(), "worker");
     }
 
     #[test]

--- a/crates/core/src/chain_dag.rs
+++ b/crates/core/src/chain_dag.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 pub struct DagNode {
     /// Step name.
     pub name: String,
-    /// Node type: `"step"` or `"sub_chain"`.
+    /// Node type: `"step"` (provider), `"sub_chain"`, `"parallel"`,
+    /// `"timer"`, `"wait_for_signal"`, or `"worker"`.
     pub node_type: String,
     /// Provider for regular steps.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -90,7 +90,7 @@ pub use chain::{
     BranchCondition, BranchOperator, ChainConfig, ChainFailurePolicy, ChainNotificationTarget,
     ChainState, ChainStatus, ChainStepConfig, ParallelExecutionState, ParallelFailurePolicy,
     ParallelJoinPolicy, ParallelStepGroup, ParallelSubStepStatus, SignalStepConfig,
-    StepFailurePolicy, StepResult, TimerStepConfig, WaitState, WorkerStepConfig,
+    StepFailurePolicy, StepKind, StepResult, TimerStepConfig, WaitState, WorkerStepConfig,
     validate_chain_graph,
 };
 pub use chain_dag::{DagEdge, DagNode, DagResponse};

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -13,7 +13,7 @@ use acteon_audit::store::AuditStore;
 use acteon_core::chain::WaitState;
 use acteon_core::{
     Action, ActionOutcome, Caller, ChainConfig, ChainState, ChainStatus, ChainStepConfig,
-    ExecutionEventType, StateMachineConfig, StepResult, StreamEvent, StreamEventType,
+    ExecutionEventType, StateMachineConfig, StepKind, StepResult, StreamEvent, StreamEventType,
     compute_fingerprint, sanitize_outcome,
 };
 use acteon_executor::{ActionExecutor, DeadLetterEntry, DeadLetterSink};
@@ -2763,307 +2763,36 @@ impl Gateway {
 
         let step_config = &chain_config.steps[step_idx];
 
-        // --- Durable timer step handling ---
-        if let Some(timer_cfg) = step_config.timer.as_ref() {
-            let now = Utc::now();
-            let wait = chain_state.wait_state.clone();
-            match wait {
-                Some(WaitState::Timer {
-                    step_index,
-                    fire_at,
-                }) if step_index == step_idx => {
-                    if now >= fire_at {
-                        chain_state.wait_state = None;
-                        chain_state.status = ChainStatus::Running;
-                        self.append_execution_history(
-                            namespace,
-                            tenant,
-                            chain_id,
-                            ExecutionEventType::TimerFired {
-                                step_name: step_config.name.clone(),
-                            },
-                            None,
-                        )
-                        .await;
-                        let step_result = StepResult::new(
-                            step_config.name.clone(),
-                            true,
-                            Some(serde_json::json!({ "fired_at": now.to_rfc3339() })),
-                            None,
-                            now,
-                        );
-                        self.complete_wait_step(
-                            namespace,
-                            tenant,
-                            chain_id,
-                            &chain_key,
-                            &pending_key,
-                            &chain_config,
-                            &mut chain_state,
-                            step_idx,
-                            step_config,
-                            step_result,
-                            &step_index_map,
-                            "chain_step_completed",
-                        )
-                        .await?;
-                    } else {
-                        // Spurious wake — re-arm at the fire time (or the
-                        // chain deadline, whichever is first).
-                        if let Some(wake) =
-                            Self::park_wake_at_ms(Some(fire_at), chain_state.expires_at)
-                        {
-                            self.state.index_chain_ready(&pending_key, wake).await?;
-                        }
-                    }
-                }
-                _ => {
-                    #[allow(clippy::cast_possible_wrap)]
-                    let fire_at = timer_cfg.until.unwrap_or_else(|| {
-                        now + chrono::Duration::seconds(
-                            timer_cfg.duration_seconds.unwrap_or(0) as i64
-                        )
-                    });
-                    chain_state.wait_state = Some(WaitState::Timer {
-                        step_index: step_idx,
+        // Exhaustive step-kind dispatch. The wait-style kinds park or resume
+        // the chain and return; only `Provider` falls through to the
+        // synthetic-action dispatch below the match.
+        match step_config.kind() {
+            // --- Durable timer step handling ---
+            StepKind::Timer(timer_cfg) => {
+                let now = Utc::now();
+                let wait = chain_state.wait_state.clone();
+                match wait {
+                    Some(WaitState::Timer {
+                        step_index,
                         fire_at,
-                    });
-                    chain_state.status = ChainStatus::WaitingTimer;
-                    chain_state.updated_at = now;
-                    self.persist_chain_state(&chain_key, &chain_state, None)
-                        .await?;
-                    self.append_execution_history(
-                        namespace,
-                        tenant,
-                        chain_id,
-                        ExecutionEventType::TimerStarted {
-                            step_name: step_config.name.clone(),
-                            fire_at,
-                        },
-                        None,
-                    )
-                    .await;
-                    if let Some(wake) = Self::park_wake_at_ms(Some(fire_at), chain_state.expires_at)
-                    {
-                        self.state.index_chain_ready(&pending_key, wake).await?;
-                    }
-                    debug!(
-                        chain_id = %chain_id,
-                        step = %step_config.name,
-                        %fire_at,
-                        "durable timer started"
-                    );
-                }
-            }
-            guard
-                .release()
-                .await
-                .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
-            return Ok(());
-        }
-
-        // --- Wait-for-signal step handling ---
-        if let Some(signal_cfg) = step_config.wait_for_signal.as_ref() {
-            let now = Utc::now();
-
-            // Consume a buffered signal if one has already been delivered
-            // (whether the chain was waiting or the signal arrived early).
-            if let Some(payload) = self
-                .peek_buffered_signal(namespace, tenant, chain_id, &signal_cfg.signal_name)
-                .await?
-            {
-                chain_state.wait_state = None;
-                chain_state.status = ChainStatus::Running;
-                let step_result =
-                    StepResult::new(step_config.name.clone(), true, Some(payload), None, now);
-                self.complete_wait_step(
-                    namespace,
-                    tenant,
-                    chain_id,
-                    &chain_key,
-                    &pending_key,
-                    &chain_config,
-                    &mut chain_state,
-                    step_idx,
-                    step_config,
-                    step_result,
-                    &step_index_map,
-                    "chain_step_completed",
-                )
-                .await?;
-                // Pop only after the consuming chain state is persisted; a
-                // crash in between re-delivers the signal (at-least-once)
-                // instead of losing it.
-                self.pop_buffered_signal(namespace, tenant, chain_id, &signal_cfg.signal_name)
-                    .await;
-                guard
-                    .release()
-                    .await
-                    .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
-                return Ok(());
-            }
-
-            let wait = chain_state.wait_state.clone();
-            match wait {
-                Some(WaitState::Signal {
-                    step_index,
-                    signal_name,
-                    timeout_at,
-                    on_timeout,
-                }) if step_index == step_idx => {
-                    if timeout_at.is_some_and(|t| now >= t) {
-                        chain_state.wait_state = None;
-                        self.append_execution_history(
-                            namespace,
-                            tenant,
-                            chain_id,
-                            ExecutionEventType::SignalTimedOut {
-                                step_name: step_config.name.clone(),
-                                signal_name: signal_name.clone(),
-                            },
-                            None,
-                        )
-                        .await;
-                        let step_result = StepResult::new(
-                            step_config.name.clone(),
-                            false,
-                            None,
-                            Some(format!("signal wait timed out: {signal_name}")),
-                            now,
-                        );
-                        let timeout_target = on_timeout
-                            .as_deref()
-                            .and_then(|t| step_index_map.get(t).copied());
-                        if let Some(target) = timeout_target {
-                            // Jump to the configured timeout step.
-                            chain_state.step_results[step_idx] = Some(step_result.clone());
+                    }) if step_index == step_idx => {
+                        if now >= fire_at {
+                            chain_state.wait_state = None;
                             chain_state.status = ChainStatus::Running;
-                            chain_state.current_step = target;
-                            chain_state.updated_at = now;
-                            chain_state
-                                .execution_path
-                                .push(chain_config.steps[target].name.clone());
-                            self.persist_chain_state(&chain_key, &chain_state, None)
-                                .await?;
-                            let ready_at = chain_config.steps[target]
-                                .delay_seconds
-                                .map_or(0, |d| now.timestamp_millis() + (d.cast_signed() * 1000));
-                            self.state.index_chain_ready(&pending_key, ready_at).await?;
-                            self.emit_chain_step_audit(
-                                &chain_state,
-                                step_config,
-                                step_idx,
-                                "chain_step_timed_out",
-                                &step_result,
-                                Duration::ZERO,
-                                None,
-                            )
-                            .await;
-                        } else {
-                            chain_state.status = ChainStatus::Running;
-                            self.fail_wait_step(
-                                namespace,
-                                tenant,
-                                chain_id,
-                                &chain_key,
-                                &pending_key,
-                                &chain_config,
-                                &mut chain_state,
-                                step_idx,
-                                step_config,
-                                step_result,
-                                &step_index_map,
-                            )
-                            .await?;
-                        }
-                    } else if let Some(wake) =
-                        Self::park_wake_at_ms(timeout_at, chain_state.expires_at)
-                    {
-                        // Spurious wake — re-arm at the timeout / deadline.
-                        self.state.index_chain_ready(&pending_key, wake).await?;
-                    }
-                }
-                _ => {
-                    #[allow(clippy::cast_possible_wrap)]
-                    let timeout_at = signal_cfg
-                        .timeout_seconds
-                        .map(|s| now + chrono::Duration::seconds(s as i64));
-                    chain_state.wait_state = Some(WaitState::Signal {
-                        step_index: step_idx,
-                        signal_name: signal_cfg.signal_name.clone(),
-                        timeout_at,
-                        on_timeout: signal_cfg.on_timeout.clone(),
-                    });
-                    chain_state.status = ChainStatus::WaitingSignal;
-                    chain_state.updated_at = now;
-                    self.persist_chain_state(&chain_key, &chain_state, None)
-                        .await?;
-                    self.append_execution_history(
-                        namespace,
-                        tenant,
-                        chain_id,
-                        ExecutionEventType::SignalAwaited {
-                            step_name: step_config.name.clone(),
-                            signal_name: signal_cfg.signal_name.clone(),
-                            timeout_at,
-                        },
-                        None,
-                    )
-                    .await;
-                    if let Some(wake) = Self::park_wake_at_ms(timeout_at, chain_state.expires_at) {
-                        self.state.index_chain_ready(&pending_key, wake).await?;
-                    }
-                    debug!(
-                        chain_id = %chain_id,
-                        step = %step_config.name,
-                        signal = %signal_cfg.signal_name,
-                        "chain waiting for signal"
-                    );
-                }
-            }
-            guard
-                .release()
-                .await
-                .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
-            return Ok(());
-        }
-
-        // --- Worker-queue step handling ---
-        if let Some(worker_cfg) = step_config.worker.as_ref() {
-            let now = Utc::now();
-            let wait = chain_state.wait_state.clone();
-            match wait {
-                Some(WaitState::Worker {
-                    step_index,
-                    task_id,
-                    timeout_at,
-                    ..
-                }) if step_index == step_idx => {
-                    // If the task already settled but the resume hook was
-                    // lost (crash between settle and resume), self-heal here.
-                    let task = self.get_worker_task(namespace, tenant, &task_id).await?;
-                    match task {
-                        Some(task) if task.status == acteon_core::WorkerTaskStatus::Completed => {
-                            // Mirror the resume hook's history event so the
-                            // timeline is identical whichever path resumed.
                             self.append_execution_history(
                                 namespace,
                                 tenant,
                                 chain_id,
-                                ExecutionEventType::TaskCompleted {
+                                ExecutionEventType::TimerFired {
                                     step_name: step_config.name.clone(),
-                                    task_id: task.task_id.clone(),
-                                    attempt: task.attempt,
                                 },
                                 None,
                             )
                             .await;
-                            chain_state.wait_state = None;
-                            chain_state.status = ChainStatus::Running;
                             let step_result = StepResult::new(
                                 step_config.name.clone(),
                                 true,
-                                Some(task.result.clone().unwrap_or_default()),
+                                Some(serde_json::json!({ "fired_at": now.to_rfc3339() })),
                                 None,
                                 now,
                             );
@@ -3082,66 +2811,120 @@ impl Gateway {
                                 "chain_step_completed",
                             )
                             .await?;
+                        } else {
+                            // Spurious wake — re-arm at the fire time (or the
+                            // chain deadline, whichever is first).
+                            if let Some(wake) =
+                                Self::park_wake_at_ms(Some(fire_at), chain_state.expires_at)
+                            {
+                                self.state.index_chain_ready(&pending_key, wake).await?;
+                            }
                         }
-                        Some(task)
-                            if task.status == acteon_core::WorkerTaskStatus::Failed
-                                || task.status == acteon_core::WorkerTaskStatus::Cancelled =>
-                        {
-                            self.append_execution_history(
-                                namespace,
-                                tenant,
-                                chain_id,
-                                ExecutionEventType::TaskFailed {
-                                    step_name: step_config.name.clone(),
-                                    task_id: task.task_id.clone(),
-                                    attempt: task.attempt,
-                                    error: task.error.clone().unwrap_or_default(),
-                                },
-                                None,
+                    }
+                    _ => {
+                        #[allow(clippy::cast_possible_wrap)]
+                        let fire_at = timer_cfg.until.unwrap_or_else(|| {
+                            now + chrono::Duration::seconds(
+                                timer_cfg.duration_seconds.unwrap_or(0) as i64
                             )
-                            .await;
-                            chain_state.wait_state = None;
-                            chain_state.status = ChainStatus::Running;
-                            let step_result =
-                                StepResult::new(
-                                    step_config.name.clone(),
-                                    false,
-                                    None,
-                                    Some(task.error.clone().unwrap_or_else(|| {
-                                        format!("worker task {:?}", task.status)
-                                    })),
-                                    now,
-                                );
-                            self.fail_wait_step(
-                                namespace,
-                                tenant,
-                                chain_id,
-                                &chain_key,
-                                &pending_key,
-                                &chain_config,
-                                &mut chain_state,
-                                step_idx,
-                                step_config,
-                                step_result,
-                                &step_index_map,
-                            )
+                        });
+                        chain_state.wait_state = Some(WaitState::Timer {
+                            step_index: step_idx,
+                            fire_at,
+                        });
+                        chain_state.status = ChainStatus::WaitingTimer;
+                        chain_state.updated_at = now;
+                        self.persist_chain_state(&chain_key, &chain_state, None)
                             .await?;
+                        self.append_execution_history(
+                            namespace,
+                            tenant,
+                            chain_id,
+                            ExecutionEventType::TimerStarted {
+                                step_name: step_config.name.clone(),
+                                fire_at,
+                            },
+                            None,
+                        )
+                        .await;
+                        if let Some(wake) =
+                            Self::park_wake_at_ms(Some(fire_at), chain_state.expires_at)
+                        {
+                            self.state.index_chain_ready(&pending_key, wake).await?;
                         }
-                        _ if timeout_at.is_some_and(|t| now >= t) => {
-                            // Worker-step timeout: cancel the task and fail
-                            // the step per its failure policy.
-                            let _ = self.cancel_worker_task(namespace, tenant, &task_id).await;
+                        debug!(
+                            chain_id = %chain_id,
+                            step = %step_config.name,
+                            %fire_at,
+                            "durable timer started"
+                        );
+                    }
+                }
+                guard
+                    .release()
+                    .await
+                    .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
+                return Ok(());
+            }
+
+            // --- Wait-for-signal step handling ---
+            StepKind::Signal(signal_cfg) => {
+                let now = Utc::now();
+
+                // Consume a buffered signal if one has already been delivered
+                // (whether the chain was waiting or the signal arrived early).
+                if let Some(payload) = self
+                    .peek_buffered_signal(namespace, tenant, chain_id, &signal_cfg.signal_name)
+                    .await?
+                {
+                    chain_state.wait_state = None;
+                    chain_state.status = ChainStatus::Running;
+                    let step_result =
+                        StepResult::new(step_config.name.clone(), true, Some(payload), None, now);
+                    self.complete_wait_step(
+                        namespace,
+                        tenant,
+                        chain_id,
+                        &chain_key,
+                        &pending_key,
+                        &chain_config,
+                        &mut chain_state,
+                        step_idx,
+                        step_config,
+                        step_result,
+                        &step_index_map,
+                        "chain_step_completed",
+                    )
+                    .await?;
+                    // Pop only after the consuming chain state is persisted; a
+                    // crash in between re-delivers the signal (at-least-once)
+                    // instead of losing it.
+                    self.pop_buffered_signal(namespace, tenant, chain_id, &signal_cfg.signal_name)
+                        .await;
+                    guard
+                        .release()
+                        .await
+                        .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
+                    return Ok(());
+                }
+
+                let wait = chain_state.wait_state.clone();
+                match wait {
+                    Some(WaitState::Signal {
+                        step_index,
+                        signal_name,
+                        timeout_at,
+                        on_timeout,
+                    }) if step_index == step_idx => {
+                        if timeout_at.is_some_and(|t| now >= t) {
                             chain_state.wait_state = None;
-                            chain_state.status = ChainStatus::Running;
                             self.append_execution_history(
                                 namespace,
                                 tenant,
                                 chain_id,
-                                ExecutionEventType::TaskFailed {
+                                ExecutionEventType::SignalTimedOut {
                                     step_name: step_config.name.clone(),
-                                    task_id: task_id.clone(),
-                                    attempt: 0,
-                                    error: "worker step timed out".into(),
+                                    signal_name: signal_name.clone(),
                                 },
                                 None,
                             )
@@ -3150,225 +2933,410 @@ impl Gateway {
                                 step_config.name.clone(),
                                 false,
                                 None,
-                                Some("worker step timed out".into()),
+                                Some(format!("signal wait timed out: {signal_name}")),
                                 now,
                             );
-                            self.fail_wait_step(
-                                namespace,
-                                tenant,
-                                chain_id,
-                                &chain_key,
-                                &pending_key,
-                                &chain_config,
-                                &mut chain_state,
-                                step_idx,
-                                step_config,
-                                step_result,
-                                &step_index_map,
-                            )
-                            .await?;
-                        }
-                        _ => {
-                            // Still pending/leased — re-arm the timeout /
-                            // chain deadline, if any; completion wakes the
-                            // chain.
-                            if let Some(wake) =
-                                Self::park_wake_at_ms(timeout_at, chain_state.expires_at)
-                            {
-                                self.state.index_chain_ready(&pending_key, wake).await?;
-                            }
-                        }
-                    }
-                }
-                _ => {
-                    // First arrival: enqueue the task and pause the chain.
-                    let payload = crate::chain::resolve_template(
-                        &step_config.payload_template,
-                        &chain_state.origin_action,
-                        &chain_state.step_results,
-                        &chain_config.steps,
-                        chain_id,
-                        step_idx,
-                        &chain_state.execution_path,
-                        &chain_state.parallel_sub_results,
-                    );
-                    let task = acteon_core::WorkerTask::new(
-                        namespace,
-                        tenant,
-                        &worker_cfg.queue,
-                        worker_cfg
-                            .action_type
-                            .clone()
-                            .unwrap_or_else(|| step_config.name.clone()),
-                        payload,
-                    )
-                    .with_max_attempts(
-                        worker_cfg
-                            .max_attempts
-                            .unwrap_or(acteon_core::DEFAULT_TASK_MAX_ATTEMPTS),
-                    )
-                    .for_chain_step(chain_id, step_idx, &step_config.name);
-                    let task_id = task.task_id.clone();
-                    self.enqueue_worker_task(task).await?;
-
-                    #[allow(clippy::cast_possible_wrap)]
-                    let timeout_at = worker_cfg
-                        .timeout_seconds
-                        .map(|s| now + chrono::Duration::seconds(s as i64));
-                    chain_state.wait_state = Some(WaitState::Worker {
-                        step_index: step_idx,
-                        task_id: task_id.clone(),
-                        queue: worker_cfg.queue.clone(),
-                        timeout_at,
-                    });
-                    chain_state.status = ChainStatus::WaitingWorker;
-                    chain_state.updated_at = now;
-                    self.persist_chain_state(&chain_key, &chain_state, None)
-                        .await?;
-                    self.append_execution_history(
-                        namespace,
-                        tenant,
-                        chain_id,
-                        ExecutionEventType::TaskEnqueued {
-                            step_name: step_config.name.clone(),
-                            task_id,
-                            queue: worker_cfg.queue.clone(),
-                        },
-                        None,
-                    )
-                    .await;
-                    if let Some(wake) = Self::park_wake_at_ms(timeout_at, chain_state.expires_at) {
-                        self.state.index_chain_ready(&pending_key, wake).await?;
-                    }
-                    debug!(
-                        chain_id = %chain_id,
-                        step = %step_config.name,
-                        queue = %worker_cfg.queue,
-                        "worker task enqueued; chain waiting"
-                    );
-                }
-            }
-            guard
-                .release()
-                .await
-                .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
-            return Ok(());
-        }
-
-        // --- Sub-chain step handling ---
-        if step_config.is_sub_chain() {
-            let sub_chain_name = step_config.sub_chain.as_deref().unwrap();
-
-            // Look for an existing child chain for this step.
-            let existing_child = self
-                .find_child_chain_for_step(&chain_state, sub_chain_name, step_idx)
-                .await?;
-
-            match existing_child {
-                None => {
-                    // No child chain yet — start one.
-                    let child_id = self
-                        .start_sub_chain(&mut chain_state, step_idx, sub_chain_name)
-                        .await?;
-
-                    chain_state.status = ChainStatus::WaitingSubChain;
-                    chain_state.updated_at = Utc::now();
-                    self.persist_chain_state(&chain_key, &chain_state, None)
-                        .await?;
-
-                    // Re-index to poll again in 5 seconds.
-                    let ready_at = Utc::now().timestamp_millis() + 5000;
-                    self.state.index_chain_ready(&pending_key, ready_at).await?;
-
-                    debug!(
-                        chain_id = %chain_id,
-                        child_chain_id = %child_id,
-                        sub_chain = %sub_chain_name,
-                        "sub-chain started, parent waiting"
-                    );
-
-                    guard
-                        .release()
-                        .await
-                        .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
-                    return Ok(());
-                }
-                Some(child_state) => {
-                    match child_state.status {
-                        ChainStatus::Completed => {
-                            // Sub-chain completed — extract result and continue.
-                            let step_result =
-                                Self::extract_sub_chain_result(sub_chain_name, &child_state);
-                            chain_state.step_results[step_idx] = Some(step_result.clone());
-                            chain_state.status = ChainStatus::Running;
-                            chain_state.updated_at = Utc::now();
-
-                            let next_step_idx = Self::resolve_next_step(
-                                &chain_config,
-                                step_idx,
-                                &step_result,
-                                &step_index_map,
-                            );
-
-                            if let Some(next_idx) = next_step_idx {
-                                chain_state.current_step = next_idx;
+                            let timeout_target = on_timeout
+                                .as_deref()
+                                .and_then(|t| step_index_map.get(t).copied());
+                            if let Some(target) = timeout_target {
+                                // Jump to the configured timeout step.
+                                chain_state.step_results[step_idx] = Some(step_result.clone());
+                                chain_state.status = ChainStatus::Running;
+                                chain_state.current_step = target;
+                                chain_state.updated_at = now;
                                 chain_state
                                     .execution_path
-                                    .push(chain_config.steps[next_idx].name.clone());
+                                    .push(chain_config.steps[target].name.clone());
                                 self.persist_chain_state(&chain_key, &chain_state, None)
                                     .await?;
                                 let ready_at =
-                                    chain_config.steps[next_idx].delay_seconds.map_or(0, |d| {
-                                        Utc::now().timestamp_millis() + (d.cast_signed() * 1000)
+                                    chain_config.steps[target].delay_seconds.map_or(0, |d| {
+                                        now.timestamp_millis() + (d.cast_signed() * 1000)
                                     });
                                 self.state.index_chain_ready(&pending_key, ready_at).await?;
-                            } else {
-                                chain_state.status = ChainStatus::Completed;
-                                self.persist_chain_state(
-                                    &chain_key,
+                                self.emit_chain_step_audit(
                                     &chain_state,
-                                    self.completed_chain_ttl,
+                                    step_config,
+                                    step_idx,
+                                    "chain_step_timed_out",
+                                    &step_result,
+                                    Duration::ZERO,
+                                    None,
+                                )
+                                .await;
+                            } else {
+                                chain_state.status = ChainStatus::Running;
+                                self.fail_wait_step(
+                                    namespace,
+                                    tenant,
+                                    chain_id,
+                                    &chain_key,
+                                    &pending_key,
+                                    &chain_config,
+                                    &mut chain_state,
+                                    step_idx,
+                                    step_config,
+                                    step_result,
+                                    &step_index_map,
                                 )
                                 .await?;
-                                self.cleanup_pending_chain(namespace, tenant, chain_id)
-                                    .await?;
-                                self.metrics.increment_chains_completed();
-                                self.emit_chain_terminal_audit(&chain_state, "chain_completed")
-                                    .await;
-                                info!(chain_id = %chain_id, "chain completed successfully");
                             }
-
-                            guard
-                                .release()
-                                .await
-                                .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
-                            return Ok(());
+                        } else if let Some(wake) =
+                            Self::park_wake_at_ms(timeout_at, chain_state.expires_at)
+                        {
+                            // Spurious wake — re-arm at the timeout / deadline.
+                            self.state.index_chain_ready(&pending_key, wake).await?;
                         }
-                        ChainStatus::Failed | ChainStatus::TimedOut | ChainStatus::Cancelled => {
-                            // Sub-chain failed — apply step on_failure policy.
-                            let error_msg =
-                                format!("sub-chain `{sub_chain_name}` {:?}", child_state.status);
-                            let step_result = StepResult {
-                                step_name: format!("sub_chain:{sub_chain_name}"),
-                                success: false,
-                                response_body: None,
-                                error: Some(error_msg.clone()),
-                                completed_at: Utc::now(),
-                                attempt: None,
-                                started_at: None,
-                            };
-                            chain_state.step_results[step_idx] = Some(step_result.clone());
-                            chain_state.status = ChainStatus::Running;
+                    }
+                    _ => {
+                        #[allow(clippy::cast_possible_wrap)]
+                        let timeout_at = signal_cfg
+                            .timeout_seconds
+                            .map(|s| now + chrono::Duration::seconds(s as i64));
+                        chain_state.wait_state = Some(WaitState::Signal {
+                            step_index: step_idx,
+                            signal_name: signal_cfg.signal_name.clone(),
+                            timeout_at,
+                            on_timeout: signal_cfg.on_timeout.clone(),
+                        });
+                        chain_state.status = ChainStatus::WaitingSignal;
+                        chain_state.updated_at = now;
+                        self.persist_chain_state(&chain_key, &chain_state, None)
+                            .await?;
+                        self.append_execution_history(
+                            namespace,
+                            tenant,
+                            chain_id,
+                            ExecutionEventType::SignalAwaited {
+                                step_name: step_config.name.clone(),
+                                signal_name: signal_cfg.signal_name.clone(),
+                                timeout_at,
+                            },
+                            None,
+                        )
+                        .await;
+                        if let Some(wake) =
+                            Self::park_wake_at_ms(timeout_at, chain_state.expires_at)
+                        {
+                            self.state.index_chain_ready(&pending_key, wake).await?;
+                        }
+                        debug!(
+                            chain_id = %chain_id,
+                            step = %step_config.name,
+                            signal = %signal_cfg.signal_name,
+                            "chain waiting for signal"
+                        );
+                    }
+                }
+                guard
+                    .release()
+                    .await
+                    .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
+                return Ok(());
+            }
 
-                            let step_policy = step_config
-                                .on_failure
-                                .as_ref()
-                                .unwrap_or(&acteon_core::chain::StepFailurePolicy::Abort);
+            // --- Worker-queue step handling ---
+            StepKind::Worker(worker_cfg) => {
+                let now = Utc::now();
+                let wait = chain_state.wait_state.clone();
+                match wait {
+                    Some(WaitState::Worker {
+                        step_index,
+                        task_id,
+                        timeout_at,
+                        ..
+                    }) if step_index == step_idx => {
+                        // If the task already settled but the resume hook was
+                        // lost (crash between settle and resume), self-heal here.
+                        let task = self.get_worker_task(namespace, tenant, &task_id).await?;
+                        match task {
+                            Some(task)
+                                if task.status == acteon_core::WorkerTaskStatus::Completed =>
+                            {
+                                // Mirror the resume hook's history event so the
+                                // timeline is identical whichever path resumed.
+                                self.append_execution_history(
+                                    namespace,
+                                    tenant,
+                                    chain_id,
+                                    ExecutionEventType::TaskCompleted {
+                                        step_name: step_config.name.clone(),
+                                        task_id: task.task_id.clone(),
+                                        attempt: task.attempt,
+                                    },
+                                    None,
+                                )
+                                .await;
+                                chain_state.wait_state = None;
+                                chain_state.status = ChainStatus::Running;
+                                let step_result = StepResult::new(
+                                    step_config.name.clone(),
+                                    true,
+                                    Some(task.result.clone().unwrap_or_default()),
+                                    None,
+                                    now,
+                                );
+                                self.complete_wait_step(
+                                    namespace,
+                                    tenant,
+                                    chain_id,
+                                    &chain_key,
+                                    &pending_key,
+                                    &chain_config,
+                                    &mut chain_state,
+                                    step_idx,
+                                    step_config,
+                                    step_result,
+                                    &step_index_map,
+                                    "chain_step_completed",
+                                )
+                                .await?;
+                            }
+                            Some(task)
+                                if task.status == acteon_core::WorkerTaskStatus::Failed
+                                    || task.status == acteon_core::WorkerTaskStatus::Cancelled =>
+                            {
+                                self.append_execution_history(
+                                    namespace,
+                                    tenant,
+                                    chain_id,
+                                    ExecutionEventType::TaskFailed {
+                                        step_name: step_config.name.clone(),
+                                        task_id: task.task_id.clone(),
+                                        attempt: task.attempt,
+                                        error: task.error.clone().unwrap_or_default(),
+                                    },
+                                    None,
+                                )
+                                .await;
+                                chain_state.wait_state = None;
+                                chain_state.status = ChainStatus::Running;
+                                let step_result = StepResult::new(
+                                    step_config.name.clone(),
+                                    false,
+                                    None,
+                                    Some(task.error.clone().unwrap_or_else(|| {
+                                        format!("worker task {:?}", task.status)
+                                    })),
+                                    now,
+                                );
+                                self.fail_wait_step(
+                                    namespace,
+                                    tenant,
+                                    chain_id,
+                                    &chain_key,
+                                    &pending_key,
+                                    &chain_config,
+                                    &mut chain_state,
+                                    step_idx,
+                                    step_config,
+                                    step_result,
+                                    &step_index_map,
+                                )
+                                .await?;
+                            }
+                            _ if timeout_at.is_some_and(|t| now >= t) => {
+                                // Worker-step timeout: cancel the task and fail
+                                // the step per its failure policy.
+                                let _ = self.cancel_worker_task(namespace, tenant, &task_id).await;
+                                chain_state.wait_state = None;
+                                chain_state.status = ChainStatus::Running;
+                                self.append_execution_history(
+                                    namespace,
+                                    tenant,
+                                    chain_id,
+                                    ExecutionEventType::TaskFailed {
+                                        step_name: step_config.name.clone(),
+                                        task_id: task_id.clone(),
+                                        attempt: 0,
+                                        error: "worker step timed out".into(),
+                                    },
+                                    None,
+                                )
+                                .await;
+                                let step_result = StepResult::new(
+                                    step_config.name.clone(),
+                                    false,
+                                    None,
+                                    Some("worker step timed out".into()),
+                                    now,
+                                );
+                                self.fail_wait_step(
+                                    namespace,
+                                    tenant,
+                                    chain_id,
+                                    &chain_key,
+                                    &pending_key,
+                                    &chain_config,
+                                    &mut chain_state,
+                                    step_idx,
+                                    step_config,
+                                    step_result,
+                                    &step_index_map,
+                                )
+                                .await?;
+                            }
+                            _ => {
+                                // Still pending/leased — re-arm the timeout /
+                                // chain deadline, if any; completion wakes the
+                                // chain.
+                                if let Some(wake) =
+                                    Self::park_wake_at_ms(timeout_at, chain_state.expires_at)
+                                {
+                                    self.state.index_chain_ready(&pending_key, wake).await?;
+                                }
+                            }
+                        }
+                    }
+                    _ => {
+                        // First arrival: enqueue the task and pause the chain.
+                        let payload = crate::chain::resolve_template(
+                            &step_config.payload_template,
+                            &chain_state.origin_action,
+                            &chain_state.step_results,
+                            &chain_config.steps,
+                            chain_id,
+                            step_idx,
+                            &chain_state.execution_path,
+                            &chain_state.parallel_sub_results,
+                        );
+                        let task = acteon_core::WorkerTask::new(
+                            namespace,
+                            tenant,
+                            &worker_cfg.queue,
+                            worker_cfg
+                                .action_type
+                                .clone()
+                                .unwrap_or_else(|| step_config.name.clone()),
+                            payload,
+                        )
+                        .with_max_attempts(
+                            worker_cfg
+                                .max_attempts
+                                .unwrap_or(acteon_core::DEFAULT_TASK_MAX_ATTEMPTS),
+                        )
+                        .for_chain_step(
+                            chain_id,
+                            step_idx,
+                            &step_config.name,
+                        );
+                        let task_id = task.task_id.clone();
+                        self.enqueue_worker_task(task).await?;
 
-                            match step_policy {
-                                acteon_core::chain::StepFailurePolicy::Abort => {
-                                    chain_state.status = ChainStatus::Failed;
-                                    chain_state.updated_at = Utc::now();
+                        #[allow(clippy::cast_possible_wrap)]
+                        let timeout_at = worker_cfg
+                            .timeout_seconds
+                            .map(|s| now + chrono::Duration::seconds(s as i64));
+                        chain_state.wait_state = Some(WaitState::Worker {
+                            step_index: step_idx,
+                            task_id: task_id.clone(),
+                            queue: worker_cfg.queue.clone(),
+                            timeout_at,
+                        });
+                        chain_state.status = ChainStatus::WaitingWorker;
+                        chain_state.updated_at = now;
+                        self.persist_chain_state(&chain_key, &chain_state, None)
+                            .await?;
+                        self.append_execution_history(
+                            namespace,
+                            tenant,
+                            chain_id,
+                            ExecutionEventType::TaskEnqueued {
+                                step_name: step_config.name.clone(),
+                                task_id,
+                                queue: worker_cfg.queue.clone(),
+                            },
+                            None,
+                        )
+                        .await;
+                        if let Some(wake) =
+                            Self::park_wake_at_ms(timeout_at, chain_state.expires_at)
+                        {
+                            self.state.index_chain_ready(&pending_key, wake).await?;
+                        }
+                        debug!(
+                            chain_id = %chain_id,
+                            step = %step_config.name,
+                            queue = %worker_cfg.queue,
+                            "worker task enqueued; chain waiting"
+                        );
+                    }
+                }
+                guard
+                    .release()
+                    .await
+                    .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
+                return Ok(());
+            }
+
+            // --- Sub-chain step handling ---
+            StepKind::SubChain(sub_chain_name) => {
+                // Look for an existing child chain for this step.
+                let existing_child = self
+                    .find_child_chain_for_step(&chain_state, sub_chain_name, step_idx)
+                    .await?;
+
+                match existing_child {
+                    None => {
+                        // No child chain yet — start one.
+                        let child_id = self
+                            .start_sub_chain(&mut chain_state, step_idx, sub_chain_name)
+                            .await?;
+
+                        chain_state.status = ChainStatus::WaitingSubChain;
+                        chain_state.updated_at = Utc::now();
+                        self.persist_chain_state(&chain_key, &chain_state, None)
+                            .await?;
+
+                        // Re-index to poll again in 5 seconds.
+                        let ready_at = Utc::now().timestamp_millis() + 5000;
+                        self.state.index_chain_ready(&pending_key, ready_at).await?;
+
+                        debug!(
+                            chain_id = %chain_id,
+                            child_chain_id = %child_id,
+                            sub_chain = %sub_chain_name,
+                            "sub-chain started, parent waiting"
+                        );
+
+                        guard
+                            .release()
+                            .await
+                            .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
+                        return Ok(());
+                    }
+                    Some(child_state) => {
+                        match child_state.status {
+                            ChainStatus::Completed => {
+                                // Sub-chain completed — extract result and continue.
+                                let step_result =
+                                    Self::extract_sub_chain_result(sub_chain_name, &child_state);
+                                chain_state.step_results[step_idx] = Some(step_result.clone());
+                                chain_state.status = ChainStatus::Running;
+                                chain_state.updated_at = Utc::now();
+
+                                let next_step_idx = Self::resolve_next_step(
+                                    &chain_config,
+                                    step_idx,
+                                    &step_result,
+                                    &step_index_map,
+                                );
+
+                                if let Some(next_idx) = next_step_idx {
+                                    chain_state.current_step = next_idx;
+                                    chain_state
+                                        .execution_path
+                                        .push(chain_config.steps[next_idx].name.clone());
+                                    self.persist_chain_state(&chain_key, &chain_state, None)
+                                        .await?;
+                                    let ready_at =
+                                        chain_config.steps[next_idx].delay_seconds.map_or(0, |d| {
+                                            Utc::now().timestamp_millis() + (d.cast_signed() * 1000)
+                                        });
+                                    self.state.index_chain_ready(&pending_key, ready_at).await?;
+                                } else {
+                                    chain_state.status = ChainStatus::Completed;
                                     self.persist_chain_state(
                                         &chain_key,
                                         &chain_state,
@@ -3377,41 +3345,46 @@ impl Gateway {
                                     .await?;
                                     self.cleanup_pending_chain(namespace, tenant, chain_id)
                                         .await?;
-                                    self.metrics.increment_chains_failed();
-                                    self.emit_chain_terminal_audit(&chain_state, "chain_failed")
+                                    self.metrics.increment_chains_completed();
+                                    self.emit_chain_terminal_audit(&chain_state, "chain_completed")
                                         .await;
-                                    warn!(
-                                        chain_id = %chain_id,
-                                        sub_chain = %sub_chain_name,
-                                        "sub-chain failed, aborting parent chain"
-                                    );
+                                    info!(chain_id = %chain_id, "chain completed successfully");
                                 }
-                                acteon_core::chain::StepFailurePolicy::Skip => {
-                                    let next_step_idx = Self::resolve_next_step(
-                                        &chain_config,
-                                        step_idx,
-                                        &step_result,
-                                        &step_index_map,
-                                    );
-                                    if let Some(next_idx) = next_step_idx {
-                                        chain_state.current_step = next_idx;
-                                        chain_state.updated_at = Utc::now();
-                                        chain_state
-                                            .execution_path
-                                            .push(chain_config.steps[next_idx].name.clone());
-                                        self.persist_chain_state(&chain_key, &chain_state, None)
-                                            .await?;
-                                        let ready_at = chain_config.steps[next_idx]
-                                            .delay_seconds
-                                            .map_or(0, |d| {
-                                                Utc::now().timestamp_millis()
-                                                    + (d.cast_signed() * 1000)
-                                            });
-                                        self.state
-                                            .index_chain_ready(&pending_key, ready_at)
-                                            .await?;
-                                    } else {
-                                        chain_state.status = ChainStatus::Completed;
+
+                                guard
+                                    .release()
+                                    .await
+                                    .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
+                                return Ok(());
+                            }
+                            ChainStatus::Failed
+                            | ChainStatus::TimedOut
+                            | ChainStatus::Cancelled => {
+                                // Sub-chain failed — apply step on_failure policy.
+                                let error_msg = format!(
+                                    "sub-chain `{sub_chain_name}` {:?}",
+                                    child_state.status
+                                );
+                                let step_result = StepResult {
+                                    step_name: format!("sub_chain:{sub_chain_name}"),
+                                    success: false,
+                                    response_body: None,
+                                    error: Some(error_msg.clone()),
+                                    completed_at: Utc::now(),
+                                    attempt: None,
+                                    started_at: None,
+                                };
+                                chain_state.step_results[step_idx] = Some(step_result.clone());
+                                chain_state.status = ChainStatus::Running;
+
+                                let step_policy = step_config
+                                    .on_failure
+                                    .as_ref()
+                                    .unwrap_or(&acteon_core::chain::StepFailurePolicy::Abort);
+
+                                match step_policy {
+                                    acteon_core::chain::StepFailurePolicy::Abort => {
+                                        chain_state.status = ChainStatus::Failed;
                                         chain_state.updated_at = Utc::now();
                                         self.persist_chain_state(
                                             &chain_key,
@@ -3421,79 +3394,137 @@ impl Gateway {
                                         .await?;
                                         self.cleanup_pending_chain(namespace, tenant, chain_id)
                                             .await?;
-                                        self.metrics.increment_chains_completed();
+                                        self.metrics.increment_chains_failed();
                                         self.emit_chain_terminal_audit(
                                             &chain_state,
-                                            "chain_completed",
+                                            "chain_failed",
+                                        )
+                                        .await;
+                                        warn!(
+                                            chain_id = %chain_id,
+                                            sub_chain = %sub_chain_name,
+                                            "sub-chain failed, aborting parent chain"
+                                        );
+                                    }
+                                    acteon_core::chain::StepFailurePolicy::Skip => {
+                                        let next_step_idx = Self::resolve_next_step(
+                                            &chain_config,
+                                            step_idx,
+                                            &step_result,
+                                            &step_index_map,
+                                        );
+                                        if let Some(next_idx) = next_step_idx {
+                                            chain_state.current_step = next_idx;
+                                            chain_state.updated_at = Utc::now();
+                                            chain_state
+                                                .execution_path
+                                                .push(chain_config.steps[next_idx].name.clone());
+                                            self.persist_chain_state(
+                                                &chain_key,
+                                                &chain_state,
+                                                None,
+                                            )
+                                            .await?;
+                                            let ready_at = chain_config.steps[next_idx]
+                                                .delay_seconds
+                                                .map_or(0, |d| {
+                                                    Utc::now().timestamp_millis()
+                                                        + (d.cast_signed() * 1000)
+                                                });
+                                            self.state
+                                                .index_chain_ready(&pending_key, ready_at)
+                                                .await?;
+                                        } else {
+                                            chain_state.status = ChainStatus::Completed;
+                                            chain_state.updated_at = Utc::now();
+                                            self.persist_chain_state(
+                                                &chain_key,
+                                                &chain_state,
+                                                self.completed_chain_ttl,
+                                            )
+                                            .await?;
+                                            self.cleanup_pending_chain(namespace, tenant, chain_id)
+                                                .await?;
+                                            self.metrics.increment_chains_completed();
+                                            self.emit_chain_terminal_audit(
+                                                &chain_state,
+                                                "chain_completed",
+                                            )
+                                            .await;
+                                        }
+                                    }
+                                    acteon_core::chain::StepFailurePolicy::Dlq => {
+                                        chain_state.status = ChainStatus::Failed;
+                                        chain_state.updated_at = Utc::now();
+                                        self.persist_chain_state(
+                                            &chain_key,
+                                            &chain_state,
+                                            self.completed_chain_ttl,
+                                        )
+                                        .await?;
+                                        self.cleanup_pending_chain(namespace, tenant, chain_id)
+                                            .await?;
+                                        self.metrics.increment_chains_failed();
+                                        self.emit_chain_terminal_audit(
+                                            &chain_state,
+                                            "chain_failed",
                                         )
                                         .await;
                                     }
                                 }
-                                acteon_core::chain::StepFailurePolicy::Dlq => {
-                                    chain_state.status = ChainStatus::Failed;
-                                    chain_state.updated_at = Utc::now();
-                                    self.persist_chain_state(
-                                        &chain_key,
-                                        &chain_state,
-                                        self.completed_chain_ttl,
-                                    )
-                                    .await?;
-                                    self.cleanup_pending_chain(namespace, tenant, chain_id)
-                                        .await?;
-                                    self.metrics.increment_chains_failed();
-                                    self.emit_chain_terminal_audit(&chain_state, "chain_failed")
-                                        .await;
-                                }
+
+                                guard
+                                    .release()
+                                    .await
+                                    .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
+                                return Ok(());
                             }
+                            ChainStatus::Running
+                            | ChainStatus::WaitingSubChain
+                            | ChainStatus::WaitingParallel
+                            | ChainStatus::WaitingTimer
+                            | ChainStatus::WaitingSignal
+                            | ChainStatus::WaitingWorker => {
+                                // Still running — re-schedule poll in 5 seconds.
+                                chain_state.status = ChainStatus::WaitingSubChain;
+                                chain_state.updated_at = Utc::now();
+                                self.persist_chain_state(&chain_key, &chain_state, None)
+                                    .await?;
+                                let ready_at = Utc::now().timestamp_millis() + 5000;
+                                self.state.index_chain_ready(&pending_key, ready_at).await?;
 
-                            guard
-                                .release()
-                                .await
-                                .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
-                            return Ok(());
-                        }
-                        ChainStatus::Running
-                        | ChainStatus::WaitingSubChain
-                        | ChainStatus::WaitingParallel
-                        | ChainStatus::WaitingTimer
-                        | ChainStatus::WaitingSignal
-                        | ChainStatus::WaitingWorker => {
-                            // Still running — re-schedule poll in 5 seconds.
-                            chain_state.status = ChainStatus::WaitingSubChain;
-                            chain_state.updated_at = Utc::now();
-                            self.persist_chain_state(&chain_key, &chain_state, None)
-                                .await?;
-                            let ready_at = Utc::now().timestamp_millis() + 5000;
-                            self.state.index_chain_ready(&pending_key, ready_at).await?;
-
-                            guard
-                                .release()
-                                .await
-                                .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
-                            return Ok(());
+                                guard
+                                    .release()
+                                    .await
+                                    .map_err(|e| GatewayError::LockFailed(e.to_string()))?;
+                                return Ok(());
+                            }
                         }
                     }
                 }
             }
-        }
 
-        // --- Parallel step handling ---
-        if step_config.is_parallel() {
-            return self
-                .advance_chain_parallel(
-                    namespace,
-                    tenant,
-                    chain_id,
-                    &chain_key,
-                    &pending_key,
-                    step_idx,
-                    step_config,
-                    &chain_config,
-                    &mut chain_state,
-                    &step_index_map,
-                    guard,
-                )
-                .await;
+            // --- Parallel step handling ---
+            StepKind::Parallel(_) => {
+                return self
+                    .advance_chain_parallel(
+                        namespace,
+                        tenant,
+                        chain_id,
+                        &chain_key,
+                        &pending_key,
+                        step_idx,
+                        step_config,
+                        &chain_config,
+                        &mut chain_state,
+                        &step_index_map,
+                        guard,
+                    )
+                    .await;
+            }
+
+            // Provider steps fall through to the dispatch below.
+            StepKind::Provider => {}
         }
 
         // Resolve the payload template.
@@ -4640,7 +4671,9 @@ impl Gateway {
         step_index_map: &HashMap<String, usize>,
         guard: Box<dyn acteon_state::LockGuard>,
     ) -> Result<(), GatewayError> {
-        let group = step_config.parallel.as_ref().unwrap();
+        let StepKind::Parallel(group) = step_config.kind() else {
+            unreachable!("advance_chain_parallel called on a non-parallel step")
+        };
 
         // Detect whether we are resuming after a crash. If `parallel_state` is
         // already set for this step, sub-steps that already have results in
@@ -5682,9 +5715,13 @@ impl Gateway {
                             || s.status == ChainStatus::WaitingSubChain
                             || s.status == ChainStatus::WaitingParallel)
                     {
-                        if step.is_sub_chain() && s.status == ChainStatus::WaitingSubChain {
+                        if matches!(step.kind(), StepKind::SubChain(_))
+                            && s.status == ChainStatus::WaitingSubChain
+                        {
                             "waiting_sub_chain".to_string()
-                        } else if step.is_parallel() && s.status == ChainStatus::WaitingParallel {
+                        } else if matches!(step.kind(), StepKind::Parallel(_))
+                            && s.status == ChainStatus::WaitingParallel
+                        {
                             "waiting_parallel".to_string()
                         } else {
                             "running".to_string()
@@ -5694,12 +5731,15 @@ impl Gateway {
                     }
                 });
 
-                let (node_type, sub_chain_name) = if step.is_sub_chain() {
-                    ("sub_chain".to_string(), step.sub_chain.clone())
-                } else if step.is_parallel() {
-                    ("parallel".to_string(), None)
-                } else {
-                    ("step".to_string(), None)
+                // Provider steps keep the legacy `"step"` node type; the
+                // other kinds use their definition-field label, giving the
+                // DAG distinct timer / wait_for_signal / worker nodes.
+                let (node_type, sub_chain_name) = match step.kind() {
+                    StepKind::Provider => ("step".to_string(), None),
+                    StepKind::SubChain(name) => {
+                        (step.kind().label().to_string(), Some(name.to_string()))
+                    }
+                    kind => (kind.label().to_string(), None),
                 };
 
                 // For sub-chain steps, recurse into the sub-chain definition.
@@ -5707,8 +5747,7 @@ impl Gateway {
                 // the definition-only structure so the hierarchy is always visible.
                 let mut child_chain_id = None;
                 let mut children = None;
-                if step.is_sub_chain() {
-                    let sub_name = step.sub_chain.as_deref().unwrap();
+                if let StepKind::SubChain(sub_name) = step.kind() {
                     if let Some(state) = chain_state {
                         if let Ok(Some(child_state)) =
                             self.find_child_chain_for_step(state, sub_name, i).await
@@ -5734,53 +5773,53 @@ impl Gateway {
                 }
 
                 // Build parallel child DagNodes if this is a parallel step.
-                let (parallel_children, parallel_join) = if step.is_parallel() {
-                    let group = step.parallel.as_ref().unwrap();
-                    let p_children: Vec<acteon_core::DagNode> = group
-                        .steps
-                        .iter()
-                        .map(|sub_step| {
-                            let sub_status = chain_state.and_then(|s| {
-                                s.parallel_sub_results.get(&sub_step.name).map(|r| {
-                                    if r.success {
-                                        "completed".to_string()
+                let (parallel_children, parallel_join) =
+                    if let StepKind::Parallel(group) = step.kind() {
+                        let p_children: Vec<acteon_core::DagNode> = group
+                            .steps
+                            .iter()
+                            .map(|sub_step| {
+                                let sub_status = chain_state.and_then(|s| {
+                                    s.parallel_sub_results.get(&sub_step.name).map(|r| {
+                                        if r.success {
+                                            "completed".to_string()
+                                        } else {
+                                            "failed".to_string()
+                                        }
+                                    })
+                                });
+                                acteon_core::DagNode {
+                                    name: sub_step.name.clone(),
+                                    node_type: "step".to_string(),
+                                    provider: if sub_step.provider.is_empty() {
+                                        None
                                     } else {
-                                        "failed".to_string()
-                                    }
-                                })
-                            });
-                            acteon_core::DagNode {
-                                name: sub_step.name.clone(),
-                                node_type: "step".to_string(),
-                                provider: if sub_step.provider.is_empty() {
-                                    None
-                                } else {
-                                    Some(sub_step.provider.clone())
-                                },
-                                action_type: if sub_step.action_type.is_empty() {
-                                    None
-                                } else {
-                                    Some(sub_step.action_type.clone())
-                                },
-                                sub_chain_name: None,
-                                status: sub_status,
-                                child_chain_id: None,
-                                children: None,
-                                parallel_children: None,
-                                parallel_join: None,
-                                attempt: None,
-                                max_retries: None,
-                            }
-                        })
-                        .collect();
-                    let join_str = match group.join {
-                        acteon_core::chain::ParallelJoinPolicy::All => "all",
-                        acteon_core::chain::ParallelJoinPolicy::Any => "any",
+                                        Some(sub_step.provider.clone())
+                                    },
+                                    action_type: if sub_step.action_type.is_empty() {
+                                        None
+                                    } else {
+                                        Some(sub_step.action_type.clone())
+                                    },
+                                    sub_chain_name: None,
+                                    status: sub_status,
+                                    child_chain_id: None,
+                                    children: None,
+                                    parallel_children: None,
+                                    parallel_join: None,
+                                    attempt: None,
+                                    max_retries: None,
+                                }
+                            })
+                            .collect();
+                        let join_str = match group.join {
+                            acteon_core::chain::ParallelJoinPolicy::All => "all",
+                            acteon_core::chain::ParallelJoinPolicy::Any => "any",
+                        };
+                        (Some(p_children), Some(join_str.to_string()))
+                    } else {
+                        (None, None)
                     };
-                    (Some(p_children), Some(join_str.to_string()))
-                } else {
-                    (None, None)
-                };
 
                 // Retry metadata from config + runtime state.
                 let attempt = chain_state
@@ -6062,34 +6101,32 @@ impl Gateway {
             // --- Gap 2, 4, 5: Parallel parent step identification ---
             // Use "parallel" as provider and step name as action_type, include
             // the join policy, and embed per-sub-step result summary.
-            let (provider, action_type) = if step_config.is_parallel() {
+            let (provider, action_type) = if let StepKind::Parallel(group) = step_config.kind() {
                 outcome_details["is_parallel_step"] = serde_json::Value::Bool(true);
-                if let Some(ref group) = step_config.parallel {
-                    let policy_str = match group.join {
-                        acteon_core::chain::ParallelJoinPolicy::All => "all",
-                        acteon_core::chain::ParallelJoinPolicy::Any => "any",
-                    };
-                    outcome_details["parallel_join_policy"] =
-                        serde_json::Value::String(policy_str.to_owned());
+                let policy_str = match group.join {
+                    acteon_core::chain::ParallelJoinPolicy::All => "all",
+                    acteon_core::chain::ParallelJoinPolicy::Any => "any",
+                };
+                outcome_details["parallel_join_policy"] =
+                    serde_json::Value::String(policy_str.to_owned());
 
-                    // Embed sub-step result summary for self-contained auditing.
-                    let sub_results: serde_json::Value = chain_state
-                        .parallel_sub_results
-                        .iter()
-                        .map(|(name, sr)| {
-                            let mut v = serde_json::json!({
-                                "step_name": name,
-                                "success": sr.success,
-                                "completed_at": sr.completed_at.to_rfc3339(),
-                            });
-                            if let Some(ref err) = sr.error {
-                                v["error"] = serde_json::Value::String(err.clone());
-                            }
-                            v
-                        })
-                        .collect();
-                    outcome_details["parallel_sub_step_results"] = sub_results;
-                }
+                // Embed sub-step result summary for self-contained auditing.
+                let sub_results: serde_json::Value = chain_state
+                    .parallel_sub_results
+                    .iter()
+                    .map(|(name, sr)| {
+                        let mut v = serde_json::json!({
+                            "step_name": name,
+                            "success": sr.success,
+                            "completed_at": sr.completed_at.to_rfc3339(),
+                        });
+                        if let Some(ref err) = sr.error {
+                            v["error"] = serde_json::Value::String(err.clone());
+                        }
+                        v
+                    })
+                    .collect();
+                outcome_details["parallel_sub_step_results"] = sub_results;
                 ("parallel".to_owned(), step_config.name.clone())
             } else {
                 (

--- a/crates/server/src/api/chains.rs
+++ b/crates/server/src/api/chains.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
-use acteon_core::{ChainConfig, ChainStatus, DagResponse};
+use acteon_core::{ChainConfig, ChainStatus, DagResponse, StepKind};
 use acteon_state::{KeyKind, StateKey};
 
 use super::AppState;
@@ -685,8 +685,14 @@ pub async fn list_definitions(State(state): State<AppState>) -> impl IntoRespons
             name: config.name.clone(),
             steps_count: config.steps.len(),
             has_branches: config.steps.iter().any(|s| !s.branches.is_empty()),
-            has_parallel: false,
-            has_sub_chains: config.steps.iter().any(|s| s.sub_chain.is_some()),
+            has_parallel: config
+                .steps
+                .iter()
+                .any(|s| matches!(s.kind(), StepKind::Parallel(_))),
+            has_sub_chains: config
+                .steps
+                .iter()
+                .any(|s| matches!(s.kind(), StepKind::SubChain(_))),
             on_failure: format_failure_policy(&config.on_failure),
             timeout_seconds: config.timeout_seconds,
         })

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -349,7 +349,7 @@ export interface ChainDefinition {
 // ---- Chain DAG ----
 export interface DagNode {
   name: string
-  node_type: 'step' | 'sub_chain' | 'parallel'
+  node_type: 'step' | 'sub_chain' | 'parallel' | 'timer' | 'wait_for_signal' | 'worker'
   provider?: string
   action_type?: string
   sub_chain_name?: string


### PR DESCRIPTION
Follow-up to #250 (same deferred-list as #251/#252), closing the **`StepKind` tagged-enum refactor** item from the adversarial review.

## What changed

`ChainStepConfig` keeps its flat, optional-field wire shape — TOML/YAML/JSON definitions, pinned definitions, and persisted snapshots are byte-for-byte unchanged — but engine code no longer probes the six mutually-exclusive `Option` fields (`provider` / `sub_chain` / `parallel` / `timer` / `wait_for_signal` / `worker`) one by one, with precedence implicit in block order at every call site.

- **New `StepKind<'_>` borrowed view** in `acteon-core`, with `ChainStepConfig::kind()` defining the kind precedence in exactly one place (documented to mirror the engine's historical dispatch order; only observable for invalid multi-kind configs, which `validate()` rejects).
- **`advance_chain`'s dispatch** — previously five early-returning `if let Some(...)` blocks followed by an unconditional fall-through to provider dispatch — is now a single exhaustive `match step_config.kind()`. Handler bodies are unchanged; the diff is dominated by the one-level reindent. Adding a seventh step kind now produces compile errors at every dispatch site instead of silently dispatching the step as a provider action.
- **`validate()`'s three scattered retry-policy checks** collapse into one exhaustive match. The `is_*()` field probes remain (documented as such) so validation can still detect steps that illegally set several kinds.
- The DAG builder, parallel-step audit, and `advance_chain_parallel`'s internal `unwrap` all dispatch through `kind()` now.

## Observable improvements (intentional, small)

- **DAG node types**: timer / wait-for-signal / worker steps were previously indistinguishable `"step"` nodes with no provider. They now render as `node_type: "timer" | "wait_for_signal" | "worker"`; provider steps keep `"step"` and sub-chain/parallel are unchanged, so existing consumers are unaffected. The UI type union is extended; the renderer already falls through to the default step node for unknown types.
- **Bug fix**: `ChainDefinitionSummary.has_parallel` in `GET /v1/chains/definitions` was hardcoded to `false`; it's now computed (and `has_sub_chains` goes through `kind()` for consistency).

## Verification

- New core unit tests: `kind()` per constructor, precedence on an invalid multi-kind step (with `validate()` still flagging it), and `label()` values.
- All 57 workspace test suites pass, including the 35 durable-execution/queue/workflow integration tests that exercise every step kind through the rewritten dispatch.
- `cargo fmt`, clippy on stable and 1.88, `cargo test --workspace --lib --bins --tests`, `cargo check --all-targets`, UI lint + build — all green.

## Out of scope (remaining #250 follow-ups)

Cross-SDK contract fixtures, gateway-level overlap enforcement, and pinned-definition GC — each still pending as its own change.

https://claude.ai/code/session_01T41GGbkbHtKcPtRFhxZ8DV

---
_Generated by [Claude Code](https://claude.ai/code/session_01T41GGbkbHtKcPtRFhxZ8DV)_