### PR TITLE
Add cross-SDK contract fixtures for the workflow wire protocol

### DIFF
--- a/clients/contract-fixtures/README.md
+++ b/clients/contract-fixtures/README.md
@@ -1,0 +1,22 @@
+# Cross-SDK contract fixtures
+
+Shared, language-neutral fixtures pinning the wire contracts that the
+worker SDKs and the Rust server must agree on. A workflow execution can
+migrate between workers written in different languages mid-flight, so
+checkpoint-key derivation and directive shapes are a compatibility
+surface, not an implementation detail.
+
+| File | Pins |
+|---|---|
+| `workflow-contract.json` | Workflow directives (`complete` / `fail` / `sleep` / `await_signal`), checkpoint-key derivation (`step:{name}#{k}`, `sleep#{k}`, `signal:{name}#{k}`, `child:{workflow}#{k}`), integer-seconds coercions, the timed-out marker, and the reserved `__workflow__` / `__child:` constants |
+
+Consumers (a drift on any side fails that side's suite):
+
+- `crates/core/tests/workflow_contract.rs` — the server parses every
+  SDK-emittable directive (and rejects the malformed ones loudly).
+- `clients/python/tests/test_contract.py` — Python SDK.
+- `clients/nodejs/src/contract.test.ts` — Node.js SDK.
+
+When adding a workflow runner to another SDK (Go, Java), add a consumer
+for this file alongside it. When changing a wire shape, update the
+fixture and every consumer in the same PR.

--- a/clients/contract-fixtures/workflow-contract.json
+++ b/clients/contract-fixtures/workflow-contract.json
@@ -1,0 +1,107 @@
+{
+  "description": "Cross-SDK contract fixtures for the checkpoint-based workflow engine. Every workflow-capable SDK (Python, Node.js) and the Rust server must agree on these wire shapes and checkpoint-key derivations, so a single execution can migrate between workers written in different languages and every SDK-emitted directive parses server-side. Consumed by crates/core/tests/workflow_contract.rs, clients/python/tests/test_contract.py, and clients/nodejs/src/contract.test.ts.",
+  "constants": {
+    "workflow_task_action_type": "__workflow__",
+    "child_result_signal_prefix": "__child:",
+    "timed_out_marker": { "timed_out": true }
+  },
+  "directives": [
+    {
+      "name": "complete",
+      "json": { "directive": "complete", "result": { "ok": true, "count": 3 } }
+    },
+    {
+      "name": "fail",
+      "json": { "directive": "fail", "error": "provisioning broke" }
+    },
+    {
+      "name": "sleep",
+      "json": { "directive": "sleep", "checkpoint": "sleep#0", "seconds": 30 }
+    },
+    {
+      "name": "await_signal",
+      "json": {
+        "directive": "await_signal",
+        "checkpoint": "signal:approved#0",
+        "name": "approved",
+        "timeout_seconds": 300
+      }
+    },
+    {
+      "name": "await_signal_no_timeout",
+      "json": { "directive": "await_signal", "checkpoint": "signal:go#0", "name": "go" }
+    }
+  ],
+  "invalid_directives": [
+    {
+      "reason": "float seconds must be rejected by the server, never emitted by an SDK",
+      "json": { "directive": "sleep", "checkpoint": "sleep#0", "seconds": 0.5 }
+    },
+    {
+      "reason": "unknown directive tag",
+      "json": { "directive": "hibernate", "checkpoint": "sleep#0" }
+    },
+    {
+      "reason": "await_signal without a signal name",
+      "json": { "directive": "await_signal", "checkpoint": "signal:x#0" }
+    }
+  ],
+  "checkpoint_key_scenarios": [
+    {
+      "name": "straight_line",
+      "ops": [
+        { "op": "step", "name": "charge" },
+        { "op": "sleep", "seconds": 5 },
+        { "op": "wait_for_signal", "name": "approved" },
+        { "op": "step", "name": "fulfill" }
+      ],
+      "expected_keys": ["step:charge#0", "sleep#0", "signal:approved#0", "step:fulfill#0"]
+    },
+    {
+      "name": "repeated_names_use_occurrence_counters",
+      "ops": [
+        { "op": "step", "name": "poll" },
+        { "op": "step", "name": "poll" },
+        { "op": "sleep", "seconds": 1 },
+        { "op": "sleep", "seconds": 1 },
+        { "op": "wait_for_signal", "name": "tick" },
+        { "op": "wait_for_signal", "name": "tick" },
+        { "op": "step", "name": "poll" }
+      ],
+      "expected_keys": [
+        "step:poll#0",
+        "step:poll#1",
+        "sleep#0",
+        "sleep#1",
+        "signal:tick#0",
+        "signal:tick#1",
+        "step:poll#2"
+      ]
+    },
+    {
+      "name": "children_and_child_waits",
+      "ops": [
+        { "op": "start_child", "workflow": "fulfillment" },
+        { "op": "wait_for_child", "child_id": "child-1" },
+        { "op": "start_child", "workflow": "fulfillment" }
+      ],
+      "expected_keys": [
+        "child:fulfillment#0",
+        "signal:__child:child-1#0",
+        "child:fulfillment#1"
+      ]
+    }
+  ],
+  "sleep_coercions": [
+    { "input_seconds": 30, "expected_seconds": 30 },
+    { "input_seconds": 0.5, "expected_seconds": 1 },
+    { "input_seconds": 30.7, "expected_seconds": 30 },
+    { "input_seconds": 0, "expected_seconds": 1 },
+    { "input_seconds": -5, "expected_seconds": 1 }
+  ],
+  "signal_timeout_coercions": [
+    { "input_seconds": 300, "expected_seconds": 300 },
+    { "input_seconds": 0.5, "expected_seconds": 1 },
+    { "input_seconds": 86399.9, "expected_seconds": 86399 }
+  ]
+}

--- a/clients/nodejs/src/contract.test.ts
+++ b/clients/nodejs/src/contract.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Node.js side of the cross-SDK workflow contract.
+ *
+ * Drives the public SDK surface (`WorkflowContext` + `runWorkflowTask`)
+ * against the shared fixtures in
+ * `clients/contract-fixtures/workflow-contract.json` — the same file
+ * consumed by the Python SDK tests and by the Rust server tests — so
+ * checkpoint-key derivation, directive wire shapes, and the
+ * integer-seconds coercions stay identical across languages. A workflow
+ * execution can migrate between Python and Node workers mid-flight;
+ * these keys and shapes are the entire compatibility surface.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, it, expect } from "vitest";
+import type { ActeonClient } from "./client.js";
+import {
+  CHILD_RESULT_SIGNAL_PREFIX,
+  WORKFLOW_TASK_ACTION_TYPE,
+  WorkflowContext,
+  WorkflowSuspend,
+  runWorkflowTask,
+  type WorkflowCheckpoint,
+  type WorkflowDirective,
+} from "./workflows.js";
+
+interface Fixtures {
+  constants: {
+    workflow_task_action_type: string;
+    child_result_signal_prefix: string;
+    timed_out_marker: Record<string, unknown>;
+  };
+  directives: { name: string; json: Record<string, unknown> }[];
+  checkpoint_key_scenarios: {
+    name: string;
+    ops: Record<string, unknown>[];
+    expected_keys: string[];
+  }[];
+  sleep_coercions: { input_seconds: number; expected_seconds: number }[];
+  signal_timeout_coercions: {
+    input_seconds: number;
+    expected_seconds: number;
+  }[];
+}
+
+const FIXTURES: Fixtures = JSON.parse(
+  readFileSync(
+    new URL("../../contract-fixtures/workflow-contract.json", import.meta.url),
+    "utf8",
+  ),
+) as Fixtures;
+
+function directiveFixture(name: string): Record<string, unknown> {
+  const found = FIXTURES.directives.find((d) => d.name === name);
+  if (!found) throw new Error(`no directive fixture: ${name}`);
+  return found.json;
+}
+
+function toCheckpoints(record: Map<string, unknown>): WorkflowCheckpoint[] {
+  return [...record.entries()].map(([name, data], i) => ({
+    seq: i + 1,
+    name,
+    data,
+    recordedAt: "2026-06-11T00:00:00Z",
+  }));
+}
+
+/** Stub client recording checkpoint keys in first-recorded order. */
+function scenarioClient(
+  checkpoints: Map<string, unknown>,
+  keys: string[],
+): ActeonClient {
+  let children = 0;
+  return {
+    async recordWorkflowCheckpoint(
+      _executionId: string,
+      _namespace: string,
+      _tenant: string,
+      name: string,
+      data: unknown,
+    ) {
+      if (!checkpoints.has(name)) {
+        keys.push(name);
+        checkpoints.set(name, data);
+      }
+      return { name, seq: keys.length, data: checkpoints.get(name) };
+    },
+    async startChildWorkflow(
+      _executionId: string,
+      _namespace: string,
+      _tenant: string,
+      checkpoint: string,
+    ) {
+      if (!checkpoints.has(checkpoint)) {
+        keys.push(checkpoint);
+        children += 1;
+        checkpoints.set(checkpoint, { child_id: `child-${children}` });
+      }
+      return (checkpoints.get(checkpoint) as { child_id: string }).child_id;
+    },
+  } as unknown as ActeonClient;
+}
+
+/**
+ * Run an op sequence continuation-style, collecting checkpoint keys.
+ * Mirrors a real execution: run from the top, let the first
+ * un-checkpointed suspension unwind, record its checkpoint (as the
+ * server would on resume), and re-run.
+ */
+async function runScenario(
+  ops: Record<string, unknown>[],
+): Promise<string[]> {
+  const checkpoints = new Map<string, unknown>();
+  const keys: string[] = [];
+
+  const workflow = async (ctx: WorkflowContext): Promise<void> => {
+    for (const op of ops) {
+      switch (op.op) {
+        case "step":
+          await ctx.step(op.name as string, () => ({ r: 1 }));
+          break;
+        case "sleep":
+          await ctx.sleep((op.seconds as number) ?? 1);
+          break;
+        case "wait_for_signal":
+          await ctx.waitForSignal(op.name as string);
+          break;
+        case "start_child":
+          await ctx.startChild(op.workflow as string, {});
+          break;
+        case "wait_for_child":
+          await ctx.waitForChild(op.child_id as string);
+          break;
+        default:
+          throw new Error(`unknown op: ${JSON.stringify(op)}`);
+      }
+    }
+  };
+
+  for (let round = 0; round < 100; round++) {
+    const ctx = new WorkflowContext(
+      scenarioClient(checkpoints, keys),
+      "ns",
+      "t1",
+      "ex-1",
+      {},
+      toCheckpoints(checkpoints),
+    );
+    try {
+      await workflow(ctx);
+      return keys;
+    } catch (error) {
+      if (!(error instanceof WorkflowSuspend)) throw error;
+      const directive = error.directive as { checkpoint: string };
+      expect(checkpoints.has(directive.checkpoint)).toBe(false);
+      keys.push(directive.checkpoint);
+      checkpoints.set(
+        directive.checkpoint,
+        error.directive.directive === "sleep" ? {} : { payload: true },
+      );
+    }
+  }
+  throw new Error("scenario did not settle in 100 continuations");
+}
+
+/** Capture the directive thrown by a context operation. */
+async function suspensionDirective(
+  run: (ctx: WorkflowContext) => Promise<unknown>,
+): Promise<WorkflowDirective> {
+  const ctx = new WorkflowContext(
+    undefined as unknown as ActeonClient,
+    "ns",
+    "t1",
+    "ex-1",
+    {},
+    [],
+  );
+  try {
+    await run(ctx);
+  } catch (error) {
+    if (error instanceof WorkflowSuspend) return error.directive;
+    throw error;
+  }
+  throw new Error("operation did not suspend");
+}
+
+describe("contract: constants", () => {
+  it("match the shared fixtures", () => {
+    expect(WORKFLOW_TASK_ACTION_TYPE).toEqual(
+      FIXTURES.constants.workflow_task_action_type,
+    );
+    expect(CHILD_RESULT_SIGNAL_PREFIX).toEqual(
+      FIXTURES.constants.child_result_signal_prefix,
+    );
+  });
+});
+
+describe("contract: checkpoint keys", () => {
+  for (const scenario of FIXTURES.checkpoint_key_scenarios) {
+    it(scenario.name, async () => {
+      expect(await runScenario(scenario.ops)).toEqual(scenario.expected_keys);
+    });
+  }
+});
+
+describe("contract: directive shapes", () => {
+  it("sleep", async () => {
+    const directive = await suspensionDirective((ctx) => ctx.sleep(30));
+    expect(directive).toEqual(directiveFixture("sleep"));
+  });
+
+  it("await_signal with timeout", async () => {
+    const directive = await suspensionDirective((ctx) =>
+      ctx.waitForSignal("approved", 300),
+    );
+    expect(directive).toEqual(directiveFixture("await_signal"));
+  });
+
+  it("await_signal without timeout", async () => {
+    const directive = await suspensionDirective((ctx) =>
+      ctx.waitForSignal("go"),
+    );
+    expect(directive).toEqual(directiveFixture("await_signal_no_timeout"));
+  });
+
+  it("complete and fail via the runner", async () => {
+    const payload = {
+      execution_id: "ex-1",
+      workflow: "wf",
+      input: {},
+      checkpoints: [],
+    };
+    const client = undefined as unknown as ActeonClient;
+
+    const complete = await runWorkflowTask(
+      client,
+      "ns",
+      "t1",
+      async () => ({ ok: true, count: 3 }),
+      payload,
+    );
+    expect(complete).toEqual(directiveFixture("complete"));
+
+    const fail = await runWorkflowTask(
+      client,
+      "ns",
+      "t1",
+      async () => {
+        throw new Error("provisioning broke");
+      },
+      payload,
+    );
+    expect(fail).toEqual(directiveFixture("fail"));
+  });
+});
+
+describe("contract: integer-seconds coercions", () => {
+  it("sleep seconds", async () => {
+    for (const c of FIXTURES.sleep_coercions) {
+      const directive = (await suspensionDirective((ctx) =>
+        ctx.sleep(c.input_seconds),
+      )) as { seconds: number };
+      expect(directive.seconds).toEqual(c.expected_seconds);
+      expect(Number.isInteger(directive.seconds)).toBe(true);
+    }
+  });
+
+  it("signal timeout seconds", async () => {
+    for (const c of FIXTURES.signal_timeout_coercions) {
+      const directive = (await suspensionDirective((ctx) =>
+        ctx.waitForSignal("x", c.input_seconds),
+      )) as { timeout_seconds?: number };
+      expect(directive.timeout_seconds).toEqual(c.expected_seconds);
+      expect(Number.isInteger(directive.timeout_seconds)).toBe(true);
+    }
+  });
+});
+
+describe("contract: timed-out marker", () => {
+  it("replays as null", async () => {
+    const ctx = new WorkflowContext(
+      undefined as unknown as ActeonClient,
+      "ns",
+      "t1",
+      "ex-1",
+      {},
+      [
+        {
+          seq: 1,
+          name: "signal:x#0",
+          data: FIXTURES.constants.timed_out_marker,
+          recordedAt: "2026-06-11T00:00:00Z",
+        },
+      ],
+    );
+    expect(await ctx.waitForSignal("x")).toBeNull();
+  });
+});

--- a/clients/python/tests/test_contract.py
+++ b/clients/python/tests/test_contract.py
@@ -1,0 +1,234 @@
+"""Python side of the cross-SDK workflow contract.
+
+Drives the public SDK surface (``WorkflowContext`` + ``Worker``) against
+the shared fixtures in ``clients/contract-fixtures/workflow-contract.json``
+— the same file consumed by the Node.js SDK tests and by the Rust server
+tests — so checkpoint-key derivation, directive wire shapes, and the
+integer-seconds coercions stay identical across languages. A workflow
+execution can migrate between Python and Node workers mid-flight; these
+keys and shapes are the entire compatibility surface.
+"""
+
+import json
+import unittest
+from pathlib import Path
+from typing import Any
+
+from acteon_client.worker import WORKFLOW_ACTION_TYPE, Worker
+from acteon_client.workflows import WorkflowCheckpoint, WorkflowContext, _Suspend
+
+FIXTURES = json.loads(
+    (Path(__file__).parent / "../../contract-fixtures/workflow-contract.json")
+    .resolve()
+    .read_text()
+)
+
+
+class _ScenarioClient:
+    """Stub client recording checkpoint keys in first-recorded order."""
+
+    def __init__(self, checkpoints: dict[str, Any], keys: list[str]):
+        self._checkpoints = checkpoints
+        self._keys = keys
+        self._children = 0
+
+    def record_workflow_checkpoint(self, execution_id, namespace, tenant, name, data):
+        if name not in self._checkpoints:
+            self._keys.append(name)
+            self._checkpoints[name] = data
+        return WorkflowCheckpoint(seq=len(self._keys), name=name, data=data)
+
+    def start_child_workflow(
+        self, execution_id, namespace, tenant, checkpoint, workflow, input, **kwargs
+    ):
+        if checkpoint not in self._checkpoints:
+            self._keys.append(checkpoint)
+            self._children += 1
+            self._checkpoints[checkpoint] = {"child_id": f"child-{self._children}"}
+        return self._checkpoints[checkpoint]["child_id"]
+
+
+def _run_scenario(ops: list[dict[str, Any]]) -> list[str]:
+    """Run an op sequence continuation-style, collecting checkpoint keys.
+
+    Mirrors how a real execution proceeds: run the workflow function from
+    the top; the first un-checkpointed suspension unwinds it; record the
+    suspension's checkpoint (as the server would on resume) and re-run.
+    The returned keys are in first-recorded order.
+    """
+    checkpoints: dict[str, Any] = {}
+    keys: list[str] = []
+
+    def workflow(ctx: WorkflowContext) -> None:
+        for op in ops:
+            if op["op"] == "step":
+                ctx.step(op["name"], lambda: {"r": 1})
+            elif op["op"] == "sleep":
+                ctx.sleep(op.get("seconds", 1))
+            elif op["op"] == "wait_for_signal":
+                ctx.wait_for_signal(op["name"])
+            elif op["op"] == "start_child":
+                ctx.start_child(op["workflow"], {})
+            elif op["op"] == "wait_for_child":
+                ctx.wait_for_child(op["child_id"])
+            else:  # pragma: no cover - fixture/runner drift
+                raise AssertionError(f"unknown op: {op}")
+
+    for _ in range(100):  # bounded; each round resolves one suspension
+        client = _ScenarioClient(checkpoints, keys)
+        ctx = WorkflowContext(client, "ns", "t1", "ex-1", {}, dict(checkpoints))
+        try:
+            workflow(ctx)
+            return keys
+        except _Suspend as s:
+            key = s.directive["checkpoint"]
+            assert key not in checkpoints, "suspended on a recorded checkpoint"
+            keys.append(key)
+            # Resolve the suspension the way the server would.
+            checkpoints[key] = (
+                {} if s.directive["directive"] == "sleep" else {"payload": True}
+            )
+    raise AssertionError("scenario did not settle in 100 continuations")
+
+
+def _suspension_directive(run) -> dict[str, Any]:
+    """Capture the directive raised by a context operation."""
+    ctx = WorkflowContext(None, "ns", "t1", "ex-1", {}, {})
+    try:
+        run(ctx)
+    except _Suspend as s:
+        return s.directive
+    raise AssertionError("operation did not suspend")
+
+
+class TestConstants(unittest.TestCase):
+    def test_workflow_task_action_type(self):
+        self.assertEqual(
+            WORKFLOW_ACTION_TYPE,
+            FIXTURES["constants"]["workflow_task_action_type"],
+        )
+
+
+class TestCheckpointKeys(unittest.TestCase):
+    def test_scenarios(self):
+        for scenario in FIXTURES["checkpoint_key_scenarios"]:
+            with self.subTest(scenario=scenario["name"]):
+                self.assertEqual(
+                    _run_scenario(scenario["ops"]), scenario["expected_keys"]
+                )
+
+
+class TestDirectiveShapes(unittest.TestCase):
+    """The directives this SDK emits must equal the fixture JSON exactly."""
+
+    def _fixture(self, name: str) -> dict[str, Any]:
+        return next(d for d in FIXTURES["directives"] if d["name"] == name)["json"]
+
+    def test_sleep(self):
+        directive = _suspension_directive(lambda ctx: ctx.sleep(30))
+        self.assertEqual(directive, self._fixture("sleep"))
+
+    def test_await_signal_with_timeout(self):
+        directive = _suspension_directive(
+            lambda ctx: ctx.wait_for_signal("approved", timeout_seconds=300)
+        )
+        self.assertEqual(directive, self._fixture("await_signal"))
+
+    def test_await_signal_without_timeout(self):
+        directive = _suspension_directive(lambda ctx: ctx.wait_for_signal("go"))
+        self.assertEqual(directive, self._fixture("await_signal_no_timeout"))
+
+    def test_complete_and_fail_via_worker(self):
+        # complete/fail are wrapped by the worker when settling the task;
+        # exercise that seam with fat payloads (no execution fetch needed).
+        for fixture_name, fn in [
+            ("complete", lambda ctx, inp: {"ok": True, "count": 3}),
+            ("fail", _raise_provisioning_broke),
+        ]:
+            with self.subTest(directive=fixture_name):
+                settled = _settle_workflow(fn)
+                self.assertEqual(settled, self._fixture(fixture_name))
+
+
+def _raise_provisioning_broke(ctx, inp):
+    raise RuntimeError("provisioning broke")
+
+
+def _settle_workflow(fn) -> dict[str, Any]:
+    """Run one continuation through the Worker and return the settle body."""
+    from acteon_client.queues import WorkerTask
+
+    task = WorkerTask(
+        task_id="t-1",
+        queue="q",
+        action_type=WORKFLOW_ACTION_TYPE,
+        payload={
+            "execution_id": "ex-1",
+            "workflow": "wf",
+            "input": {},
+            "checkpoints": [],
+        },
+        status="leased",
+        attempt=1,
+        max_attempts=3,
+        lease_token="lease-1",
+        created_at="2026-06-11T00:00:00Z",
+        updated_at="2026-06-11T00:00:00Z",
+    )
+
+    settled: list[Any] = []
+
+    class _Client:
+        def poll_tasks(self, *args, **kwargs):
+            return [task] if not settled else []
+
+        def heartbeat_task(self, *args, **kwargs):
+            return task
+
+        def complete_task(self, task_id, namespace, tenant, lease_token, result):
+            settled.append(result)
+            return task
+
+        def fail_task(self, *args, **kwargs):  # pragma: no cover - contract drift
+            raise AssertionError("workflow continuation must settle via complete")
+
+    worker = Worker(_Client(), "ns", "t1", "q", lease_seconds=60)
+    worker.register_workflow("wf", fn)
+    worker.run_once()
+    assert len(settled) == 1
+    return settled[0]
+
+
+class TestCoercions(unittest.TestCase):
+    def test_sleep_seconds_coercion(self):
+        for case in FIXTURES["sleep_coercions"]:
+            with self.subTest(input=case["input_seconds"]):
+                directive = _suspension_directive(
+                    lambda ctx, s=case["input_seconds"]: ctx.sleep(s)
+                )
+                self.assertEqual(directive["seconds"], case["expected_seconds"])
+                self.assertIsInstance(directive["seconds"], int)
+
+    def test_signal_timeout_coercion(self):
+        for case in FIXTURES["signal_timeout_coercions"]:
+            with self.subTest(input=case["input_seconds"]):
+                directive = _suspension_directive(
+                    lambda ctx, s=case["input_seconds"]: ctx.wait_for_signal(
+                        "x", timeout_seconds=s
+                    )
+                )
+                self.assertEqual(
+                    directive["timeout_seconds"], case["expected_seconds"]
+                )
+                self.assertIsInstance(directive["timeout_seconds"], int)
+
+
+class TestTimedOutMarker(unittest.TestCase):
+    def test_timed_out_checkpoint_replays_as_none(self):
+        marker = FIXTURES["constants"]["timed_out_marker"]
+        ctx = WorkflowContext(None, "ns", "t1", "ex-1", {}, {"signal:x#0": marker})
+        self.assertIsNone(ctx.wait_for_signal("x"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/core/tests/workflow_contract.rs
+++ b/crates/core/tests/workflow_contract.rs
@@ -1,0 +1,83 @@
+//! Server side of the cross-SDK workflow contract.
+//!
+//! The fixtures in `clients/contract-fixtures/workflow-contract.json` pin
+//! the wire shapes shared by the worker SDKs (Python, Node.js) and this
+//! crate: every directive an SDK can emit must parse into
+//! [`WorkflowDirective`] (and round-trip byte-for-byte), the malformed
+//! shapes must be rejected by `from_task_result` (the settle path turns
+//! those into a workflow failure instead of a silent completion), and the
+//! reserved constants must match. The SDK test suites consume the same
+//! file, so a drift on either side fails somewhere.
+
+use acteon_core::{CHILD_RESULT_SIGNAL_PREFIX, WORKFLOW_TASK_ACTION_TYPE, WorkflowDirective};
+
+const FIXTURES: &str = include_str!("../../../clients/contract-fixtures/workflow-contract.json");
+
+fn fixtures() -> serde_json::Value {
+    serde_json::from_str(FIXTURES).expect("contract fixtures must be valid JSON")
+}
+
+#[test]
+fn reserved_constants_match_the_contract() {
+    let fixtures = fixtures();
+    assert_eq!(
+        fixtures["constants"]["workflow_task_action_type"],
+        serde_json::json!(WORKFLOW_TASK_ACTION_TYPE)
+    );
+    assert_eq!(
+        fixtures["constants"]["child_result_signal_prefix"],
+        serde_json::json!(CHILD_RESULT_SIGNAL_PREFIX)
+    );
+}
+
+#[test]
+fn every_sdk_directive_parses_and_round_trips() {
+    let fixtures = fixtures();
+    let cases = fixtures["directives"].as_array().unwrap();
+    assert!(!cases.is_empty());
+    for case in cases {
+        let name = case["name"].as_str().unwrap();
+        let json = &case["json"];
+
+        // The settle path must accept it…
+        let directive = WorkflowDirective::from_task_result(json)
+            .unwrap_or_else(|| panic!("directive fixture `{name}` did not parse: {json}"));
+
+        // …agree on the variant…
+        let expected_tag = json["directive"].as_str().unwrap();
+        let actual_tag = match &directive {
+            WorkflowDirective::Complete { .. } => "complete",
+            WorkflowDirective::Fail { .. } => "fail",
+            WorkflowDirective::Sleep { .. } => "sleep",
+            WorkflowDirective::AwaitSignal { .. } => "await_signal",
+        };
+        assert_eq!(actual_tag, expected_tag, "fixture `{name}`");
+
+        // …and serialize back to the exact fixture shape (so directives the
+        // server echoes, e.g. in task results, stay SDK-parseable).
+        let round_tripped = serde_json::to_value(&directive).unwrap();
+        assert_eq!(&round_tripped, json, "fixture `{name}` round trip");
+    }
+}
+
+#[test]
+fn malformed_directives_are_rejected_not_misread() {
+    let fixtures = fixtures();
+    let cases = fixtures["invalid_directives"].as_array().unwrap();
+    assert!(!cases.is_empty());
+    for case in cases {
+        let reason = case["reason"].as_str().unwrap();
+        let json = &case["json"];
+        assert!(
+            WorkflowDirective::from_task_result(json).is_none(),
+            "invalid directive parsed ({reason}): {json}"
+        );
+        // Every invalid fixture still carries the `directive` key — that is
+        // what routes it to a loud workflow failure in the settle path
+        // rather than being mistaken for a plain completion result.
+        assert!(
+            json.get("directive").is_some(),
+            "invalid fixture must carry a `directive` key ({reason})"
+        );
+    }
+}


### PR DESCRIPTION
Follow-up to #250 (deferred-list item 1 of the remaining 3), adding **cross-SDK contract fixtures** for the workflow wire protocol.

## Why

A workflow execution can migrate between Python and Node workers mid-flight, and every directive a worker emits must parse server-side — checkpoint-key derivation and directive shapes are a compatibility surface, not an implementation detail. Until now nothing pinned them across languages: each SDK asserted its own behavior in isolation, so two SDKs could drift apart (or away from the server) with every suite still green.

## What changed

New `clients/contract-fixtures/workflow-contract.json` — one language-neutral file pinning:

- **Directive wire shapes** (`complete` / `fail` / `sleep` / `await_signal`, with and without timeout), plus malformed shapes the server must reject loudly (float seconds, unknown tag, missing signal name).
- **Checkpoint-key derivation** (`step:{name}#{k}`, `sleep#{k}`, `signal:{name}#{k}`, `child:{workflow}#{k}`, `signal:__child:{id}#{k}`) — scenarios are driven *continuation-style* through each SDK's real replay path (run from the top, suspend, record, re-run), not just unit-asserted.
- **Integer-seconds coercions** for `sleep` and signal timeouts (floats truncate, minimum 1).
- The **timed-out marker** (`{"timed_out": true}` replays as `None`/`null`) and the reserved `__workflow__` / `__child:` constants.

Three consumers, so a drift on any side fails that side's suite:

| Consumer | Asserts |
|---|---|
| `crates/core/tests/workflow_contract.rs` | every SDK-emittable directive parses via `from_task_result`, round-trips byte-for-byte, malformed ones are rejected (→ loud workflow failure, not silent completion) |
| `clients/python/tests/test_contract.py` | keys, shapes (via `WorkflowContext` + the real `Worker` settle seam), coercions, marker |
| `clients/nodejs/src/contract.test.ts` | same via `WorkflowContext` + `runWorkflowTask` |

The fixtures README documents the rule: changing a wire shape means updating the fixture and every consumer in the same PR, and a future Go/Java workflow runner gets a consumer alongside it.

## Verification

- Rust: 3 new contract tests pass; all 58 workspace suites green; fmt/clippy(stable+1.88)/`check --all-targets` clean.
- Python: 200 tests pass (9 new + 13 subtests).
- Node: 331 tests pass (11 new).

## Remaining #250 follow-ups

Gateway-level overlap enforcement and pinned-definition GC — coming as the next two PRs.

https://claude.ai/code/session_01T41GGbkbHtKcPtRFhxZ8DV

---
_Generated by [Claude Code](https://claude.ai/code/session_01T41GGbkbHtKcPtRFhxZ8DV)_