### PR TITLE
Move recurring overlap enforcement into the gateway

### DIFF
--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -11,6 +11,7 @@ pub mod gateway;
 pub mod group_manager;
 pub mod metrics;
 mod quota_enforcement;
+pub mod recurring_overlap;
 mod silence_enforcement;
 pub(crate) mod sync_state;
 pub mod task_chain_bridge;
@@ -35,6 +36,7 @@ pub use execution::ExecutionFilter;
 pub use gateway::{ApprovalKey, ApprovalKeySet, ApprovalRecord, ApprovalStatus, Gateway};
 pub use group_manager::GroupManager;
 pub use metrics::{GatewayMetrics, MetricsSnapshot, ProviderMetrics, ProviderStatsSnapshot};
+pub use recurring_overlap::OverlapDecision;
 pub use silence_enforcement::CachedSilence;
 pub use task_chain_bridge::{
     BridgeError as TaskChainBridgeError, link_task_to_chain, project_chain_status_to_task_state,

--- a/crates/gateway/src/recurring_overlap.rs
+++ b/crates/gateway/src/recurring_overlap.rs
@@ -1,0 +1,108 @@
+//! Gateway-level enforcement of recurring-action overlap policies.
+//!
+//! Overlap only matters when an occurrence spawns a chain execution (plain
+//! provider dispatches complete synchronously and never overlap), and the
+//! chain engine lives here — so the enforcement decision does too. Any
+//! consumer dispatching recurring occurrences (the bundled server's
+//! consumer, or an embedder driving the gateway directly) calls
+//! [`Gateway::enforce_overlap_policy`] before dispatch and honors the
+//! returned [`OverlapDecision`].
+
+use tracing::{debug, info};
+
+use acteon_core::{OverlapPolicy, RecurringAction};
+
+use crate::gateway::Gateway;
+
+/// Decision for one recurring occurrence under its overlap policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OverlapDecision {
+    /// Dispatch the occurrence.
+    Proceed,
+    /// The execution spawned by the previous occurrence is still running
+    /// and the policy is `skip`: drop this occurrence. The caller keeps
+    /// the schedule alive (the next occurrence is already re-armed) but
+    /// must not dispatch or count this one as executed.
+    Skip {
+        /// The still-active previous execution.
+        previous_execution_id: String,
+    },
+}
+
+impl Gateway {
+    /// Enforce a recurring action's overlap policy ahead of dispatching an
+    /// occurrence.
+    ///
+    /// - `allow_all` (default): always [`OverlapDecision::Proceed`].
+    /// - `skip`: while the chain execution spawned by the previous
+    ///   occurrence is still active, return [`OverlapDecision::Skip`]
+    ///   (counted in the `recurring_skipped` metric).
+    /// - `cancel_other`: cancel the still-active previous execution
+    ///   (best-effort), then proceed.
+    ///
+    /// Enforcement is best-effort by design: a failed status read proceeds
+    /// (an overlapping dispatch beats silently stalling the schedule), and
+    /// a failed cancel proceeds (the execution may have settled between
+    /// the status read and the cancel).
+    pub async fn enforce_overlap_policy(
+        &self,
+        namespace: &str,
+        tenant: &str,
+        recurring_id: &str,
+        recurring: &RecurringAction,
+    ) -> OverlapDecision {
+        if recurring.overlap_policy == OverlapPolicy::AllowAll {
+            return OverlapDecision::Proceed;
+        }
+        let Some(prev_id) = recurring.last_execution_id.as_deref() else {
+            return OverlapDecision::Proceed;
+        };
+        let still_active = matches!(
+            self.get_chain_status(namespace, tenant, prev_id).await,
+            Ok(Some(prev)) if prev.status.is_active()
+        );
+        if !still_active {
+            return OverlapDecision::Proceed;
+        }
+        match recurring.overlap_policy {
+            OverlapPolicy::Skip => {
+                info!(
+                    recurring_id,
+                    previous_execution = prev_id,
+                    "previous execution still running; occurrence skipped (overlap policy)"
+                );
+                self.metrics().increment_recurring_skipped();
+                OverlapDecision::Skip {
+                    previous_execution_id: prev_id.to_owned(),
+                }
+            }
+            OverlapPolicy::CancelOther => {
+                info!(
+                    recurring_id,
+                    previous_execution = prev_id,
+                    "cancelling still-running previous execution (overlap policy)"
+                );
+                if let Err(e) = self
+                    .cancel_chain(
+                        namespace,
+                        tenant,
+                        prev_id,
+                        Some("superseded by next recurring occurrence".to_owned()),
+                        Some(format!("recurring:{recurring_id}")),
+                    )
+                    .await
+                {
+                    // The execution may have settled between the status
+                    // read and the cancel — proceed.
+                    debug!(
+                        previous_execution = prev_id,
+                        error = %e,
+                        "overlap cancel failed (execution may have settled)"
+                    );
+                }
+                OverlapDecision::Proceed
+            }
+            OverlapPolicy::AllowAll => unreachable!(),
+        }
+    }
+}

--- a/crates/gateway/tests/recurring_overlap.rs
+++ b/crates/gateway/tests/recurring_overlap.rs
@@ -1,0 +1,279 @@
+//! Integration tests for gateway-level recurring overlap enforcement:
+//! `Gateway::enforce_overlap_policy` must make the same decisions for any
+//! consumer (the bundled server's recurring consumer or an embedder).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Utc;
+
+use acteon_core::chain::{ChainConfig, ChainStepConfig, SignalStepConfig};
+use acteon_core::{
+    Action, ActionOutcome, ChainStatus, OverlapPolicy, ProviderResponse, RecurringAction,
+    RecurringActionTemplate,
+};
+use acteon_executor::ExecutorConfig;
+use acteon_gateway::{Gateway, GatewayBuilder, OverlapDecision};
+use acteon_provider::{DynProvider, ProviderError};
+use acteon_rules::ir::expr::{BinaryOp, Expr};
+use acteon_rules::ir::rule::{Rule, RuleAction};
+use acteon_state_memory::{MemoryDistributedLock, MemoryStateStore};
+
+const NS: &str = "notifications";
+const TENANT: &str = "tenant-1";
+
+struct MockProvider;
+
+#[async_trait]
+impl DynProvider for MockProvider {
+    fn name(&self) -> &'static str {
+        "email"
+    }
+
+    async fn execute(&self, _action: &Action) -> Result<ProviderResponse, ProviderError> {
+        Ok(ProviderResponse::success(serde_json::json!({"ok": true})))
+    }
+
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        Ok(())
+    }
+}
+
+fn build_gateway(chain: ChainConfig) -> Gateway {
+    let rule = Rule::new(
+        "start-chain",
+        Expr::Binary(
+            BinaryOp::Eq,
+            Box::new(Expr::Field(
+                Box::new(Expr::Ident("action".into())),
+                "action_type".into(),
+            )),
+            Box::new(Expr::String("start_chain".into())),
+        ),
+        RuleAction::Chain {
+            chain: "test-chain".into(),
+        },
+    );
+    GatewayBuilder::new()
+        .state(Arc::new(MemoryStateStore::new()))
+        .lock(Arc::new(MemoryDistributedLock::new()))
+        .rules(vec![rule])
+        .provider(Arc::new(MockProvider))
+        .executor_config(ExecutorConfig {
+            max_retries: 0,
+            execution_timeout: Duration::from_secs(5),
+            max_concurrent: 10,
+            ..ExecutorConfig::default()
+        })
+        .chain(chain)
+        .build()
+        .expect("gateway should build")
+}
+
+/// A chain that parks indefinitely on a signal (stays active).
+fn parked_chain() -> ChainConfig {
+    ChainConfig::new("test-chain").with_step(ChainStepConfig::new_wait_for_signal(
+        "wait",
+        SignalStepConfig {
+            signal_name: "go".into(),
+            timeout_seconds: None,
+            on_timeout: None,
+        },
+    ))
+}
+
+/// A chain with one provider step (completes on first advance).
+fn quick_chain() -> ChainConfig {
+    ChainConfig::new("test-chain").with_step(ChainStepConfig::new(
+        "notify",
+        "email",
+        "send_email",
+        serde_json::json!({}),
+    ))
+}
+
+async fn start_chain(gateway: &Gateway) -> String {
+    let action = Action::new(NS, TENANT, "email", "start_chain", serde_json::json!({}));
+    match gateway.dispatch(action, None).await.unwrap() {
+        ActionOutcome::ChainStarted { chain_id, .. } => chain_id,
+        other => panic!("expected ChainStarted, got {other:?}"),
+    }
+}
+
+fn recurring(policy: OverlapPolicy, last_execution_id: Option<String>) -> RecurringAction {
+    let now = Utc::now();
+    RecurringAction {
+        id: "rec-1".into(),
+        namespace: NS.into(),
+        tenant: TENANT.into(),
+        cron_expr: "*/5 * * * *".into(),
+        timezone: "UTC".into(),
+        enabled: true,
+        action_template: RecurringActionTemplate {
+            provider: "email".into(),
+            action_type: "start_chain".into(),
+            payload: serde_json::json!({}),
+            metadata: HashMap::new(),
+            dedup_key: None,
+        },
+        created_at: now,
+        updated_at: now,
+        last_executed_at: None,
+        next_execution_at: None,
+        ends_at: None,
+        max_executions: None,
+        execution_count: 0,
+        description: None,
+        labels: HashMap::new(),
+        overlap_policy: policy,
+        last_execution_id,
+    }
+}
+
+#[tokio::test]
+async fn allow_all_always_proceeds() {
+    let gateway = build_gateway(parked_chain());
+    let chain_id = start_chain(&gateway).await;
+    gateway.advance_chain(NS, TENANT, &chain_id).await.unwrap();
+
+    let decision = gateway
+        .enforce_overlap_policy(
+            NS,
+            TENANT,
+            "rec-1",
+            &recurring(OverlapPolicy::AllowAll, Some(chain_id)),
+        )
+        .await;
+    assert_eq!(decision, OverlapDecision::Proceed);
+}
+
+#[tokio::test]
+async fn skip_drops_occurrence_while_previous_is_active() {
+    let gateway = build_gateway(parked_chain());
+    let chain_id = start_chain(&gateway).await;
+    gateway.advance_chain(NS, TENANT, &chain_id).await.unwrap();
+    let state = gateway
+        .get_chain_status(NS, TENANT, &chain_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(state.status, ChainStatus::WaitingSignal);
+
+    let decision = gateway
+        .enforce_overlap_policy(
+            NS,
+            TENANT,
+            "rec-1",
+            &recurring(OverlapPolicy::Skip, Some(chain_id.clone())),
+        )
+        .await;
+    assert_eq!(
+        decision,
+        OverlapDecision::Skip {
+            previous_execution_id: chain_id
+        }
+    );
+    assert_eq!(gateway.metrics().snapshot().recurring_skipped, 1);
+}
+
+#[tokio::test]
+async fn skip_proceeds_once_previous_settles() {
+    let gateway = build_gateway(quick_chain());
+    let chain_id = start_chain(&gateway).await;
+    gateway.advance_chain(NS, TENANT, &chain_id).await.unwrap();
+    let state = gateway
+        .get_chain_status(NS, TENANT, &chain_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(state.status, ChainStatus::Completed);
+
+    let decision = gateway
+        .enforce_overlap_policy(
+            NS,
+            TENANT,
+            "rec-1",
+            &recurring(OverlapPolicy::Skip, Some(chain_id)),
+        )
+        .await;
+    assert_eq!(decision, OverlapDecision::Proceed);
+    assert_eq!(gateway.metrics().snapshot().recurring_skipped, 0);
+}
+
+#[tokio::test]
+async fn skip_proceeds_without_a_previous_execution() {
+    let gateway = build_gateway(parked_chain());
+
+    // No previous execution recorded.
+    let decision = gateway
+        .enforce_overlap_policy(NS, TENANT, "rec-1", &recurring(OverlapPolicy::Skip, None))
+        .await;
+    assert_eq!(decision, OverlapDecision::Proceed);
+
+    // A recorded ID whose execution no longer exists (e.g. expired TTL).
+    let decision = gateway
+        .enforce_overlap_policy(
+            NS,
+            TENANT,
+            "rec-1",
+            &recurring(OverlapPolicy::Skip, Some("gone".into())),
+        )
+        .await;
+    assert_eq!(decision, OverlapDecision::Proceed);
+}
+
+#[tokio::test]
+async fn cancel_other_cancels_previous_then_proceeds() {
+    let gateway = build_gateway(parked_chain());
+    let chain_id = start_chain(&gateway).await;
+    gateway.advance_chain(NS, TENANT, &chain_id).await.unwrap();
+
+    let decision = gateway
+        .enforce_overlap_policy(
+            NS,
+            TENANT,
+            "rec-1",
+            &recurring(OverlapPolicy::CancelOther, Some(chain_id.clone())),
+        )
+        .await;
+    assert_eq!(decision, OverlapDecision::Proceed);
+
+    let state = gateway
+        .get_chain_status(NS, TENANT, &chain_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(state.status, ChainStatus::Cancelled);
+    assert_eq!(state.cancelled_by.as_deref(), Some("recurring:rec-1"));
+    assert_eq!(
+        state.cancel_reason.as_deref(),
+        Some("superseded by next recurring occurrence")
+    );
+}
+
+#[tokio::test]
+async fn cancel_other_proceeds_when_previous_already_settled() {
+    let gateway = build_gateway(quick_chain());
+    let chain_id = start_chain(&gateway).await;
+    gateway.advance_chain(NS, TENANT, &chain_id).await.unwrap();
+
+    let decision = gateway
+        .enforce_overlap_policy(
+            NS,
+            TENANT,
+            "rec-1",
+            &recurring(OverlapPolicy::CancelOther, Some(chain_id.clone())),
+        )
+        .await;
+    assert_eq!(decision, OverlapDecision::Proceed);
+
+    // Completed executions are left untouched.
+    let state = gateway
+        .get_chain_status(NS, TENANT, &chain_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(state.status, ChainStatus::Completed);
+}

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -2197,84 +2197,48 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 // Enforce the overlap policy when the previous occurrence
                 // spawned a chain execution that is still running. The
-                // pre-dispatch re-arm in the background worker has already
-                // indexed the next occurrence, so skipping here keeps the
-                // schedule alive.
-                if recurring.overlap_policy != acteon_core::OverlapPolicy::AllowAll
-                    && let Some(prev_id) = recurring.last_execution_id.as_deref()
-                    && let Ok(Some(prev)) = gw
-                        .get_chain_status(event.namespace.as_str(), event.tenant.as_str(), prev_id)
-                        .await
-                    && prev.status.is_active()
+                // gateway makes the decision (and cancels under
+                // `cancel_other`); the pre-dispatch re-arm in the background
+                // worker has already indexed the next occurrence, so
+                // skipping here keeps the schedule alive.
+                if let acteon_gateway::OverlapDecision::Skip { .. } = gw
+                    .enforce_overlap_policy(
+                        event.namespace.as_str(),
+                        event.tenant.as_str(),
+                        &event.recurring_id,
+                        recurring,
+                    )
+                    .await
                 {
-                    match recurring.overlap_policy {
-                        acteon_core::OverlapPolicy::Skip => {
-                            info!(
-                                recurring_id = %event.recurring_id,
-                                previous_execution = %prev_id,
-                                "previous execution still running; occurrence skipped (overlap policy)"
-                            );
-                            gw.metrics().increment_recurring_skipped();
-                            // Keep visibility live on skips: refresh
-                            // updated_at and next_execution_at (the worker
-                            // already re-armed the index), without touching
-                            // execution_count / last_executed_at.
-                            let rec_key = acteon_state::StateKey::new(
-                                event.namespace.as_str(),
-                                event.tenant.as_str(),
-                                acteon_state::KeyKind::RecurringAction,
-                                &event.recurring_id,
-                            );
-                            if let Ok(Some(raw_str)) = recurring_store.get(&rec_key).await
-                                && let Ok(data_str) = gw.decrypt_state_value(&raw_str)
-                                && let Ok(mut rec) =
-                                    serde_json::from_str::<acteon_core::RecurringAction>(&data_str)
-                            {
-                                rec.updated_at = now;
-                                rec.next_execution_at =
-                                    acteon_core::validate_cron_expr(&rec.cron_expr)
-                                        .ok()
-                                        .and_then(|cron| {
-                                            acteon_core::validate_timezone(&rec.timezone)
-                                                .ok()
-                                                .and_then(|tz| {
-                                                    acteon_core::next_occurrence(&cron, tz, &now)
-                                                })
-                                        });
-                                if let Ok(json) = serde_json::to_string(&rec) {
-                                    let encrypted = gw.encrypt_state_value(&json).unwrap_or(json);
-                                    let _ = recurring_store.set(&rec_key, &encrypted, None).await;
-                                }
-                            }
-                            continue;
+                    // Keep visibility live on skips: refresh
+                    // updated_at and next_execution_at (the worker
+                    // already re-armed the index), without touching
+                    // execution_count / last_executed_at.
+                    let rec_key = acteon_state::StateKey::new(
+                        event.namespace.as_str(),
+                        event.tenant.as_str(),
+                        acteon_state::KeyKind::RecurringAction,
+                        &event.recurring_id,
+                    );
+                    if let Ok(Some(raw_str)) = recurring_store.get(&rec_key).await
+                        && let Ok(data_str) = gw.decrypt_state_value(&raw_str)
+                        && let Ok(mut rec) =
+                            serde_json::from_str::<acteon_core::RecurringAction>(&data_str)
+                    {
+                        rec.updated_at = now;
+                        rec.next_execution_at = acteon_core::validate_cron_expr(&rec.cron_expr)
+                            .ok()
+                            .and_then(|cron| {
+                                acteon_core::validate_timezone(&rec.timezone)
+                                    .ok()
+                                    .and_then(|tz| acteon_core::next_occurrence(&cron, tz, &now))
+                            });
+                        if let Ok(json) = serde_json::to_string(&rec) {
+                            let encrypted = gw.encrypt_state_value(&json).unwrap_or(json);
+                            let _ = recurring_store.set(&rec_key, &encrypted, None).await;
                         }
-                        acteon_core::OverlapPolicy::CancelOther => {
-                            info!(
-                                recurring_id = %event.recurring_id,
-                                previous_execution = %prev_id,
-                                "cancelling still-running previous execution (overlap policy)"
-                            );
-                            if let Err(e) = gw
-                                .cancel_chain(
-                                    event.namespace.as_str(),
-                                    event.tenant.as_str(),
-                                    prev_id,
-                                    Some("superseded by next recurring occurrence".to_owned()),
-                                    Some(format!("recurring:{}", event.recurring_id)),
-                                )
-                                .await
-                            {
-                                // The execution may have settled between the
-                                // status read and the cancel — proceed.
-                                tracing::debug!(
-                                    previous_execution = %prev_id,
-                                    error = %e,
-                                    "overlap cancel failed (execution may have settled)"
-                                );
-                            }
-                        }
-                        acteon_core::OverlapPolicy::AllowAll => unreachable!(),
                     }
+                    continue;
                 }
 
                 match gw.dispatch(action, None).await {

--- a/docs/book/features/recurring-actions.md
+++ b/docs/book/features/recurring-actions.md
@@ -685,6 +685,14 @@ occurrences increment the `recurring_skipped` metric and do not advance
 `execution_count`; the schedule itself continues normally. Plain provider
 dispatches complete synchronously and are unaffected.
 
+Enforcement lives in the gateway (`Gateway::enforce_overlap_policy`), so
+embedders driving the gateway directly get the same semantics as the
+bundled server: call it before dispatching an occurrence and drop the
+dispatch when it returns a `Skip` decision. Enforcement is best-effort by
+design — a failed status read proceeds rather than stalling the schedule,
+and a failed `cancel_other` cancel proceeds because the previous execution
+may have settled in between.
+
 ## Backfill
 
 `POST /v1/recurring/{id}/backfill` dispatches one action per cron


### PR DESCRIPTION
Follow-up to #250 (deferred-list item 2 of the remaining 3): **gateway-level overlap enforcement** for recurring actions.

## Why

The `skip` / `cancel_other` overlap decision lived inline in the bundled server's recurring consumer (`main.rs`). Embedders driving `acteon-gateway` directly — or any alternative consumer of recurring events — silently got `allow_all` semantics regardless of the configured policy.

## What changed

- New `Gateway::enforce_overlap_policy(namespace, tenant, recurring_id, &RecurringAction) -> OverlapDecision` (module `recurring_overlap`, `OverlapDecision` exported from the crate root):
  - `allow_all` → `Proceed`, always.
  - `skip` → `Skip { previous_execution_id }` while the chain spawned by the previous occurrence is still active; counts the `recurring_skipped` metric.
  - `cancel_other` → cancels the still-active previous execution (attributed `recurring:{id}`, reason "superseded by next recurring occurrence"), then `Proceed`.
  - Best-effort by design: a failed status read proceeds (an overlapping dispatch beats silently stalling the schedule) and a failed cancel proceeds (the execution may have settled in between) — same semantics the server consumer had.
- The server consumer now delegates the decision and keeps only its own bookkeeping (refreshing the recurring record's `updated_at`/`next_execution_at` on skip). Behavior of the bundled server is unchanged.
- Docs: the Overlap Policies section in `recurring-actions.md` now documents the gateway API and the best-effort semantics for embedders.

## Verification

- Six new gateway integration tests (`crates/gateway/tests/recurring_overlap.rs`): all three policies against active, settled, and missing previous executions, including cancelled-by attribution and the skip metric.
- All 58 workspace test suites pass; fmt, clippy (stable + 1.88), `cargo check --all-targets` clean.

## Remaining #250 follow-ups

Cross-SDK contract fixtures are in flight as #254; pinned-definition GC comes next.

https://claude.ai/code/session_01T41GGbkbHtKcPtRFhxZ8DV

---
_Generated by [Claude Code](https://claude.ai/code/session_01T41GGbkbHtKcPtRFhxZ8DV)_