### PR TITLE
Garbage-collect unreferenced pinned chain definitions

### DIFF
--- a/crates/gateway/src/background/mod.rs
+++ b/crates/gateway/src/background/mod.rs
@@ -463,6 +463,19 @@ impl BackgroundProcessor {
                     if let Err(e) = self.run_retention_reaper().await {
                         error!(error = %e, "error running retention reaper");
                     }
+                    // Pinned-definition GC shares the retention cadence:
+                    // drop chain-definition versions that no execution can
+                    // resolve anymore (runs regardless of retention
+                    // policies — unreferenced pins are garbage by
+                    // definition).
+                    if let Some(ref gw) = self.gateway {
+                        let gw = gw.read().await;
+                        match gw.gc_pinned_definitions().await {
+                            Ok(0) => {}
+                            Ok(deleted) => debug!(deleted, "pinned-definition GC completed"),
+                            Err(e) => error!(error = %e, "error running pinned-definition GC"),
+                        }
+                    }
                 }
                 _ = stale_task_interval.tick(), if self.config.enable_stale_task_reaper => {
                     if let Err(e) = self.run_stale_task_reaper().await {

--- a/crates/gateway/src/execution.rs
+++ b/crates/gateway/src/execution.rs
@@ -227,6 +227,138 @@ impl Gateway {
         Ok(())
     }
 
+    /// Garbage-collect pinned chain definitions that nothing can resolve
+    /// anymore. Returns the number of entries deleted.
+    ///
+    /// A pinned `{name}@{version}` entry is deleted only when **both** hold:
+    ///
+    /// - no chain state (active, or terminal but not yet expired) in that
+    ///   namespace/tenant still references `(name, version)` — terminal
+    ///   states keep resolving their definition for detail/history
+    ///   endpoints until their TTL reaps them, so they count as references;
+    /// - the version is older than `current - 1` for the registry's
+    ///   definition of that name. New executions always pin the *current*
+    ///   registry version, so keeping the latest version closes the
+    ///   pin-then-persist window (a pin written mid-GC is never a delete
+    ///   candidate); keeping `current - 1` additionally covers an execution
+    ///   that read the definition just before an update and persists its
+    ///   first state just after the reference scan.
+    ///
+    /// Conservative on read failures: if any chain state cannot be
+    /// decrypted or parsed, the cycle aborts without deleting anything —
+    /// that record might be the only reference to a candidate.
+    pub async fn gc_pinned_definitions(&self) -> Result<usize, GatewayError> {
+        let pinned = self
+            .state
+            .scan_keys_by_kind(KeyKind::Custom(PINNED_CHAIN_DEF_KIND.into()))
+            .await?;
+        if pinned.is_empty() {
+            return Ok(0);
+        }
+
+        // Read the registry versions BEFORE the reference scan: a version
+        // that becomes non-current during the scan stays protected for
+        // this cycle and is reconsidered on the next one.
+        let current_versions: HashMap<String, u64> = self
+            .chains
+            .read()
+            .iter()
+            .map(|(name, config)| (name.clone(), config.version))
+            .collect();
+
+        // Reference set: every (namespace, tenant, name, version) some
+        // chain state still resolves.
+        let mut referenced: std::collections::HashSet<(String, String, String, u64)> =
+            std::collections::HashSet::new();
+        for (key, raw) in self.state.scan_keys_by_kind(KeyKind::Chain).await? {
+            // Canonical key: {namespace}:{tenant}:chain:{chain_id}
+            let parts: Vec<&str> = key.splitn(4, ':').collect();
+            if parts.len() < 4 {
+                continue;
+            }
+            let json = self.decrypt_state_value(&raw).map_err(|e| {
+                GatewayError::ChainError(format!(
+                    "pinned-definition GC aborted: failed to decrypt chain state {key}: {e}"
+                ))
+            })?;
+            let value: serde_json::Value = serde_json::from_str(&json).map_err(|e| {
+                GatewayError::ChainError(format!(
+                    "pinned-definition GC aborted: failed to parse chain state {key}: {e}"
+                ))
+            })?;
+            let Some(name) = value.get("chain_name").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            // Pre-versioning states deserialize with the version default.
+            let version = value
+                .get("chain_version")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(1);
+            referenced.insert((
+                parts[0].to_owned(),
+                parts[1].to_owned(),
+                name.to_owned(),
+                version,
+            ));
+        }
+
+        let mut deleted = 0usize;
+        for (key, _) in pinned {
+            // Canonical key: {namespace}:{tenant}:chain_def_pinned:{name}@{version}
+            let parts: Vec<&str> = key.splitn(4, ':').collect();
+            if parts.len() < 4 {
+                continue;
+            }
+            let (namespace, tenant, id) = (parts[0], parts[1], parts[3]);
+            // The version is numeric and names may contain `@`, so split on
+            // the LAST `@`. Unparseable ids are kept (never delete what we
+            // don't understand).
+            let Some((name, version)) = id.rsplit_once('@') else {
+                continue;
+            };
+            let Ok(version) = version.parse::<u64>() else {
+                continue;
+            };
+            if let Some(&current) = current_versions.get(name)
+                && version.saturating_add(1) >= current
+            {
+                continue; // current or current-1 (or ahead of the registry)
+            }
+            if referenced.contains(&(
+                namespace.to_owned(),
+                tenant.to_owned(),
+                name.to_owned(),
+                version,
+            )) {
+                continue;
+            }
+            let state_key = StateKey::new(
+                namespace,
+                tenant,
+                KeyKind::Custom(PINNED_CHAIN_DEF_KIND.into()),
+                id,
+            );
+            match self.state.delete(&state_key).await {
+                Ok(_) => {
+                    deleted += 1;
+                    self.pinned_config_cache.write().remove(&(
+                        namespace.to_owned(),
+                        tenant.to_owned(),
+                        name.to_owned(),
+                        version,
+                    ));
+                }
+                Err(e) => {
+                    warn!(key = %key, error = %e, "failed to delete unreferenced pinned definition");
+                }
+            }
+        }
+        if deleted > 0 {
+            debug!(deleted, "pinned-definition GC removed unreferenced entries");
+        }
+        Ok(deleted)
+    }
+
     /// Resolve the definition an execution runs against, in order:
     /// process-local cache → pinned-definition store → the legacy snapshot
     /// embedded in pre-store executions → the live registry (pre-pinning

--- a/crates/gateway/tests/pinned_def_gc.rs
+++ b/crates/gateway/tests/pinned_def_gc.rs
@@ -1,0 +1,200 @@
+//! Integration tests for pinned-definition garbage collection:
+//! `Gateway::gc_pinned_definitions` must delete only `{name}@{version}`
+//! entries that no chain state references AND that are older than the
+//! registry's `current - 1` for that name.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use acteon_core::chain::{ChainConfig, ChainStepConfig, SignalStepConfig};
+use acteon_core::{Action, ActionOutcome, ProviderResponse};
+use acteon_executor::ExecutorConfig;
+use acteon_gateway::{Gateway, GatewayBuilder};
+use acteon_provider::{DynProvider, ProviderError};
+use acteon_rules::ir::expr::{BinaryOp, Expr};
+use acteon_rules::ir::rule::{Rule, RuleAction};
+use acteon_state::{KeyKind, StateKey, StateStore};
+use acteon_state_memory::{MemoryDistributedLock, MemoryStateStore};
+
+const NS: &str = "notifications";
+const TENANT: &str = "tenant-1";
+const PINNED_KIND: &str = "chain_def_pinned";
+
+struct MockProvider;
+
+#[async_trait]
+impl DynProvider for MockProvider {
+    fn name(&self) -> &'static str {
+        "email"
+    }
+
+    async fn execute(&self, _action: &Action) -> Result<ProviderResponse, ProviderError> {
+        Ok(ProviderResponse::success(serde_json::json!({"ok": true})))
+    }
+
+    async fn health_check(&self) -> Result<(), ProviderError> {
+        Ok(())
+    }
+}
+
+fn test_chain() -> ChainConfig {
+    // Parks on a signal so the execution stays active until we delete it.
+    ChainConfig::new("test-chain").with_step(ChainStepConfig::new_wait_for_signal(
+        "wait",
+        SignalStepConfig {
+            signal_name: "go".into(),
+            timeout_seconds: None,
+            on_timeout: None,
+        },
+    ))
+}
+
+fn build_gateway() -> (Gateway, Arc<dyn StateStore>) {
+    let store = Arc::new(MemoryStateStore::new());
+    let dyn_store: Arc<dyn StateStore> = store.clone();
+    let rule = Rule::new(
+        "start-chain",
+        Expr::Binary(
+            BinaryOp::Eq,
+            Box::new(Expr::Field(
+                Box::new(Expr::Ident("action".into())),
+                "action_type".into(),
+            )),
+            Box::new(Expr::String("start_chain".into())),
+        ),
+        RuleAction::Chain {
+            chain: "test-chain".into(),
+        },
+    );
+    let gateway = GatewayBuilder::new()
+        .state(store)
+        .lock(Arc::new(MemoryDistributedLock::new()))
+        .rules(vec![rule])
+        .provider(Arc::new(MockProvider))
+        .executor_config(ExecutorConfig {
+            max_retries: 0,
+            execution_timeout: Duration::from_secs(5),
+            max_concurrent: 10,
+            ..ExecutorConfig::default()
+        })
+        .chain(test_chain())
+        .build()
+        .expect("gateway should build");
+    (gateway, dyn_store)
+}
+
+async fn start_chain(gateway: &Gateway) -> String {
+    let action = Action::new(NS, TENANT, "email", "start_chain", serde_json::json!({}));
+    match gateway.dispatch(action, None).await.unwrap() {
+        ActionOutcome::ChainStarted { chain_id, .. } => chain_id,
+        other => panic!("expected ChainStarted, got {other:?}"),
+    }
+}
+
+async fn pinned_ids(store: &Arc<dyn StateStore>) -> Vec<String> {
+    let mut ids: Vec<String> = store
+        .scan_keys(NS, TENANT, KeyKind::Custom(PINNED_KIND.into()), None)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|(key, _)| key.rsplit(':').next().unwrap().to_owned())
+        .collect();
+    ids.sort();
+    ids
+}
+
+async fn delete_chain_state(store: &Arc<dyn StateStore>, chain_id: &str) {
+    store
+        .delete(&StateKey::new(NS, TENANT, KeyKind::Chain, chain_id))
+        .await
+        .unwrap();
+}
+
+/// Bump the registry definition `times` times.
+fn bump_version(gateway: &Gateway, times: u64) {
+    for _ in 0..times {
+        gateway.set_chain_config(test_chain()).unwrap();
+    }
+}
+
+#[tokio::test]
+async fn gc_keeps_versions_referenced_by_executions() {
+    let (gateway, store) = build_gateway();
+    start_chain(&gateway).await;
+    assert_eq!(pinned_ids(&store).await, vec!["test-chain@1"]);
+
+    // Even far behind the registry, a referenced version survives.
+    bump_version(&gateway, 5);
+    assert_eq!(gateway.gc_pinned_definitions().await.unwrap(), 0);
+    assert_eq!(pinned_ids(&store).await, vec!["test-chain@1"]);
+}
+
+#[tokio::test]
+async fn gc_removes_unreferenced_old_versions() {
+    let (gateway, store) = build_gateway();
+    let chain_id = start_chain(&gateway).await;
+
+    // The execution's state expires (simulated delete) and the
+    // definition moves far past v1.
+    delete_chain_state(&store, &chain_id).await;
+    bump_version(&gateway, 5);
+
+    assert_eq!(gateway.gc_pinned_definitions().await.unwrap(), 1);
+    assert!(pinned_ids(&store).await.is_empty());
+}
+
+#[tokio::test]
+async fn gc_grace_window_keeps_current_and_previous_versions() {
+    let (gateway, store) = build_gateway();
+    let chain_id = start_chain(&gateway).await;
+    delete_chain_state(&store, &chain_id).await;
+
+    // current = 2: v1 is `current - 1` and stays protected.
+    bump_version(&gateway, 1);
+    assert_eq!(gateway.gc_pinned_definitions().await.unwrap(), 0);
+    assert_eq!(pinned_ids(&store).await, vec!["test-chain@1"]);
+
+    // current = 3: v1 falls out of the grace window.
+    bump_version(&gateway, 1);
+    assert_eq!(gateway.gc_pinned_definitions().await.unwrap(), 1);
+    assert!(pinned_ids(&store).await.is_empty());
+}
+
+#[tokio::test]
+async fn gc_removes_pins_of_deleted_definitions() {
+    let (gateway, store) = build_gateway();
+    let chain_id = start_chain(&gateway).await;
+    delete_chain_state(&store, &chain_id).await;
+
+    // Removing the definition drops the registry protection; with no
+    // execution referencing v1 the pin is garbage.
+    gateway.remove_chain_config("test-chain").unwrap();
+    assert_eq!(gateway.gc_pinned_definitions().await.unwrap(), 1);
+    assert!(pinned_ids(&store).await.is_empty());
+}
+
+#[tokio::test]
+async fn gc_kept_version_still_resolves_for_the_execution() {
+    let (gateway, store) = build_gateway();
+    let chain_id = start_chain(&gateway).await;
+    bump_version(&gateway, 5);
+
+    assert_eq!(gateway.gc_pinned_definitions().await.unwrap(), 0);
+
+    // The parked execution still advances against its pinned v1.
+    gateway.advance_chain(NS, TENANT, &chain_id).await.unwrap();
+    let state = gateway
+        .get_chain_status(NS, TENANT, &chain_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(state.chain_version, 1);
+    assert_eq!(
+        state.status,
+        acteon_core::ChainStatus::WaitingSignal,
+        "execution should park on its pinned definition's wait step"
+    );
+    assert_eq!(pinned_ids(&store).await, vec!["test-chain@1"]);
+}

--- a/docs/book/features/durable-executions.md
+++ b/docs/book/features/durable-executions.md
@@ -96,6 +96,13 @@ executions; new executions pick up the latest version. Deleting a
 definition that other definitions still reference as a sub-chain is
 rejected.
 
+Old pinned versions are garbage-collected on the retention cadence
+(hourly by default): a `{name}@{version}` entry is deleted only when no
+execution — active, or terminal but not yet expired — still references it
+*and* it is older than the registry's previous version for that name.
+Executions sleeping for months keep their pinned definition for as long
+as their state exists.
+
 ## Visibility & search attributes
 
 `GET /v1/executions` lists executions across all chains — including


### PR DESCRIPTION
Follow-up to #250 (deferred-list item 3 of the remaining 3, completing the list): **pinned-definition garbage collection**.

## Why

Pinned chain definitions (#251) are written once per `{name}@{version}` with **no TTL** — an execution may sleep for months and must still resolve its version. The flip side: fully-retired versions accumulated forever.

## What changed

New `Gateway::gc_pinned_definitions()`, run on the background processor's retention tick (hourly by default, independent of retention policies). A pinned entry is deleted only when **both** hold:

1. **Unreferenced** — no chain state (active, or terminal but not yet expired) in that namespace/tenant still resolves `(name, version)`. Terminal states count as references because the detail/history/DAG endpoints keep resolving their definition until their TTL reaps them.
2. **Outside the grace window** — the version is older than `current − 1` for the registry's definition of that name.

The grace window closes the pin-then-persist race without needing timestamps: new executions always pin the registry's *current* version, so a pin written mid-GC is never a delete candidate; keeping `current − 1` additionally covers an execution that read the definition just before an update and persists its first state just after the reference scan. Deleted entries are also evicted from the process-local cache.

Failure posture is conservative: if any chain state fails to decrypt or parse, the cycle aborts without deleting anything — that record might be the only reference to a candidate. Unparseable pinned ids are kept.

## Verification

- Five integration tests (`crates/gateway/tests/pinned_def_gc.rs`): referenced versions survive even far behind the registry; unreferenced old versions are removed; the `current`/`current−1` grace window; pins of deleted definitions are collected once unreferenced; and a kept version still resolves for its parked execution after GC.
- All 58 workspace test suites pass; fmt, clippy (stable + 1.88), `cargo check --all-targets` clean.
- Docs: the definition-versioning section in `durable-executions.md` documents the GC rules.

## Status of the #250 deferred list

With #254 (contract fixtures), #255 (gateway overlap enforcement), and this PR, every follow-up deferred from the #250 adversarial review is closed.

https://claude.ai/code/session_01T41GGbkbHtKcPtRFhxZ8DV

---
_Generated by [Claude Code](https://claude.ai/code/session_01T41GGbkbHtKcPtRFhxZ8DV)_